### PR TITLE
Fix JSON object store

### DIFF
--- a/slab/slab.go
+++ b/slab/slab.go
@@ -16,9 +16,14 @@ type EncryptionKey struct {
 	entropy *[32]byte
 }
 
+// String returns a hex-encoded representation of the key.
+func (k EncryptionKey) String() (s string) {
+	return "key:" + hex.EncodeToString(k.entropy[:])
+}
+
 // MarshalJSON implements the json.Marshaler interface.
 func (k EncryptionKey) MarshalJSON() ([]byte, error) {
-	return []byte(`"key:` + hex.EncodeToString(k.entropy[:]) + `"`), nil
+	return []byte(`"` + k.String() + `"`), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.


### PR DESCRIPTION
Changed the type of `EphemeralObjectStore.slabs` to `map[string]refSlab`. The JSON object store was not persisted because `slab.EncryptionKey` did not implement encoding.TextMarshaller. There was an additional reference issue between the slabs map and `refObject.SlabID` after reloading the store if left as a `slab.EncryptionKey`.