### PR TITLE
Add ping to `/rhp/scan`

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -8,7 +8,7 @@ import (
 	"go.sia.tech/renterd/bus"
 	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/consensus"
-	rhpv2 "go.sia.tech/renterd/rhp/v2"
+	"go.sia.tech/renterd/worker"
 )
 
 type Store interface {
@@ -25,7 +25,7 @@ type Bus interface {
 }
 
 type Worker interface {
-	RHPScan(hostKey consensus.PublicKey, hostIP string) (resp rhpv2.HostSettings, err error)
+	RHPScan(hostKey consensus.PublicKey, hostIP string) (worker.RHPScanResponse, error)
 }
 
 type Autopilot struct {

--- a/autopilot/hosts.go
+++ b/autopilot/hosts.go
@@ -36,8 +36,8 @@ func (ap *Autopilot) hostScanLoop() {
 			resChan := make(chan res)
 			for _, h := range hosts {
 				go func(h hostdb.Host) {
-					settings, err := ap.worker.RHPScan(h.PublicKey, h.NetAddress())
-					resChan <- res{h.PublicKey, settings, err}
+					scan, err := ap.worker.RHPScan(h.PublicKey, h.NetAddress())
+					resChan <- res{h.PublicKey, scan.HostSettings, err}
 				}(h)
 			}
 			for range hosts {

--- a/autopilot/hosts.go
+++ b/autopilot/hosts.go
@@ -37,7 +37,7 @@ func (ap *Autopilot) hostScanLoop() {
 			for _, h := range hosts {
 				go func(h hostdb.Host) {
 					scan, err := ap.worker.RHPScan(h.PublicKey, h.NetAddress())
-					resChan <- res{h.PublicKey, scan.HostSettings, err}
+					resChan <- res{h.PublicKey, scan.Settings, err}
 				}(h)
 			}
 			for range hosts {

--- a/worker/api.go
+++ b/worker/api.go
@@ -1,6 +1,9 @@
 package worker
 
 import (
+	"strconv"
+	"time"
+
 	"go.sia.tech/renterd/internal/consensus"
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	rhpv3 "go.sia.tech/renterd/rhp/v3"
@@ -20,6 +23,25 @@ type (
 	PrivateKey = consensus.PrivateKey
 )
 
+// A Duration is the elapsed time between two instants. Durations are encoded as
+// an integer number of milliseconds.
+type Duration time.Duration
+
+// MarshalText implements encoding.TextMarshaler.
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(strconv.FormatInt(time.Duration(d).Milliseconds(), 10)), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (d *Duration) UnmarshalText(b []byte) error {
+	ms, err := strconv.ParseInt(string(b), 10, 64)
+	if err != nil {
+		return err
+	}
+	*d = Duration(time.Duration(ms) * time.Millisecond)
+	return nil
+}
+
 // RHPScanRequest is the request type for the /rhp/scan endpoint.
 type RHPScanRequest struct {
 	HostKey PublicKey `json:"hostKey"`
@@ -28,8 +50,8 @@ type RHPScanRequest struct {
 
 // RHPScanResponse is the response type for the /rhp/scan endpoint.
 type RHPScanResponse struct {
-	HostSettings rhpv2.HostSettings `json:"hostSettings"`
-	Ping         int64              `json:"ping"`
+	Settings rhpv2.HostSettings `json:"settings"`
+	Ping     Duration           `json:"ping"`
 }
 
 // RHPPrepareFormRequest is the request type for the /rhp/prepare/form endpoint.

--- a/worker/api.go
+++ b/worker/api.go
@@ -26,6 +26,12 @@ type RHPScanRequest struct {
 	HostIP  string    `json:"hostIP"`
 }
 
+// RHPScanResponse is the response type for the /rhp/scan endpoint.
+type RHPScanResponse struct {
+	HostSettings rhpv2.HostSettings `json:"hostSettings"`
+	Ping         int64              `json:"ping"`
+}
+
 // RHPPrepareFormRequest is the request type for the /rhp/prepare/form endpoint.
 type RHPPrepareFormRequest struct {
 	RenterKey      PrivateKey         `json:"renterKey"`

--- a/worker/client.go
+++ b/worker/client.go
@@ -22,7 +22,7 @@ type Client struct {
 }
 
 // RHPScan scans a host, returning its current settings.
-func (c *Client) RHPScan(hostKey PublicKey, hostIP string) (resp rhpv2.HostSettings, err error) {
+func (c *Client) RHPScan(hostKey PublicKey, hostIP string) (resp RHPScanResponse, err error) {
 	err = c.c.POST("/rhp/scan", RHPScanRequest{hostKey, hostIP}, &resp)
 	return
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -109,10 +109,15 @@ func (w *Worker) rhpScanHandler(jc jape.Context) {
 	if jc.Decode(&rsr) != nil {
 		return
 	}
+	start := time.Now()
 	settings, err := w.rhp.Settings(jc.Request.Context(), rsr.HostIP, rsr.HostKey)
-	if jc.Check("couldn't scan host", err) == nil {
-		jc.Encode(settings)
+	if jc.Check("couldn't scan host", err) != nil {
+		return
 	}
+	jc.Encode(RHPScanResponse{
+		HostSettings: settings,
+		Ping:         time.Since(start).Milliseconds(),
+	})
 }
 
 func (w *Worker) rhpFormHandler(jc jape.Context) {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -115,8 +115,8 @@ func (w *Worker) rhpScanHandler(jc jape.Context) {
 		return
 	}
 	jc.Encode(RHPScanResponse{
-		HostSettings: settings,
-		Ping:         time.Since(start).Milliseconds(),
+		Settings: settings,
+		Ping:     Duration(time.Since(start)),
 	})
 }
 


### PR DESCRIPTION
Add a new field, `ping`, to the response type returned by `/rhp/scan`.  
It represents the time it takes to fetch the host's settings, returned in milliseconds.  
This field can be used to perform a very rudimentary host ranking based on its latency.