### PR TITLE
Contract Loop - Initial Structure

### DIFF
--- a/autopilot/api.go
+++ b/autopilot/api.go
@@ -18,9 +18,12 @@ type Config struct {
 		ScoreOverrides map[consensus.PublicKey]float64
 	}
 	Contracts struct {
-		Allowance types.Currency
-		Hosts     uint64
-		Period    uint64
+		Allowance   types.Currency
+		Hosts       uint64
+		Period      uint64
+		RenewWindow uint64
+		Download    uint64
+		Upload      uint64
 	}
 	Objects struct {
 		MinShards   uint8
@@ -33,7 +36,10 @@ func DefaultConfig() (c Config) {
 	c.Hosts.ScoreOverrides = make(map[consensus.PublicKey]float64)
 	c.Contracts.Allowance = types.SiacoinPrecision.Mul64(1000)
 	c.Contracts.Hosts = 50
-	c.Contracts.Period = 144 * 7 * 6 // 6 weeks
+	c.Contracts.Period = 144 * 7 * 6      // 6 weeks
+	c.Contracts.RenewWindow = 144 * 7 * 2 // 2 weeks
+	c.Contracts.Upload = 1 << 30          // 1 GiB
+	c.Contracts.Download = 1 << 33        // 8 GiB
 	c.Objects.MinShards = 10
 	c.Objects.TotalShards = 30
 	return

--- a/autopilot/api.go
+++ b/autopilot/api.go
@@ -31,6 +31,15 @@ type Config struct {
 	}
 }
 
+// State contains all autopilot state variables.
+// TODO: could be defined on the autopilot directly
+// TODO: synced could be a channel
+type State struct {
+	BlockHeight   uint64
+	CurrentPeriod uint64
+	Synced        bool
+}
+
 func DefaultConfig() (c Config) {
 	c.Wallet.DefragThreshold = 1000
 	c.Hosts.ScoreOverrides = make(map[consensus.PublicKey]float64)
@@ -38,8 +47,8 @@ func DefaultConfig() (c Config) {
 	c.Contracts.Hosts = 50
 	c.Contracts.Period = 144 * 7 * 6      // 6 weeks
 	c.Contracts.RenewWindow = 144 * 7 * 2 // 2 weeks
-	c.Contracts.Upload = 1 << 30          // 1 GiB
-	c.Contracts.Download = 1 << 33        // 8 GiB
+	c.Contracts.Upload = 1 << 40          // 1 TiB
+	c.Contracts.Download = 1 << 40        // 1 TiB
 	c.Objects.MinShards = 10
 	c.Objects.TotalShards = 30
 	return

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -8,24 +8,53 @@ import (
 	"go.sia.tech/renterd/bus"
 	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/consensus"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
+	"go.sia.tech/renterd/wallet"
 	"go.sia.tech/renterd/worker"
+	"go.sia.tech/siad/types"
 )
 
 type Store interface {
 	Tip() consensus.ChainIndex
+	Synced() bool // TODO: should be added to `Tip` | should be moved over to Bus
+
 	Config() Config
 	SetConfig(c Config) error
 }
 
+// TODO: should be defined in bus package, should be the interface of the client
 type Bus interface {
+	// wallet
+	WalletBalance() (types.Currency, error)
+	WalletAddress() (types.UnlockHash, error)
+	WalletTransactions(since time.Time, max int) ([]wallet.Transaction, error)
+	WalletFund(txn *types.Transaction, amount types.Currency) ([]types.OutputID, []types.Transaction, error)
+	WalletDiscard(txn types.Transaction) error
+	WalletSign(txn *types.Transaction, toSign []types.OutputID, cf types.CoveredFields) error
+
+	// hostdb
 	AllHosts() ([]hostdb.Host, error)
 	Hosts(notSince time.Time, max int) ([]hostdb.Host, error)
+	Host(hostKey consensus.PublicKey) (hostdb.Host, error)
 	RecordHostInteraction(hostKey consensus.PublicKey, hi hostdb.Interaction) error
+
+	// contracts
+	AddContract(c rhpv2.Contract) error
+	RenewableContracts(renewWindow uint64) ([]bus.Contract, error)
+	AcquireContractLock(types.FileContractID) (types.FileContractRevision, error)
+	ReleaseContractLock(types.FileContractID) error
+
+	// contractsets
+	SetHostSet(name string, hosts []consensus.PublicKey) error
 	HostSetContracts(name string) ([]bus.Contract, error)
 }
 
 type Worker interface {
 	RHPScan(hostKey consensus.PublicKey, hostIP string) (worker.RHPScanResponse, error)
+	RHPPrepareForm(renterKey consensus.PrivateKey, hostKey consensus.PublicKey, renterFunds types.Currency, renterAddress types.UnlockHash, hostCollateral types.Currency, endHeight uint64, hostSettings rhpv2.HostSettings) (types.FileContract, types.Currency, error)
+	RHPPrepareRenew(contract types.FileContractRevision, renterKey consensus.PrivateKey, hostKey consensus.PublicKey, renterFunds types.Currency, renterAddress types.UnlockHash, hostCollateral types.Currency, endHeight uint64, hostSettings rhpv2.HostSettings) (types.FileContract, types.Currency, types.Currency, error)
+	RHPForm(renterKey consensus.PrivateKey, hostKey consensus.PublicKey, hostIP string, transactionSet []types.Transaction) (rhpv2.Contract, []types.Transaction, error)
+	RHPRenew(renterKey consensus.PrivateKey, hostKey consensus.PublicKey, hostIP string, contractID types.FileContractID, transactionSet []types.Transaction, finalPayment types.Currency) (rhpv2.Contract, []types.Transaction, error)
 }
 
 type Autopilot struct {
@@ -53,6 +82,7 @@ func (ap *Autopilot) Actions(since time.Time, max int) []Action {
 }
 
 func (ap *Autopilot) Run() error {
+	go ap.contractLoop()
 	go ap.hostScanLoop()
 	<-ap.stopChan
 	return nil // TODO
@@ -68,6 +98,8 @@ func New(store Store, bus Bus, worker Worker) (*Autopilot, error) {
 		store:  store,
 		bus:    bus,
 		worker: worker,
+
+		stopChan: make(chan struct{}),
 	}, nil
 }
 

--- a/autopilot/contracts.go
+++ b/autopilot/contracts.go
@@ -1,16 +1,34 @@
 package autopilot
 
 import (
+	"time"
+
+	"gitlab.com/NebulousLabs/errors"
 	"go.sia.tech/renterd/internal/consensus"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/renterd/worker"
 	"go.sia.tech/siad/types"
 	"golang.org/x/crypto/blake2b"
 )
 
+const contractSetName = "autopilot"
+
+func logErr(err error) {} // TODO
+
 func (ap *Autopilot) currentHeight() uint64 {
 	return ap.store.Tip().Height
 }
 
+func (ap *Autopilot) currentPeriod() uint64 {
+	c := ap.store.Config()
+	h := ap.store.Tip().Height
+	return h + c.Contracts.Period
+}
+
+// TODO: deriving the renter key from the host key using the master key only
+// works if we persist a hash of the renter's master key in the database and
+// compare it on startup, otherwise there's no way of knowing the derived key is
+// usuable
 func (ap *Autopilot) deriveRenterKey(hostKey consensus.PublicKey) consensus.PrivateKey {
 	seed := blake2b.Sum256(append(ap.masterKey[:], hostKey[:]...))
 	pk := consensus.NewPrivateKeyFromSeed(seed[:])
@@ -21,7 +39,7 @@ func (ap *Autopilot) deriveRenterKey(hostKey consensus.PublicKey) consensus.Priv
 }
 
 func (ap *Autopilot) defaultContracts() ([]worker.Contract, error) {
-	cs, err := ap.bus.HostSetContracts("autopilot")
+	cs, err := ap.bus.HostSetContracts(contractSetName)
 	if err != nil {
 		return nil, err
 	}
@@ -38,4 +56,265 @@ func (ap *Autopilot) defaultContracts() ([]worker.Contract, error) {
 		})
 	}
 	return contracts, nil
+}
+
+func (ap *Autopilot) renewableContracts(renewWindow uint64) ([]worker.Contract, error) {
+	cs, err := ap.bus.RenewableContracts(renewWindow)
+	if err != nil {
+		return nil, err
+	}
+	contracts := make([]worker.Contract, 0, len(cs))
+	for _, c := range cs {
+		if c.ID == (types.FileContractID{}) || c.HostIP == "" {
+			continue
+		}
+		contracts = append(contracts, worker.Contract{
+			HostKey:   c.HostKey,
+			HostIP:    c.HostIP,
+			ID:        c.ID,
+			RenterKey: ap.deriveRenterKey(c.HostKey),
+		})
+	}
+	return contracts, nil
+}
+
+func (ap *Autopilot) contractLoop() {
+	for {
+		select {
+		// TODO: use build var for loop interval
+		// TODO: add wakeChan (to trigger loop)
+		// TODO: run loop immediately
+		// TODO: logging
+		case <-ap.stopChan:
+			return
+		case <-time.After(time.Hour):
+		}
+
+		// don't run the contract loop if we are not synced
+		if !ap.store.Synced() {
+			continue
+		}
+
+		// fetch all contracts
+		cs, err := ap.defaultContracts()
+		if err != nil {
+			logErr(err)
+			continue
+		}
+
+		// run checks on the contract set
+		// TODO: dedupe existing contracts (?)
+		// TODO: check for IP range violations (?)
+
+		// run checks on the contracts individually
+		// TODO: separate loop (?)
+		csMap := make(map[string]int)
+		for i, c := range cs {
+			csMap[c.ID.String()] = i
+			// TODO: is host in host DB
+			// TODO: is max revision
+			// TODO: is offline
+			// TODO: is gouging
+			// TODO: is low score
+			// TODO: is out of funds
+			// TODO: update some contract metadata entity to reflect these checks
+		}
+
+		// gather some basic info
+		config := ap.store.Config()
+		needed := config.Contracts.Hosts
+		renewW := config.Contracts.RenewWindow
+		period := ap.currentPeriod()
+		renterAddress, err := ap.bus.WalletAddress()
+		if err != nil {
+			logErr(err)
+			continue
+		}
+
+		// TODO: check remaining funds before renew | form
+
+		// renew all renewable contracts
+		toRenew, err := ap.renewableContracts(renewW)
+		if err != nil {
+			logErr(err)
+			continue
+		}
+		for _, renew := range toRenew {
+			// renew contract
+			renterKey := ap.deriveRenterKey(renew.HostKey)
+			renewed, err := ap.renewContract(renew, renterKey, renterAddress, period)
+			if err != nil {
+				// TODO: handle error properly, if the wallet ran out of outputs
+				// here there's no point in renewing more contracts until a
+				// block is mined, maybe we could/should wait for pending transactions?
+				logErr(err)
+				continue
+			}
+
+			// swap contract in contract set
+			cs[csMap[renew.ID.String()]] = worker.Contract{
+				HostKey:   renew.HostKey,
+				HostIP:    renew.HostIP,
+				ID:        renewed.ID(),
+				RenterKey: renterKey,
+			}
+
+			// persist the contract
+			err = ap.bus.AddContract(renewed)
+			if err != nil {
+				logErr(err)
+				continue
+			}
+		}
+
+		// form missing contracts
+		missing := int(needed) - len(cs)              // TODO: add leeway so we don't form hosts if we dip slightly under `needed` (?)
+		canidates, _ := ap.hostsForContracts(missing) // TODO: add leeway so we have more than enough canidates
+		for h := 0; missing > 0 && h < len(canidates); h++ {
+			// fetch host IP
+			candidate := canidates[h]
+			host, err := ap.bus.Host(candidate)
+			if err != nil {
+				logErr(err)
+				continue
+			}
+			hostIP := host.NetAddress()
+
+			// form contract
+			renterKey := ap.deriveRenterKey(candidate)
+			formed, err := ap.formContract(candidate, hostIP, renterKey, renterAddress, period)
+			if err != nil {
+				// TODO: handle error properly, if the wallet ran out of outputs
+				// here there's no point in forming more contracts until a block
+				// is mined, maybe we could/should wait for pending transactions?
+				logErr(err)
+				continue
+			}
+
+			// add contract to contract set
+			cs = append(cs, worker.Contract{
+				HostKey:   candidate,
+				HostIP:    hostIP,
+				ID:        formed.ID(),
+				RenterKey: renterKey,
+			})
+
+			// persist contract in store
+			err = ap.bus.AddContract(formed)
+			if err != nil {
+				logErr(err)
+				continue
+			}
+
+			missing--
+		}
+
+		// TODO update contract set
+		contracts := make([]consensus.PublicKey, len(cs))
+		for i, c := range cs {
+			contracts[i] = c.HostKey
+		}
+		err = ap.bus.SetHostSet(contractSetName, contracts)
+		if err != nil {
+			logErr(err)
+		}
+	}
+}
+
+func (ap *Autopilot) formContract(hostKey consensus.PublicKey, hostIP string, renterKey consensus.PrivateKey, renterAddress types.UnlockHash, period uint64) (rhpv2.Contract, error) {
+	// fetch host settings
+	scan, err := ap.worker.RHPScan(hostKey, hostIP)
+	if err != nil {
+		return rhpv2.Contract{}, err
+	}
+
+	// prepare contract formation
+	endHeight := ap.currentHeight() + period
+	renterFunds, hostCollateral := ap.calculateFundsAndCollateral(scan.Settings)
+	fc, cost, err := ap.worker.RHPPrepareForm(renterKey, hostKey, renterFunds, renterAddress, hostCollateral, endHeight, scan.Settings)
+	if err != nil {
+		return rhpv2.Contract{}, err
+	}
+
+	// fund the transaction
+	txn := types.Transaction{FileContracts: []types.FileContract{fc}}
+	toSign, parents, err := ap.bus.WalletFund(&txn, cost)
+	if err != nil {
+		return rhpv2.Contract{}, errors.Compose(err, ap.bus.WalletDiscard(txn))
+	}
+
+	// sign the transaction
+	err = ap.bus.WalletSign(&txn, toSign, types.FullCoveredFields)
+	if err != nil {
+		return rhpv2.Contract{}, errors.Compose(err, ap.bus.WalletDiscard(txn))
+	}
+
+	// form the contract
+	contract, _, err := ap.worker.RHPForm(renterKey, hostKey, hostIP, append(parents, txn))
+	if err != nil {
+		return rhpv2.Contract{}, errors.Compose(err, ap.bus.WalletDiscard(txn))
+	}
+
+	return contract, nil
+}
+
+func (ap *Autopilot) renewContract(c worker.Contract, renterKey consensus.PrivateKey, renterAddress types.UnlockHash, period uint64) (contract rhpv2.Contract, err error) {
+	// handle contract locking
+	revision, err := ap.bus.AcquireContractLock(c.ID)
+	if err != nil {
+		return rhpv2.Contract{}, nil
+	}
+	defer func() {
+		err = errors.Compose(err, ap.bus.ReleaseContractLock(c.ID))
+	}()
+
+	// fetch host settings
+	scan, err := ap.worker.RHPScan(c.HostKey, c.HostIP)
+	if err != nil {
+		return rhpv2.Contract{}, err
+	}
+
+	// prepare the renewal
+	endHeight := ap.currentHeight() + period
+	renterFunds, hostCollateral := ap.calculateFundsAndCollateral(scan.Settings)
+	fc, cost, finalPayment, err := ap.worker.RHPPrepareRenew(revision, renterKey, c.HostKey, renterFunds, renterAddress, hostCollateral, endHeight, scan.Settings)
+	if err != nil {
+		return rhpv2.Contract{}, err
+	}
+
+	// fund the transaction
+	txn := types.Transaction{FileContracts: []types.FileContract{fc}}
+	toSign, parents, err := ap.bus.WalletFund(&txn, cost)
+	if err != nil {
+		return rhpv2.Contract{}, errors.Compose(err, ap.bus.WalletDiscard(txn))
+	}
+
+	// sign the transaction
+	err = ap.bus.WalletSign(&txn, toSign, types.FullCoveredFields)
+	if err != nil {
+		return rhpv2.Contract{}, errors.Compose(err, ap.bus.WalletDiscard(txn))
+	}
+
+	// renew the contract
+	txnSet := append(parents, txn)
+	renewed, _, err := ap.worker.RHPRenew(renterKey, c.HostKey, c.HostIP, c.ID, txnSet, finalPayment)
+	if err != nil {
+		return rhpv2.Contract{}, errors.Compose(err, ap.bus.WalletDiscard(txn))
+	}
+	return renewed, nil
+}
+
+func (ap *Autopilot) calculateFundsAndCollateral(hs rhpv2.HostSettings) (types.Currency, types.Currency) {
+	c := ap.store.Config()
+	download := c.Contracts.Download
+	upload := c.Contracts.Upload
+	duration := c.Contracts.Period
+
+	uploadCost := hs.UploadBandwidthPrice.Mul64(upload)
+	downloadCost := hs.DownloadBandwidthPrice.Mul64(download)
+	storageCost := hs.StoragePrice.Mul64(upload).Mul64(duration)
+
+	renterFunds := hs.ContractPrice.Add(uploadCost).Add(downloadCost).Add(storageCost)
+	hostCollateral := hs.Collateral.Mul64(upload).Mul64(duration)
+	return renterFunds, hostCollateral
 }

--- a/bus/api.go
+++ b/bus/api.go
@@ -88,8 +88,23 @@ type ObjectsResponse struct {
 // A Contract uniquely identifies a Sia file contract on a host, along with the
 // host's IP.
 type Contract struct {
-	HostKey   PublicKey            `json:"hostKey"`
-	HostIP    string               `json:"hostIP"`
-	ID        types.FileContractID `json:"id"`
-	EndHeight uint64               `json:"endHeight"`
+	HostKey     PublicKey            `json:"hostKey"`
+	HostIP      string               `json:"hostIP"`
+	ID          types.FileContractID `json:"id"`
+	StartHeight uint64               `json:"startHeight"`
+	EndHeight   uint64               `json:"endHeight"`
+	Metadata    ContractMetadata     `json:"metadata"`
+}
+
+// ContractMetadata contains all metadata for a contract.
+type ContractMetadata struct {
+	RenewedFrom types.FileContractID `json:"renewedFrom"`
+	Spending    ContractSpending     `json:"spending"`
+}
+
+// ContractSpending contains all spending details for a contract.
+type ContractSpending struct {
+	Uploads     types.Currency `json:"uploads"`
+	Downloads   types.Currency `json:"downloads"`
+	FundAccount types.Currency `json:"fundAccount"`
 }

--- a/bus/api.go
+++ b/bus/api.go
@@ -88,7 +88,8 @@ type ObjectsResponse struct {
 // A Contract uniquely identifies a Sia file contract on a host, along with the
 // host's IP.
 type Contract struct {
-	HostKey PublicKey            `json:"hostKey"`
-	HostIP  string               `json:"hostIP"`
-	ID      types.FileContractID `json:"id"`
+	HostKey   PublicKey            `json:"hostKey"`
+	HostIP    string               `json:"hostIP"`
+	ID        types.FileContractID `json:"id"`
+	EndHeight uint64               `json:"endHeight"`
 }

--- a/bus/client.go
+++ b/bus/client.go
@@ -215,12 +215,28 @@ func (c *Client) HostSetContracts(name string) (contracts []Contract, err error)
 	return
 }
 
-// TODO
 func (c *Client) AcquireContractLock(types.FileContractID) (types.FileContractRevision, error) {
 	panic("unimplemented")
 }
-func (c *Client) ReleaseContractLock(types.FileContractID) error { panic("unimplemented") }
-func (c *Client) RenewableContracts(renewWindow uint64) ([]Contract, error) {
+func (c *Client) ReleaseContractLock(types.FileContractID) error {
+	panic("unimplemented")
+}
+func (c *Client) ActiveContracts(maxEndHeight uint64) ([]Contract, error) {
+	panic("unimplemented")
+}
+func (c *Client) AllContracts(currentPeriod uint64) ([]Contract, error) {
+	panic("unimplemented")
+}
+func (c *Client) ContractData(types.FileContractID) (rhpv2.Contract, error) {
+	panic("unimplemented")
+}
+func (c *Client) ContractHistory(types.FileContractID, uint64) ([]Contract, error) {
+	panic("unimplemented")
+}
+func (c *Client) UpdateContractMetadata(types.FileContractID, ContractMetadata) error {
+	panic("unimplemented")
+}
+func (c *Client) RecommendedFee() (types.Currency, error) {
 	panic("unimplemented")
 }
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -215,6 +215,15 @@ func (c *Client) HostSetContracts(name string) (contracts []Contract, err error)
 	return
 }
 
+// TODO
+func (c *Client) AcquireContractLock(types.FileContractID) (types.FileContractRevision, error) {
+	panic("unimplemented")
+}
+func (c *Client) ReleaseContractLock(types.FileContractID) error { panic("unimplemented") }
+func (c *Client) RenewableContracts(renewWindow uint64) ([]Contract, error) {
+	panic("unimplemented")
+}
+
 func (c *Client) objects(path string) (or ObjectsResponse, err error) {
 	err = c.c.GET(fmt.Sprintf("/objects/%s", path), &or)
 	return

--- a/internal/stores/autopilot.go
+++ b/internal/stores/autopilot.go
@@ -47,6 +47,11 @@ func (s *EphemeralAutopilotStore) ProcessConsensusChange(cc modules.ConsensusCha
 	panic("unimplemented")
 }
 
+// Synced implements autopilot.Store.
+func (s *EphemeralAutopilotStore) Synced() bool {
+	panic("unimplemented")
+}
+
 // NewEphemeralAutopilotStore returns a new EphemeralAutopilotStore.
 func NewEphemeralAutopilotStore() *EphemeralAutopilotStore {
 	return &EphemeralAutopilotStore{}

--- a/internal/stores/autopilot.go
+++ b/internal/stores/autopilot.go
@@ -9,22 +9,15 @@ import (
 	"time"
 
 	"go.sia.tech/renterd/autopilot"
-	"go.sia.tech/renterd/internal/consensus"
 	"go.sia.tech/siad/modules"
+	"go.sia.tech/siad/types"
 )
 
 // EphemeralAutopilotStore implements autopilot.Store in memory.
 type EphemeralAutopilotStore struct {
 	mu     sync.Mutex
-	tip    consensus.ChainIndex
 	config autopilot.Config
-}
-
-// Tip implements autopilot.Store.
-func (s *EphemeralAutopilotStore) Tip() consensus.ChainIndex {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.tip
+	state  autopilot.State
 }
 
 // Config implements autopilot.Store.
@@ -42,14 +35,45 @@ func (s *EphemeralAutopilotStore) SetConfig(c autopilot.Config) error {
 	return nil
 }
 
-// ProcessConsensusChange implements chain.Subscriber.
-func (s *EphemeralAutopilotStore) ProcessConsensusChange(cc modules.ConsensusChange) {
-	panic("unimplemented")
+// State implements autopilot.Store.
+func (s *EphemeralAutopilotStore) State() autopilot.State {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state
 }
 
-// Synced implements autopilot.Store.
-func (s *EphemeralAutopilotStore) Synced() bool {
-	panic("unimplemented")
+// SetState implements autopilot.Store.
+func (s *EphemeralAutopilotStore) SetState(state autopilot.State) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.state = state
+	return nil
+}
+
+// ProcessConsensusChange implements chain.Subscriber.
+func (s *EphemeralAutopilotStore) ProcessConsensusChange(cc modules.ConsensusChange) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, block := range cc.RevertedBlocks {
+		if block.ID() != types.GenesisID {
+			s.state.BlockHeight--
+		}
+	}
+	for _, block := range cc.AppliedBlocks {
+		if block.ID() != types.GenesisID {
+			s.state.BlockHeight++
+		}
+	}
+
+	// update current period
+	if s.state.BlockHeight >= s.state.CurrentPeriod+s.config.Contracts.Period {
+		s.state.CurrentPeriod += s.config.Contracts.Period
+	}
+
+	// update synced state
+	// TODO: might need a channel here
+	s.state.Synced = cc.Synced
 }
 
 // NewEphemeralAutopilotStore returns a new EphemeralAutopilotStore.
@@ -66,6 +90,7 @@ type JSONAutopilotStore struct {
 
 type jsonAutopilotPersistData struct {
 	Config autopilot.Config
+	State  autopilot.State
 }
 
 func (s *JSONAutopilotStore) save() error {
@@ -73,6 +98,7 @@ func (s *JSONAutopilotStore) save() error {
 	defer s.mu.Unlock()
 	var p jsonAutopilotPersistData
 	p.Config = s.config
+	p.State = s.state
 	js, _ := json.MarshalIndent(p, "", "  ")
 
 	// atomic save
@@ -104,6 +130,8 @@ func (s *JSONAutopilotStore) load() error {
 		return err
 	}
 	s.config = p.Config
+	s.state = p.State
+	s.state.Synced = false
 	return nil
 }
 


### PR DESCRIPTION
This PR adds an initial version of the contract loop. I have extended the `Bus` interface with some methods that I found are going to be required in some shape or form, these are however not finalised yet and I want to revisit them in consecutive PRs.

It essentially defines a loop that performs the following steps:
- run contract checks
- perform renewals
- form new contracts

The contract checks are a series of checks that update a contract's metadata to signal whether the contract is good for upload and/or renew. Both the renewal code as well as the contract formation code has some TODOs in there still but all-in-all should be close to how it will end up being implemented.

I have added a `State` variable to the autopilot, that contains things like the current block height and period. I figured I could do that because the store is subscribed to the consensus. Immediately following this PR I want to add a new `contractor` package so I can add a little more structure. This is also why it would be nice to merge this PR more or less as-is and tackle issues in follow-up PRs. After a small refactor to add some structure I want to focus on contract metadata and period spending.

