### PR TITLE
Host Interactions

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"time"
 
 	"go.sia.tech/renterd/internal/consensus"
@@ -196,16 +197,33 @@ type SlabsUploadRequest struct {
 	CurrentHeight uint64     `json:"currentHeight"`
 }
 
+// SlabsUploadResponse is the response type for the /slabs/upload endpoint.
+type SlabsUploadResponse struct {
+	Slab     slab.Slab         `json:"slab"`
+	Metadata []HostInteraction `json:"metadata"`
+}
+
 // SlabsDownloadRequest is the request type for the /slabs/download endpoint.
 type SlabsDownloadRequest struct {
 	Slab      slab.Slice `json:"slab"`
 	Contracts []Contract `json:"contracts"`
 }
 
+// SlabsDownloadResponse is the response type for the /slabs/download endpoint.
+type SlabsDownloadResponse struct {
+	Data     []byte            `json:"data"`
+	Metadata []HostInteraction `json:"metadata"`
+}
+
 // SlabsDeleteRequest is the request type for the /slabs/delete endpoint.
 type SlabsDeleteRequest struct {
 	Slabs     []slab.Slab `json:"slabs"`
 	Contracts []Contract  `json:"contracts"`
+}
+
+// SlabsDeleteResponse is the response type for the /slabs/delete endpoint.
+type SlabsDeleteResponse struct {
+	Metadata []HostInteraction `json:"metadata"`
 }
 
 // SlabsMigrateRequest is the request type for the /slabs/migrate endpoint.
@@ -216,8 +234,25 @@ type SlabsMigrateRequest struct {
 	CurrentHeight uint64     `json:"currentHeight"`
 }
 
