### PR TITLE
Host Score

### DIFF
--- a/autopilot/api.go
+++ b/autopilot/api.go
@@ -24,6 +24,7 @@ type Config struct {
 		RenewWindow uint64
 		Download    uint64
 		Upload      uint64
+		Storage     uint64
 	}
 	Objects struct {
 		MinShards   uint8
@@ -40,6 +41,7 @@ func DefaultConfig() (c Config) {
 	c.Contracts.RenewWindow = 144 * 7 * 2 // 2 weeks
 	c.Contracts.Upload = 1 << 40          // 1 TiB
 	c.Contracts.Download = 1 << 40        // 1 TiB
+	c.Contracts.Storage = 1 << 42         // 4 TiB
 	c.Objects.MinShards = 10
 	c.Objects.TotalShards = 30
 	return

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -33,7 +33,7 @@ type Bus interface {
 	AddContract(c rhpv2.Contract) error
 	AllContracts() ([]bus.Contract, error)
 	ActiveContracts() ([]bus.Contract, error)
-	DeleteContracts(ids ...types.FileContractID) error
+	DeleteContracts(ids []types.FileContractID) error
 
 	Contract(id types.FileContractID) (contract rhpv2.Contract, err error)
 	ContractMetadata(id types.FileContractID) (bus.ContractMetadata, error)

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -70,7 +70,7 @@ func (c *contractor) performContractMaintenance(cfg Config) error {
 	}
 
 	// delete contracts
-	err = c.ap.bus.DeleteContracts(toDelete...)
+	err = c.ap.bus.DeleteContracts(toDelete)
 	if err != nil {
 		return err
 	}

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 
@@ -18,7 +19,7 @@ const (
 
 // isUsableHost returns whether the given host is usable along with a list of
 // reasons why it was deemed unusable.
-func isUsableHost(cfg Config, f *ipFilter, h Host, scoreThreshold float64) (bool, []string) {
+func isUsableHost(cfg Config, f *ipFilter, h Host) (bool, []string) {
 	var reasons []string
 
 	if !cfg.isWhitelisted(h) {
@@ -33,8 +34,13 @@ func isUsableHost(cfg Config, f *ipFilter, h Host, scoreThreshold float64) (bool
 	if f.isRedundantIP(h) {
 		reasons = append(reasons, "host IP is redundant")
 	}
-	if isLowScore(cfg, h, scoreThreshold) {
-		reasons = append(reasons, "host score is too low")
+	if bad, reason := hasBadSettings(cfg, h); bad {
+		reasons = append(reasons, fmt.Sprintf("host has bad settings, %v", reason))
+	}
+
+	// sanity check - should never happen but this would cause a zero score
+	if len(h.Announcements) == 0 {
+		reasons = append(reasons, "host is not announced")
 	}
 
 	return len(reasons) == 0, reasons
@@ -85,8 +91,26 @@ func isUpForRenewal(cfg Config, c rhpv2.Contract, blockHeight uint64) bool {
 	return blockHeight+cfg.Contracts.RenewWindow/2 >= c.EndHeight()
 }
 
-func isLowScore(cfg Config, h Host, threshold float64) bool {
-	return hostScore(cfg, h) < threshold
+func hasBadSettings(cfg Config, h Host) (bool, string) {
+	settings, _, found := h.LastKnownSettings()
+	if !found {
+		return true, "no settings found"
+	}
+	if !settings.AcceptingContracts {
+		return true, "not accepting contracts"
+	}
+	if cfg.Contracts.Period+cfg.Contracts.RenewWindow > settings.MaxDuration {
+		return true, fmt.Sprintf("max duration too low, %v > %v", cfg.Contracts.Period+cfg.Contracts.RenewWindow, settings.MaxDuration)
+	}
+	maxBaseRPCPrice := settings.DownloadBandwidthPrice.Mul64(maxBaseRPCPriceVsBandwidth)
+	if settings.BaseRPCPrice.Cmp(maxBaseRPCPrice) > 0 {
+		return true, fmt.Sprintf("base RPC price too high, %v > %v", settings.BaseRPCPrice, maxBaseRPCPrice)
+	}
+	maxSectorAccessPrice := settings.DownloadBandwidthPrice.Mul64(maxSectorAccessPriceVsBandwidth)
+	if settings.SectorAccessPrice.Cmp(maxSectorAccessPrice) > 0 {
+		return true, fmt.Sprintf("sector access price too high, %v > %v", settings.BaseRPCPrice, maxBaseRPCPrice)
+	}
+	return false, ""
 }
 
 func (cfg Config) isBlacklisted(h Host) bool {

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -40,6 +40,10 @@ func hostScore(cfg Config, h Host) float64 {
 }
 
 func ageScore(h Host) float64 {
+	if len(h.Announcements) == 0 {
+		return math.SmallestNonzeroFloat64
+	}
+
 	const day = 24 * time.Hour
 	weights := []struct {
 		age    time.Duration

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -1,0 +1,256 @@
+package autopilot
+
+import (
+	"math"
+	"math/big"
+	"sort"
+	"time"
+
+	"go.sia.tech/renterd/hostdb"
+	"go.sia.tech/siad/build"
+	"lukechampine.com/frand"
+)
+
+const (
+	// maxBaseRPCPriceVsBandwidth is the max ratio for sane pricing between the
+	// MinBaseRPCPrice and the MinDownloadBandwidthPrice. This ensures that 1
+	// million base RPC charges are at most 1% of the cost to download 4TB. This
+	// ratio should be used by checking that the MinBaseRPCPrice is less than or
+	// equal to the MinDownloadBandwidthPrice multiplied by this constant
+	maxBaseRPCPriceVsBandwidth = uint64(40e3)
+
+	// maxSectorAccessPriceVsBandwidth is the max ratio for sane pricing between
+	// the MinSectorAccessPrice and the MinDownloadBandwidthPrice. This ensures
+	// that 1 million base accesses are at most 10% of the cost to download 4TB.
+	// This ratio should be used by checking that the MinSectorAccessPrice is
+	// less than or equal to the MinDownloadBandwidthPrice multiplied by this
+	// constant
+	maxSectorAccessPriceVsBandwidth = uint64(400e3)
+)
+
+func hostScore(cfg Config, h Host) float64 {
+	// TODO: priceAdjustmentScore
+	// TODO: storageRemainingScore
+	return ageScore(h) *
+		collateralScore(cfg, h) *
+		interactionScore(h) *
+		settingsScore(cfg, h) *
+		uptimeScore(h) *
+		versionScore(h)
+}
+
+func ageScore(h Host) float64 {
+	const day = 24 * time.Hour
+	weights := []struct {
+		age    time.Duration
+		factor float64
+	}{
+		{128 * day, 1.5},
+		{64 * day, 2},
+		{32 * day, 2},
+		{16 * day, 2},
+		{8 * day, 3},
+		{4 * day, 3},
+		{2 * day, 3},
+		{1 * day, 3},
+	}
+
+	age := time.Since(h.Announcements[0].Timestamp)
+	weight := 1.0
+	for _, w := range weights {
+		if age >= w.age {
+			break
+		}
+		weight /= w.factor
+	}
+
+	return weight
+}
+
+func collateralScore(cfg Config, h Host) float64 {
+	settings, _, ok := h.LastKnownSettings()
+	if !ok {
+		return math.SmallestNonzeroFloat64
+	}
+
+	// NOTE: This math is copied directly from the old siad hostdb. It would
+	// probably benefit from a thorough review.
+
+	// NOTE: We are not multiplying the `Storage` with redundancy, which is
+	// different from the siad implementation
+
+	// convenience variables
+	allowance := cfg.Contracts.Allowance
+	numhosts := cfg.Contracts.Hosts
+	duration := cfg.Contracts.Period
+	storage := cfg.Contracts.Storage
+
+	// calculate the collateral
+	contractCollateral := settings.Collateral.Mul64(storage).Mul64(duration)
+	contractCollateralMax := settings.MaxCollateral.Div64(2) // 2x buffer - renter may end up storing extra data
+	if contractCollateral.Cmp(contractCollateralMax) > 0 {
+		contractCollateral = contractCollateralMax
+	}
+	collateral, _ := new(big.Rat).SetInt(contractCollateral.Big()).Float64()
+	collateral = math.Max(1, collateral) // ensure collateral is at least 1
+
+	// calculate the cutoff
+	expectedFundsPerHost := allowance.Div64(numhosts)
+	cutoff, _ := new(big.Rat).SetInt(expectedFundsPerHost.Div64(5).Big()).Float64()
+	cutoff = math.Max(1, cutoff)          // ensure cutoff is at least 1
+	cutoff = math.Min(cutoff, collateral) // ensure cutoff is not greater than collateral
+
+	// calculate the weight
+	ratio := collateral / cutoff
+	smallWeight := math.Pow(cutoff, 4)
+	largeWeight := math.Pow(ratio, 0.5)
+	weight := smallWeight * largeWeight
+	return weight
+}
+
+func interactionScore(h Host) float64 {
+	success, fail := 30.0, 1.0
+	for _, hi := range h.Interactions {
+		if hi.Success {
+			success++
+		} else {
+			fail++
+		}
+	}
+
+	weight := math.Pow(success/(success+fail), 10)
+	return weight
+}
+
+func settingsScore(cfg Config, h Host) float64 {
+	settings, _, found := h.LastKnownSettings()
+	if !found {
+		return math.SmallestNonzeroFloat64
+	}
+
+	maxBaseRPCPrice := settings.DownloadBandwidthPrice.Mul64(maxBaseRPCPriceVsBandwidth)
+	maxSectorAccessPrice := settings.DownloadBandwidthPrice.Mul64(maxSectorAccessPriceVsBandwidth)
+
+	if !settings.AcceptingContracts ||
+		cfg.Contracts.Period+cfg.Contracts.RenewWindow > settings.MaxDuration ||
+		settings.BaseRPCPrice.Cmp(maxBaseRPCPrice) > 0 ||
+		settings.SectorAccessPrice.Cmp(maxSectorAccessPrice) > 0 {
+		return math.SmallestNonzeroFloat64
+	}
+
+	return 1
+}
+
+func uptimeScore(h Host) float64 {
+	sorted := append([]hostdb.Interaction(nil), h.Interactions...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Timestamp.Before(sorted[j].Timestamp)
+	})
+
+	// special cases
+	weight := float64(1)
+	switch len(sorted) {
+	case 0:
+		weight = 0.25
+	case 1:
+		if sorted[0].Success {
+			weight = 0.75
+		} else {
+			weight = 0.25
+		}
+	case 2:
+		if sorted[0].Success && sorted[1].Success {
+			weight = 0.85
+		} else if sorted[0].Success || sorted[1].Success {
+			weight = 0.5
+		} else {
+			weight = 0.05
+		}
+	}
+	if weight < 1 {
+		return weight
+	}
+
+	// compute the total uptime and downtime by assuming that a host's
+	// online/offline state persists in the interval between each interaction
+	var downtime, uptime time.Duration
+	for i := 1; i < len(sorted); i++ {
+		prev, cur := sorted[i-1], sorted[i]
+		interval := cur.Timestamp.Sub(prev.Timestamp)
+		if prev.Success {
+			uptime += interval
+		} else {
+			downtime += interval
+		}
+	}
+	// account for the interval between the most recent interaction and the
+	// current time
+	finalInterval := time.Since(sorted[len(sorted)-1].Timestamp)
+	if sorted[len(sorted)-1].Success {
+		uptime += finalInterval
+	} else {
+		downtime += finalInterval
+	}
+	ratio := float64(uptime) / float64(uptime+downtime)
+
+	// unconditionally forgive up to 2% downtime
+	if ratio >= 0.98 {
+		ratio = 1
+	}
+
+	// forgive downtime inversely proportional to the number of interactions;
+	// e.g. if we have only interacted 4 times, and half of the interactions
+	// failed, assume a ratio of 88% rather than 50%
+	ratio = math.Max(ratio, 1-(0.03*float64(len(sorted))))
+
+	// Calculate the penalty for poor uptime. Penalties increase extremely
+	// quickly as uptime falls away from 95%.
+	weight = math.Pow(ratio, 200*math.Min(1-ratio, 0.30))
+	return weight
+}
+
+func versionScore(h Host) float64 {
+	settings, _, ok := h.LastKnownSettings()
+	if !ok {
+		return math.SmallestNonzeroFloat64
+	}
+
+	versions := []struct {
+		version string
+		penalty float64
+	}{
+		{"1.5.10", 1.0},
+		{"1.5.9", 0.99},
+		{"1.5.8", 0.99},
+		{"1.5.6", 0.90},
+	}
+	weight := 1.0
+	for _, v := range versions {
+		if build.VersionCmp(settings.Version, v.version) < 0 {
+			weight *= v.penalty
+		}
+	}
+	return weight
+}
+
+func randSelectByWeight(weights []float64) int {
+	// normalize
+	var total float64
+	for _, w := range weights {
+		total += w
+	}
+	for i, w := range weights {
+		weights[i] = w / total
+	}
+
+	// select
+	r := frand.Float64()
+	var sum float64
+	for i, w := range weights {
+		sum += w
+		if r < sum {
+			return i
+		}
+	}
+	return len(weights) - 1
+}

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -238,6 +238,9 @@ func versionScore(h Host) float64 {
 }
 
 func randSelectByWeight(weights []float64) int {
+	// deep copy the input
+	weights = append([]float64{}, weights...)
+
 	// normalize
 	var total float64
 	for _, w := range weights {

--- a/autopilot/hostscore_test.go
+++ b/autopilot/hostscore_test.go
@@ -1,0 +1,102 @@
+package autopilot
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"go.sia.tech/renterd/hostdb"
+	"go.sia.tech/renterd/internal/consensus"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
+	"go.sia.tech/siad/types"
+)
+
+func TestHostScore(t *testing.T) {
+	cfg := DefaultConfig()
+	day := 24 * time.Hour
+
+	h1 := newTestHost(newTestHostSettings())
+	h2 := newTestHost(newTestHostSettings())
+
+	// assert both hosts score equal
+	if hostScore(cfg, h1) != hostScore(cfg, h2) {
+		t.Fatal("unexpected")
+	}
+
+	// assert age affects the score
+	h1.Announcements[0].Timestamp = time.Now().Add(-1 * day)
+	if hostScore(cfg, h1) <= hostScore(cfg, h2) {
+		t.Fatal("unexpected")
+	}
+
+	// assert collateral affects the score
+	settings := newTestHostSettings()
+	settings.Collateral = types.NewCurrency64(1)
+	settings.MaxCollateral = types.NewCurrency64(10)
+	h1 = newTestHost(settings) // reset
+	if hostScore(cfg, h1) <= hostScore(cfg, h2) {
+		t.Fatal("unexpected")
+	}
+
+	// assert interactions affect the score
+	h1 = newTestHost(newTestHostSettings()) // reset
+	h1.Interactions = append(h1.Interactions, newTestScan(newTestHostSettings()))
+	if hostScore(cfg, h1) <= hostScore(cfg, h2) {
+		t.Fatal("unexpected")
+	}
+
+	// assert settings affect the score
+	h1 = newTestHost(newTestHostSettings()) // reset
+	h2Settings := newTestHostSettings()
+	h2Settings.AcceptingContracts = false
+	h2.Interactions = append(h2.Interactions, newTestScan(h2Settings))
+	if hostScore(cfg, h1) <= hostScore(cfg, h2) {
+		t.Fatal("unexpected")
+	}
+
+	// assert uptime affects the score
+	h2 = newTestHost(newTestHostSettings())
+	h2.Interactions[0].Success = false
+	if hostScore(cfg, h1) <= hostScore(cfg, h2) || ageScore(h1) != ageScore(h2) {
+		t.Fatal("unexpected")
+	}
+
+	// assert version affects the score
+	h2Settings = newTestHostSettings()
+	h2Settings.Version = "1.5.6" // lower
+	h2 = newTestHost(h2Settings) // reset
+	if hostScore(cfg, h1) <= hostScore(cfg, h2) {
+		t.Fatal("unexpected")
+	}
+}
+
+func newTestHost(settings *rhpv2.HostSettings) Host {
+	return Host{
+		hostdb.Host{
+			Announcements: []hostdb.Announcement{{Timestamp: time.Now()}},
+			Interactions:  []hostdb.Interaction{newTestScan(settings)},
+			PublicKey:     consensus.PublicKey{1},
+		},
+	}
+}
+
+func newTestHostSettings() *rhpv2.HostSettings {
+	return &rhpv2.HostSettings{
+		AcceptingContracts: true,
+		MaxDuration:        144 * 7 * 12, // 12w
+		Version:            "1.5.10",
+	}
+}
+
+func newTestScan(settings *rhpv2.HostSettings) hostdb.Interaction {
+	js, err := json.Marshal(settings)
+	if err != nil {
+		panic(err)
+	}
+	return hostdb.Interaction{
+		Timestamp: time.Now(),
+		Type:      "scan",
+		Success:   true,
+		Result:    json.RawMessage(js),
+	}
+}

--- a/autopilot/hostscore_test.go
+++ b/autopilot/hostscore_test.go
@@ -47,15 +47,6 @@ func TestHostScore(t *testing.T) {
 		t.Fatal("unexpected")
 	}
 
-	// assert settings affect the score
-	h1 = newTestHost(newTestHostSettings()) // reset
-	h2Settings := newTestHostSettings()
-	h2Settings.AcceptingContracts = false
-	h2.Interactions = append(h2.Interactions, newTestScan(h2Settings))
-	if hostScore(cfg, h1) <= hostScore(cfg, h2) {
-		t.Fatal("unexpected")
-	}
-
 	// assert uptime affects the score
 	h2 = newTestHost(newTestHostSettings())
 	h2.Interactions[0].Success = false
@@ -64,7 +55,7 @@ func TestHostScore(t *testing.T) {
 	}
 
 	// assert version affects the score
-	h2Settings = newTestHostSettings()
+	h2Settings := newTestHostSettings()
 	h2Settings.Version = "1.5.6" // lower
 	h2 = newTestHost(h2Settings) // reset
 	if hostScore(cfg, h1) <= hostScore(cfg, h2) {

--- a/bus/client.go
+++ b/bus/client.go
@@ -237,7 +237,7 @@ func (c *Client) ReleaseContractLock(types.FileContractID) error {
 func (c *Client) ActiveContracts() ([]Contract, error) {
 	panic("unimplemented")
 }
-func (c *Client) DeleteContracts(ids ...types.FileContractID) error {
+func (c *Client) DeleteContracts(ids []types.FileContractID) error {
 	panic("unimplemented")
 }
 func (c *Client) AllContracts() ([]Contract, error) {


### PR DESCRIPTION
This PR adds a new file that holds all scoring functions we apply to a host.

Left two TODOs:
- `priceAdjustmentScore`
- `storageRemainingScore` 

Those use a bunch of arbitrary values we might want to revisit or get rid of all together.
I'll add those in a separate PR to keep the PR small. 

