### PR TITLE
Hosts query fix

### DIFF
--- a/autopilot/scanner_test.go
+++ b/autopilot/scanner_test.go
@@ -136,7 +136,7 @@ func TestScanner(t *testing.T) {
 	if !s.isScanning() {
 		t.Fatal("unexpected")
 	}
-	close(w.blockChan) // use blockchan to avoid NDF when checking isScanning
+	close(w.blockChan) // we have to block on a channel to avoid an NDF on the isScanning check
 
 	// immediately interrupt the scanner
 	close(s.stopChan)

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -317,7 +317,7 @@ func (db *SQLStore) Hosts(notSince time.Time, max int) ([]hostdb.Host, error) {
 		Joins("LEFT JOIN host_interactions ON host_interactions.db_host_id = hosts.ID").
 		Select("Public_key").
 		Group("Public_Key").
-		Having("MAX(COALESCE(Timestamp, CAST(0 as datetime))) < ?", notSince.UTC()). // use UTC since we stored timestamps in UTC
+		Having("IFNULL(MAX(Timestamp), 0) < ?", notSince.UTC()). // use UTC since we stored timestamps in UTC
 		Limit(max).
 		Find(&foundHosts).
 		Error

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -314,10 +314,10 @@ func (db *SQLStore) Hosts(notSince time.Time, max int) ([]hostdb.Host, error) {
 	// given time.
 	var foundHosts [][]byte
 	err := db.db.Table("hosts").
-		Joins("JOIN host_interactions ON host_interactions.db_host_id = hosts.ID").
+		Joins("LEFT JOIN host_interactions ON host_interactions.db_host_id = hosts.ID").
 		Select("Public_key").
 		Group("Public_Key").
-		Having("MAX(Timestamp) < ?", notSince.UTC()). // use UTC since we stored timestamps in UTC
+		Having("MAX(COALESCE(Timestamp, CAST(0 as datetime))) < ?", notSince.UTC()). // use UTC since we stored timestamps in UTC
 		Limit(max).
 		Find(&foundHosts).
 		Error

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -306,6 +306,5 @@ func TestSQLHosts(t *testing.T) {
 
 // addTestHost ensures a host with given hostkey exists in the db.
 func (s *SQLStore) addTestHost(hk consensus.PublicKey) error {
-	var host dbHost
-	return s.db.FirstOrCreate(&host, &dbHost{PublicKey: hk}).Error
+	return s.db.FirstOrCreate(&dbHost{}, &dbHost{PublicKey: hk}).Error
 }

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -10,17 +10,8 @@ import (
 	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/consensus"
 	"go.sia.tech/siad/modules"
+	"gorm.io/gorm"
 )
-
-// addTestHost adds a host to the db by creating a fake interaction for it.
-func (s *SQLStore) addTestHost(hk consensus.PublicKey) error {
-	return s.RecordInteraction(hk, hostdb.Interaction{
-		Timestamp: time.Now(),
-		Type:      "foo1",
-
-		Result: []byte{1},
-	})
-}
 
 // TestSQLHostDB tests the basic functionality of SQLHostDB using an in-memory
 // SQLite DB.
@@ -33,33 +24,56 @@ func TestSQLHostDB(t *testing.T) {
 		t.Fatal("wrong ccid", ccid, modules.ConsensusChangeBeginning)
 	}
 
-	// Create a host and 2 interactions. One interaction is an hour in the
-	// past and one is an hour in the future.
-	hostKey := consensus.GeneratePrivateKey().PublicKey()
+	// Try to fetch a random host. Should fail.
+	hk := consensus.GeneratePrivateKey().PublicKey()
+	_, err = hdb.Host(hk)
+	if !errors.Is(err, ErrHostNotFound) {
+		t.Fatal(err)
+	}
+
+	// Add the host
+	err = hdb.addTestHost(hk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert it's returned
+	allHosts, err := hdb.Hosts(time.Now(), -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(allHosts) != 1 || allHosts[0].PublicKey != hk {
+		t.Fatal("unexpected result", len(allHosts))
+	}
+
+	// Add an interaction one hour in the past
 	currentTime := time.Now().UTC().Round(time.Second)
 	hi1 := hostdb.Interaction{
-		Timestamp: currentTime,
+		Timestamp: currentTime.Add(-time.Hour),
 		Type:      "foo1",
 
 		Result: []byte{1},
 	}
+	if err := hdb.RecordInteraction(hk, hi1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert it's excluded from the return set if we pass a `notSince` before the interaction
+	allHosts, err = hdb.Hosts(time.Now().Add(-2*time.Hour), -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(allHosts) != 0 {
+		t.Fatal("unexpected result", len(allHosts))
+	}
+
+	// Add another interaction.
 	hi2 := hostdb.Interaction{
 		Timestamp: currentTime,
 		Type:      "foo2",
 		Result:    []byte{2},
 	}
-
-	// Try to fetch the host. Should fail.
-	_, err = hdb.Host(hostKey)
-	if !errors.Is(err, ErrHostNotFound) {
-		t.Fatal(err)
-	}
-
-	// Add the interactions to the db.
-	if err := hdb.RecordInteraction(hostKey, hi1); err != nil {
-		t.Fatal(err)
-	}
-	if err := hdb.RecordInteraction(hostKey, hi2); err != nil {
+	if err := hdb.RecordInteraction(hk, hi2); err != nil {
 		t.Fatal(err)
 	}
 
@@ -89,7 +103,7 @@ func TestSQLHostDB(t *testing.T) {
 		Timestamp:  time.Now().UTC().Round(time.Second),
 		NetAddress: "host.com",
 	}
-	err = insertAnnouncement(hdb.db, hostKey, a)
+	err = insertAnnouncement(hdb.db, hk, a)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +140,7 @@ func TestSQLHostDB(t *testing.T) {
 	}
 
 	// Same thing again but with Host.
-	h2, err := hdb.Host(hostKey)
+	h2, err := hdb.Host(hk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +181,7 @@ func TestSQLHostDB(t *testing.T) {
 	if ccid != ccid2 {
 		t.Fatal("ccid wasn't updated", ccid, ccid2)
 	}
-	_, err = hdb2.Host(hostKey)
+	_, err = hdb2.Host(hk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,4 +302,12 @@ func TestSQLHosts(t *testing.T) {
 	if err1 != nil && err2 != nil && err3 != nil {
 		t.Fatal(err1, err2, err3)
 	}
+}
+
+// addTestHost ensures a host with given hostkey exists in the db.
+func (s *SQLStore) addTestHost(hk consensus.PublicKey) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		var host dbHost
+		return tx.FirstOrCreate(&host, &dbHost{PublicKey: hk}).Error
+	})
 }

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -57,13 +57,14 @@ func TestSQLHostDB(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Assert it's excluded from the return set if we pass a `notSince` before the interaction
+	// Assert we can include/exclude the host if we play around with the notSince param
 	allHosts, err = hdb.Hosts(time.Now().Add(-2*time.Hour), -1)
-	if err != nil {
-		t.Fatal(err)
+	if err != nil || len(allHosts) != 0 {
+		t.Fatal("unexpected result", err, len(allHosts))
 	}
-	if len(allHosts) != 0 {
-		t.Fatal("unexpected result", len(allHosts))
+	allHosts, err = hdb.Hosts(time.Now().Add(-30*time.Minute), -1)
+	if err != nil || len(allHosts) != 1 || allHosts[0].PublicKey != hk {
+		t.Fatal("unexpected result", err, len(allHosts))
 	}
 
 	// Add another interaction.

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -10,7 +10,6 @@ import (
 	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/consensus"
 	"go.sia.tech/siad/modules"
-	"gorm.io/gorm"
 )
 
 // TestSQLHostDB tests the basic functionality of SQLHostDB using an in-memory
@@ -306,8 +305,6 @@ func TestSQLHosts(t *testing.T) {
 
 // addTestHost ensures a host with given hostkey exists in the db.
 func (s *SQLStore) addTestHost(hk consensus.PublicKey) error {
-	return s.db.Transaction(func(tx *gorm.DB) error {
-		var host dbHost
-		return tx.FirstOrCreate(&host, &dbHost{PublicKey: hk}).Error
-	})
+	var host dbHost
+	return s.db.FirstOrCreate(&host, &dbHost{PublicKey: hk}).Error
 }


### PR DESCRIPTION
There's a bug in `AllHosts` where it does not return hosts without interactions. This is because of the `notSince` parameter that needs to `JOIN` on interactions to figure out `MAX(timestamp)` to be able to compare it to `notSince`. I updated the query a bit and added a test.

The end result is actually quite a funny catch-22, the autopilot's scanner fetches all hosts in order to scan them and add interactions, but in fact is getting an empty list every time because hosts don't have interactions attached.

edit: highjacking this PR to take a small NDF fix along wrt scanner_test