### PR TITLE
Fix superfluous response.WriteHeader call

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -223,7 +223,7 @@ func (s *server) walletPrepareFormHandler(jc jape.Context) {
 	}
 	txn.MinerFees = []types.Currency{s.tp.RecommendedFee().Mul64(uint64(len(encoding.Marshal(txn))))}
 	toSign, err := s.w.FundTransaction(s.cm.TipState(), &txn, cost.Add(txn.MinerFees[0]), s.tp.Transactions())
-	if jc.Check("couldn't fund transaction", err) == nil {
+	if jc.Check("couldn't fund transaction", err) != nil {
 		return
 	}
 	cf := wallet.ExplicitCoveredFields(txn)
@@ -256,7 +256,7 @@ func (s *server) walletPrepareRenewHandler(jc jape.Context) {
 	}
 	txn.MinerFees = []types.Currency{s.tp.RecommendedFee().Mul64(uint64(len(encoding.Marshal(txn))))}
 	toSign, err := s.w.FundTransaction(s.cm.TipState(), &txn, cost.Add(txn.MinerFees[0]), s.tp.Transactions())
-	if jc.Check("couldn't fund transaction", err) == nil {
+	if jc.Check("couldn't fund transaction", err) != nil {
 		return
 	}
 	cf := wallet.ExplicitCoveredFields(txn)


### PR DESCRIPTION
I ran into the following error a couple of times 

_http: superfluous response.WriteHeader call from go.sia.tech/jape.Context.Error (server.go:34)_

There was a couple of is-nil checks that were supposed to be is-not-nil checks.