### PR TITLE
Add Contractor and Scanner

### DIFF
--- a/autopilot/api.go
+++ b/autopilot/api.go
@@ -32,12 +32,8 @@ type Config struct {
 }
 
 // State contains all autopilot state variables.
-//
-// TODO: get rid of consensus state
 type State struct {
-	BlockHeight   uint64
 	CurrentPeriod uint64
-	Synced        bool
 }
 
 func DefaultConfig() (c Config) {

--- a/autopilot/api.go
+++ b/autopilot/api.go
@@ -32,8 +32,8 @@ type Config struct {
 }
 
 // State contains all autopilot state variables.
-// TODO: could be defined on the autopilot directly
-// TODO: synced could be a channel
+//
+// TODO: get rid of consensus state
 type State struct {
 	BlockHeight   uint64
 	CurrentPeriod uint64

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1,0 +1,536 @@
+package autopilot
+
+import (
+	"errors"
+	"math"
+	"sync"
+	"time"
+
+	"go.sia.tech/renterd/bus"
+	"go.sia.tech/renterd/internal/consensus"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
+	"go.sia.tech/renterd/worker"
+	"go.sia.tech/siad/types"
+)
+
+const (
+	// estimatedFileContractTransactionSetSize is the estimated blockchain size
+	// of a transaction set between a renter and a host that contains a file
+	// contract.
+	//
+	// TODO: move this constant to a separate package along with all others
+	estimatedFileContractTransactionSetSize = 2048
+
+	// stopTimeout is the amount of time we wait on stop before erroring out
+	// indicating an unclean shutdown
+	stopTimeout = time.Minute
+)
+
+type contractor struct {
+	ap                   *Autopilot
+	contractLoopInterval time.Duration
+
+	wg       sync.WaitGroup
+	stopChan chan struct{}
+	wakeChan chan struct{}
+}
+
+func newContractor(ap *Autopilot, contractLoopInterval time.Duration) *contractor {
+	return &contractor{
+		ap:                   ap,
+		contractLoopInterval: contractLoopInterval,
+		stopChan:             make(chan struct{}),
+		wakeChan:             make(chan struct{}),
+	}
+}
+
+func (c *contractor) run() {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.contractLoop()
+	}()
+
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.triggerLoop()
+	}()
+}
+
+func (c *contractor) stop() error {
+	close(c.stopChan)
+
+	doneChan := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(doneChan)
+	}()
+	select {
+	case <-doneChan:
+	case <-time.After(stopTimeout):
+		return errors.New("unclean contractor shutdown")
+	}
+	return nil
+}
+
+func (c *contractor) triggerLoop() {
+	for {
+		select {
+		case <-c.stopChan:
+			return
+		case <-time.After(c.contractLoopInterval):
+			c.wake()
+		}
+	}
+}
+
+func (c *contractor) wake() {
+	select {
+	case c.wakeChan <- struct{}{}:
+	default:
+	}
+}
+
+func (c *contractor) contractLoop() {
+	for {
+		select {
+		case <-c.stopChan:
+			return
+		case <-c.wakeChan:
+		}
+
+		// re-use same state and config in every iteration
+		config := c.ap.store.Config()
+		state := c.ap.store.State()
+
+		// don't run the contract loop if we are not synced
+		if !state.Synced {
+			continue
+		}
+
+		// return early if no hosts are requested
+		if config.Contracts.Hosts == 0 {
+			return
+		}
+
+		// fetch our wallet address
+		address, err := c.ap.bus.WalletAddress()
+		if err != nil {
+			logErr(err)
+			continue
+		}
+
+		// run checks
+		err = c.runContractChecks()
+		if err != nil {
+			logErr(err)
+			continue
+		}
+
+		// figure out remaining funds
+		spent, err := c.periodSpending()
+		if err != nil {
+			logErr(err)
+			continue
+		}
+		var remaining types.Currency
+		if config.Contracts.Allowance.Cmp(spent) > 0 {
+			remaining = config.Contracts.Allowance.Sub(spent)
+		}
+
+		// run renewals
+		renewed, err := c.runContractRenewals(config, state, &remaining, address)
+		if err != nil {
+			logErr(err)
+			continue
+		}
+
+		// run formations
+		formed, err := c.runContractFormations(config, state, &remaining, address)
+		if err != nil {
+			logErr(err)
+			continue
+		}
+
+		// update contract set
+		err = c.ap.updateDefaultContracts(renewed, formed)
+		if err != nil {
+			logErr(err)
+			continue
+		}
+	}
+}
+
+func (c *contractor) runContractChecks() error {
+	// fetch all active contracts
+	active, err := c.ap.bus.ActiveContracts(math.MaxUint64)
+	if err != nil {
+		return err
+	}
+
+	// TODO: check for IP range violations
+
+	// run checks on the contracts individually
+	for _, contract := range active {
+		// grab contract metadata
+		metadata := contract.Metadata
+
+		// update metadata:
+		// TODO: is host in host DB
+		// TODO: is max revision
+		// TODO: is offline
+		// TODO: is gouging
+		// TODO: is low score
+		// TODO: is out of funds
+
+		// TODO: is up for renewal
+		// TODO: is GFU limited (allowance # hsots)
+
+		// update contract metadata
+		err = c.ap.bus.UpdateContractMetadata(contract.ID, metadata)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *contractor) runContractRenewals(cfg Config, s State, budget *types.Currency, renterAddress types.UnlockHash) ([]worker.Contract, error) {
+	// fetch all contracts that are up for renew
+	toRenew, err := c.ap.renewableContracts(s.BlockHeight + cfg.Contracts.RenewWindow)
+	if err != nil {
+		return nil, err
+	}
+
+	// perform the renewals
+	var renewed []worker.Contract
+	for _, renew := range toRenew {
+		// check our budget
+		renterFunds, err := c.renewFundingEstimate(cfg, s, renew.ID)
+		if budget.Cmp(renterFunds) < 0 {
+			break
+		}
+
+		// derive the renter key
+		renterKey := c.ap.deriveRenterKey(renew.HostKey)
+		if err != nil {
+			return nil, err
+		}
+
+		var hostCollateral types.Currency // TODO
+		contract, err := c.renewContract(cfg, s, renew, renterKey, renterAddress, renterFunds, hostCollateral)
+		if err != nil {
+			// TODO: handle error properly, if the wallet ran out of outputs
+			// here there's no point in renewing more contracts until a
+			// block is mined, maybe we could/should wait for pending transactions?
+			return nil, err
+		}
+
+		// update the budget
+		*budget = budget.Sub(renterFunds)
+
+		// persist the contract
+		err = c.ap.bus.AddContract(contract)
+		if err != nil {
+			return nil, err
+		}
+
+		// persist the metadata
+		err = c.ap.bus.UpdateContractMetadata(contract.ID(), bus.ContractMetadata{
+			RenewedFrom: renew.ID,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		// add to set
+		renewed = append(renewed, worker.Contract{
+			HostKey:   renew.HostKey,
+			HostIP:    renew.HostIP,
+			ID:        contract.ID(),
+			RenterKey: renterKey,
+		})
+	}
+
+	return renewed, nil
+}
+
+func (c *contractor) runContractFormations(cfg Config, s State, budget *types.Currency, renterAddress types.UnlockHash) ([]worker.Contract, error) {
+	// fetch all active contracts
+	active, err := c.ap.bus.ActiveContracts(math.MaxUint64)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch recommended txn fee
+	fee, err := c.ap.bus.RecommendedFee()
+	if err != nil {
+		return nil, err
+	}
+
+	// calculate min/max contract funds
+	allowance := cfg.Contracts.Allowance.Div64(cfg.Contracts.Hosts)
+	maxInitialContractFunds := allowance.Div64(10) // TODO: arbitrary divisor
+	minInitialContractFunds := allowance.Div64(20) // TODO: arbitrary divisor
+
+	// form missing contracts
+	var formed []worker.Contract
+	missing := int(cfg.Contracts.Hosts) - len(active) // TODO: add leeway so we don't form hosts if we dip slightly under `needed` (?)
+	canidates, _ := c.ap.hostsForContracts(missing)   // TODO: add leeway so we have more than enough canidates
+	for h := 0; missing > 0 && h < len(canidates); h++ {
+		// fetch host IP
+		candidate := canidates[h]
+		host, err := c.ap.bus.Host(candidate)
+		if err != nil {
+			logErr(err)
+			continue
+		}
+		hostIP := host.NetAddress()
+
+		// fetch host settings
+		scan, err := c.ap.worker.RHPScan(host.PublicKey, hostIP)
+		if err != nil {
+			logErr(err)
+			continue
+		}
+		hostSettings := scan.Settings
+
+		// check our budget
+		txnFee := fee.Mul64(estimatedFileContractTransactionSetSize)
+		renterFunds := c.initialContractFunding(hostSettings, txnFee, minInitialContractFunds, maxInitialContractFunds)
+		if budget.Cmp(renterFunds) < 0 {
+			break
+		}
+
+		// form contract
+		renterKey := c.ap.deriveRenterKey(candidate)
+		var hostCollateral types.Currency // TODO
+		contract, err := c.formContract(cfg, s, candidate, hostIP, hostSettings, renterKey, renterAddress, renterFunds, hostCollateral)
+		if err != nil {
+			// TODO: handle error properly, if the wallet ran out of outputs
+			// here there's no point in forming more contracts until a block
+			// is mined, maybe we could/should wait for pending transactions?
+			logErr(err)
+			continue
+		}
+
+		// update the budget
+		*budget = budget.Sub(renterFunds)
+
+		// persist contract in store
+		err = c.ap.bus.AddContract(contract)
+		if err != nil {
+			logErr(err)
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		// add contract to contract set
+		formed = append(formed, worker.Contract{
+			HostKey:   candidate,
+			HostIP:    hostIP,
+			ID:        contract.ID(),
+			RenterKey: renterKey,
+		})
+
+		missing--
+	}
+
+	return formed, nil
+}
+
+func (c *contractor) renewContract(cfg Config, s State, toRenew worker.Contract, renterKey consensus.PrivateKey, renterAddress types.UnlockHash, renterFunds, hostCollateral types.Currency) (rhpv2.Contract, error) {
+	// handle contract locking
+	revision, err := c.ap.bus.AcquireContractLock(toRenew.ID)
+	if err != nil {
+		return rhpv2.Contract{}, nil
+	}
+	defer c.ap.bus.ReleaseContractLock(toRenew.ID)
+
+	// fetch host settings
+	scan, err := c.ap.worker.RHPScan(toRenew.HostKey, toRenew.HostIP)
+	if err != nil {
+		return rhpv2.Contract{}, nil
+	}
+
+	// prepare the renewal
+	endHeight := s.CurrentPeriod + cfg.Contracts.Period + cfg.Contracts.RenewWindow
+	fc, cost, finalPayment, err := c.ap.worker.RHPPrepareRenew(revision, renterKey, toRenew.HostKey, renterFunds, renterAddress, hostCollateral, endHeight, scan.Settings)
+	if err != nil {
+		return rhpv2.Contract{}, nil
+	}
+
+	// fund the transaction
+	txn := types.Transaction{FileContracts: []types.FileContract{fc}}
+	toSign, parents, err := c.ap.bus.WalletFund(&txn, cost)
+	if err != nil {
+		_ = c.ap.bus.WalletDiscard(txn) // ignore error
+		return rhpv2.Contract{}, err
+	}
+
+	// sign the transaction
+	err = c.ap.bus.WalletSign(&txn, toSign, types.FullCoveredFields)
+	if err != nil {
+		_ = c.ap.bus.WalletDiscard(txn) // ignore error
+		return rhpv2.Contract{}, err
+	}
+
+	// renew the contract
+	txnSet := append(parents, txn)
+	renewed, _, err := c.ap.worker.RHPRenew(renterKey, toRenew.HostKey, toRenew.HostIP, toRenew.ID, txnSet, finalPayment)
+	if err != nil {
+		_ = c.ap.bus.WalletDiscard(txn) // ignore error
+		return rhpv2.Contract{}, err
+	}
+	return renewed, nil
+}
+
+func (c *contractor) formContract(cfg Config, s State, hostKey consensus.PublicKey, hostIP string, hostSettings rhpv2.HostSettings, renterKey consensus.PrivateKey, renterAddress types.UnlockHash, renterFunds, hostCollateral types.Currency) (rhpv2.Contract, error) {
+	// prepare contract formation
+	endHeight := s.CurrentPeriod + cfg.Contracts.Period + cfg.Contracts.RenewWindow
+	fc, cost, err := c.ap.worker.RHPPrepareForm(renterKey, hostKey, renterFunds, renterAddress, hostCollateral, endHeight, hostSettings)
+	if err != nil {
+		return rhpv2.Contract{}, err
+	}
+
+	// fund the transaction
+	txn := types.Transaction{FileContracts: []types.FileContract{fc}}
+	toSign, parents, err := c.ap.bus.WalletFund(&txn, cost)
+	if err != nil {
+		_ = c.ap.bus.WalletDiscard(txn) // ignore error
+		return rhpv2.Contract{}, err
+	}
+
+	// sign the transaction
+	err = c.ap.bus.WalletSign(&txn, toSign, types.FullCoveredFields)
+	if err != nil {
+		_ = c.ap.bus.WalletDiscard(txn) // ignore error
+		return rhpv2.Contract{}, err
+	}
+
+	// form the contract
+	contract, _, err := c.ap.worker.RHPForm(renterKey, hostKey, hostIP, append(parents, txn))
+	if err != nil {
+		_ = c.ap.bus.WalletDiscard(txn) // ignore error
+		return rhpv2.Contract{}, err
+	}
+
+	return contract, nil
+}
+
+// TODO
+func (c *contractor) periodSpending() (types.Currency, error) {
+	return types.ZeroCurrency, nil
+}
+
+func (c *contractor) initialContractFunding(settings rhpv2.HostSettings, txnFee, min, max types.Currency) types.Currency {
+	if !max.IsZero() && min.Cmp(max) > 0 {
+		panic("given min is larger than max") // developer error
+	}
+
+	funding := settings.ContractPrice.Add(txnFee).Mul64(10) // TODO arbitrary multiplier
+	if !min.IsZero() && funding.Cmp(min) < 0 {
+		return min
+	}
+	if !max.IsZero() && funding.Cmp(max) > 0 {
+		return max
+	}
+	return funding
+}
+
+func (c *contractor) renewFundingEstimate(cfg Config, s State, cID types.FileContractID) (types.Currency, error) {
+	// fetch contract
+	contract, err := c.ap.bus.ContractData(cID)
+	if err != nil {
+		return types.ZeroCurrency, err
+	}
+
+	// fetch host
+	host, err := c.ap.bus.Host(contract.HostKey())
+	if err != nil {
+		return types.ZeroCurrency, err
+	}
+
+	// fetch host settings
+	scan, err := c.ap.worker.RHPScan(contract.HostKey(), host.NetAddress())
+	if err != nil {
+		return types.ZeroCurrency, err
+	}
+
+	// estimate the cost of the current data stored
+	dataStored := contract.Revision.ToTransaction().FileContractRevisions[0].NewFileSize
+	storageCost := types.NewCurrency64(dataStored).Mul64(cfg.Contracts.Period).Mul(scan.Settings.StoragePrice)
+
+	// loop over the contract history to figure out the amount of money spent
+	var prevUploadSpending types.Currency
+	var prevDownloadSpending types.Currency
+	var prevFundAccountSpending types.Currency
+	hierarchy, err := c.ap.bus.ContractHistory(cID, s.CurrentPeriod)
+	if err != nil {
+		return types.ZeroCurrency, err
+	}
+	for _, contract := range hierarchy {
+		spending := contract.Metadata.Spending
+		prevUploadSpending = prevUploadSpending.Add(spending.Uploads)
+		prevDownloadSpending = prevUploadSpending.Add(spending.Downloads)
+		prevFundAccountSpending = prevUploadSpending.Add(spending.FundAccount)
+	}
+
+	// estimate the amount of data uploaded, sanity check with data stored
+	//
+	// TODO: estimate is not ideal because price can change, better would be to
+	// look at the amount of data stored in the contract from the previous cycle
+	prevUploadDataEstimate := prevUploadSpending
+	if !scan.Settings.UploadBandwidthPrice.IsZero() {
+		prevUploadDataEstimate = prevUploadDataEstimate.Div(scan.Settings.UploadBandwidthPrice)
+	}
+	if prevUploadDataEstimate.Cmp(types.NewCurrency64(dataStored)) > 0 {
+		prevUploadDataEstimate = types.NewCurrency64(dataStored)
+	}
+
+	// estimate the
+	// - upload cost: previous uploads + prev storage
+	// - download cost: assumed to be the same
+	// - fund acount cost: assumed to be the same
+	newUploadsCost := prevUploadSpending.Add(prevUploadDataEstimate.Mul64(cfg.Contracts.Period).Mul(scan.Settings.StoragePrice))
+	newDownloadsCost := prevDownloadSpending
+	newFundAccountCost := prevFundAccountSpending
+
+	// estimate the siafund fees
+	//
+	// NOTE: the transaction fees are not included in the siafunds estimate
+	// because users are not charged siafund fees on money that doesn't go into
+	// the file contract (and the transaction fee goes to the miners, not the
+	// file contract).
+	subTtotal := storageCost.Add(newUploadsCost).Add(newDownloadsCost).Add(newFundAccountCost).Add(scan.Settings.ContractPrice)
+	siaFundFeeEstimate := types.Tax(types.BlockHeight(s.BlockHeight), subTtotal)
+
+	// estimate the txn fee
+	txnFee, err := c.ap.bus.RecommendedFee()
+	if err != nil {
+		return types.ZeroCurrency, err
+	}
+	txnFeeEstimate := txnFee.Mul64(estimatedFileContractTransactionSetSize)
+
+	// add them all up and then return the estimate plus 33% for error margin
+	// and just general volatility of usage pattern.
+	estimatedCost := subTtotal.Add(siaFundFeeEstimate).Add(txnFeeEstimate)
+	estimatedCost = estimatedCost.Add(estimatedCost.Div64(3)) // TODO: arbitrary divisor
+
+	// check for a sane minimum that is equal to the initial contract funding
+	// but without an upper cap.
+	initialContractFunds := cfg.Contracts.Allowance.Div64(cfg.Contracts.Hosts)
+	minInitialContractFunds := initialContractFunds.Div64(20) // TODO: arbitrary divisor
+	minimum := c.initialContractFunding(scan.Settings, txnFeeEstimate, minInitialContractFunds, types.ZeroCurrency)
+	if estimatedCost.Cmp(minimum) < 0 {
+		estimatedCost = minimum
+	}
+	return estimatedCost, nil
+}
+
+func logErr(err error) {} // TODO

--- a/autopilot/contracts.go
+++ b/autopilot/contracts.go
@@ -1,108 +1,50 @@
 package autopilot
 
 import (
-	"math"
-	"time"
-
 	"go.sia.tech/renterd/bus"
 	"go.sia.tech/renterd/internal/consensus"
-	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/renterd/worker"
 	"go.sia.tech/siad/types"
-	"golang.org/x/crypto/blake2b"
 )
 
 const (
-	// contractSetName defines the name of the default contract set
-	contractSetName = "autopilot"
-
-	// contractLoopInterval defines the interval with which we run the contract loop
-	contractLoopInterval = 15 * time.Minute
-
-	// estimatedFileContractTransactionSetSize is the estimated blockchain size
-	// of a transaction set between a renter and a host that contains a file
-	// contract.
-	estimatedFileContractTransactionSetSize = 2048
+	// defaultSetName defines the name of the default contract set
+	defaultSetName = "autopilot"
 )
 
-func logErr(err error) {} // TODO
-
-func (ap *Autopilot) contractLoop() {
-	ticker := time.NewTicker(contractLoopInterval)
-
-	for {
-		// TODO: add wakeChan
-		// TODO: use triggerChan
-		select {
-		case <-ap.stopChan:
-			return
-		case <-ticker.C:
-		}
-
-		// re-use same state and config in every iteration
-		config := ap.store.Config()
-		state := ap.store.State()
-
-		// don't run the contract loop if we are not synced
-		// TODO: use a channel
-		if !state.Synced {
+func (ap *Autopilot) toWorkerContracts(contracts []bus.Contract) []worker.Contract {
+	out := make([]worker.Contract, 0, len(contracts))
+	for _, c := range contracts {
+		if c.ID == (types.FileContractID{}) || c.HostIP == "" {
 			continue
 		}
-
-		// return early if no hosts are requested
-		if config.Contracts.Hosts == 0 {
-			return
-		}
-
-		// fetch our wallet address
-		address, err := ap.bus.WalletAddress()
-		if err != nil {
-			logErr(err)
-			continue
-		}
-
-		// run checks
-		err = ap.runContractChecks()
-		if err != nil {
-			logErr(err)
-			continue
-		}
-
-		// figure out remaining funds
-		spent, err := ap.periodSpending()
-		if err != nil {
-			logErr(err)
-			continue
-		}
-		var remaining types.Currency
-		if config.Contracts.Allowance.Cmp(spent) > 0 {
-			remaining = config.Contracts.Allowance.Sub(spent)
-		}
-
-		// run renewals
-		renewed, err := ap.runContractRenewals(config, state, &remaining, address)
-		if err != nil {
-			logErr(err)
-			continue
-		}
-
-		// run formations
-		formed, err := ap.runContractFormations(config, state, &remaining, address)
-		if err != nil {
-			logErr(err)
-			continue
-		}
-
-		// update contract set
-		err = ap.updateDefaultContractSet(renewed, formed)
-		if err != nil {
-			logErr(err)
-			continue
-		}
+		out = append(out, worker.Contract{
+			HostKey:   c.HostKey,
+			HostIP:    c.HostIP,
+			ID:        c.ID,
+			RenterKey: ap.deriveRenterKey(c.HostKey),
+		})
 	}
+	return out
 }
 
-func (ap *Autopilot) updateDefaultContractSet(renewed, formed []worker.Contract) error {
+func (ap *Autopilot) defaultContracts() ([]worker.Contract, error) {
+	cs, err := ap.bus.HostSetContracts(defaultSetName)
+	if err != nil {
+		return nil, err
+	}
+	return ap.toWorkerContracts(cs), nil
+}
+
+func (ap *Autopilot) renewableContracts(endHeight uint64) ([]worker.Contract, error) {
+	cs, err := ap.bus.ActiveContracts(endHeight)
+	if err != nil {
+		return nil, err
+	}
+	return ap.toWorkerContracts(cs), nil
+}
+
+func (ap *Autopilot) updateDefaultContracts(renewed, formed []worker.Contract) error {
 	// fetch current set
 	cs, err := ap.defaultContracts()
 	if err != nil {
@@ -142,436 +84,9 @@ func (ap *Autopilot) updateDefaultContractSet(renewed, formed []worker.Contract)
 	for i, c := range cs {
 		contracts[i] = c.HostKey
 	}
-	err = ap.bus.SetHostSet(contractSetName, contracts)
+	err = ap.bus.SetHostSet(defaultSetName, contracts)
 	if err != nil {
 		return err
 	}
 	return nil
-}
-
-func (ap *Autopilot) runContractChecks() error {
-	// fetch all active contracts
-	active, err := ap.bus.ActiveContracts(math.MaxUint64)
-	if err != nil {
-		return err
-	}
-
-	// TODO: check for IP range violations
-
-	// run checks on the contracts individually
-	for _, contract := range active {
-		// grab contract metadata
-		metadata := contract.Metadata
-
-		// update metadata:
-		// TODO: is host in host DB
-		// TODO: is max revision
-		// TODO: is offline
-		// TODO: is gouging
-		// TODO: is low score
-		// TODO: is out of funds
-
-		// TODO: is up for renewal
-		// TODO: is GFU limited (allowance # hsots)
-
-		// update contract metadata
-		err = ap.bus.UpdateContractMetadata(contract.ID, metadata)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (ap *Autopilot) runContractRenewals(cfg Config, s State, budget *types.Currency, renterAddress types.UnlockHash) ([]worker.Contract, error) {
-	// fetch all contracts that are up for renew
-	toRenew, err := ap.renewableContracts(s.BlockHeight + cfg.Contracts.RenewWindow)
-	if err != nil {
-		return nil, err
-	}
-
-	// perform the renewals
-	var renewed []worker.Contract
-	for _, renew := range toRenew {
-		// check our budget
-		renterFunds, err := ap.renewFundingEstimate(cfg, s, renew.ID)
-		if budget.Cmp(renterFunds) < 0 {
-			break
-		}
-
-		// derive the renter key
-		renterKey := ap.deriveRenterKey(renew.HostKey)
-		if err != nil {
-			return nil, err
-		}
-
-		var hostCollateral types.Currency // TODO
-		contract, err := ap.renewContract(cfg, s, renew, renterKey, renterAddress, renterFunds, hostCollateral)
-		if err != nil {
-			// TODO: handle error properly, if the wallet ran out of outputs
-			// here there's no point in renewing more contracts until a
-			// block is mined, maybe we could/should wait for pending transactions?
-			return nil, err
-		}
-
-		// update the budget
-		*budget = budget.Sub(renterFunds)
-
-		// persist the contract
-		err = ap.bus.AddContract(contract)
-		if err != nil {
-			return nil, err
-		}
-
-		// persist the metadata
-		err = ap.bus.UpdateContractMetadata(contract.ID(), bus.ContractMetadata{
-			RenewedFrom: renew.ID,
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		// add to set
-		renewed = append(renewed, worker.Contract{
-			HostKey:   renew.HostKey,
-			HostIP:    renew.HostIP,
-			ID:        contract.ID(),
-			RenterKey: renterKey,
-		})
-	}
-
-	return renewed, nil
-}
-
-func (ap *Autopilot) runContractFormations(cfg Config, s State, budget *types.Currency, renterAddress types.UnlockHash) ([]worker.Contract, error) {
-	// fetch all active contracts
-	active, err := ap.bus.ActiveContracts(math.MaxUint64)
-	if err != nil {
-		return nil, err
-	}
-
-	// fetch recommended txn fee
-	fee, err := ap.bus.RecommendedFee()
-	if err != nil {
-		return nil, err
-	}
-
-	// calculate min/max contract funds
-	allowance := cfg.Contracts.Allowance.Div64(cfg.Contracts.Hosts)
-	maxInitialContractFunds := allowance.Div64(10) // TODO: arbitrary divisor
-	minInitialContractFunds := allowance.Div64(20) // TODO: arbitrary divisor
-
-	// form missing contracts
-	var formed []worker.Contract
-	missing := int(cfg.Contracts.Hosts) - len(active) // TODO: add leeway so we don't form hosts if we dip slightly under `needed` (?)
-	canidates, _ := ap.hostsForContracts(missing)     // TODO: add leeway so we have more than enough canidates
-	for h := 0; missing > 0 && h < len(canidates); h++ {
-		// fetch host IP
-		candidate := canidates[h]
-		host, err := ap.bus.Host(candidate)
-		if err != nil {
-			logErr(err)
-			continue
-		}
-		hostIP := host.NetAddress()
-
-		// fetch host settings
-		scan, err := ap.worker.RHPScan(host.PublicKey, hostIP)
-		if err != nil {
-			logErr(err)
-			continue
-		}
-		hostSettings := scan.Settings
-
-		// check our budget
-		txnFee := fee.Mul64(estimatedFileContractTransactionSetSize)
-		renterFunds := ap.initialContractFunding(hostSettings, txnFee, minInitialContractFunds, maxInitialContractFunds)
-		if budget.Cmp(renterFunds) < 0 {
-			break
-		}
-
-		// form contract
-		renterKey := ap.deriveRenterKey(candidate)
-		var hostCollateral types.Currency // TODO
-		contract, err := ap.formContract(cfg, s, candidate, hostIP, hostSettings, renterKey, renterAddress, renterFunds, hostCollateral)
-		if err != nil {
-			// TODO: handle error properly, if the wallet ran out of outputs
-			// here there's no point in forming more contracts until a block
-			// is mined, maybe we could/should wait for pending transactions?
-			logErr(err)
-			continue
-		}
-
-		// update the budget
-		*budget = budget.Sub(renterFunds)
-
-		// persist contract in store
-		err = ap.bus.AddContract(contract)
-		if err != nil {
-			logErr(err)
-			continue
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-		// add contract to contract set
-		formed = append(formed, worker.Contract{
-			HostKey:   candidate,
-			HostIP:    hostIP,
-			ID:        contract.ID(),
-			RenterKey: renterKey,
-		})
-
-		missing--
-	}
-
-	return formed, nil
-}
-
-func (ap *Autopilot) renewContract(cfg Config, s State, toRenew worker.Contract, renterKey consensus.PrivateKey, renterAddress types.UnlockHash, renterFunds, hostCollateral types.Currency) (rhpv2.Contract, error) {
-	// handle contract locking
-	revision, err := ap.bus.AcquireContractLock(toRenew.ID)
-	if err != nil {
-		return rhpv2.Contract{}, nil
-	}
-	defer ap.bus.ReleaseContractLock(toRenew.ID)
-
-	// fetch host settings
-	scan, err := ap.worker.RHPScan(toRenew.HostKey, toRenew.HostIP)
-	if err != nil {
-		return rhpv2.Contract{}, nil
-	}
-
-	// prepare the renewal
-	endHeight := s.CurrentPeriod + cfg.Contracts.Period + cfg.Contracts.RenewWindow
-	fc, cost, finalPayment, err := ap.worker.RHPPrepareRenew(revision, renterKey, toRenew.HostKey, renterFunds, renterAddress, hostCollateral, endHeight, scan.Settings)
-	if err != nil {
-		return rhpv2.Contract{}, nil
-	}
-
-	// fund the transaction
-	txn := types.Transaction{FileContracts: []types.FileContract{fc}}
-	toSign, parents, err := ap.bus.WalletFund(&txn, cost)
-	if err != nil {
-		_ = ap.bus.WalletDiscard(txn) // ignore error
-		return rhpv2.Contract{}, err
-	}
-
-	// sign the transaction
-	err = ap.bus.WalletSign(&txn, toSign, types.FullCoveredFields)
-	if err != nil {
-		_ = ap.bus.WalletDiscard(txn) // ignore error
-		return rhpv2.Contract{}, err
-	}
-
-	// renew the contract
-	txnSet := append(parents, txn)
-	renewed, _, err := ap.worker.RHPRenew(renterKey, toRenew.HostKey, toRenew.HostIP, toRenew.ID, txnSet, finalPayment)
-	if err != nil {
-		_ = ap.bus.WalletDiscard(txn) // ignore error
-		return rhpv2.Contract{}, err
-	}
-	return renewed, nil
-}
-
-func (ap *Autopilot) formContract(cfg Config, s State, hostKey consensus.PublicKey, hostIP string, hostSettings rhpv2.HostSettings, renterKey consensus.PrivateKey, renterAddress types.UnlockHash, renterFunds, hostCollateral types.Currency) (rhpv2.Contract, error) {
-	// prepare contract formation
-	endHeight := s.CurrentPeriod + cfg.Contracts.Period + cfg.Contracts.RenewWindow
-	fc, cost, err := ap.worker.RHPPrepareForm(renterKey, hostKey, renterFunds, renterAddress, hostCollateral, endHeight, hostSettings)
-	if err != nil {
-		return rhpv2.Contract{}, err
-	}
-
-	// fund the transaction
-	txn := types.Transaction{FileContracts: []types.FileContract{fc}}
-	toSign, parents, err := ap.bus.WalletFund(&txn, cost)
-	if err != nil {
-		_ = ap.bus.WalletDiscard(txn) // ignore error
-		return rhpv2.Contract{}, err
-	}
-
-	// sign the transaction
-	err = ap.bus.WalletSign(&txn, toSign, types.FullCoveredFields)
-	if err != nil {
-		_ = ap.bus.WalletDiscard(txn) // ignore error
-		return rhpv2.Contract{}, err
-	}
-
-	// form the contract
-	contract, _, err := ap.worker.RHPForm(renterKey, hostKey, hostIP, append(parents, txn))
-	if err != nil {
-		_ = ap.bus.WalletDiscard(txn) // ignore error
-		return rhpv2.Contract{}, err
-	}
-
-	return contract, nil
-}
-
-func (ap *Autopilot) defaultContracts() ([]worker.Contract, error) {
-	cs, err := ap.bus.HostSetContracts(contractSetName)
-	if err != nil {
-		return nil, err
-	}
-	contracts := make([]worker.Contract, 0, len(cs))
-	for _, c := range cs {
-		if c.ID == (types.FileContractID{}) || c.HostIP == "" {
-			continue
-		}
-		contracts = append(contracts, worker.Contract{
-			HostKey:   c.HostKey,
-			HostIP:    c.HostIP,
-			ID:        c.ID,
-			RenterKey: ap.deriveRenterKey(c.HostKey),
-		})
-	}
-	return contracts, nil
-}
-
-func (ap *Autopilot) renewableContracts(endHeight uint64) ([]worker.Contract, error) {
-	cs, err := ap.bus.ActiveContracts(endHeight)
-	if err != nil {
-		return nil, err
-	}
-	contracts := make([]worker.Contract, 0, len(cs))
-	for _, c := range cs {
-		if c.ID == (types.FileContractID{}) || c.HostIP == "" {
-			continue
-		}
-		contracts = append(contracts, worker.Contract{
-			HostKey:   c.HostKey,
-			HostIP:    c.HostIP,
-			ID:        c.ID,
-			RenterKey: ap.deriveRenterKey(c.HostKey),
-		})
-	}
-	return contracts, nil
-}
-
-func (ap *Autopilot) initialContractFunding(settings rhpv2.HostSettings, txnFee, min, max types.Currency) types.Currency {
-	if !max.IsZero() && min.Cmp(max) > 0 {
-		panic("given min is larger than max") // developer error
-	}
-
-	funding := settings.ContractPrice.Add(txnFee).Mul64(10) // TODO arbitrary multiplier
-	if !min.IsZero() && funding.Cmp(min) < 0 {
-		return min
-	}
-	if !max.IsZero() && funding.Cmp(max) > 0 {
-		return max
-	}
-	return funding
-}
-
-func (ap *Autopilot) renewFundingEstimate(cfg Config, s State, cID types.FileContractID) (types.Currency, error) {
-	// fetch contract
-	c, err := ap.bus.ContractData(cID)
-	if err != nil {
-		return types.ZeroCurrency, err
-	}
-
-	// fetch host
-	host, err := ap.bus.Host(c.HostKey())
-	if err != nil {
-		return types.ZeroCurrency, err
-	}
-
-	// fetch host settings
-	scan, err := ap.worker.RHPScan(c.HostKey(), host.NetAddress())
-	if err != nil {
-		return types.ZeroCurrency, err
-	}
-
-	// estimate the cost of the current data stored
-	dataStored := c.Revision.ToTransaction().FileContractRevisions[0].NewFileSize
-	storageCost := types.NewCurrency64(dataStored).Mul64(cfg.Contracts.Period).Mul(scan.Settings.StoragePrice)
-
-	// loop over the contract history to figure out the amount of money spent
-	var prevUploadSpending types.Currency
-	var prevDownloadSpending types.Currency
-	var prevFundAccountSpending types.Currency
-	hierarchy, err := ap.bus.ContractHistory(cID, s.CurrentPeriod)
-	if err != nil {
-		return types.ZeroCurrency, err
-	}
-	for _, contract := range hierarchy {
-		spending := contract.Metadata.Spending
-		prevUploadSpending = prevUploadSpending.Add(spending.Uploads)
-		prevDownloadSpending = prevUploadSpending.Add(spending.Downloads)
-		prevFundAccountSpending = prevUploadSpending.Add(spending.FundAccount)
-	}
-
-	// estimate the amount of data uploaded, sanity check with data stored
-	//
-	// TODO: estimate is not ideal because price can change, better would be to
-	// look at the amount of data stored in the contract from the previous cycle
-	prevUploadDataEstimate := prevUploadSpending
-	if !scan.Settings.UploadBandwidthPrice.IsZero() {
-		prevUploadDataEstimate = prevUploadDataEstimate.Div(scan.Settings.UploadBandwidthPrice)
-	}
-	if prevUploadDataEstimate.Cmp(types.NewCurrency64(dataStored)) > 0 {
-		prevUploadDataEstimate = types.NewCurrency64(dataStored)
-	}
-
-	// estimate the
-	// - upload cost: previous uploads + prev storage
-	// - download cost: assumed to be the same
-	// - fund acount cost: assumed to be the same
-	newUploadsCost := prevUploadSpending.Add(prevUploadDataEstimate.Mul64(cfg.Contracts.Period).Mul(scan.Settings.StoragePrice))
-	newDownloadsCost := prevDownloadSpending
-	newFundAccountCost := prevFundAccountSpending
-
-	// estimate the siafund fees
-	//
-	// NOTE: the transaction fees are not included in the siafunds estimate
-	// because users are not charged siafund fees on money that doesn't go into
-	// the file contract (and the transaction fee goes to the miners, not the
-	// file contract).
-	subTtotal := storageCost.Add(newUploadsCost).Add(newDownloadsCost).Add(newFundAccountCost).Add(scan.Settings.ContractPrice)
-	siaFundFeeEstimate := types.Tax(types.BlockHeight(s.BlockHeight), subTtotal)
-
-	// estimate the txn fee
-	txnFee, err := ap.bus.RecommendedFee()
-	if err != nil {
-		return types.ZeroCurrency, err
-	}
-	txnFeeEstimate := txnFee.Mul64(estimatedFileContractTransactionSetSize)
-
-	// add them all up and then return the estimate plus 33% for error margin
-	// and just general volatility of usage pattern.
-	estimatedCost := subTtotal.Add(siaFundFeeEstimate).Add(txnFeeEstimate)
-	estimatedCost = estimatedCost.Add(estimatedCost.Div64(3)) // TODO: arbitrary divisor
-
-	// check for a sane minimum that is equal to the initial contract funding
-	// but without an upper cap.
-	initialContractFunds := cfg.Contracts.Allowance.Div64(cfg.Contracts.Hosts)
-	minInitialContractFunds := initialContractFunds.Div64(20) // TODO: arbitrary divisor
-	minimum := ap.initialContractFunding(scan.Settings, txnFeeEstimate, minInitialContractFunds, types.ZeroCurrency)
-	if estimatedCost.Cmp(minimum) < 0 {
-		estimatedCost = minimum
-	}
-	return estimatedCost, nil
-}
-
-// TODO: deriving the renter key from the host key using the master key only
-// works if we persist a hash of the renter's master key in the database and
-// compare it on startup, otherwise there's no way of knowing the derived key is
-// usuable
-//
-// TODO: instead of deriving a renter key use a randomly generated salt so we're
-// not limited to one key per host
-func (ap *Autopilot) deriveRenterKey(hostKey consensus.PublicKey) consensus.PrivateKey {
-	seed := blake2b.Sum256(append(ap.masterKey[:], hostKey[:]...))
-	pk := consensus.NewPrivateKeyFromSeed(seed[:])
-	for i := range seed {
-		seed[i] = 0
-	}
-	return pk
-}
-
-// TODO
-func (ap *Autopilot) periodSpending() (types.Currency, error) {
-	return types.ZeroCurrency, nil
 }

--- a/autopilot/hosts.go
+++ b/autopilot/hosts.go
@@ -13,8 +13,25 @@ import (
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/siad/build"
 	"go.sia.tech/siad/types"
+	"golang.org/x/crypto/blake2b"
 	"lukechampine.com/frand"
 )
+
+// TODO: deriving the renter key from the host key using the master key only
+// works if we persist a hash of the renter's master key in the database and
+// compare it on startup, otherwise there's no way of knowing the derived key is
+// usuable
+//
+// TODO: instead of deriving a renter key use a randomly generated salt so we're
+// not limited to one key per host
+func (ap *Autopilot) deriveRenterKey(hostKey consensus.PublicKey) consensus.PrivateKey {
+	seed := blake2b.Sum256(append(ap.masterKey[:], hostKey[:]...))
+	pk := consensus.NewPrivateKeyFromSeed(seed[:])
+	for i := range seed {
+		seed[i] = 0
+	}
+	return pk
+}
 
 func (ap *Autopilot) hostsForContracts(n int) ([]consensus.PublicKey, error) {
 	// select randomly using score as weights, excluding existing contracts

--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -1,0 +1,128 @@
+package autopilot
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+
+	"go.sia.tech/renterd/hostdb"
+	"go.sia.tech/renterd/internal/consensus"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
+)
+
+type scanner struct {
+	ap               *Autopilot
+	scanLoopInterval time.Duration
+
+	wg       sync.WaitGroup
+	stopChan chan struct{}
+	wakeChan chan struct{}
+}
+
+func newScanner(ap *Autopilot, scanLoopInterval time.Duration) *scanner {
+	return &scanner{
+		ap:               ap,
+		scanLoopInterval: scanLoopInterval,
+		stopChan:         make(chan struct{}),
+		wakeChan:         make(chan struct{}),
+	}
+}
+
+func (s *scanner) run() {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.scanLoop()
+	}()
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.triggerLoop()
+	}()
+}
+
+func (s *scanner) stop() error {
+	close(s.stopChan)
+
+	doneChan := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(doneChan)
+	}()
+	select {
+	case <-doneChan:
+	case <-time.After(stopTimeout):
+		return errors.New("unclean scanner shutdown")
+	}
+	return nil
+}
+
+func (s *scanner) triggerLoop() {
+	for {
+		select {
+		case <-s.stopChan:
+			return
+		case <-time.After(s.scanLoopInterval):
+			s.wake()
+		}
+	}
+}
+
+func (s *scanner) wake() {
+	select {
+	case s.wakeChan <- struct{}{}:
+	default:
+	}
+}
+
+func (s *scanner) scanLoop() {
+	// TODO: initial scan with much shorter
+	for {
+		select {
+		case <-s.stopChan:
+			return
+		case <-s.wakeChan:
+		}
+
+		// scan up to 10 hosts that we haven't interacted with in at least 1 week
+		hosts, err := s.ap.bus.Hosts(time.Now().Add(-7*24*time.Hour), 10)
+		if err != nil {
+			return
+		}
+		type res struct {
+			hostKey  consensus.PublicKey
+			settings rhpv2.HostSettings
+			err      error
+		}
+		resChan := make(chan res)
+		for _, h := range hosts {
+			go func(h hostdb.Host) {
+				scan, err := s.ap.worker.RHPScan(h.PublicKey, h.NetAddress())
+				resChan <- res{h.PublicKey, scan.Settings, err}
+			}(h)
+		}
+		for range hosts {
+			r := <-resChan
+			if r.err != nil {
+				err := s.ap.bus.RecordHostInteraction(r.hostKey, hostdb.Interaction{
+					Timestamp: time.Now(),
+					Type:      "scan",
+					Success:   false,
+					Result:    json.RawMessage(`{"error": "` + r.err.Error() + `"}`),
+				})
+				_ = err // TODO
+			} else {
+				js, _ := json.Marshal(r.settings)
+				err := s.ap.bus.RecordHostInteraction(r.hostKey, hostdb.Interaction{
+					Timestamp: time.Now(),
+					Type:      "scan",
+					Success:   true,
+					Result:    json.RawMessage(js),
+				})
+				_ = err // TODO
+			}
+		}
+	}
+}

--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -32,12 +32,15 @@ func (s *scanner) tryPerformHostScan() {
 	s.running = true
 	s.mu.Unlock()
 
-	defer func() {
+	go func() {
+		s.performHostScan()
 		s.mu.Lock()
-		defer s.mu.Unlock()
 		s.running = false
+		s.mu.Unlock()
 	}()
+}
 
+func (s *scanner) performHostScan() {
 	// TODO: initial scan with much shorter
 	// scan up to 10 hosts that we haven't interacted with in at least 1 week
 	hosts, err := s.ap.bus.Hosts(time.Now().Add(-7*24*time.Hour), 10)

--- a/autopilot/server.go
+++ b/autopilot/server.go
@@ -1,0 +1,37 @@
+package autopilot
+
+import (
+	"net/http"
+	"time"
+
+	"go.sia.tech/jape"
+)
+
+// NewServer returns an HTTP handler that serves the renterd autopilot API.
+func NewServer(ap *Autopilot) http.Handler {
+	return jape.Mux(map[string]jape.Handler{
+		"GET    /actions": ap.actionsHandler,
+		"GET    /config":  ap.configHandlerGET,
+		"PUT    /config":  ap.configHandlerPUT,
+	})
+}
+
+func (ap *Autopilot) actionsHandler(jc jape.Context) {
+	var since time.Time
+	max := -1
+	if jc.DecodeForm("since", (*paramTime)(&since)) != nil || jc.DecodeForm("max", &max) != nil {
+		return
+	}
+	jc.Encode(ap.Actions(since, max))
+}
+
+func (ap *Autopilot) configHandlerGET(jc jape.Context) {
+	jc.Encode(ap.Config())
+}
+
+func (ap *Autopilot) configHandlerPUT(jc jape.Context) {
+	var c Config
+	if jc.Decode(&c) == nil {
+		ap.SetConfig(c)
+	}
+}

--- a/bus/api.go
+++ b/bus/api.go
@@ -21,6 +21,12 @@ type (
 	PrivateKey = consensus.PrivateKey
 )
 
+// ConsensusState holds the current blockheight and whether we are synced or not.
+type ConsensusState struct {
+	BlockHeight uint64
+	Synced      bool
+}
+
 // for encoding/decoding time.Time values in API params
 type paramTime time.Time
 

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -19,6 +19,7 @@ type (
 	// A ChainManager manages blockchain state.
 	ChainManager interface {
 		TipState() consensus.State
+		Synced() bool
 	}
 
 	// A Syncer can connect to other peers and synchronize the blockchain.
@@ -101,8 +102,11 @@ func (b *Bus) syncerConnectHandler(jc jape.Context) {
 	}
 }
 
-func (b *Bus) consensusTipHandler(jc jape.Context) {
-	jc.Encode(b.cm.TipState().Index)
+func (b *Bus) consensusStateHandler(jc jape.Context) {
+	jc.Encode(ConsensusState{
+		BlockHeight: b.cm.TipState().Index.Height,
+		Synced:      b.cm.Synced(),
+	})
 }
 
 func (b *Bus) txpoolTransactionsHandler(jc jape.Context) {
@@ -438,7 +442,7 @@ func NewServer(b *Bus) http.Handler {
 		"GET    /syncer/peers":   b.syncerPeersHandler,
 		"POST   /syncer/connect": b.syncerConnectHandler,
 
-		"GET    /consensus/tip": b.consensusTipHandler,
+		"GET    /consensus/state": b.consensusStateHandler,
 
 		"GET    /txpool/transactions": b.txpoolTransactionsHandler,
 		"POST   /txpool/broadcast":    b.txpoolBroadcastHandler,

--- a/bus/client.go
+++ b/bus/client.go
@@ -30,9 +30,10 @@ func (c *Client) SyncerConnect(addr string) (err error) {
 	return
 }
 
-// ConsensusTip returns the current tip index.
-func (c *Client) ConsensusTip() (resp ChainIndex, err error) {
-	err = c.c.GET("/consensus/tip", &resp)
+// ConsensusState returns the current block height and whether the node is
+// synced.
+func (c *Client) ConsensusState() (resp ConsensusState, err error) {
+	err = c.c.GET("/consensus/state", &resp)
 	return
 }
 

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"time"
 
 	"go.sia.tech/jape"
 	"go.sia.tech/renterd/autopilot"
@@ -79,6 +80,7 @@ func main() {
 	flag.BoolVar(&busCfg.bootstrap, "bus.bootstrap", true, "bootstrap the gateway and consensus modules")
 	flag.StringVar(&busCfg.gatewayAddr, "bus.gatewayAddr", ":9981", "address to listen on for Sia peer connections")
 	flag.BoolVar(&autopilotCfg.enabled, "autopilot.enabled", true, "enable the autopilot API")
+	flag.DurationVar(&autopilotCfg.loopInterval, "autopilot.loopInterval", time.Minute, "with which the autopilot loop is triggered")
 	flag.Parse()
 
 	log.Println("renterd v0.1.0")

--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -20,8 +20,6 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
-const defaultAutopilotLoopInterval = time.Minute
-
 type workerConfig struct {
 	enabled     bool
 	busAddr     string
@@ -40,6 +38,7 @@ type autopilotConfig struct {
 	busPassword    string
 	workerAddr     string
 	workerPassword string
+	loopInterval   time.Duration
 }
 
 type chainManager struct {
@@ -234,7 +233,7 @@ func newAutopilot(cfg autopilotConfig, dir string) (*autopilot.Autopilot, func()
 	}
 	b := bus.NewClient(cfg.busAddr, cfg.busPassword)
 	w := worker.NewClient(cfg.workerAddr, cfg.workerPassword)
-	a, err := autopilot.New(store, b, w, defaultAutopilotLoopInterval)
+	a, err := autopilot.New(store, b, w, cfg.loopInterval)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"go.sia.tech/renterd/autopilot"
 	"go.sia.tech/renterd/bus"
@@ -231,7 +232,7 @@ func newAutopilot(cfg autopilotConfig, dir string) (*autopilot.Autopilot, func()
 	}
 	b := bus.NewClient(cfg.busAddr, cfg.busPassword)
 	w := worker.NewClient(cfg.workerAddr, cfg.workerPassword)
-	a, err := autopilot.New(store, b, w)
+	a, err := autopilot.New(store, b, w, time.Minute)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
+const defaultAutopilotLoopInterval = time.Minute
+
 type workerConfig struct {
 	enabled     bool
 	busAddr     string
@@ -232,7 +234,7 @@ func newAutopilot(cfg autopilotConfig, dir string) (*autopilot.Autopilot, func()
 	}
 	b := bus.NewClient(cfg.busAddr, cfg.busPassword)
 	w := worker.NewClient(cfg.workerAddr, cfg.workerPassword)
-	a, err := autopilot.New(store, b, w, time.Minute)
+	a, err := autopilot.New(store, b, w, defaultAutopilotLoopInterval)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -45,6 +45,10 @@ type chainManager struct {
 	cs modules.ConsensusSet
 }
 
+func (cm chainManager) Synced() bool {
+	return cm.cs.Synced()
+}
+
 func (cm chainManager) TipState() consensus.State {
 	return consensus.State{
 		Index: consensus.ChainIndex{

--- a/internal/stores/autopilot.go
+++ b/internal/stores/autopilot.go
@@ -10,7 +10,6 @@ import (
 
 	"go.sia.tech/renterd/autopilot"
 	"go.sia.tech/siad/modules"
-	"go.sia.tech/siad/types"
 )
 
 // EphemeralAutopilotStore implements autopilot.Store in memory.
@@ -52,28 +51,7 @@ func (s *EphemeralAutopilotStore) SetState(state autopilot.State) error {
 
 // ProcessConsensusChange implements chain.Subscriber.
 func (s *EphemeralAutopilotStore) ProcessConsensusChange(cc modules.ConsensusChange) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	for _, block := range cc.RevertedBlocks {
-		if block.ID() != types.GenesisID {
-			s.state.BlockHeight--
-		}
-	}
-	for _, block := range cc.AppliedBlocks {
-		if block.ID() != types.GenesisID {
-			s.state.BlockHeight++
-		}
-	}
-
-	// update current period
-	if s.state.BlockHeight >= s.state.CurrentPeriod+s.config.Contracts.Period {
-		s.state.CurrentPeriod += s.config.Contracts.Period
-	}
-
-	// update synced state
-	// TODO: might need a channel here
-	s.state.Synced = cc.Synced
+	panic("not implemented")
 }
 
 // NewEphemeralAutopilotStore returns a new EphemeralAutopilotStore.
@@ -131,7 +109,6 @@ func (s *JSONAutopilotStore) load() error {
 	}
 	s.config = p.Config
 	s.state = p.State
-	s.state.Synced = false
 	return nil
 }
 

--- a/slab/metrics.go
+++ b/slab/metrics.go
@@ -1,1 +1,0 @@
-package slab


### PR DESCRIPTION
This PR adds `contractor` and `scanner` structs. It's an attempt to add some structure in the `autopilot` and house certain responsibilities under separate entities that can each manage their own respective state.

Originally I went for a design where every "subsystem" had its own lifecycle and managed its own loops, but Luke pointed out that it would be better to have a single lifecycle in the autopilot in combination with inert subsystems that are being controlled by the autopilot, which I like because it makes for cleaner stack traces.

In the current proposal the `autopilot` uses a `ticker` which can be useful in testing. What I don't really like is that the `contractor` and `scanner` also need a way to break out of semi-long running loops (like renewals), for this they would need to check the autopilot's `stopChan` currently. I liked the `waitgroup` + `timeout` better from the previous design, where calling `stop` on an autopilot would give subsystems some time to wrap up and then report a shutdown timeout if necessary.