### PR TITLE
fix consensus race

### DIFF
--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -57,7 +57,9 @@ func newNode(addr, dir string, walletKey consensus.PrivateKey) (*node, error) {
 	cm, errCh := mconsensus.New(g, false, consensusDir)
 	select {
 	case err := <-errCh:
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	default:
 		go func() {
 			if err := <-errCh; err != nil {


### PR DESCRIPTION
`errCh` will always receive either an error or nil, causing a panic if the error case is hit. 
```
renterd v0.1.0
renterKey: key:0000000000000000000000000000000000000000000000000000000000000000
Using RENTERD_WALLET_SEED environment variable
Enter API password: 
panic: runtime error: invalid memory address or nil pointer dereference
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1029804ec]

goroutine 1 [running]:
main.(*node).Close(0x0)
        /Users/n8maninger/Projects/github.com/SiaFoundation/renterd/cmd/renterd/node.go:104 +0x1c
main.main.func1()
        /Users/n8maninger/Projects/github.com/SiaFoundation/renterd/cmd/renterd/main.go:88 +0x20
panic({0x102aa13e0, 0x102e0a9c0})
        /usr/local/go/src/runtime/panic.go:884 +0x204
main.main()
        /Users/n8maninger/Projects/github.com/SiaFoundation/renterd/cmd/renterd/main.go:92 +0x46c
exit status 2
```