### PR TITLE
Replace JSONContractStore with SQLContractStore

### DIFF
--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -122,7 +122,7 @@ func main() {
 		defer cleanup()
 		mux.sub["/api/worker"] = treeMux{h: auth(worker.NewServer(w))}
 		autopilotCfg.busAddr = *apiAddr + "/worker/"
-		autopilotCfg.busPassword = apiPassword
+		autopilotCfg.workerPassword = apiPassword
 	}
 	if autopilotCfg.enabled {
 		a, cleanup, err := newAutopilot(autopilotCfg, *dir)

--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -185,7 +185,7 @@ func newBus(cfg busConfig, dir string, walletKey consensus.PrivateKey) (*bus.Bus
 	if err := os.MkdirAll(contractsDir, 0700); err != nil {
 		return nil, nil, err
 	}
-	cs, err := stores.NewJSONContractStore(contractsDir)
+	cs, err := stores.NewSQLContractStore(dbConn, true)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/stores/contracts.go
+++ b/internal/stores/contracts.go
@@ -20,11 +20,11 @@ import (
 var (
 	// ErrContractNotFound is returned when a contract can't be retrieved from the
 	// database.
-	ErrContractNotFound = errors.New("couldn't find contract with specified id")
+	ErrContractNotFound = errors.New("couldn't find contract")
 
 	// ErrHostSetNotFound is returned when a contract can't be retrieved from the
 	// database.
-	ErrHostSetNotFound = errors.New("couldn't find host set with specified name")
+	ErrHostSetNotFound = errors.New("couldn't find host set")
 )
 
 // EphemeralContractStore implements api.ContractStore and api.HostSetStore in memory.
@@ -440,7 +440,7 @@ func (s *SQLContractStore) AddContract(c rhpv2.Contract) error {
 
 		// Prepare contract revision.
 		revision := dbFileContractRevision{
-			//ParentID: fcid,
+			ParentID:              fcid,
 			UnlockConditions:      unlockConditions,
 			NewRevisionNumber:     c.Revision.NewRevisionNumber,
 			NewFileSize:           c.Revision.NewFileSize,
@@ -523,7 +523,7 @@ func (s *SQLContractStore) HostSet(name string) ([]consensus.PublicKey, error) {
 		Preload("Hosts").
 		Take(&hostSet).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, ErrHostSetNotFound
+		return nil, fmt.Errorf("name: %v; %w", name, ErrHostNotFound)
 	} else if err != nil {
 		return nil, err
 	}

--- a/internal/stores/contracts.go
+++ b/internal/stores/contracts.go
@@ -467,7 +467,7 @@ func (s *SQLContractStore) HostSet(name string) ([]consensus.PublicKey, error) {
 		Preload("Hosts").
 		Take(&hostSet).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, ErrHostNotFound
+		return nil, ErrHostSetNotFound
 	} else if err != nil {
 		return nil, err
 	}

--- a/internal/stores/contracts_test.go
+++ b/internal/stores/contracts_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"go.sia.tech/renterd/internal/consensus"
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/types"
@@ -154,5 +155,52 @@ func TestSQLContractStore(t *testing.T) {
 	}
 	if err := tableCountCheck(&dbTransactionSignature{}, 0); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestSQLHostSetStore tests the bus.HostSetStore methods on the SQLContractStore.
+func TestSQLHostSetStore(t *testing.T) {
+	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
+
+	conn := NewEphemeralSQLiteConnection(dbName)
+	cs, err := NewSQLContractStore(conn, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check db before adding a set.
+	setName := "foo"
+	sets, err := cs.HostSets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sets) != 0 {
+		t.Fatalf("expected 0 sets got %v", len(sets))
+	}
+	_, err = cs.HostSet(setName)
+	if !errors.Is(err, ErrHostSetNotFound) {
+		t.Fatal("should fail", err)
+	}
+
+	// Add another one.
+	pks := []consensus.PublicKey{{1, 2, 3}, {3, 2, 1}}
+	if err := cs.SetHostSet(setName, pks); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check again.
+	sets, err = cs.HostSets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sets) != 1 {
+		t.Fatalf("expected 0 sets got %v", len(sets))
+	}
+	set, err := cs.HostSet(setName)
+	if err != nil {
+		t.Fatal("should fail", err)
+	}
+	if !reflect.DeepEqual(set, pks) {
+		t.Fatal("set mismatch")
 	}
 }

--- a/internal/stores/contracts_test.go
+++ b/internal/stores/contracts_test.go
@@ -1,0 +1,19 @@
+package stores
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"lukechampine.com/frand"
+)
+
+// TestSQLContractStore tests SQLContractStore functionality.
+func TestSQLContractStore(t *testing.T) {
+	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
+
+	conn := NewEphemeralSQLiteConnection(dbName)
+	_, err := NewSQLContractStore(conn, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/stores/contracts_test.go
+++ b/internal/stores/contracts_test.go
@@ -144,16 +144,7 @@ func TestSQLContractStore(t *testing.T) {
 	if err := tableCountCheck(&dbFileContractRevision{}, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := tableCountCheck(&dbUnlockConditions{}, 0); err != nil {
-		t.Fatal(err)
-	}
-	if err := tableCountCheck(&dbSiaPublicKey{}, 0); err != nil {
-		t.Fatal(err)
-	}
 	if err := tableCountCheck(&dbValidSiacoinOutput{}, 0); err != nil {
-		t.Fatal(err)
-	}
-	if err := tableCountCheck(&dbTransactionSignature{}, 0); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/stores/contracts_test.go
+++ b/internal/stores/contracts_test.go
@@ -2,8 +2,14 @@ package stores
 
 import (
 	"encoding/hex"
+	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
+	"go.sia.tech/siad/crypto"
+	"go.sia.tech/siad/types"
 	"lukechampine.com/frand"
 )
 
@@ -12,8 +18,79 @@ func TestSQLContractStore(t *testing.T) {
 	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
 
 	conn := NewEphemeralSQLiteConnection(dbName)
-	_, err := NewSQLContractStore(conn, true)
+	cs, err := NewSQLContractStore(conn, true)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Create random unlock conditions.
+	uc, _ := types.GenerateDeterministicMultisig(1, 2, "salt")
+	uc.Timelock = 192837
+
+	// Create a contract and set all fields.
+	fcid := types.FileContractID{1, 1, 1, 1, 1}
+	c := rhpv2.Contract{
+		Revision: types.FileContractRevision{
+			ParentID:          fcid,
+			UnlockConditions:  uc,
+			NewRevisionNumber: 200,
+			NewFileSize:       4096,
+			NewFileMerkleRoot: crypto.Hash{222},
+			NewWindowStart:    400,
+			NewWindowEnd:      500,
+			NewValidProofOutputs: []types.SiacoinOutput{
+				{
+					Value:      types.NewCurrency64(121),
+					UnlockHash: types.UnlockHash{2, 1, 2},
+				},
+			},
+			NewMissedProofOutputs: []types.SiacoinOutput{
+				{
+					Value:      types.NewCurrency64(323),
+					UnlockHash: types.UnlockHash{2, 3, 2},
+				},
+			},
+			NewUnlockHash: types.UnlockHash{6, 6, 6},
+		},
+		Signatures: [2]types.TransactionSignature{
+			{
+				ParentID:       crypto.Hash(fcid),
+				PublicKeyIndex: 0,
+				Timelock:       100000,
+				CoveredFields:  types.FullCoveredFields,
+				Signature:      []byte("signature1"),
+			},
+			{
+				ParentID:       crypto.Hash(fcid),
+				PublicKeyIndex: 1,
+				Timelock:       200000,
+				CoveredFields:  types.FullCoveredFields,
+				Signature:      []byte("signature2"),
+			},
+		},
+	}
+
+	// Look it up. Should fail.
+	_, err = cs.Contract(c.ID())
+	if !errors.Is(err, ErrContractNotFound) {
+		t.Fatal(err)
+	}
+
+	// Insert it.
+	if err := cs.AddContract(c); err != nil {
+		t.Fatal(err)
+	}
+
+	// Look it up again.
+	fetched, err := cs.Contract(c.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fetched, c) {
+		fmt.Println(fetched.Revision)
+		fmt.Println(c.Revision)
+		t.Fatal("contract mismatch")
+	}
+
+	// TODO: delete it
 }

--- a/internal/stores/contracts_test.go
+++ b/internal/stores/contracts_test.go
@@ -15,12 +15,16 @@ import (
 	"lukechampine.com/frand"
 )
 
+// newTestSQLStore creates a new SQLContractStore for testing.
+func newTestSQLStore() (*SQLContractStore, error) {
+	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
+	conn := NewEphemeralSQLiteConnection(dbName)
+	return NewSQLContractStore(conn, true)
+}
+
 // TestSQLContractStore tests SQLContractStore functionality.
 func TestSQLContractStore(t *testing.T) {
-	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
-
-	conn := NewEphemeralSQLiteConnection(dbName)
-	cs, err := NewSQLContractStore(conn, true)
+	cs, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,10 +155,7 @@ func TestSQLContractStore(t *testing.T) {
 
 // TestSQLHostSetStore tests the bus.HostSetStore methods on the SQLContractStore.
 func TestSQLHostSetStore(t *testing.T) {
-	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
-
-	conn := NewEphemeralSQLiteConnection(dbName)
-	cs, err := NewSQLContractStore(conn, true)
+	cs, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -437,6 +437,12 @@ func (db *SQLHostDB) ProcessConsensusChange(cc modules.ConsensusChange) {
 }
 
 func insertAnnouncement(tx *gorm.DB, hostKey consensus.PublicKey, a hostdb.Announcement) error {
+	// Create a host if it doesn't exist yet.
+	if err := tx.FirstOrCreate(&dbHost{}, &dbHost{PublicKey: hostKey}).Error; err != nil {
+		return err
+	}
+
+	// Create the announcement.
 	return tx.Create(&dbAnnouncement{
 		Host:        hostKey,
 		BlockHeight: a.Index.Height,

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -3,6 +3,7 @@ package stores
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -339,7 +340,7 @@ func (db *SQLHostDB) Host(hostKey consensus.PublicKey) (hostdb.Host, error) {
 		Preload("Announcements").
 		Take(&h)
 	if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
-		return hostdb.Host{}, ErrHostNotFound
+		return hostdb.Host{}, fmt.Errorf("host: %v; %w", hostKey, ErrHostNotFound)
 	}
 	return h.Host(), tx.Error
 }

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -67,10 +67,10 @@ func TestSQLHostDB(t *testing.T) {
 	if tx.RowsAffected != 2 {
 		t.Fatalf("expected %v rows but got %v", 2, tx.RowsAffected)
 	}
-	if !reflect.DeepEqual(interactions[0].Interaction(), hi1) {
+	if !reflect.DeepEqual(interactions[0].convert(), hi1) {
 		t.Fatal("interaction mismatch", interactions[0], hi1)
 	}
-	if !reflect.DeepEqual(interactions[1].Interaction(), hi2) {
+	if !reflect.DeepEqual(interactions[1].convert(), hi2) {
 		t.Fatal("interaction mismatch", interactions[1], hi2)
 	}
 
@@ -97,7 +97,7 @@ func TestSQLHostDB(t *testing.T) {
 	if len(announcements) != 1 {
 		t.Fatalf("wrong number of announcements %v != %v", len(announcements), 1)
 	}
-	if !reflect.DeepEqual(announcements[0].Announcement(), a) {
+	if !reflect.DeepEqual(announcements[0].convert(), a) {
 		t.Fatal("announcement mismatch", announcements[0], a)
 	}
 

--- a/internal/stores/objects.go
+++ b/internal/stores/objects.go
@@ -378,8 +378,8 @@ func NewSQLObjectStore(conn gorm.Dialector, migrate bool) (*SQLObjectStore, erro
 	}, nil
 }
 
-// Object turns a dbObject into a object.Object.
-func (o dbObject) Object() (object.Object, error) {
+// convert turns a dbObject into a object.Object.
+func (o dbObject) convert() (object.Object, error) {
 	var objKey object.EncryptionKey
 	if err := objKey.UnmarshalText(o.Key); err != nil {
 		return object.Object{}, err
@@ -438,7 +438,7 @@ func (s *SQLObjectStore) Get(key string) (object.Object, error) {
 	if err != nil {
 		return object.Object{}, err
 	}
-	return obj.Object()
+	return obj.convert()
 }
 
 // Put implements the bus.ObjectStore interface.

--- a/internal/stores/objects.go
+++ b/internal/stores/objects.go
@@ -326,7 +326,7 @@ type (
 		SlabID uint64 `gorm:"index;NOT NULL"`
 
 		// Root uniquely identifies a sector and is therefore the primary key.
-		Root consenus.Hash256 `gorm:"index;NOT NULL;type:bytes;serializer:gob"`
+		Root consensus.Hash256 `gorm:"index;NOT NULL;type:bytes;serializer:gob"`
 
 		// Host is the key of the host that stores the sector.
 		// TODO: once we migrate the contract store over to a relational
@@ -403,8 +403,8 @@ func (o dbObject) convert() (object.Object, error) {
 			Length: sl.Length,
 		}
 		for j, sh := range sl.Slab.Shards {
-			copy(obj.Slabs[i].Shards[j].Host[:], sh.Sector.Host)
-			copy(obj.Slabs[i].Shards[j].Root[:], sh.Sector.Root)
+			obj.Slabs[i].Shards[j].Host = sh.Host
+			obj.Slabs[i].Shards[j].Root = sh.Root
 		}
 	}
 	return obj, nil
@@ -494,8 +494,8 @@ func (s *SQLObjectStore) Put(key string, o object.Object) error {
 				// Create sector. Might exist already.
 				var sector dbSector
 				err = tx.FirstOrCreate(&sector, &dbSector{
-					Host: shard.Host[:],
-					Root: shard.Root[:],
+					Host: shard.Host,
+					Root: shard.Root,
 				}).Error
 				if err != nil {
 					return err
@@ -503,8 +503,8 @@ func (s *SQLObjectStore) Put(key string, o object.Object) error {
 				// Create shard.
 				err = tx.Create(&dbSector{
 					SlabID: slab.ID,
-					Host:   shard.Host[:],
-					Root:   shard.Root[:],
+					Host:   shard.Host,
+					Root:   shard.Root,
 				}).Error
 				if err != nil {
 					return err

--- a/internal/stores/objects.go
+++ b/internal/stores/objects.go
@@ -491,15 +491,6 @@ func (s *SQLObjectStore) Put(key string, o object.Object) error {
 			}
 
 			for _, shard := range ss.Shards {
-				// Create sector. Might exist already.
-				var sector dbSector
-				err = tx.FirstOrCreate(&sector, &dbSector{
-					Host: shard.Host,
-					Root: shard.Root,
-				}).Error
-				if err != nil {
-					return err
-				}
 				// Create shard.
 				err = tx.Create(&dbSector{
 					SlabID: slab.ID,

--- a/internal/stores/objects.go
+++ b/internal/stores/objects.go
@@ -290,7 +290,7 @@ type (
 		ID string `gorm:"primaryKey"`
 
 		// Object related fields.
-		Key   string    // json string
+		Key   []byte
 		Slabs []dbSlice `gorm:"constraint:OnDelete:CASCADE;foreignKey:ObjectID;references:ID"` // CASCADE to delete slices too
 	}
 
@@ -313,7 +313,7 @@ type (
 	// NOTE: A Slab is uniquely identified by its key.
 	dbSlab struct {
 		ID        uint64 `gorm:"primaryKey"`
-		Key       string `gorm:"unique;NOT NULL"` // json string
+		Key       []byte `gorm:"unique;NOT NULL"` // json string
 		MinShards uint8
 		Shards    []dbSector `gorm:"constraint:OnDelete:CASCADE;foreignKey:SlabID;references:ID"` // CASCADE to delete shards too
 	}
@@ -326,14 +326,14 @@ type (
 		SlabID uint64 `gorm:"index;NOT NULL"`
 
 		// Root uniquely identifies a sector and is therefore the primary key.
-		Root []byte `gorm:"index;NOT NULL"`
+		Root consenus.Hash256 `gorm:"index;NOT NULL;type:bytes;serializer:gob"`
 
 		// Host is the key of the host that stores the sector.
 		// TODO: once we migrate the contract store over to a relational
 		// db as well, we might want to put the contract ID here and
 		// have a contract table with a mapping of contract ID to host.
 		// That makes for better migrations.
-		Host []byte `gorm:"index; NOT NULL"`
+		Host consensus.PublicKey `gorm:"index;NOT NULL;type:bytes;serializer:gob"`
 	}
 )
 
@@ -381,7 +381,7 @@ func NewSQLObjectStore(conn gorm.Dialector, migrate bool) (*SQLObjectStore, erro
 // Object turns a dbObject into a object.Object.
 func (o dbObject) Object() (object.Object, error) {
 	var objKey object.EncryptionKey
-	if err := objKey.UnmarshalText([]byte(o.Key)); err != nil {
+	if err := objKey.UnmarshalText(o.Key); err != nil {
 		return object.Object{}, err
 	}
 	obj := object.Object{
@@ -390,7 +390,7 @@ func (o dbObject) Object() (object.Object, error) {
 	}
 	for i, sl := range o.Slabs {
 		var slabKey slab.EncryptionKey
-		if err := slabKey.UnmarshalText([]byte(sl.Slab.Key)); err != nil {
+		if err := slabKey.UnmarshalText(sl.Slab.Key); err != nil {
 			return object.Object{}, err
 		}
 		obj.Slabs[i] = slab.Slice{
@@ -403,8 +403,8 @@ func (o dbObject) Object() (object.Object, error) {
 			Length: sl.Length,
 		}
 		for j, sh := range sl.Slab.Shards {
-			copy(obj.Slabs[i].Shards[j].Host[:], sh.Host)
-			copy(obj.Slabs[i].Shards[j].Root[:], sh.Root)
+			copy(obj.Slabs[i].Shards[j].Host[:], sh.Sector.Host)
+			copy(obj.Slabs[i].Shards[j].Root[:], sh.Sector.Root)
 		}
 	}
 	return obj, nil
@@ -459,7 +459,7 @@ func (s *SQLObjectStore) Put(key string, o object.Object) error {
 		}
 		err = tx.Create(&dbObject{
 			ID:  key,
-			Key: string(objKey),
+			Key: objKey,
 		}).Error
 		if err != nil {
 			return err
@@ -477,13 +477,13 @@ func (s *SQLObjectStore) Put(key string, o object.Object) error {
 			}
 
 			// Create Slab.
-			var slab dbSlab
-			ssKey, err := ss.Key.MarshalText()
+			slabKey, err := ss.Key.MarshalText()
 			if err != nil {
 				return err
 			}
+			var slab dbSlab
 			err = tx.FirstOrCreate(&slab, &dbSlab{
-				Key:       string(ssKey),
+				Key:       slabKey,
 				MinShards: ss.MinShards,
 			}).Error
 			if err != nil {
@@ -491,6 +491,15 @@ func (s *SQLObjectStore) Put(key string, o object.Object) error {
 			}
 
 			for _, shard := range ss.Shards {
+				// Create sector. Might exist already.
+				var sector dbSector
+				err = tx.FirstOrCreate(&sector, &dbSector{
+					Host: shard.Host[:],
+					Root: shard.Root[:],
+				}).Error
+				if err != nil {
+					return err
+				}
 				// Create shard.
 				err = tx.Create(&dbSector{
 					SlabID: slab.ID,

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -180,21 +180,21 @@ func TestSQLObjectStore(t *testing.T) {
 
 	expectedObj := dbObject{
 		ID:  objID,
-		Key: string(obj1Key),
+		Key: obj1Key,
 		Slabs: []dbSlice{
 			{
 				ID:       1,
 				ObjectID: objID,
 				Slab: dbSlab{
 					ID:        1,
-					Key:       string(obj1Slab0Key),
+					Key:       obj1Slab0Key,
 					MinShards: 1,
 					Shards: []dbSector{
 						{
 							ID:     1,
 							SlabID: 1,
-							Root:   obj1.Slabs[0].Shards[0].Root[:],
-							Host:   obj1.Slabs[0].Shards[0].Host[:],
+							Root:   obj1.Slabs[0].Shards[0].Root,
+							Host:   obj1.Slabs[0].Shards[0].Host,
 						},
 					},
 				},
@@ -206,14 +206,14 @@ func TestSQLObjectStore(t *testing.T) {
 				ObjectID: objID,
 				Slab: dbSlab{
 					ID:        2,
-					Key:       string(obj1Slab1Key),
+					Key:       obj1Slab1Key,
 					MinShards: 2,
 					Shards: []dbSector{
 						{
 							ID:     2,
 							SlabID: 2,
-							Root:   obj1.Slabs[1].Shards[0].Root[:],
-							Host:   obj1.Slabs[1].Shards[0].Host[:],
+							Root:   obj1.Slabs[1].Shards[0].Root,
+							Host:   obj1.Slabs[1].Shards[0].Host,
 						},
 					},
 				},


### PR DESCRIPTION
Same refactor as before. Migrating the contract store to a SQL based backend.

NOTE: Still a WIP so no need to review yet. The diff will clear up once https://github.com/SiaFoundation/renterd/pull/22 is merged