+// SlabsMigrateResponse is the response type for the /slabs/migrate endpoint.
+type SlabsMigrateResponse struct {
+	Slab     slab.Slab         `json:"slab"`
+	Metadata []HostInteraction `json:"metadata"`
+}
+
 // ObjectsResponse is the response type for the /objects endpoint.
 type ObjectsResponse struct {
 	Entries []string       `json:"entries,omitempty"`
 	Object  *object.Object `json:"object,omitempty"`
+}
+
+// A HostInteraction contains information about an interaction with a host.
+// These objects eventually end up as host interactions in the host
+// database.
+type HostInteraction struct {
+	Timestamp int64           `json:"timestamp"`
+	Type      string          `json:"type"`
+	HostKey   PublicKey       `json:"hostKey"`
+	Metadata  json.RawMessage `json:"metadata,omitempty"`
+	Error     string          `json:"error,omitempty"`
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -115,6 +115,9 @@ func (sm *mockSlabMover) MigrateSlab(ctx context.Context, s *slab.Slab, currentH
 	return slab.MigrateSlab(s, sm.hostsForContracts(from), sm.hostsForContracts(to))
 }
 
+// hostsForContracts returns a list of hosts that correspond to the given
+// contracts. This method panics if the corresponding host can not be found as
+// it should never happen and indicates a developer error.
 func (sm *mockSlabMover) hostsForContracts(contracts []api.Contract) []slab.Host {
 	hosts := make([]slab.Host, len(contracts))
 	for i, c := range contracts {
@@ -401,6 +404,7 @@ func TestHostInteractions(t *testing.T) {
 	}
 }
 
+// formTestContracts forms a contract with the given hosts.
 func formTestContracts(c *api.Client, hosts []consensus.PublicKey) ([]api.Contract, error) {
 	var contracts []api.Contract
 	for _, hostKey := range hosts {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -3,11 +3,15 @@ package api_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	"go.sia.tech/jape"
 	"go.sia.tech/renterd/api"
@@ -95,20 +99,36 @@ type mockSlabMover struct {
 	hosts []slab.Host
 }
 
-func (sm *mockSlabMover) UploadSlab(ctx context.Context, r io.Reader, m, n uint8, currentHeight uint64, contracts []api.Contract) (slab.Slab, error) {
-	return slab.UploadSlab(r, m, n, sm.hosts)
+func (sm *mockSlabMover) UploadSlab(ctx context.Context, r io.Reader, m, n uint8, currentHeight uint64, contracts []api.Contract) (slab.Slab, []*slab.HostInteraction, error) {
+	return slab.UploadSlab(r, m, n, sm.hostsForContracts(contracts))
 }
 
-func (sm *mockSlabMover) DownloadSlab(ctx context.Context, w io.Writer, s slab.Slice, contracts []api.Contract) error {
-	return slab.DownloadSlab(w, s, sm.hosts)
+func (sm *mockSlabMover) DownloadSlab(ctx context.Context, w io.Writer, s slab.Slice, contracts []api.Contract) ([]*slab.HostInteraction, error) {
+	return slab.DownloadSlab(w, s, sm.hostsForContracts(contracts))
 }
 
-func (sm *mockSlabMover) DeleteSlabs(ctx context.Context, slabs []slab.Slab, contracts []api.Contract) error {
-	return slab.DeleteSlabs(slabs, sm.hosts)
+func (sm *mockSlabMover) DeleteSlabs(ctx context.Context, slabs []slab.Slab, contracts []api.Contract) ([]*slab.HostInteraction, error) {
+	return slab.DeleteSlabs(slabs, sm.hostsForContracts(contracts))
 }
 
-func (sm *mockSlabMover) MigrateSlab(ctx context.Context, s *slab.Slab, currentHeight uint64, from, to []api.Contract) error {
-	return slab.MigrateSlab(s, sm.hosts, sm.hosts)
+func (sm *mockSlabMover) MigrateSlab(ctx context.Context, s *slab.Slab, currentHeight uint64, from, to []api.Contract) ([]*slab.HostInteraction, error) {
+	return slab.MigrateSlab(s, sm.hostsForContracts(from), sm.hostsForContracts(to))
+}
+
+func (sm *mockSlabMover) hostsForContracts(contracts []api.Contract) []slab.Host {
+	hosts := make([]slab.Host, len(contracts))
+	for i, c := range contracts {
+		for _, h := range sm.hosts {
+			if c.HostKey == h.PublicKey() {
+				hosts[i] = h
+				break
+			}
+		}
+		if hosts[i] == nil {
+			panic("no host found")
+		}
+	}
+	return hosts
 }
 
 type node struct {
@@ -155,51 +175,22 @@ func TestObject(t *testing.T) {
 	c, shutdown := runServer(n)
 	defer shutdown()
 
+	// add hosts
 	hosts := make([]consensus.PublicKey, 3)
 	for i := range hosts {
 		hosts[i] = n.addHost()
 	}
 
 	// form contracts
-	var contracts []api.Contract
-	for _, hostKey := range hosts {
-		const hostIP = ""
-		settings, err := c.RHPScan(hostKey, hostIP)
-		if err != nil {
-			t.Fatal(err)
-		}
-		renterKey := consensus.GeneratePrivateKey()
-		addr, _ := c.WalletAddress()
-		fc, cost, err := c.RHPPrepareForm(renterKey, hostKey, types.ZeroCurrency, addr, types.ZeroCurrency, 0, settings)
-		if err != nil {
-			t.Fatal(err)
-		}
-		txn := types.Transaction{
-			FileContracts: []types.FileContract{fc},
-		}
-		toSign, parents, err := c.WalletFund(&txn, cost)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := c.WalletSign(&txn, toSign, wallet.ExplicitCoveredFields(txn)); err != nil {
-			t.Fatal(err)
-		}
-		c, _, err := c.RHPForm(renterKey, hostKey, hostIP, append(parents, txn))
-		if err != nil {
-			t.Fatal(err)
-		}
-		contracts = append(contracts, api.Contract{
-			HostKey:   c.HostKey(),
-			HostIP:    hostIP,
-			ID:        c.ID(),
-			RenterKey: renterKey,
-		})
+	contracts, err := formTestContracts(c, hosts)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// upload
 	data := frand.Bytes(12345)
 	key := object.GenerateEncryptionKey()
-	s, err := c.UploadSlab(key.Encrypt(bytes.NewReader(data)), 2, 3, 0, contracts)
+	s, _, err := c.UploadSlab(key.Encrypt(bytes.NewReader(data)), 2, 3, 0, contracts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +207,6 @@ func TestObject(t *testing.T) {
 	if err := c.AddObject("foo", o); err != nil {
 		t.Fatal(err)
 	}
-
 	// retrieve object
 	o, err = c.Object("foo")
 	if err != nil {
@@ -225,17 +215,17 @@ func TestObject(t *testing.T) {
 
 	// download
 	var buf bytes.Buffer
-	if err := c.DownloadSlab(key.Decrypt(&buf, 0), o.Slabs[0], contracts); err != nil {
+	if _, err := c.DownloadSlab(key.Decrypt(&buf, 0), o.Slabs[0], contracts); err != nil {
 		t.Fatal(err)
 	} else if !bytes.Equal(buf.Bytes(), data) {
 		t.Fatalf("data mismatch:\n%v (%v)\n%v (%v)", buf.Bytes(), len(buf.Bytes()), data, len(data))
 	}
 
 	// delete slabs
-	if err := c.DeleteSlabs([]slab.Slab{s}, contracts); err != nil {
+	if _, err := c.DeleteSlabs([]slab.Slab{s}, contracts); err != nil {
 		t.Fatal(err)
 	}
-	if err := c.DownloadSlab(ioutil.Discard, o.Slabs[0], contracts); err == nil {
+	if _, err := c.DownloadSlab(ioutil.Discard, o.Slabs[0], contracts); err == nil {
 		t.Error("slabs should no longer be retrievable")
 	}
 
@@ -246,4 +236,204 @@ func TestObject(t *testing.T) {
 	if _, err := c.Object("foo"); err == nil {
 		t.Error("object should no longer be retrievable")
 	}
+}
+
+// TestHostInteractions verifies slab endpoints return a set of host
+// interactions that are populated with all of the expected fields and metadata about.
+func TestHostInteractions(t *testing.T) {
+	isInitialized := func(hi api.HostInteraction) (bool, string) {
+		if hi.HostKey.String() == "" {
+			return false, "no hostkey"
+		}
+		if hi.Type == "" {
+			return false, "no type"
+		}
+		if hi.Timestamp == (time.Time{}).Unix() {
+			return false, "no timestamp"
+		}
+		var metadata struct {
+			Duration int64 `json:"dur"`
+		}
+		json.Unmarshal(hi.Metadata, &metadata)
+		if metadata.Duration == 0 {
+			return false, fmt.Sprintf("no duration, %s", string(hi.Metadata))
+		}
+		return true, ""
+	}
+
+	n := newTestNode()
+	c, shutdown := runServer(n)
+	defer shutdown()
+
+	// add hosts
+	hosts := make([]consensus.PublicKey, 3)
+	for i := range hosts {
+		hosts[i] = n.addHost()
+	}
+
+	// form contracts
+	contracts, err := formTestContracts(c, hosts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// upload
+	data := frand.Bytes(12345)
+	key := object.GenerateEncryptionKey()
+	s, his, err := c.UploadSlab(key.Encrypt(bytes.NewReader(data)), 2, 3, 0, contracts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert host interactions
+	if len(his) != 3 {
+		t.Fatalf("unexpected number of host interactions, %v != 3", len(his))
+	}
+	for _, hi := range his {
+		if ok, reason := isInitialized(hi); !ok || hi.Type != "UploadSector" {
+			t.Fatal("unexpected", reason, hi)
+		}
+	}
+
+	// prepare slice
+	slice := slab.Slice{
+		Slab:   s,
+		Offset: 0,
+		Length: uint32(len(data)),
+	}
+
+	// download
+	var buf bytes.Buffer
+	his, err = c.DownloadSlab(key.Decrypt(&buf, 0), slice, contracts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf.Bytes(), data) {
+		t.Fatalf("data mismatch:\n%v (%v)\n%v (%v)", buf.Bytes(), len(buf.Bytes()), data, len(data))
+	}
+
+	// assert host interactions
+	if len(his) != 2 {
+		t.Fatalf("unexpected number of host interactions, %v != 2", len(his))
+	}
+	for _, hi := range his {
+		if ok, reason := isInitialized(hi); !ok || hi.Type != "DownloadSector" {
+			t.Fatal("unexpected", reason, hi)
+		}
+	}
+
+	// corrupt first shard
+	bkp := s.Shards[0].Root
+	s.Shards[0].Root = consensus.Hash256{}
+
+	// retry download
+	buf.Reset()
+	his, err = c.DownloadSlab(key.Decrypt(&buf, 0), slice, contracts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf.Bytes(), data) {
+		t.Fatalf("data mismatch:\n%v (%v)\n%v (%v)", buf.Bytes(), len(buf.Bytes()), data, len(data))
+	}
+
+	// reset shards
+	s.Shards[0].Root = bkp
+
+	// assert host interactions
+	if len(his) != 3 {
+		t.Fatalf("unexpected number of host interactions, %v != 3", len(his))
+	}
+	hasError := false
+	for _, hi := range his {
+		hasError = hasError || strings.Contains(hi.Error, "unknown root")
+		if ok, reason := isInitialized(hi); !ok || hi.Type != "DownloadSector" {
+			t.Fatal("unexpected", reason, hi)
+		}
+	}
+	if !hasError {
+		t.Fatal("expected to find one error")
+	}
+
+	// form two new contracts
+	newHosts := []consensus.PublicKey{n.addHost(), n.addHost()}
+	to, err := formTestContracts(c, newHosts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// perform migration
+	ci, err := c.ConsensusTip()
+	if err != nil {
+		t.Fatal(err)
+	}
+	his, err = c.MigrateSlab(&s, contracts[:2], append(to, contracts[2]), ci.Height)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert migration
+	s1 := s.Sector(newHosts[0])
+	s2 := s.Sector(newHosts[1])
+	s3 := s.Sector(contracts[2].HostKey)
+	if s1 == nil || s2 == nil || s3 == nil {
+		t.Fatal("unexpected")
+	}
+
+	// assert host interactions
+	if len(his) != 4 {
+		t.Fatalf("unexpected number of host interactions, %v != 4", len(his))
+	}
+	var downloads, uploads int
+	for _, hi := range his {
+		if ok, reason := isInitialized(hi); !ok {
+			t.Fatal("unexpected", reason, hi)
+		}
+		if hi.Type == "DownloadSector" {
+			downloads++
+		}
+		if hi.Type == "UploadSector" {
+			uploads++
+		}
+	}
+	if downloads != 2 || uploads != 2 {
+		t.Fatal("unexpected")
+	}
+}
+
+func formTestContracts(c *api.Client, hosts []consensus.PublicKey) ([]api.Contract, error) {
+	var contracts []api.Contract
+	for _, hostKey := range hosts {
+		const hostIP = ""
+		settings, err := c.RHPScan(hostKey, hostIP)
+		if err != nil {
+			return nil, err
+		}
+		renterKey := consensus.GeneratePrivateKey()
+		addr, _ := c.WalletAddress()
+		fc, cost, err := c.RHPPrepareForm(renterKey, hostKey, types.ZeroCurrency, addr, types.ZeroCurrency, 0, settings)
+		if err != nil {
+			return nil, err
+		}
+		txn := types.Transaction{
+			FileContracts: []types.FileContract{fc},
+		}
+		toSign, parents, err := c.WalletFund(&txn, cost)
+		if err != nil {
+			return nil, err
+		}
+		if err := c.WalletSign(&txn, toSign, wallet.ExplicitCoveredFields(txn)); err != nil {
+			return nil, err
+		}
+		c, _, err := c.RHPForm(renterKey, hostKey, hostIP, append(parents, txn))
+		if err != nil {
+			return nil, err
+		}
+		contracts = append(contracts, api.Contract{
+			HostKey:   c.HostKey(),
+			HostIP:    hostIP,
+			ID:        c.ID(),
+			RenterKey: renterKey,
+		})
+	}
+	return contracts, nil
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -99,19 +99,19 @@ type mockSlabMover struct {
 	hosts []slab.Host
 }
 
-func (sm *mockSlabMover) UploadSlab(ctx context.Context, r io.Reader, m, n uint8, currentHeight uint64, contracts []api.Contract) (slab.Slab, []*slab.HostInteraction, error) {
+func (sm *mockSlabMover) UploadSlab(ctx context.Context, r io.Reader, m, n uint8, currentHeight uint64, contracts []api.Contract) (slab.Slab, []slab.HostInteraction, error) {
 	return slab.UploadSlab(r, m, n, sm.hostsForContracts(contracts))
 }
 
-func (sm *mockSlabMover) DownloadSlab(ctx context.Context, w io.Writer, s slab.Slice, contracts []api.Contract) ([]*slab.HostInteraction, error) {
+func (sm *mockSlabMover) DownloadSlab(ctx context.Context, w io.Writer, s slab.Slice, contracts []api.Contract) ([]slab.HostInteraction, error) {
 	return slab.DownloadSlab(w, s, sm.hostsForContracts(contracts))
 }
 
-func (sm *mockSlabMover) DeleteSlabs(ctx context.Context, slabs []slab.Slab, contracts []api.Contract) ([]*slab.HostInteraction, error) {
+func (sm *mockSlabMover) DeleteSlabs(ctx context.Context, slabs []slab.Slab, contracts []api.Contract) ([]slab.HostInteraction, error) {
 	return slab.DeleteSlabs(slabs, sm.hostsForContracts(contracts))
 }
 
-func (sm *mockSlabMover) MigrateSlab(ctx context.Context, s *slab.Slab, currentHeight uint64, from, to []api.Contract) ([]*slab.HostInteraction, error) {
+func (sm *mockSlabMover) MigrateSlab(ctx context.Context, s *slab.Slab, currentHeight uint64, from, to []api.Contract) ([]slab.HostInteraction, error) {
 	return slab.MigrateSlab(s, sm.hostsForContracts(from), sm.hostsForContracts(to))
 }
 
@@ -239,7 +239,8 @@ func TestObject(t *testing.T) {
 }
 
 // TestHostInteractions verifies slab endpoints return a set of host
-// interactions that are populated with all of the expected fields and metadata about.
+// interactions that are populated with all of the expected fields and metadata
+// about that particular host interaction.
 func TestHostInteractions(t *testing.T) {
 	isInitialized := func(hi api.HostInteraction) (bool, string) {
 		if hi.HostKey.String() == "" {

--- a/api/server.go
+++ b/api/server.go
@@ -89,10 +89,10 @@ type (
 
 	// A SlabMover uploads, downloads, and migrates slabs.
 	SlabMover interface {
-		UploadSlab(ctx context.Context, r io.Reader, m, n uint8, currentHeight uint64, contracts []Contract) (slab.Slab, []*slab.HostInteraction, error)
-		DownloadSlab(ctx context.Context, w io.Writer, slab slab.Slice, contracts []Contract) ([]*slab.HostInteraction, error)
-		DeleteSlabs(ctx context.Context, slabs []slab.Slab, contracts []Contract) ([]*slab.HostInteraction, error)
-		MigrateSlab(ctx context.Context, s *slab.Slab, currentHeight uint64, from, to []Contract) ([]*slab.HostInteraction, error)
+		UploadSlab(ctx context.Context, r io.Reader, m, n uint8, currentHeight uint64, contracts []Contract) (slab.Slab, []slab.HostInteraction, error)
+		DownloadSlab(ctx context.Context, w io.Writer, slab slab.Slice, contracts []Contract) ([]slab.HostInteraction, error)
+		DeleteSlabs(ctx context.Context, slabs []slab.Slab, contracts []Contract) ([]slab.HostInteraction, error)
+		MigrateSlab(ctx context.Context, s *slab.Slab, currentHeight uint64, from, to []Contract) ([]slab.HostInteraction, error)
 	}
 
 	// An ObjectStore stores objects.

--- a/api/transforms.go
+++ b/api/transforms.go
@@ -7,6 +7,9 @@ import (
 	"go.sia.tech/renterd/slab"
 )
 
+// toHostInteractions receives an input of any kind and tries to transform it
+// into a list of host interactions. If the input type is not recognized a panic
+// is thrown as it indicates a developer error.
 func toHostInteractions(in interface{}) []HostInteraction {
 	switch t := in.(type) {
 	case []slab.HostInteraction:
@@ -20,6 +23,8 @@ func toHostInteractions(in interface{}) []HostInteraction {
 	}
 }
 
+// transformSlabHostInteraction transforms a HostInteraction from the slab
+// package to a HostInteraction from the api package.
 func transformSlabHostInteraction(shi slab.HostInteraction) HostInteraction {
 	hi := HostInteraction{
 		Timestamp: shi.Timestamp.Unix(),

--- a/api/transforms.go
+++ b/api/transforms.go
@@ -9,9 +9,9 @@ import (
 
 func toHostInteractions(in interface{}) []HostInteraction {
 	switch t := in.(type) {
-	case []*slab.HostInteraction:
-		his := make([]HostInteraction, len(in.([]*slab.HostInteraction)))
-		for i, shi := range in.([]*slab.HostInteraction) {
+	case []slab.HostInteraction:
+		his := make([]HostInteraction, len(in.([]slab.HostInteraction)))
+		for i, shi := range in.([]slab.HostInteraction) {
 			his[i] = transformSlabHostInteraction(shi)
 		}
 		return his
@@ -20,7 +20,7 @@ func toHostInteractions(in interface{}) []HostInteraction {
 	}
 }
 
-func transformSlabHostInteraction(shi *slab.HostInteraction) HostInteraction {
+func transformSlabHostInteraction(shi slab.HostInteraction) HostInteraction {
 	hi := HostInteraction{
 		Timestamp: shi.Timestamp.Unix(),
 		HostKey:   shi.HostKey,

--- a/api/transforms.go
+++ b/api/transforms.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.sia.tech/renterd/slab"
+)
+
+func toHostInteractions(in interface{}) []HostInteraction {
+	switch t := in.(type) {
+	case []*slab.HostInteraction:
+		his := make([]HostInteraction, len(in.([]*slab.HostInteraction)))
+		for i, shi := range in.([]*slab.HostInteraction) {
+			his[i] = transformSlabHostInteraction(shi)
+		}
+		return his
+	default:
+		panic(fmt.Sprintf("unknown type '%v'", t))
+	}
+}
+
+func transformSlabHostInteraction(shi *slab.HostInteraction) HostInteraction {
+	hi := HostInteraction{
+		Timestamp: shi.Timestamp.Unix(),
+		HostKey:   shi.HostKey,
+		Type:      shi.Type,
+		Error:     shi.Error(),
+	}
+
+	durInMS := shi.Duration.Milliseconds()
+	if durInMS == 0 && shi.Duration > 0 {
+		durInMS = 1
+	}
+
+	hi.Metadata, _ = json.Marshal(struct {
+		Duration int64  `json:"dur"`
+		NumRoots uint64 `json:"n,omitempty"`
+	}{
+		Duration: durInMS,
+		NumRoots: shi.NumRoots,
+	})
+
+	return hi
+}

--- a/cmd/renterd/slab.go
+++ b/cmd/renterd/slab.go
@@ -39,7 +39,7 @@ func (sm slabMover) withHosts(ctx context.Context, contracts []api.Contract, fn 
 	return fn(hosts)
 }
 
-func (sm slabMover) UploadSlab(ctx context.Context, r io.Reader, m, n uint8, currentHeight uint64, contracts []api.Contract) (s slab.Slab, his []*slab.HostInteraction, err error) {
+func (sm slabMover) UploadSlab(ctx context.Context, r io.Reader, m, n uint8, currentHeight uint64, contracts []api.Contract) (s slab.Slab, his []slab.HostInteraction, err error) {
 	sm.pool.SetCurrentHeight(currentHeight)
 	err = sm.withHosts(ctx, contracts, func(hosts []slab.Host) error {
 		s, his, err = slab.UploadSlab(r, m, n, hosts)
@@ -48,7 +48,7 @@ func (sm slabMover) UploadSlab(ctx context.Context, r io.Reader, m, n uint8, cur
 	return
 }
 
-func (sm slabMover) DownloadSlab(ctx context.Context, w io.Writer, s slab.Slice, contracts []api.Contract) (his []*slab.HostInteraction, err error) {
+func (sm slabMover) DownloadSlab(ctx context.Context, w io.Writer, s slab.Slice, contracts []api.Contract) (his []slab.HostInteraction, err error) {
 	err = sm.withHosts(ctx, contracts, func(hosts []slab.Host) error {
 		his, err = slab.DownloadSlab(w, s, hosts)
 		return err
@@ -56,7 +56,7 @@ func (sm slabMover) DownloadSlab(ctx context.Context, w io.Writer, s slab.Slice,
 	return
 }
 
-func (sm slabMover) DeleteSlabs(ctx context.Context, slabs []slab.Slab, contracts []api.Contract) (his []*slab.HostInteraction, err error) {
+func (sm slabMover) DeleteSlabs(ctx context.Context, slabs []slab.Slab, contracts []api.Contract) (his []slab.HostInteraction, err error) {
 	err = sm.withHosts(ctx, contracts, func(hosts []slab.Host) error {
 		his, err = slab.DeleteSlabs(slabs, hosts)
 		return err
@@ -64,7 +64,7 @@ func (sm slabMover) DeleteSlabs(ctx context.Context, slabs []slab.Slab, contract
 	return
 }
 
-func (sm slabMover) MigrateSlab(ctx context.Context, s *slab.Slab, currentHeight uint64, from, to []api.Contract) (his []*slab.HostInteraction, err error) {
+func (sm slabMover) MigrateSlab(ctx context.Context, s *slab.Slab, currentHeight uint64, from, to []api.Contract) (his []slab.HostInteraction, err error) {
 	sm.pool.SetCurrentHeight(currentHeight)
 	var fromHosts []slab.Host
 	for _, c := range from {

--- a/cmd/renterd/slab.go
+++ b/cmd/renterd/slab.go
@@ -39,28 +39,32 @@ func (sm slabMover) withHosts(ctx context.Context, contracts []api.Contract, fn 
 	return fn(hosts)
 }
 
-func (sm slabMover) UploadSlab(ctx context.Context, r io.Reader, m, n uint8, currentHeight uint64, contracts []api.Contract) (s slab.Slab, err error) {
+func (sm slabMover) UploadSlab(ctx context.Context, r io.Reader, m, n uint8, currentHeight uint64, contracts []api.Contract) (s slab.Slab, his []*slab.HostInteraction, err error) {
 	sm.pool.SetCurrentHeight(currentHeight)
 	err = sm.withHosts(ctx, contracts, func(hosts []slab.Host) error {
-		s, err = slab.UploadSlab(r, m, n, hosts)
+		s, his, err = slab.UploadSlab(r, m, n, hosts)
 		return err
 	})
 	return
 }
 
-func (sm slabMover) DownloadSlab(ctx context.Context, w io.Writer, s slab.Slice, contracts []api.Contract) error {
-	return sm.withHosts(ctx, contracts, func(hosts []slab.Host) error {
-		return slab.DownloadSlab(w, s, hosts)
+func (sm slabMover) DownloadSlab(ctx context.Context, w io.Writer, s slab.Slice, contracts []api.Contract) (his []*slab.HostInteraction, err error) {
+	err = sm.withHosts(ctx, contracts, func(hosts []slab.Host) error {
+		his, err = slab.DownloadSlab(w, s, hosts)
+		return err
 	})
+	return
 }
 
-func (sm slabMover) DeleteSlabs(ctx context.Context, slabs []slab.Slab, contracts []api.Contract) error {
-	return sm.withHosts(ctx, contracts, func(hosts []slab.Host) error {
-		return slab.DeleteSlabs(slabs, hosts)
+func (sm slabMover) DeleteSlabs(ctx context.Context, slabs []slab.Slab, contracts []api.Contract) (his []*slab.HostInteraction, err error) {
+	err = sm.withHosts(ctx, contracts, func(hosts []slab.Host) error {
+		his, err = slab.DeleteSlabs(slabs, hosts)
+		return err
 	})
+	return
 }
 
-func (sm slabMover) MigrateSlab(ctx context.Context, s *slab.Slab, currentHeight uint64, from, to []api.Contract) (err error) {
+func (sm slabMover) MigrateSlab(ctx context.Context, s *slab.Slab, currentHeight uint64, from, to []api.Contract) (his []*slab.HostInteraction, err error) {
 	sm.pool.SetCurrentHeight(currentHeight)
 	var fromHosts []slab.Host
 	for _, c := range from {

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -38,7 +38,7 @@ func TestMultipleObjects(t *testing.T) {
 	}
 	var slabs []slab.Slab
 	for {
-		s, err := slab.UploadSlab(r, 3, 10, hosts)
+		s, _, err := slab.UploadSlab(r, 3, 10, hosts)
 		if err == io.EOF {
 			break
 		} else if err != nil {
@@ -68,7 +68,7 @@ func TestMultipleObjects(t *testing.T) {
 		dst := o.Key.Decrypt(&buf, int64(offset))
 		ss := slab.SlabsForDownload(o.Slabs, int64(offset), int64(length))
 		for _, s := range ss {
-			if err := slab.DownloadSlab(dst, s, hosts); err != nil {
+			if _, err := slab.DownloadSlab(dst, s, hosts); err != nil {
 				t.Error(err)
 				return
 			}

--- a/slab/session.go
+++ b/slab/session.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -13,36 +12,6 @@ import (
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/siad/types"
 )
-
-// A HostError associates an error with a given host.
-type HostError struct {
-	HostKey consensus.PublicKey
-	Err     error
-}
-
-// Error implements error.
-func (he HostError) Error() string {
-	return fmt.Sprintf("%x: %v", he.HostKey[:4], he.Err.Error())
-}
-
-// Unwrap returns the underlying error.
-func (he HostError) Unwrap() error {
-	return he.Err
-}
-
-// A HostErrorSet is a collection of errors from various hosts.
-type HostErrorSet []*HostError
-
-// Error implements error.
-func (hes HostErrorSet) Error() string {
-	strs := make([]string, len(hes))
-	for i := range strs {
-		strs[i] = hes[i].Error()
-	}
-	// include a leading newline so that the first error isn't printed on the
-	// same line as the error context
-	return "\n" + strings.Join(strs, "\n")
-}
 
 // A sharedSession wraps a RHPv2 session with useful metadata and methods.
 type sharedSession struct {

--- a/slab/slab.go
+++ b/slab/slab.go
@@ -73,6 +73,16 @@ func (s Slab) Encrypt(shards [][]byte) {
 	}
 }
 
+// Sector returns the sector corresponding to the given host.
+func (s Slab) Sector(host consensus.PublicKey) *Sector {
+	for _, sector := range s.Shards {
+		if sector.Host == host {
+			return &sector
+		}
+	}
+	return nil
+}
+
 // A Slice is a contiguous region within a Slab. Note that the offset and length
 // always refer to the reconstructed data, and therefore may not necessarily be
 // aligned to a leaf or chunk boundary. Use the SectorRegion method to compute

--- a/slab/transfer.go
+++ b/slab/transfer.go
@@ -3,7 +3,10 @@ package slab
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
+	"strings"
+	"time"
 
 	"go.sia.tech/renterd/internal/consensus"
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
@@ -16,11 +19,59 @@ type Host interface {
 	DownloadSector(w io.Writer, root consensus.Hash256, offset, length uint32) error
 	DeleteSectors(roots []consensus.Hash256) error
 }
+type (
+	// A HostInteractionSet groups host interactions in the order they occurred.
+	HostInteractionSet []*HostInteraction
+
+	// A HostInteraction contains relevant information about an interaction with
+	// a host involving slabs.
+	HostInteraction struct {
+		Timestamp time.Time
+		Type      string
+		HostKey   consensus.PublicKey
+		Duration  time.Duration
+		Err       error
+
+		NumRoots uint64 // only for DeleteSectors
+	}
+)
+
+// Error implements error.
+func (hi HostInteraction) Error() string {
+	if hi.Err == nil {
+		return ""
+	}
+	return fmt.Sprintf("%x: %v", hi.HostKey[:4], hi.Err.Error())
+}
+
+// Error implements error.
+func (his HostInteractionSet) Error() string {
+	var sb strings.Builder
+	for _, hi := range his {
+		if hi.Err != nil {
+			sb.WriteString(hi.Error())
+		}
+	}
+	// include a leading newline so that the first error isn't printed on the
+	// same line as the error context
+	return "\n" + sb.String()
+}
+
+// HasError returns true if the interaction set contains at least one
+// interaction that resulted in an error.
+func (his HostInteractionSet) HasError() bool {
+	for _, hi := range his {
+		if hi.Err != nil {
+			return true
+		}
+	}
+	return false
+}
 
 // parallelUploadSlab uploads the provided shards in parallel.
-func parallelUploadSlab(shards [][]byte, hosts []Host) ([]Sector, error) {
+func parallelUploadSlab(shards [][]byte, hosts []Host) ([]Sector, []*HostInteraction, error) {
 	if len(hosts) < len(shards) {
-		return nil, errors.New("fewer hosts than shards")
+		return nil, nil, errors.New("fewer hosts than shards")
 	}
 
 	type req struct {
@@ -28,17 +79,19 @@ func parallelUploadSlab(shards [][]byte, hosts []Host) ([]Sector, error) {
 		shardIndex int
 	}
 	type resp struct {
-		req  req
-		root consensus.Hash256
-		err  error
+		req      req
+		root     consensus.Hash256
+		duration time.Duration
+		err      error
 	}
 	reqChan := make(chan req, len(shards))
 	defer close(reqChan)
 	respChan := make(chan resp, len(shards))
 	worker := func() {
 		for req := range reqChan {
+			start := time.Now()
 			root, err := req.host.UploadSector((*[rhpv2.SectorSize]byte)(shards[req.shardIndex]))
-			respChan <- resp{req, root, err}
+			respChan <- resp{req, root, time.Since(start), err}
 		}
 	}
 
@@ -52,14 +105,22 @@ func parallelUploadSlab(shards [][]byte, hosts []Host) ([]Sector, error) {
 		inflight++
 	}
 	// collect responses
+	var interactions HostInteractionSet
 	sectors := make([]Sector, len(shards))
 	rem := len(shards)
-	var errs HostErrorSet
 	for rem > 0 && inflight > 0 {
 		resp := <-respChan
 		inflight--
+
+		interactions = append(interactions, &HostInteraction{
+			Timestamp: time.Now(),
+			Duration:  resp.duration,
+			Err:       resp.err,
+			HostKey:   resp.req.host.PublicKey(),
+			Type:      "UploadSector",
+		})
+
 		if resp.err != nil {
-			errs = append(errs, &HostError{resp.req.host.PublicKey(), resp.err})
 			// try next host
 			if hostIndex < len(hosts) {
 				reqChan <- req{hosts[hostIndex], resp.req.shardIndex}
@@ -75,18 +136,18 @@ func parallelUploadSlab(shards [][]byte, hosts []Host) ([]Sector, error) {
 		}
 	}
 	if rem > 0 {
-		return nil, errs
+		return nil, interactions, fmt.Errorf("slab upload failed, %v shards remaining, host errors: %v", rem, interactions.Error())
 	}
-	return sectors, nil
+	return sectors, interactions, nil
 }
 
 // UploadSlab uploads a slab.
-func UploadSlab(r io.Reader, m, n uint8, hosts []Host) (Slab, error) {
+func UploadSlab(r io.Reader, m, n uint8, hosts []Host) (Slab, []*HostInteraction, error) {
 	buf := make([]byte, int(m)*rhpv2.SectorSize)
 	shards := make([][]byte, n)
 	_, err := io.ReadFull(r, buf)
 	if err != nil && err != io.ErrUnexpectedEOF {
-		return Slab{}, err
+		return Slab{}, nil, err
 	}
 	s := Slab{
 		Key:       GenerateEncryptionKey(),
@@ -94,26 +155,29 @@ func UploadSlab(r io.Reader, m, n uint8, hosts []Host) (Slab, error) {
 	}
 	s.Encode(buf, shards)
 	s.Encrypt(shards)
-	s.Shards, err = parallelUploadSlab(shards, hosts)
+
+	var interactions []*HostInteraction
+	s.Shards, interactions, err = parallelUploadSlab(shards, hosts)
 	if err != nil {
-		return Slab{}, err
+		return Slab{}, interactions, err
 	}
-	return s, nil
+	return s, interactions, nil
 }
 
 // parallelDownloadSlab downloads the shards comprising a slab in parallel.
-func parallelDownloadSlab(s Slice, hosts []Host) ([][]byte, error) {
+func parallelDownloadSlab(s Slice, hosts []Host) ([][]byte, []*HostInteraction, error) {
 	if len(hosts) < int(s.MinShards) {
-		return nil, errors.New("not enough hosts to recover shard")
+		return nil, nil, errors.New("not enough hosts to recover shard")
 	}
 
 	type req struct {
 		hostIndex int
 	}
 	type resp struct {
-		req   req
-		shard []byte
-		err   error
+		req      req
+		shard    []byte
+		duration time.Duration
+		err      error
 	}
 	reqChan := make(chan req, s.MinShards)
 	defer close(reqChan)
@@ -129,13 +193,14 @@ func parallelDownloadSlab(s Slice, hosts []Host) ([][]byte, error) {
 				}
 			}
 			if shard == nil {
-				respChan <- resp{req, nil, errors.New("slab is not stored on this host")}
+				respChan <- resp{req, nil, 0, errors.New("slab is not stored on this host")}
 				continue
 			}
 			offset, length := s.SectorRegion()
 			var buf bytes.Buffer
+			start := time.Now()
 			err := h.DownloadSector(&buf, shard.Root, offset, length)
-			respChan <- resp{req, buf.Bytes(), err}
+			respChan <- resp{req, buf.Bytes(), time.Since(start), err}
 		}
 	}
 
@@ -149,14 +214,22 @@ func parallelDownloadSlab(s Slice, hosts []Host) ([][]byte, error) {
 		inflight++
 	}
 	// collect responses
+	var interactions HostInteractionSet
 	shards := make([][]byte, len(s.Shards))
 	rem := s.MinShards
-	var errs HostErrorSet
 	for rem > 0 && inflight > 0 {
 		resp := <-respChan
 		inflight--
+
+		interactions = append(interactions, &HostInteraction{
+			Timestamp: time.Now(),
+			Duration:  resp.duration,
+			Err:       resp.err,
+			HostKey:   hosts[resp.req.hostIndex].PublicKey(),
+			Type:      "DownloadSector",
+		})
+
 		if resp.err != nil {
-			errs = append(errs, &HostError{hosts[resp.req.hostIndex].PublicKey(), resp.err})
 			// try next host
 			if hostIndex < len(hosts) {
 				reqChan <- req{hostIndex}
@@ -174,22 +247,22 @@ func parallelDownloadSlab(s Slice, hosts []Host) ([][]byte, error) {
 		}
 	}
 	if rem > 0 {
-		return nil, errs
+		return nil, interactions, fmt.Errorf("slab download failed, %v shards remaining, host errors: %v", rem, interactions.Error())
 	}
-	return shards, nil
+	return shards, interactions, nil
 }
 
 // DownloadSlab downloads slab data.
-func DownloadSlab(w io.Writer, s Slice, hosts []Host) error {
-	shards, err := parallelDownloadSlab(s, hosts)
+func DownloadSlab(w io.Writer, s Slice, hosts []Host) ([]*HostInteraction, error) {
+	shards, interactions, err := parallelDownloadSlab(s, hosts)
 	if err != nil {
-		return err
+		return interactions, err
 	}
 	s.Decrypt(shards)
 	if err := s.Recover(w, shards); err != nil {
-		return err
+		return interactions, err
 	}
-	return nil
+	return interactions, nil
 }
 
 // SlabsForDownload returns the slices that comprise the specified offset-length
@@ -222,39 +295,45 @@ func SlabsForDownload(slabs []Slice, offset, length int64) []Slice {
 }
 
 // DeleteSlabs deletes a set of slabs from the provided hosts.
-func DeleteSlabs(slabs []Slab, hosts []Host) error {
+func DeleteSlabs(slabs []Slab, hosts []Host) ([]*HostInteraction, error) {
 	rootsByHost := make(map[consensus.PublicKey][]consensus.Hash256)
 	for _, s := range slabs {
 		for _, sector := range s.Shards {
 			rootsByHost[sector.Host] = append(rootsByHost[sector.Host], sector.Root)
 		}
 	}
-	errChan := make(chan *HostError)
+
+	interactionChan := make(chan *HostInteraction)
 	for _, h := range hosts {
 		go func(h Host) {
 			// NOTE: if host is not storing any sectors, the map lookup will return
 			// nil, making this a no-op
-			if err := h.DeleteSectors(rootsByHost[h.PublicKey()]); err != nil {
-				errChan <- &HostError{h.PublicKey(), err}
-			} else {
-				errChan <- nil
+			start := time.Now()
+			err := h.DeleteSectors(rootsByHost[h.PublicKey()])
+			interactionChan <- &HostInteraction{
+				Timestamp: time.Now(),
+				HostKey:   h.PublicKey(),
+				Err:       err,
+				Duration:  time.Since(start),
+				Type:      "DeleteSectors",
+				NumRoots:  uint64(len(rootsByHost[h.PublicKey()])),
 			}
 		}(h)
 	}
-	var errs HostErrorSet
-	for range hosts {
-		if err := <-errChan; err != nil {
-			errs = append(errs, err)
-		}
+
+	interactions := make([]*HostInteraction, len(hosts))
+	for i := range hosts {
+		interactions[i] = <-interactionChan
 	}
-	if len(errs) > 0 {
-		return errs
+
+	if HostInteractionSet(interactions).HasError() {
+		return interactions, HostInteractionSet(interactions)
 	}
-	return nil
+	return interactions, nil
 }
 
 // MigrateSlab migrates a slab.
-func MigrateSlab(s *Slab, from, to []Host) error {
+func MigrateSlab(s *Slab, from, to []Host) ([]*HostInteraction, error) {
 	// determine which shards need migration
 	var shardIndices []int
 outer:
@@ -267,74 +346,39 @@ outer:
 		shardIndices = append(shardIndices, i)
 	}
 	if len(shardIndices) == 0 {
-		return nil
+		return nil, nil
 	} else if len(shardIndices) > len(to) {
-		return errors.New("not enough hosts to migrate shard")
+		return nil, errors.New("not enough hosts to migrate shard")
 	}
 
 	// download + reconstruct slab
 	ss := Slice{*s, 0, uint32(s.MinShards) * rhpv2.SectorSize}
-	shards, err := parallelDownloadSlab(ss, from)
+	shards, dlInteractions, err := parallelDownloadSlab(ss, from)
 	if err != nil {
-		return err
+		return dlInteractions, err
 	}
 	ss.Decrypt(shards)
 	if err := s.Reconstruct(shards); err != nil {
-		return err
+		return dlInteractions, err
 	}
 	s.Encrypt(shards)
 
-	// spawn workers and send initial requests
-	type req struct {
-		host       Host
-		shardIndex int
-	}
-	type resp struct {
-		req  req
-		root consensus.Hash256
-		err  error
-	}
-	reqChan := make(chan req, len(shardIndices))
-	defer close(reqChan)
-	respChan := make(chan resp, len(shardIndices))
-	worker := func() {
-		for req := range reqChan {
-			root, err := req.host.UploadSector((*[rhpv2.SectorSize]byte)(shards[req.shardIndex]))
-			respChan <- resp{req, root, err}
-		}
-	}
-	hostIndex := 0
-	inflight := 0
+	// reupload + overwrite migrated shards
+	var m int
+	migrations := make([][]byte, len(shardIndices))
 	for _, i := range shardIndices {
-		go worker()
-		reqChan <- req{to[hostIndex], i}
-		hostIndex++
-		inflight++
+		migrations[m] = shards[i]
+		m++
 	}
-	// collect responses
-	rem := len(shardIndices)
-	var errs HostErrorSet
-	for rem > 0 && inflight > 0 {
-		resp := <-respChan
-		inflight--
-		if resp.err != nil {
-			errs = append(errs, &HostError{resp.req.host.PublicKey(), resp.err})
-			// try next host
-			if hostIndex < len(to) {
-				reqChan <- req{to[hostIndex], resp.req.shardIndex}
-				hostIndex++
-				inflight++
-			}
-		} else {
-			s.Shards[resp.req.shardIndex] = Sector{
-				Host: resp.req.host.PublicKey(),
-				Root: resp.root,
-			}
-			rem--
-		}
+
+	migrated, ulInteractions, err := parallelUploadSlab(migrations, to)
+	if err != nil {
+		return append(dlInteractions, ulInteractions...), err
 	}
-	if rem > 0 {
-		return errs
+	m = 0
+	for _, i := range shardIndices {
+		s.Shards[i] = migrated[m]
+		m++
 	}
-	return nil
+	return append(dlInteractions, ulInteractions...), nil
 }

--- a/slab/transfer_test.go
+++ b/slab/transfer_test.go
@@ -21,7 +21,7 @@ func TestSlabs(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		hosts = append(hosts, slabutil.NewMockHost())
 	}
-	s, err := slab.UploadSlab(bytes.NewReader(data), 3, 10, hosts)
+	s, _, err := slab.UploadSlab(bytes.NewReader(data), 3, 10, hosts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func TestSlabs(t *testing.T) {
 		t.Helper()
 		var buf bytes.Buffer
 
-		if err := slab.DownloadSlab(&buf, slab.Slice{s, offset, length}, hosts); err != nil {
+		if _, err := slab.DownloadSlab(&buf, slab.Slice{s, offset, length}, hosts); err != nil {
 			t.Error(err)
 			return
 		}
@@ -60,7 +60,7 @@ func TestSlabs(t *testing.T) {
 	checkDownloadFail := func(offset, length uint32) {
 		t.Helper()
 		var buf bytes.Buffer
-		if err := slab.DownloadSlab(&buf, slab.Slice{s, offset, length}, hosts); err == nil {
+		if _, err := slab.DownloadSlab(&buf, slab.Slice{s, offset, length}, hosts); err == nil {
 			t.Error("expected error, got nil")
 		}
 	}
@@ -74,7 +74,7 @@ func TestSlabs(t *testing.T) {
 		to = append(to, slabutil.NewMockHost())
 	}
 	old := fmt.Sprint(s)
-	if err := slab.MigrateSlab(&s, from, to); err != nil {
+	if _, err := slab.MigrateSlab(&s, from, to); err != nil {
 		t.Fatal(err)
 	}
 	if fmt.Sprint(s) == old {
@@ -89,7 +89,7 @@ func TestSlabs(t *testing.T) {
 	checkDownload(84923, uint32(len(data[84923:])-53219))
 
 	// delete
-	if err := slab.DeleteSlabs([]slab.Slab{s}, to); err != nil {
+	if _, err := slab.DeleteSlabs([]slab.Slab{s}, to); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This PR changes the response types of all slab endpoints to include a list of host interactions. This metadata can (or should) be used to populate the `Interactions` field on a host db entry. The `metadata` field contains a duration that can be used by the `workers` (or renter APIs) to keep track of internally and rank hosts based on their performance.

I decided to add a separate `HostInteraction` type in the `api` package to ensure we never expose internal types but instead use a transformer function that maps one type on the other. I could have used the type defined in the `hostdb` but feel it's better to keep all of these separate and avoid circular dependencies and tight coupling.

This PR alters the implementation of `MigrateSlabs` in that it re-uses `parallellUploadSlabs`, please pay special attention there when reviewing.