### PR TITLE
Replace JSONObjectStore with SQLObjectStore

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -72,7 +72,7 @@ type (
 
 	// An ObjectStore stores objects.
 	ObjectStore interface {
-		List(key string) []string
+		List(key string) ([]string, error)
 		Get(key string) (object.Object, error)
 		Put(key string, o object.Object) error
 		Delete(key string) error
@@ -390,7 +390,10 @@ func (b *Bus) hostsetsContractsHandler(jc jape.Context) {
 
 func (b *Bus) objectsKeyHandlerGET(jc jape.Context) {
 	if strings.HasSuffix(jc.PathParam("key"), "/") {
-		jc.Encode(ObjectsResponse{Entries: b.os.List(jc.PathParam("key"))})
+		keys, err := b.os.List(jc.PathParam("key"))
+		if jc.Check("couldn't list objects", err) == nil {
+			jc.Encode(ObjectsResponse{Entries: keys})
+		}
 		return
 	}
 	o, err := b.os.Get(jc.PathParam("key"))

--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -192,7 +192,7 @@ func newBus(cfg busConfig, dir string, walletKey consensus.PrivateKey) (*bus.Bus
 	if err := os.MkdirAll(objectsDir, 0700); err != nil {
 		return nil, nil, err
 	}
-	os, err := stores.NewJSONObjectStore(objectsDir)
+	os, err := stores.NewSQLObjectStore(dbConn, true)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -393,7 +393,7 @@ func (db *SQLHostDB) RecordInteraction(hostKey consensus.PublicKey, hi hostdb.In
 		// Create an interaction.
 		return tx.Create(&dbInteraction{
 			Host:      hostKey[:],
-			Timestamp: hi.Timestamp,
+			Timestamp: hi.Timestamp.UTC(), // explicitly store timestamp as UTC
 			Type:      hi.Type,
 			Result:    hi.Result,
 		}).Error
@@ -445,7 +445,7 @@ func insertAnnouncement(tx *gorm.DB, hostKey consensus.PublicKey, a hostdb.Annou
 		Host:        hostKey[:],
 		BlockHeight: a.Index.Height,
 		BlockID:     a.Index.ID[:],
-		Timestamp:   a.Timestamp,
+		Timestamp:   a.Timestamp.UTC(), // explicitly store timestamp as UTC
 		NetAddress:  a.NetAddress,
 	}).Error
 }

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -238,24 +238,16 @@ type (
 )
 
 // TableName implements the gorm.Tabler interface.
-func (dbHost) TableName() string {
-	return "hosts"
-}
+func (dbHost) TableName() string { return "hosts" }
 
 // TableName implements the gorm.Tabler interface.
-func (dbAnnouncement) TableName() string {
-	return "announcements"
-}
+func (dbAnnouncement) TableName() string { return "announcements" }
 
 // TableName implements the gorm.Tabler interface.
-func (dbInteraction) TableName() string {
-	return "host_interactions"
-}
+func (dbInteraction) TableName() string { return "host_interactions" }
 
 // TableName implements the gorm.Tabler interface.
-func (dbConsensusInfo) TableName() string {
-	return "consensus_infos"
-}
+func (dbConsensusInfo) TableName() string { return "consensus_infos" }
 
 // Host converts a host into a hostdb.Host.
 func (h dbHost) Host() hostdb.Host {
@@ -306,8 +298,7 @@ func NewSQLHostDB(conn gorm.Dialector, migrate bool) (*SQLHostDB, modules.Consen
 
 	if migrate {
 		// Create the tables.
-		tables := []interface {
-		}{
+		tables := []interface{}{
 			&dbHost{},
 			&dbInteraction{},
 			&dbAnnouncement{},

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -202,10 +202,12 @@ type (
 	}
 
 	// dbHost defines a hostdb.Interaction as persisted in the DB.
+	// Deleting a host from the db will cascade the deletion and also delete
+	// the corresponding announcements and interactions with that host.
 	dbHost struct {
 		PublicKey     []byte           `gorm:"primaryKey"`
-		Announcements []dbAnnouncement `gorm:"foreignKey:Host;references:PublicKey"`
-		Interactions  []dbInteraction  `gorm:"foreignKey:Host;references:PublicKey"`
+		Announcements []dbAnnouncement `gorm:"foreignKey:Host;references:PublicKey;OnDelete:CASCADE"`
+		Interactions  []dbInteraction  `gorm:"foreignKey:Host;references:PublicKey;OnDelete:CASCADE"`
 	}
 
 	dbAnnouncement struct {

--- a/internal/stores/objects.go
+++ b/internal/stores/objects.go
@@ -278,7 +278,7 @@ type (
 		Slabs []dbSlice `gorm:"constraint:OnDelete:CASCADE;foreignKey:ObjectID;references:ID"` // CASCADE to delete slices too
 	}
 
-	// dbObject describes a reference to a slab.Slab in the database.
+	// dbSlice describes a reference to a slab.Slab in the database.
 	dbSlice struct {
 		// ID uniquely identifies a slice in the db.
 		ID uint64 `gorm:"primaryKey"`
@@ -293,7 +293,7 @@ type (
 		Length uint32
 	}
 
-	// dbObject describes a slab.Slab in the database.
+	// dbSlab describes a slab.Slab in the database.
 	// NOTE: A Slab is uniquely identified by its key.
 	// NOTE TO REVIEWERS: Is this ok? What if there is no key or we want 2
 	// slabs with the same shared key but different sharding?

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -3,7 +3,6 @@ package stores
 import (
 	"encoding/hex"
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 
@@ -106,60 +105,6 @@ func TestJSONObjectStore(t *testing.T) {
 
 // TestSQLObjectStore tests basic SQLObjectStore functionality.
 func TestSQLObjectStore(t *testing.T) {
-	//dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
-	dbName := "test.db"
-
-	//conn := NewEphemeralSQLiteConnection(dbName)
-	os.RemoveAll(dbName)
-	conn := NewSQLiteConnection(dbName)
-	os, err := NewSQLObjectStore(conn, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Create some sectors.
-	sector1 := dbSector{
-		Root: []byte{1, 2},
-	}
-	sector2 := dbSector{
-		Root: []byte{2, 1},
-	}
-
-	err = os.db.Create(&dbSlab{
-		Key:       "foo1",
-		MinShards: 10,
-		Shards: []dbShard{
-			{
-				Sector: sector1,
-			},
-			{
-				Sector: sector2,
-			},
-		},
-	}).Error
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = os.db.Create(&dbSlab{
-		Key:       "foo2",
-		MinShards: 10,
-		Shards: []dbShard{
-			{
-				Sector: sector1,
-			},
-			{
-				Sector: sector2,
-			},
-		},
-	}).Error
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-// TestSQLPut verifies the functionality of (*SQLObjectStore).Put and Get.
-func TestSQLObjectStorePut(t *testing.T) {
 	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
 
 	conn := NewEphemeralSQLiteConnection(dbName)
@@ -350,10 +295,9 @@ func TestSQLObjectStorePut(t *testing.T) {
 
 // TestSQLList is a test for (*SQLObjectStore).List.
 func TestSQLList(t *testing.T) {
-	//dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
-	dbName := "/Users/cschinnerl/Desktop/test.sqlite"
+	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
 	//conn := NewEphemeralSQLiteConnection(dbName)
-	conn := NewSQLiteConnection(dbName)
+	conn := NewEphemeralSQLiteConnection(dbName)
 	os, err := NewSQLObjectStore(conn, true)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -1,6 +1,7 @@
 package stores
 
 import (
+	"encoding/hex"
 	"reflect"
 	"testing"
 
@@ -96,5 +97,16 @@ func TestJSONObjectStore(t *testing.T) {
 		t.Fatal("object not found")
 	} else if !reflect.DeepEqual(got, obj) {
 		t.Fatal("objects are not equal")
+	}
+}
+
+// TestSQLObjectStore tests basic SQLObjectStore functionality.
+func TestSQLObjectStore(t *testing.T) {
+	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
+
+	conn := NewEphemeralSQLiteConnection(dbName)
+	_, err := NewSQLObjectStore(conn, true)
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -165,16 +165,29 @@ func TestSQLObjectStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	obj1Key, err := obj1.Key.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj1Slab0Key, err := obj1.Slabs[0].Key.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj1Slab1Key, err := obj1.Slabs[1].Key.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	expectedObj := dbObject{
 		ID:  objID,
-		Key: obj1.Key.String(),
+		Key: string(obj1Key),
 		Slabs: []dbSlice{
 			{
 				ID:       1,
 				ObjectID: objID,
 				Slab: dbSlab{
 					ID:        1,
-					Key:       obj1.Slabs[0].Key.String(),
+					Key:       string(obj1Slab0Key),
 					MinShards: 1,
 					Shards: []dbShard{
 						{
@@ -196,7 +209,7 @@ func TestSQLObjectStore(t *testing.T) {
 				ObjectID: objID,
 				Slab: dbSlab{
 					ID:        2,
-					Key:       obj1.Slabs[1].Key.String(),
+					Key:       string(obj1Slab1Key),
 					MinShards: 2,
 					Shards: []dbShard{
 						{
@@ -240,8 +253,6 @@ func TestSQLObjectStore(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(fullObj, obj1) {
-		fmt.Println(fullObj)
-		fmt.Println(obj1)
 		t.Fatal("object mismatch")
 	}
 

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -1,6 +1,8 @@
 package stores
 
 import (
+	"encoding/hex"
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -8,6 +10,7 @@ import (
 	"go.sia.tech/renterd/internal/consensus"
 	"go.sia.tech/renterd/object"
 	"go.sia.tech/renterd/slab"
+	"gorm.io/gorm/schema"
 	"lukechampine.com/frand"
 )
 
@@ -156,13 +159,11 @@ func TestSQLObjectStore(t *testing.T) {
 
 }
 
-// TestSQLPut verifies the functionality of (*SQLObjectStore).Put.
+// TestSQLPut verifies the functionality of (*SQLObjectStore).Put and Get.
 func TestSQLObjectStorePut(t *testing.T) {
-	//dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
-	dbName := "/Users/cschinnerl/Desktop/db2.sqlite"
+	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
 
 	//conn := NewEphemeralSQLiteConnection(dbName)
-	os.RemoveAll(dbName)
 	conn := NewSQLiteConnection(dbName)
 	os, err := NewSQLObjectStore(conn, true)
 	if err != nil {
@@ -205,12 +206,146 @@ func TestSQLObjectStorePut(t *testing.T) {
 	}
 
 	// Store it.
-	if err := os.Put("key1", obj1, false); err != nil {
+	objID := "key1"
+	if err := os.Put(objID, obj1); err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to store it again. Should work.
-	if err := os.Put("key1", obj1, true); err != nil {
+	if err := os.Put(objID, obj1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fetch it using get and verify every field.
+	obj, err := os.get(objID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedObj := dbObject{
+		ID:  objID,
+		Key: obj1.Key.String(),
+		Slabs: []dbSlice{
+			{
+				ID:       1,
+				ObjectID: objID,
+				Slab: dbSlab{
+					ID:        1,
+					Key:       obj1.Slabs[0].Key.String(),
+					MinShards: 1,
+					Shards: []dbShard{
+						{
+							ID:       1,
+							SlabID:   1,
+							SectorID: obj1.Slabs[0].Shards[0].Root[:],
+							Sector: dbSector{
+								Root: obj1.Slabs[0].Shards[0].Root[:],
+								Host: obj1.Slabs[0].Shards[0].Host[:],
+							},
+						},
+					},
+				},
+				Offset: 10,
+				Length: 100,
+			},
+			{
+				ID:       2,
+				ObjectID: objID,
+				Slab: dbSlab{
+					ID:        2,
+					Key:       obj1.Slabs[1].Key.String(),
+					MinShards: 2,
+					Shards: []dbShard{
+						{
+							ID:       2,
+							SlabID:   2,
+							SectorID: obj1.Slabs[1].Shards[0].Root[:],
+							Sector: dbSector{
+								Root: obj1.Slabs[1].Shards[0].Root[:],
+								Host: obj1.Slabs[1].Shards[0].Host[:],
+							},
+						},
+					},
+				},
+				Offset: 20,
+				Length: 200,
+			},
+		},
+	}
+	if !reflect.DeepEqual(obj, expectedObj) {
+		t.Fatal("object mismatch")
+	}
+
+	// Fetch it using Get and verify again.
+	fullObj, err := os.Get(objID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fullObj, obj1) {
+		t.Fatal("object mismatch")
+	}
+
+	// Remove the first slab of the object and change the min shards of the
+	// second one.
+	obj1.Slabs = obj1.Slabs[1:]
+	obj1.Slabs[0].Slab.MinShards = 123
+	if err := os.Put(objID, obj1); err != nil {
+		t.Fatal(err)
+	}
+	fullObj, err = os.Get(objID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fullObj, obj1) {
+		fmt.Println(fullObj)
+		fmt.Println(obj1)
+		t.Fatal("object mismatch")
+	}
+
+	// Sanity check the db at the end of the test. We expect:
+	// - 1 element in the object table since we only stored and overwrote a single object
+	// - 1 element in the slabs table since we updated the object to only have 1 slab
+	// - 1 element in the slices table for the same reason
+	// - 2 elements in the sectors table because we don't delete sectors
+	countCheck := func(objCount, sliceCount, slabCount, shardCount, sectorCount int64) error {
+		tableCountCheck := func(table interface{}, tblCount int64) error {
+			var count int64
+			if err := os.db.Model(table).Count(&count).Error; err != nil {
+				return err
+			}
+			if count != tblCount {
+				return fmt.Errorf("expected %v objects in table %v but got %v", tblCount, table.(schema.Tabler).TableName(), count)
+			}
+			return nil
+		}
+		// Check all tables.
+		if err := tableCountCheck(&dbObject{}, objCount); err != nil {
+			return err
+		}
+		if err := tableCountCheck(&dbSlice{}, sliceCount); err != nil {
+			return err
+		}
+		if err := tableCountCheck(&dbSlab{}, slabCount); err != nil {
+			return err
+		}
+		if err := tableCountCheck(&dbShard{}, shardCount); err != nil {
+			return err
+		}
+		if err := tableCountCheck(&dbSector{}, sectorCount); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err := countCheck(1, 1, 1, 1, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the object. Due to the cascade this should delete everything
+	// but the sectors.
+	if err := os.Delete(objID); err != nil {
+		t.Fatal(err)
+	}
+	if err := countCheck(0, 0, 0, 0, 2); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -156,7 +156,6 @@ func TestSQLObjectStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 // TestSQLPut verifies the functionality of (*SQLObjectStore).Put and Get.

--- a/object/object.go
+++ b/object/object.go
@@ -17,9 +17,14 @@ type EncryptionKey struct {
 	entropy *[32]byte
 }
 
+// String returns a hex-encoded representation of the key.
+func (k EncryptionKey) String() (s string) {
+	return "key:" + hex.EncodeToString(k.entropy[:])
+}
+
 // MarshalJSON implements the json.Marshaler interface.
 func (k EncryptionKey) MarshalJSON() ([]byte, error) {
-	return []byte(`"key:` + hex.EncodeToString(k.entropy[:]) + `"`), nil
+	return []byte(`"` + k.String() + `"`), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.

--- a/slab/slab.go
+++ b/slab/slab.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
+	"strings"
 
 	"go.sia.tech/renterd/internal/consensus"
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
@@ -21,6 +22,17 @@ func (k EncryptionKey) String() (s string) {
 	return "key:" + hex.EncodeToString(k.entropy[:])
 }
 
+// LoadString loads an EncryptionKey from a string.
+func (k *EncryptionKey) LoadString(s string) error {
+	k.entropy = new([32]byte)
+	if n, err := hex.Decode(k.entropy[:], []byte(strings.TrimPrefix(s, "key:"))); err != nil {
+		return err
+	} else if n != len(k.entropy) {
+		return errors.New("wrong seed length")
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaler interface.
 func (k EncryptionKey) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + k.String() + `"`), nil
@@ -28,13 +40,7 @@ func (k EncryptionKey) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (k *EncryptionKey) UnmarshalJSON(b []byte) error {
-	k.entropy = new([32]byte)
-	if n, err := hex.Decode(k.entropy[:], bytes.TrimPrefix(bytes.Trim(b, `"`), []byte("key:"))); err != nil {
-		return err
-	} else if n != len(k.entropy) {
-		return errors.New("wrong seed length")
-	}
-	return nil
+	return k.LoadString(string(bytes.Trim(b, `"`)))
 }
 
 // GenerateEncryptionKey returns a random encryption key.

--- a/slab/slab.go
+++ b/slab/slab.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
-	"strings"
 
 	"go.sia.tech/renterd/internal/consensus"
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
@@ -17,30 +16,20 @@ type EncryptionKey struct {
 	entropy *[32]byte
 }
 
-// String returns a hex-encoded representation of the key.
-func (k EncryptionKey) String() (s string) {
-	return "key:" + hex.EncodeToString(k.entropy[:])
+// MarshalText implements the encoding.TextMarshaler interface.
+func (k EncryptionKey) MarshalText() ([]byte, error) {
+	return []byte("key:" + hex.EncodeToString(k.entropy[:])), nil
 }
 
-// LoadString loads an EncryptionKey from a string.
-func (k *EncryptionKey) LoadString(s string) error {
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (k *EncryptionKey) UnmarshalText(b []byte) error {
 	k.entropy = new([32]byte)
-	if n, err := hex.Decode(k.entropy[:], []byte(strings.TrimPrefix(s, "key:"))); err != nil {
+	if n, err := hex.Decode(k.entropy[:], []byte(bytes.TrimPrefix(b, []byte("key:")))); err != nil {
 		return err
 	} else if n != len(k.entropy) {
 		return errors.New("wrong seed length")
 	}
 	return nil
-}
-
-// MarshalJSON implements the json.Marshaler interface.
-func (k EncryptionKey) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + k.String() + `"`), nil
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface.
-func (k *EncryptionKey) UnmarshalJSON(b []byte) error {
-	return k.LoadString(string(bytes.Trim(b, `"`)))
 }
 
 // GenerateEncryptionKey returns a random encryption key.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -26,7 +26,7 @@ type (
 
 	// An ObjectStore stores objects.
 	ObjectStore interface {
-		List(key string) []string
+		List(key string) ([]string, error)
 		Get(key string) (object.Object, error)
 		Put(key string, o object.Object) error
 		Delete(key string) error


### PR DESCRIPTION
Similar to the HostDB this PR replaces the JSON-based store for storing objects with an SQL based one.
For now the interface remains exactly the same and the behaviour as well.
