### PR TITLE
Timeout Middleware

### DIFF
--- a/cmd/renterd/api.go
+++ b/cmd/renterd/api.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+func timeoutMiddleware(def, min, max time.Duration, param string) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if timeout, err := parseTimeout(req, def, min, max, param); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			} else if timeout > 0 {
+				ctx, cancel := context.WithTimeout(req.Context(), timeout)
+				defer cancel()
+				req = req.WithContext(ctx)
+			}
+			h.ServeHTTP(w, req)
+		})
+	}
+}
+
+func (cfg workerConfig) timeout() func(http.Handler) http.Handler {
+	if !cfg.reqTimeoutEnabled {
+		panic("timeout disabled") // developer error
+	}
+	return timeoutMiddleware(
+		cfg.reqTimeoutDef,
+		cfg.reqTimeoutMin,
+		cfg.reqTimeoutMax,
+		cfg.reqTimeoutParam,
+	)
+}
+
+func parseTimeout(req *http.Request, def, min, max time.Duration, param string) (time.Duration, error) {
+	timeout, err := parseDuration(req, param)
+	if err != nil {
+		return 0, err
+	}
+	if timeout == 0 {
+		return def, nil
+	}
+	if max > 0 && timeout > max {
+		return 0, fmt.Errorf("'%s' exceeds maximum duration of %v", param, max)
+	}
+	if min > 0 && timeout < min {
+		return 0, fmt.Errorf("'%s' falls below minimum duration of %v", param, min)
+	}
+	return timeout, nil
+}
+
+func parseDuration(req *http.Request, param string) (time.Duration, error) {
+	queryForm, err := url.ParseQuery(req.URL.RawQuery)
+	if err != nil {
+		return 0, errors.New(http.StatusText(http.StatusBadRequest))
+	}
+
+	durationStr := queryForm.Get(param)
+	if durationStr == "" {
+		return 0, nil
+	}
+
+	dur, err := time.ParseDuration(durationStr)
+	if err != nil {
+		return 0, fmt.Errorf("unable to parse '%s', err %w", param, err)
+	}
+
+	return dur, nil
+}

--- a/cmd/renterd/api_test.go
+++ b/cmd/renterd/api_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTimeoutMiddleware(t *testing.T) {
+	ms := time.Millisecond
+	timeout := timeoutMiddleware(ms*50, ms, ms*100, paramTimeout)
+	handler := timeout(http.HandlerFunc(testHandler))
+
+	cases := []struct {
+		name    string
+		timeout time.Duration
+		request time.Duration // duration of sleep in handler
+		status  int
+		body    string
+	}{
+		{
+			"below min duration",
+			time.Nanosecond,
+			0,
+			http.StatusBadRequest,
+			fmt.Sprintf("'%s' falls below minimum duration of 1ms", paramTimeout),
+		},
+		{
+			"above max duration",
+			time.Minute,
+			0,
+			http.StatusBadRequest,
+			fmt.Sprintf("'%s' exceeds maximum duration of 100ms", paramTimeout),
+		},
+		{
+			"zero timeout",
+			0,
+			0,
+			http.StatusOK,
+			"OK",
+		},
+		{
+			"no timeout", // passing neg value ensures query param is not set
+			-1,
+			0,
+			http.StatusOK,
+			"OK",
+		},
+		{
+			"request timeout, exceeds default timeout",
+			0, // uses default of 50ms
+			time.Millisecond * 100,
+			http.StatusRequestTimeout,
+			"request timed out",
+		},
+		{
+			"request timeout, exceeds provided timeout",
+			time.Millisecond * 20,
+			time.Millisecond * 30,
+			http.StatusRequestTimeout,
+			"request timed out",
+		},
+		{
+			"no timeout, custom timeout provided",
+			0, // uses default of 50ms
+			time.Millisecond * 30,
+			http.StatusOK,
+			"OK",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// build request url
+			query := url.Values{}
+			query.Set("request", tt.request.String())
+			if tt.timeout >= 0 {
+				query.Set(paramTimeout, tt.timeout.String())
+			}
+			url := fmt.Sprintf("/foo?%s", query.Encode())
+
+			// process request
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			// assert response
+			res := w.Result()
+			defer res.Body.Close()
+			if want, got := tt.status, res.StatusCode; want != got {
+				t.Fatalf("unexpected status code, %v != %v", got, want)
+			}
+
+			data, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				t.Fatal("failed to read body", err)
+			}
+			if want, got := tt.body, strings.TrimSuffix(string(data), "\n"); want != got {
+				t.Fatalf("unexpected response body: '%v' != '%v'", got, want)
+			}
+		})
+	}
+}
+
+func testHandler(w http.ResponseWriter, r *http.Request) {
+	dur, err := parseDuration(r, "request")
+	if err != nil {
+		panic(err) // developer error
+	}
+
+	select {
+	case <-time.After(dur):
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, http.StatusText(http.StatusOK))
+	case <-r.Context().Done():
+		w.WriteHeader(http.StatusRequestTimeout)
+		fmt.Fprintf(w, "request timed out")
+	}
+}

--- a/cmd/renterd/api_test.go
+++ b/cmd/renterd/api_test.go
@@ -54,21 +54,21 @@ func TestTimeoutMiddleware(t *testing.T) {
 		{
 			"request timeout, exceeds default timeout",
 			0, // uses default of 50ms
-			time.Millisecond * 100,
+			time.Second,
 			http.StatusRequestTimeout,
 			"request timed out",
 		},
 		{
 			"request timeout, exceeds provided timeout",
 			time.Millisecond * 20,
-			time.Millisecond * 30,
+			time.Millisecond * 200,
 			http.StatusRequestTimeout,
 			"request timed out",
 		},
 		{
 			"no timeout, custom timeout provided",
 			0, // uses default of 50ms
-			time.Millisecond * 30,
+			time.Millisecond * 10,
 			http.StatusOK,
 			"OK",
 		},

--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"go.sia.tech/renterd/autopilot"
 	"go.sia.tech/renterd/bus"
@@ -23,6 +24,13 @@ type workerConfig struct {
 	enabled     bool
 	busAddr     string
 	busPassword string
+
+	// server config
+	reqTimeoutEnabled bool
+	reqTimeoutParam   string
+	reqTimeoutDef     time.Duration
+	reqTimeoutMin     time.Duration
+	reqTimeoutMax     time.Duration
 }
 
 type busConfig struct {


### PR DESCRIPTION
The middleware parses a predefined timeout parameter (defaults to `timeout`) from the query string and applies that timeout to the request context. It allows defining a min, max and default timeout, all of which can be disabled if the node operator so choses.

I added it because we need a way to limit the scan time in the host scanner. We want scans, and especially the initial scans, to be as fast as possible. Especially since hosts might be offline, we don't want to wait for scan responses for the full duration of the connection timeout.

There are many other ways of solving this. There's server side timeouts, there's client side timeouts, but I kind of like this idea of a timeout middleware because the `worker` API is defined alongside other APIs (so server side timeouts can be tricky since it would apply to all APIs). Further more, by allowing to pass a timeout value in the query string we preserve server resources since we can use the context to cancel any inflight requests rather than the client simply dropping the connection. I considered using the `http.TimeoutHandler` but by doing it this way we allow the client to pass timeouts dynamically, which will be useful for our API users I think.

Let me know what you think!

