### PR TITLE
Store refactor

### DIFF
--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -174,10 +174,10 @@ func newBus(cfg busConfig, dir string, walletKey consensus.PrivateKey) (*bus.Bus
 	if err := os.MkdirAll(hostdbDir, 0700); err != nil {
 		return nil, nil, err
 	}
-	hdb, ccid, err := stores.NewSQLHostDB(dbConn, true)
+	sqlStore, ccid, err := stores.NewSQLStore(dbConn, true)
 	if err != nil {
 		return nil, nil, err
-	} else if err := cm.ConsensusSetSubscribe(hdb, ccid, nil); err != nil {
+	} else if err := cm.ConsensusSetSubscribe(sqlStore, ccid, nil); err != nil {
 		return nil, nil, err
 	}
 
@@ -185,17 +185,9 @@ func newBus(cfg busConfig, dir string, walletKey consensus.PrivateKey) (*bus.Bus
 	if err := os.MkdirAll(contractsDir, 0700); err != nil {
 		return nil, nil, err
 	}
-	cs, err := stores.NewSQLContractStore(dbConn, true)
-	if err != nil {
-		return nil, nil, err
-	}
 
 	objectsDir := filepath.Join(dir, "objects")
 	if err := os.MkdirAll(objectsDir, 0700); err != nil {
-		return nil, nil, err
-	}
-	os, err := stores.NewSQLObjectStore(dbConn, true)
-	if err != nil {
 		return nil, nil, err
 	}
 
@@ -213,7 +205,7 @@ func newBus(cfg busConfig, dir string, walletKey consensus.PrivateKey) (*bus.Bus
 		return nil
 	}
 
-	b := bus.New(syncer{g, tp}, chainManager{cm}, txpool{tp}, w, hdb, cs, cs, os)
+	b := bus.New(syncer{g, tp}, chainManager{cm}, txpool{tp}, w, sqlStore, sqlStore, sqlStore, sqlStore)
 	return b, cleanup, nil
 }
 

--- a/internal/stores/contracts.go
+++ b/internal/stores/contracts.go
@@ -196,12 +196,6 @@ func NewJSONContractStore(dir string) (*JSONContractStore, error) {
 }
 
 type (
-	// SQLContractStore implements the bus.ContractStore interface using SQL as the
-	// persistence backend.
-	SQLContractStore struct {
-		db *gorm.DB
-	}
-
 	dbContractRHPv2 struct {
 		dbCommon
 
@@ -357,40 +351,8 @@ func (c dbContractRHPv2) convert() (rhpv2.Contract, error) {
 	}, nil
 }
 
-// NewSQLContractStore creates a new SQLContractStore from a given gorm
-// Dialector.
-func NewSQLContractStore(conn gorm.Dialector, migrate bool) (*SQLContractStore, error) {
-	db, err := gorm.Open(conn, &gorm.Config{})
-	if err != nil {
-		return nil, err
-	}
-
-	if migrate {
-		// Create the tables.
-		tables := []interface{}{
-			&dbContractRHPv2{},
-			&dbFileContractRevision{},
-			&dbTransactionSignature{},
-			&dbValidSiacoinOutput{},
-			&dbMissedSiacoinOutput{},
-			&dbHostSet{},
-			&dbHostSetEntry{},
-		}
-		if err := db.AutoMigrate(tables...); err != nil {
-			return nil, err
-		}
-		if res := db.Exec("PRAGMA foreign_keys = ON", nil); res.Error != nil {
-			return nil, res.Error
-		}
-	}
-
-	return &SQLContractStore{
-		db: db,
-	}, nil
-}
-
 // AddContract implements the bus.ContractStore interface.
-func (s *SQLContractStore) AddContract(c rhpv2.Contract) error {
+func (s *SQLStore) AddContract(c rhpv2.Contract) error {
 	fcid := c.ID()
 
 	// Prepare valid and missed outputs.
@@ -434,7 +396,7 @@ func (s *SQLContractStore) AddContract(c rhpv2.Contract) error {
 }
 
 // Contract implements the bus.ContractStore interface.
-func (s *SQLContractStore) Contract(id types.FileContractID) (rhpv2.Contract, error) {
+func (s *SQLStore) Contract(id types.FileContractID) (rhpv2.Contract, error) {
 	// Fetch contract.
 	contract, err := s.contract(id)
 	if err != nil {
@@ -444,7 +406,7 @@ func (s *SQLContractStore) Contract(id types.FileContractID) (rhpv2.Contract, er
 }
 
 // Contracts implements the bus.ContractStore interface.
-func (s *SQLContractStore) Contracts() ([]rhpv2.Contract, error) {
+func (s *SQLStore) Contracts() ([]rhpv2.Contract, error) {
 	dbContracts, err := s.contracts()
 	if err != nil {
 		return nil, err
@@ -461,53 +423,11 @@ func (s *SQLContractStore) Contracts() ([]rhpv2.Contract, error) {
 }
 
 // RemoveContract implements the bus.ContractStore interface.
-func (s *SQLContractStore) RemoveContract(id types.FileContractID) error {
+func (s *SQLStore) RemoveContract(id types.FileContractID) error {
 	return s.db.Delete(&dbContractRHPv2{ID: id}).Error
 }
 
-// HostSets implements the bus.HostSetStore interface.
-func (s *SQLContractStore) HostSets() ([]string, error) {
-	var setNames []string
-	tx := s.db.Model(&dbHostSet{}).
-		Select("Name").
-		Find(&setNames)
-	return setNames, tx.Error
-}
-
-// HostSet implements the bus.HostSetStore interface.
-func (s *SQLContractStore) HostSet(name string) ([]consensus.PublicKey, error) {
-	var hostSet dbHostSet
-	err := s.db.Where(&dbHostSet{Name: name}).
-		Preload("Hosts").
-		Take(&hostSet).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, ErrHostSetNotFound
-	} else if err != nil {
-		return nil, err
-	}
-	pks := make([]consensus.PublicKey, len(hostSet.Hosts))
-	for i, entry := range hostSet.Hosts {
-		pks[i] = entry.PublicKey
-	}
-	return pks, nil
-}
-
-// SetHostSet implements the bus.HostSetStore interface.
-func (s *SQLContractStore) SetHostSet(name string, hosts []consensus.PublicKey) error {
-	hostSetEntries := make([]dbHostSetEntry, len(hosts))
-	for i, pk := range hosts {
-		hostSetEntries[i] = dbHostSetEntry{
-			HostSetName: name,
-			PublicKey:   pk,
-		}
-	}
-	return s.db.Create(&dbHostSet{
-		Name:  name,
-		Hosts: hostSetEntries,
-	}).Error
-}
-
-func (s *SQLContractStore) contract(id types.FileContractID) (dbContractRHPv2, error) {
+func (s *SQLStore) contract(id types.FileContractID) (dbContractRHPv2, error) {
 	var contract dbContractRHPv2
 	err := s.db.Where(&dbContractRHPv2{ID: id}).
 		Preload("Revision.NewValidProofOutputs").
@@ -519,7 +439,7 @@ func (s *SQLContractStore) contract(id types.FileContractID) (dbContractRHPv2, e
 	return contract, err
 }
 
-func (s *SQLContractStore) contracts() ([]dbContractRHPv2, error) {
+func (s *SQLStore) contracts() ([]dbContractRHPv2, error) {
 	var contracts []dbContractRHPv2
 	err := s.db.Model(&dbContractRHPv2{}).
 		Preload("Revision.NewValidProofOutputs").

--- a/internal/stores/contracts.go
+++ b/internal/stores/contracts.go
@@ -203,12 +203,16 @@ type (
 	}
 
 	dbContractRHPv2 struct {
+		dbCommon
+
 		ID         types.FileContractID         `gorm:"primaryKey,type:bytes;serializer:gob;NOT NULL"`
 		Revision   dbFileContractRevision       `gorm:"constraint:OnDelete:CASCADE;foreignKey:ParentID;references:ID;NOT NULL"` //CASCADE to delete revision too
 		Signatures []types.TransactionSignature `gorm:"type:bytes;serializer:gob;NOT NULL"`
 	}
 
 	dbFileContractRevision struct {
+		dbCommon
+
 		ParentID              types.FileContractID   `gorm:"primaryKey;type:bytes;serializer:gob;NOT NULL"` // only one revision for a given parent
 		UnlockConditions      types.UnlockConditions `gorm:"NOT NULL;type:bytes;serializer:gob"`
 		NewRevisionNumber     uint64                 `gorm:"index"`
@@ -222,6 +226,8 @@ type (
 	}
 
 	dbTransactionSignature struct {
+		dbCommon
+
 		ID             uint64               `gorm:"primaryKey"`
 		ParentID       types.FileContractID `gorm:"index;type:bytes;serializer:gob;NOT NULL"`
 		PublicKeyIndex uint64
@@ -231,6 +237,8 @@ type (
 	}
 
 	dbValidSiacoinOutput struct {
+		dbCommon
+
 		ID         uint64               `gorm:"primaryKey"`
 		ParentID   types.FileContractID `gorm:"index;type:bytes;serializer:gob;NOT NULL"`
 		UnlockHash types.UnlockHash     `gorm:"index;type:bytes;serializer:gob"`
@@ -238,6 +246,8 @@ type (
 	}
 
 	dbMissedSiacoinOutput struct {
+		dbCommon
+
 		ID         uint64               `gorm:"primaryKey"`
 		ParentID   types.FileContractID `gorm:"index;type:bytes;serializer:gob;NOT NULL"`
 		UnlockHash types.UnlockHash     `gorm:"index;type:bytes;serializer:gob"`
@@ -245,11 +255,15 @@ type (
 	}
 
 	dbHostSet struct {
+		dbCommon
+
 		Name  string           `gorm:"primaryKey"`
 		Hosts []dbHostSetEntry `gorm:"constraing:OnDelete:CASCADE;foreignKey:HostSetName;references:Name"`
 	}
 
 	dbHostSetEntry struct {
+		dbCommon
+
 		ID          uint64              `gorm:"primaryKey"`
 		HostSetName string              `gorm:"index;NOT NULL"`
 		PublicKey   consensus.PublicKey `gorm:"NOT NULL;type:bytes;serializer:gob"`

--- a/internal/stores/contracts_test.go
+++ b/internal/stores/contracts_test.go
@@ -1,30 +1,20 @@
 package stores
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
-	"go.sia.tech/renterd/internal/consensus"
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/types"
 	"gorm.io/gorm/schema"
-	"lukechampine.com/frand"
 )
-
-// newTestSQLContractStore creates a new SQLContractStore for testing.
-func newTestSQLContractStore() (*SQLContractStore, error) {
-	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
-	conn := NewEphemeralSQLiteConnection(dbName)
-	return NewSQLContractStore(conn, true)
-}
 
 // TestSQLContractStore tests SQLContractStore functionality.
 func TestSQLContractStore(t *testing.T) {
-	cs, err := newTestSQLContractStore()
+	cs, _, _, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,49 +140,5 @@ func TestSQLContractStore(t *testing.T) {
 	}
 	if err := tableCountCheck(&dbValidSiacoinOutput{}, 0); err != nil {
 		t.Fatal(err)
-	}
-}
-
-// TestSQLHostSetStore tests the bus.HostSetStore methods on the SQLContractStore.
-func TestSQLHostSetStore(t *testing.T) {
-	cs, err := newTestSQLContractStore()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Check db before adding a set.
-	setName := "foo"
-	sets, err := cs.HostSets()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(sets) != 0 {
-		t.Fatalf("expected 0 sets got %v", len(sets))
-	}
-	_, err = cs.HostSet(setName)
-	if !errors.Is(err, ErrHostSetNotFound) {
-		t.Fatal("should fail", err)
-	}
-
-	// Add another one.
-	pks := []consensus.PublicKey{{1, 2, 3}, {3, 2, 1}}
-	if err := cs.SetHostSet(setName, pks); err != nil {
-		t.Fatal(err)
-	}
-
-	// Check again.
-	sets, err = cs.HostSets()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(sets) != 1 {
-		t.Fatalf("expected 0 sets got %v", len(sets))
-	}
-	set, err := cs.HostSet(setName)
-	if err != nil {
-		t.Fatal("should fail", err)
-	}
-	if !reflect.DeepEqual(set, pks) {
-		t.Fatal("set mismatch")
 	}
 }

--- a/internal/stores/contracts_test.go
+++ b/internal/stores/contracts_test.go
@@ -15,8 +15,8 @@ import (
 	"lukechampine.com/frand"
 )
 
-// newTestSQLStore creates a new SQLContractStore for testing.
-func newTestSQLStore() (*SQLContractStore, error) {
+// newTestSQLContractStore creates a new SQLContractStore for testing.
+func newTestSQLContractStore() (*SQLContractStore, error) {
 	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
 	conn := NewEphemeralSQLiteConnection(dbName)
 	return NewSQLContractStore(conn, true)
@@ -24,7 +24,7 @@ func newTestSQLStore() (*SQLContractStore, error) {
 
 // TestSQLContractStore tests SQLContractStore functionality.
 func TestSQLContractStore(t *testing.T) {
-	cs, err := newTestSQLStore()
+	cs, err := newTestSQLContractStore()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestSQLContractStore(t *testing.T) {
 
 // TestSQLHostSetStore tests the bus.HostSetStore methods on the SQLContractStore.
 func TestSQLHostSetStore(t *testing.T) {
-	cs, err := newTestSQLStore()
+	cs, err := newTestSQLContractStore()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -205,12 +205,16 @@ type (
 	// Deleting a host from the db will cascade the deletion and also delete
 	// the corresponding announcements and interactions with that host.
 	dbHost struct {
+		dbCommon
+
 		PublicKey     consensus.PublicKey `gorm:"primaryKey;type:bytes;serializer:gob"`
-		Announcements []dbAnnouncement    `gorm:"foreignKey:Host;OnDelete:CASCADE"`
-		Interactions  []dbInteraction     `gorm:"foreignKey:Host;OnDelete:CASCADE"`
+		Announcements []dbAnnouncement    `gorm:"foreignKey:Host;references:PublicKey;OnDelete:CASCADE"`
+		Interactions  []dbInteraction     `gorm:"foreignKey:Host;references:PublicKey;OnDelete:CASCADE"`
 	}
 
 	dbAnnouncement struct {
+		dbCommon
+
 		ID          uint64              `gorm:"primaryKey"`
 		Host        consensus.PublicKey `gorm:"NOT NULL;type:bytes;serializer:gob"`
 		BlockHeight uint64              `gorm:"NOT NULL"`
@@ -221,6 +225,8 @@ type (
 
 	// dbInteraction defines a hostdb.Interaction as persisted in the DB.
 	dbInteraction struct {
+		dbCommon
+
 		ID        uint64              `gorm:"primaryKey"`
 		Host      consensus.PublicKey `gorm:"index; NOT NULL;type:bytes;serializer:gob"`
 		Result    json.RawMessage
@@ -232,6 +238,8 @@ type (
 	// known to the hostdb. It should only ever contain a single entry with
 	// the consensusInfoID primary key.
 	dbConsensusInfo struct {
+		dbCommon
+
 		ID   uint8 `gorm:"primaryKey"`
 		CCID []byte
 	}

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 	"time"

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -1,10 +1,8 @@
 package stores
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -12,16 +10,12 @@ import (
 	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/consensus"
 	"go.sia.tech/siad/modules"
-	"lukechampine.com/frand"
 )
 
 // TestSQLHostDB tests the basic functionality of SQLHostDB using an in-memory
 // SQLite DB.
 func TestSQLHostDB(t *testing.T) {
-	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
-
-	conn := NewEphemeralSQLiteConnection(dbName)
-	hdb, ccid, err := NewSQLHostDB(conn, true)
+	hdb, dbName, ccid, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +150,7 @@ func TestSQLHostDB(t *testing.T) {
 
 	// Connect to the same DB again.
 	conn2 := NewEphemeralSQLiteConnection(dbName)
-	hdb2, ccid, err := NewSQLHostDB(conn2, false)
+	hdb2, ccid, err := NewSQLStore(conn2, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,10 +165,7 @@ func TestSQLHostDB(t *testing.T) {
 
 // TestSQLHosts tests the Hosts method of the SQLHostDB type.
 func TestSQLHosts(t *testing.T) {
-	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
-
-	conn := NewEphemeralSQLiteConnection(dbName)
-	hdb, _, err := NewSQLHostDB(conn, true)
+	hdb, _, _, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/stores/hostsets.go
+++ b/internal/stores/hostsets.go
@@ -1,0 +1,50 @@
+package stores
+
+import (
+	"errors"
+
+	"go.sia.tech/renterd/internal/consensus"
+	"gorm.io/gorm"
+)
+
+// HostSets implements the bus.HostSetStore interface.
+func (s *SQLStore) HostSets() ([]string, error) {
+	var setNames []string
+	tx := s.db.Model(&dbHostSet{}).
+		Select("Name").
+		Find(&setNames)
+	return setNames, tx.Error
+}
+
+// HostSet implements the bus.HostSetStore interface.
+func (s *SQLStore) HostSet(name string) ([]consensus.PublicKey, error) {
+	var hostSet dbHostSet
+	err := s.db.Where(&dbHostSet{Name: name}).
+		Preload("Hosts").
+		Take(&hostSet).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrHostSetNotFound
+	} else if err != nil {
+		return nil, err
+	}
+	pks := make([]consensus.PublicKey, len(hostSet.Hosts))
+	for i, entry := range hostSet.Hosts {
+		pks[i] = entry.PublicKey
+	}
+	return pks, nil
+}
+
+// SetHostSet implements the bus.HostSetStore interface.
+func (s *SQLStore) SetHostSet(name string, hosts []consensus.PublicKey) error {
+	hostSetEntries := make([]dbHostSetEntry, len(hosts))
+	for i, pk := range hosts {
+		hostSetEntries[i] = dbHostSetEntry{
+			HostSetName: name,
+			PublicKey:   pk,
+		}
+	}
+	return s.db.Create(&dbHostSet{
+		Name:  name,
+		Hosts: hostSetEntries,
+	}).Error
+}

--- a/internal/stores/hostsets_test.go
+++ b/internal/stores/hostsets_test.go
@@ -1,0 +1,53 @@
+package stores
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"go.sia.tech/renterd/internal/consensus"
+)
+
+// TestSQLHostSetStore tests the bus.HostSetStore methods on the SQLContractStore.
+func TestSQLHostSetStore(t *testing.T) {
+	cs, _, _, err := newTestSQLStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check db before adding a set.
+	setName := "foo"
+	sets, err := cs.HostSets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sets) != 0 {
+		t.Fatalf("expected 0 sets got %v", len(sets))
+	}
+	_, err = cs.HostSet(setName)
+	if !errors.Is(err, ErrHostSetNotFound) {
+		t.Fatal("should fail", err)
+	}
+
+	// Add another one.
+	pks := []consensus.PublicKey{{1, 2, 3}, {3, 2, 1}}
+	if err := cs.SetHostSet(setName, pks); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check again.
+	sets, err = cs.HostSets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sets) != 1 {
+		t.Fatalf("expected 0 sets got %v", len(sets))
+	}
+	set, err := cs.HostSet(setName)
+	if err != nil {
+		t.Fatal("should fail", err)
+	}
+	if !reflect.DeepEqual(set, pks) {
+		t.Fatal("set mismatch")
+	}
+}

--- a/internal/stores/objects.go
+++ b/internal/stores/objects.go
@@ -284,6 +284,8 @@ type (
 
 	// dbObject describes an object.Object in the database.
 	dbObject struct {
+		dbCommon
+
 		// ID uniquely identifies an Object within the database. Since
 		// this ID is also exposed via the API it's a string for
 		// convenience.
@@ -296,6 +298,8 @@ type (
 
 	// dbSlice describes a reference to a slab.Slab in the database.
 	dbSlice struct {
+		dbCommon
+
 		// ID uniquely identifies a slice in the db.
 		ID uint64 `gorm:"primaryKey"`
 
@@ -312,6 +316,8 @@ type (
 	// dbSlab describes a slab.Slab in the database.
 	// NOTE: A Slab is uniquely identified by its key.
 	dbSlab struct {
+		dbCommon
+
 		ID        uint64 `gorm:"primaryKey"`
 		Key       []byte `gorm:"unique;NOT NULL"` // json string
 		MinShards uint8
@@ -322,6 +328,8 @@ type (
 	// multiple times in the sectors table since it can belong to multiple
 	// slabs.
 	dbSector struct {
+		dbCommon
+
 		ID     uint64 `gorm:"primaryKey"`
 		SlabID uint64 `gorm:"index;NOT NULL"`
 

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -1,7 +1,6 @@
 package stores
 
 import (
-	"encoding/hex"
 	"fmt"
 	"reflect"
 	"testing"
@@ -105,10 +104,7 @@ func TestJSONObjectStore(t *testing.T) {
 
 // TestSQLObjectStore tests basic SQLObjectStore functionality.
 func TestSQLObjectStore(t *testing.T) {
-	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
-
-	conn := NewEphemeralSQLiteConnection(dbName)
-	os, err := NewSQLObjectStore(conn, true)
+	os, _, _, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,10 +293,7 @@ func TestSQLObjectStore(t *testing.T) {
 
 // TestSQLList is a test for (*SQLObjectStore).List.
 func TestSQLList(t *testing.T) {
-	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
-	//conn := NewEphemeralSQLiteConnection(dbName)
-	conn := NewEphemeralSQLiteConnection(dbName)
-	os, err := NewSQLObjectStore(conn, true)
+	os, _, _, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -4,16 +4,34 @@ import (
 	"fmt"
 	"time"
 
+	"go.sia.tech/renterd/bus"
+	"go.sia.tech/siad/modules"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
 
-// dbCommon specifies all fields that every table in the database should have.
-type dbCommon struct {
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	DeletedAt gorm.DeletedAt `gorm:"index"`
-}
+type (
+
+	// dbCommon specifies all fields that every table in the database should have.
+	dbCommon struct {
+		CreatedAt time.Time
+		UpdatedAt time.Time
+		DeletedAt gorm.DeletedAt `gorm:"index"`
+	}
+
+	// SQLStore is a helper type for interacting with a SQL-based backend.
+	SQLStore struct {
+		db *gorm.DB
+	}
+)
+
+// Check that the SQLStore implements all the required interfaces.
+var (
+	_ bus.ContractStore = &SQLStore{}
+	_ bus.HostDB        = &SQLStore{}
+	_ bus.HostSetStore  = &SQLStore{}
+	_ bus.ObjectStore   = &SQLStore{}
+)
 
 // NewEphemeralSQLiteConnection creates a connection to an in-memory SQLite DB.
 // NOTE: Use simple names such as a random hex identifier or the filepath.Base
@@ -26,4 +44,66 @@ func NewEphemeralSQLiteConnection(name string) gorm.Dialector {
 // NewSQLiteConnection opens a sqlite db at the given path.
 func NewSQLiteConnection(path string) gorm.Dialector {
 	return sqlite.Open(path)
+}
+
+// NewSQLHostDB uses a given Dialector to connect to a SQL database.  NOTE: Only
+// pass migrate=true for the first instance of SQLHostDB if you connect via the
+// same Dialector multiple times.
+func NewSQLStore(conn gorm.Dialector, migrate bool) (*SQLStore, modules.ConsensusChangeID, error) {
+	db, err := gorm.Open(conn, &gorm.Config{})
+	if err != nil {
+		return nil, modules.ConsensusChangeID{}, err
+	}
+
+	if migrate {
+		// Create the tables.
+		tables := []interface{}{
+			// bus.ContractStore tables
+			&dbContractRHPv2{},
+			&dbFileContractRevision{},
+			&dbTransactionSignature{},
+			&dbValidSiacoinOutput{},
+			&dbMissedSiacoinOutput{},
+
+			// bus.HostDB tables
+			&dbHost{},
+			&dbInteraction{},
+			&dbAnnouncement{},
+			&dbConsensusInfo{},
+
+			// bus.HostSetStore tables
+			&dbHostSet{},
+			&dbHostSetEntry{},
+
+			// bus.ObjectStore tables
+			&dbObject{},
+			&dbSlice{},
+			&dbSlab{},
+			&dbSector{},
+		}
+		if err := db.AutoMigrate(tables...); err != nil {
+			return nil, modules.ConsensusChangeID{}, err
+		}
+		if res := db.Exec("PRAGMA foreign_keys = ON", nil); res.Error != nil {
+			return nil, modules.ConsensusChangeID{}, res.Error
+		}
+	}
+
+	// Get latest consensus change ID or init db.
+	var ci dbConsensusInfo
+	err = db.Where(&dbConsensusInfo{ID: consensusInfoID}).
+		Attrs(dbConsensusInfo{
+			ID:   consensusInfoID,
+			CCID: modules.ConsensusChangeBeginning[:],
+		}).
+		FirstOrCreate(&ci).Error
+	if err != nil {
+		return nil, modules.ConsensusChangeID{}, err
+	}
+	var ccid modules.ConsensusChangeID
+	copy(ccid[:], ci.CCID)
+
+	return &SQLStore{
+		db: db,
+	}, ccid, nil
 }

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -46,7 +46,7 @@ func NewSQLiteConnection(path string) gorm.Dialector {
 	return sqlite.Open(path)
 }
 
-// NewSQLHostDB uses a given Dialector to connect to a SQL database.  NOTE: Only
+// NewSQLStore uses a given Dialector to connect to a SQL database.  NOTE: Only
 // pass migrate=true for the first instance of SQLHostDB if you connect via the
 // same Dialector multiple times.
 func NewSQLStore(conn gorm.Dialector, migrate bool) (*SQLStore, modules.ConsensusChangeID, error) {

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -2,10 +2,18 @@ package stores
 
 import (
 	"fmt"
+	"time"
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+// dbCommon specifies all fields that every table in the database should have.
+type dbCommon struct {
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
+}
 
 // NewEphemeralSQLiteConnection creates a connection to an in-memory SQLite DB.
 // NOTE: Use simple names such as a random hex identifier or the filepath.Base

--- a/internal/stores/sql_test.go
+++ b/internal/stores/sql_test.go
@@ -1,0 +1,19 @@
+package stores
+
+import (
+	"encoding/hex"
+
+	"go.sia.tech/siad/modules"
+	"lukechampine.com/frand"
+)
+
+// newTestSQLContractStore creates a new SQLContractStore for testing.
+func newTestSQLStore() (*SQLStore, string, modules.ConsensusChangeID, error) {
+	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
+	conn := NewEphemeralSQLiteConnection(dbName)
+	sqlStore, ccid, err := NewSQLStore(conn, true)
+	if err != nil {
+		return nil, "", modules.ConsensusChangeID{}, err
+	}
+	return sqlStore, dbName, ccid, nil
+}

--- a/internal/stores/sql_test.go
+++ b/internal/stores/sql_test.go
@@ -7,7 +7,7 @@ import (
 	"lukechampine.com/frand"
 )
 
-// newTestSQLContractStore creates a new SQLContractStore for testing.
+// newTestSQLStore creates a new SQLStore for testing.
 func newTestSQLStore() (*SQLStore, string, modules.ConsensusChangeID, error) {
 	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
 	conn := NewEphemeralSQLiteConnection(dbName)


### PR DESCRIPTION
This PR does a few smaller refactors.

1. add soft-deletion and update/creation/deletion times to the db by adding the corresponding columns to the database tables.
2. Refactor the database types into a single one that simply implements the corresponding interfaces.
3. Moves the methods for the hostsets into a separate file. That way every interface gets its own file.