### PR TITLE
Fix: unlock contract in goroutine

### DIFF
--- a/cmd/renterd/slab.go
+++ b/cmd/renterd/slab.go
@@ -26,7 +26,6 @@ func (sm slabMover) withHosts(ctx context.Context, contracts []api.Contract, fn 
 			}
 		case <-ctx.Done():
 			for _, h := range hosts {
-				sm.pool.UnlockContract(h.(*slab.Session))
 				sm.pool.ForceClose(h.(*slab.Session))
 			}
 		}


### PR DESCRIPTION
If you try and perform many downloads in parallel, all requests are stalled until the slowest download is finished.

```
============================
 benchmark
============================

- thread count 16...

Percentile stats (15 timings):
50p: 8075ms
80p: 8075ms
90p: 8075ms
99p: 8075ms
99.9p: 8075ms
```

In `DownloadSector` in `session.go` we acquire the session and defer a release after `readSector` is finished. This is a problem because `withHosts` defers a call to `UnlockContract` that tries to acquire the mutex that's being released after `readSector`. The PR unlocks the contract in a goroutine ensuring the request itself is unblocked and contract is unlocked.

```
============================
 benchmark
============================

- thread count 16...

Percentile stats (15 timings):
50p: 5249ms
80p: 8316ms
90p: 8724.5ms
99p: 9185ms
99.9p: 9185ms
```



