### PR TITLE
Settings

### DIFF
--- a/autopilot/api.go
+++ b/autopilot/api.go
@@ -27,10 +27,6 @@ type (
 		Upload      uint64
 		Storage     uint64
 	}
-	ObjectsConfig struct {
-		MinShards   uint8
-		TotalShards uint8
-	}
 )
 
 // Config contains all autopilot configuration parameters.
@@ -38,7 +34,6 @@ type Config struct {
 	Wallet    WalletConfig
 	Hosts     HostsConfig
 	Contracts ContractsConfig
-	Objects   ObjectsConfig
 }
 
 func DefaultConfig() (c Config) {
@@ -51,8 +46,6 @@ func DefaultConfig() (c Config) {
 	c.Contracts.Upload = 1 << 40          // 1 TiB
 	c.Contracts.Download = 1 << 40        // 1 TiB
 	c.Contracts.Storage = 1 << 42         // 4 TiB
-	c.Objects.MinShards = 10
-	c.Objects.TotalShards = 30
 	return
 }
 

--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -281,7 +281,7 @@ func (s *scanner) performHostScans() error {
 		}
 	}
 
-	return utils.JoinErrors(errs)
+	return utils.JoinErrors(errs...)
 }
 
 func (s *scanner) isScanRequired() bool {

--- a/bus/api.go
+++ b/bus/api.go
@@ -168,3 +168,14 @@ type UploadParams struct {
 	TotalShards   uint8
 	ContractSet   string
 }
+
+type RedundancySettings struct {
+	MinShards   int
+	TotalShards int
+}
+
+func DefaultRedundancySettings() (rs RedundancySettings) {
+	rs.MinShards = 10
+	rs.TotalShards = 30
+	return
+}

--- a/bus/api.go
+++ b/bus/api.go
@@ -170,12 +170,6 @@ type UploadParams struct {
 }
 
 type RedundancySettings struct {
-	MinShards   int
-	TotalShards int
-}
-
-func DefaultRedundancySettings() (rs RedundancySettings) {
-	rs.MinShards = 10
-	rs.TotalShards = 30
-	return
+	MinShards   uint64
+	TotalShards uint64
 }

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -112,7 +112,7 @@ type bus struct {
 	ss  SettingStore
 }
 
-func (b *bus) loadDefaultSettings() (err error) {
+func (b *bus) ensureRedundancySettings() (err error) {
 	rs := DefaultRedundancySettings()
 
 	// check min shards setting
@@ -696,7 +696,7 @@ func New(s Syncer, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, cs
 		ss:  ss,
 	}
 
-	if err := b.loadDefaultSettings(); err != nil {
+	if err := b.ensureRedundancySettings(); err != nil {
 		return nil, err
 	}
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -324,6 +324,29 @@ func (c *Client) ContractsForSlab(shards []object.Sector) (contracts []renterd.C
 	panic("unimplemented")
 }
 
+// Setting returns the value for the setting with given key.
+func (c *Client) Setting(key string) (setting string, err error) {
+	err = c.c.GET(fmt.Sprintf("/setting/%s", key), &setting)
+	return
+}
+
+// Settings returns the keys of all settings in the store.
+func (c *Client) Settings() (settings []string, err error) {
+	err = c.c.GET("/settings", &settings)
+	return
+}
+
+// UpdateSetting will update or insert the setting for given key with the given value.
+func (c *Client) UpdateSetting(key, value string) error {
+	return c.c.POST(fmt.Sprintf("/setting/%s/%s", key, value), nil, nil)
+}
+
+// RedundancySettings returns the configured redundancy settings.
+func (c *Client) RedundancySettings() (rs RedundancySettings, err error) {
+	err = c.c.GET("/settings/redundancy", &rs)
+	return
+}
+
 // Object returns the object at the given path, or, if path ends in '/', the
 // entries under that path.
 func (c *Client) Object(path string) (o object.Object, entries []string, err error) {

--- a/bus/client.go
+++ b/bus/client.go
@@ -350,14 +350,15 @@ func (c *Client) UpdateSetting(key string, value interface{}) error {
 	return c.c.POST(fmt.Sprintf("/setting/%s/%s", key, url.QueryEscape(string(v))), nil, nil)
 }
 
-func (c *Client) UpdateRedundancySettings(rs RedundancySettings) error {
-	return c.UpdateSetting(SettingRedundancy, rs)
-}
-
-// RedundancySettings returns the configured redundancy settings.
+// RedundancySettings returns the redundancy settings.
 func (c *Client) RedundancySettings() (rs RedundancySettings, err error) {
 	err = c.Setting(SettingRedundancy, &rs)
 	return
+}
+
+// UpdateRedundancySettings allows configuring the redundancy.
+func (c *Client) UpdateRedundancySettings(rs RedundancySettings) error {
+	return c.UpdateSetting(SettingRedundancy, rs)
 }
 
 // Object returns the object at the given path, or, if path ends in '/', the

--- a/bus/client_test.go
+++ b/bus/client_test.go
@@ -1,0 +1,99 @@
+package bus_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.sia.tech/jape"
+	"go.sia.tech/renterd/bus"
+	"go.sia.tech/renterd/internal/consensus"
+	"go.sia.tech/renterd/internal/node"
+	"go.sia.tech/renterd/internal/utils"
+)
+
+func TestClient(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	c, serveFn, shutdownFn, err := newTestClient(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := shutdownFn(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+	go serveFn()
+
+	// assert setting 'foo' is not found
+	err = c.Setting("foo", nil)
+	if err == nil || !strings.Contains(err.Error(), "setting not found") {
+		t.Fatal("unexpected err", err)
+	}
+
+	// update setting 'foo' to some random type
+	want := bus.RedundancySettings{
+		MinShards:   10,
+		TotalShards: 30,
+	}
+	if err := c.UpdateSetting("foo", want); err != nil {
+		t.Fatal(err)
+	}
+
+	// fetch setting 'foo' and assert it matches
+	var got bus.RedundancySettings
+	if err := c.Setting("foo", &got); err != nil {
+		t.Fatal("unexpected err", err)
+	}
+	if got.MinShards != want.MinShards || got.TotalShards != want.TotalShards {
+		wb, _ := json.Marshal(want)
+		gb, _ := json.Marshal(got)
+		t.Fatal("unexpected result", string(wb), string(gb))
+	}
+}
+
+func newTestClient(dir string) (*bus.Client, func() error, func(context.Context) error, error) {
+	// create listener
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// create client
+	client := bus.NewClient("http://"+l.Addr().String(), "test")
+
+	b, cleanup, err := node.NewBus(node.BusConfig{
+		Bootstrap:   false,
+		GatewayAddr: "127.0.0.1:0",
+		Miner:       node.NewMiner(client),
+	}, filepath.Join(dir, "bus"), consensus.GeneratePrivateKey())
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// create server
+	server := http.Server{Handler: jape.BasicAuth("test")(b)}
+
+	serveFn := func() error {
+		err := server.Serve(l)
+		if err != nil && !strings.Contains(err.Error(), "Server closed") {
+			return err
+		}
+		return nil
+	}
+
+	shutdownFn := func(ctx context.Context) error {
+		return utils.JoinErrors(
+			cleanup(),
+			server.Shutdown(ctx),
+		)
+	}
+	return client, serveFn, shutdownFn, nil
+}

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -101,6 +101,8 @@ func main() {
 	flag.StringVar(&busCfg.remoteAddr, "bus.remoteAddr", "", "URL of remote bus service")
 	flag.StringVar(&busCfg.apiPassword, "bus.apiPassword", "", "API password for remote bus service")
 	flag.BoolVar(&busCfg.Bootstrap, "bus.bootstrap", true, "bootstrap the gateway and consensus modules")
+	flag.Uint64Var(&busCfg.MinShards, "bus.minShards", 10, "min amount of shards needed to reconstruct the slab")
+	flag.Uint64Var(&busCfg.TotalShards, "bus.totalShards", 30, "total amount of shards for each slab")
 	flag.StringVar(&busCfg.GatewayAddr, "bus.gatewayAddr", ":9981", "address to listen on for Sia peer connections")
 	flag.StringVar(&workerCfg.remoteAddr, "worker.remoteAddr", "", "URL of remote worker service")
 	flag.StringVar(&workerCfg.apiPassword, "worker.apiPassword", "", "API password for remote worker service")

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -222,7 +222,10 @@ func NewBus(cfg BusConfig, dir string, walletKey consensus.PrivateKey) (http.Han
 		return nil
 	}
 
-	b := bus.New(syncer{g, tp}, chainManager{cm}, txpool{tp}, w, sqlStore, sqlStore, sqlStore, sqlStore)
+	b, err := bus.New(syncer{g, tp}, chainManager{cm}, txpool{tp}, w, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore)
+	if err != nil {
+		return nil, nil, err
+	}
 	return b, cleanup, nil
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -29,6 +29,8 @@ type BusConfig struct {
 	Bootstrap   bool
 	GatewayAddr string
 	Miner       *Miner
+
+	bus.RedundancySettings
 }
 
 type AutopilotConfig struct {
@@ -222,7 +224,7 @@ func NewBus(cfg BusConfig, dir string, walletKey consensus.PrivateKey) (http.Han
 		return nil
 	}
 
-	b, err := bus.New(syncer{g, tp}, chainManager{cm}, txpool{tp}, w, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore)
+	b, err := bus.New(syncer{g, tp}, chainManager{cm}, txpool{tp}, w, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, cfg.RedundancySettings)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/stores/settingsdb.go
+++ b/internal/stores/settingsdb.go
@@ -14,7 +14,7 @@ type (
 	dbSetting struct {
 		Model
 
-		Key   string `gorm:"unique;index"`
+		Key   string `gorm:"unique;index;NOT NULL"`
 		Value string `gorm:"NOT NULL"`
 	}
 )

--- a/internal/stores/settingsdb.go
+++ b/internal/stores/settingsdb.go
@@ -1,0 +1,55 @@
+package stores
+
+import (
+	"errors"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ErrSettingNotFound is returned if a specific setting can't be retrieved from the db.
+var ErrSettingNotFound = errors.New("setting not found")
+
+type (
+	dbSetting struct {
+		Model
+
+		Key   string `gorm:"unique;index"`
+		Value string `gorm:"NOT NULL"`
+	}
+)
+
+// TableName implements the gorm.Tabler interface.
+func (dbSetting) TableName() string { return "settings" }
+
+// Setting implements the bus.SettingStore interface.
+func (s *SQLStore) Setting(key string) (string, error) {
+	var entry dbSetting
+	err := s.db.Where(&dbSetting{Key: key}).
+		Take(&entry).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", ErrSettingNotFound
+	} else if err != nil {
+		return "", err
+	}
+
+	return entry.Value, nil
+}
+
+// Settings implements the bus.SettingStore interface.
+func (s *SQLStore) Settings() ([]string, error) {
+	var keys []string
+	tx := s.db.Model(&dbSetting{}).Select("Key").Find(&keys)
+	return keys, tx.Error
+}
+
+// Setting implements the bus.SettingStore interface.
+func (s *SQLStore) UpdateSetting(key, value string) error {
+	return s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value"}),
+	}).Create(&dbSetting{
+		Key:   key,
+		Value: value,
+	}).Error
+}

--- a/internal/stores/settingsdb.go
+++ b/internal/stores/settingsdb.go
@@ -2,6 +2,7 @@ package stores
 
 import (
 	"errors"
+	"fmt"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -28,7 +29,7 @@ func (s *SQLStore) Setting(key string) (string, error) {
 	err := s.db.Where(&dbSetting{Key: key}).
 		Take(&entry).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return "", ErrSettingNotFound
+		return "", fmt.Errorf("key '%s' err: %w", key, ErrSettingNotFound)
 	} else if err != nil {
 		return "", err
 	}

--- a/internal/stores/settingsdb_test.go
+++ b/internal/stores/settingsdb_test.go
@@ -19,7 +19,7 @@ func TestSQLSettingStore(t *testing.T) {
 	}
 
 	// add a setting
-	if err = ss.UpdateSetting("foo", "bar"); err != nil {
+	if err := ss.UpdateSetting("foo", "bar"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -40,7 +40,7 @@ func TestSQLSettingStore(t *testing.T) {
 	}
 
 	// assert we can update the setting
-	if err = ss.UpdateSetting("foo", "barbaz"); err != nil {
+	if err := ss.UpdateSetting("foo", "barbaz"); err != nil {
 		t.Fatal(err)
 	} else if value, err := ss.Setting("foo"); err != nil {
 		t.Fatal(err)

--- a/internal/stores/settingsdb_test.go
+++ b/internal/stores/settingsdb_test.go
@@ -1,0 +1,50 @@
+package stores
+
+import (
+	"testing"
+)
+
+// TestSQLSettingStore tests the bus.SettingStore methods on the SQLSettingStore.
+func TestSQLSettingStore(t *testing.T) {
+	ss, _, _, err := newTestSQLStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert there are no settings
+	if keys, err := ss.Settings(); err != nil {
+		t.Fatal(err)
+	} else if len(keys) != 0 {
+		t.Fatalf("unexpected number of settings, %v != 0", len(keys))
+	}
+
+	// add a setting
+	if err = ss.UpdateSetting("foo", "bar"); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert it's returned
+	if keys, err := ss.Settings(); err != nil {
+		t.Fatal(err)
+	} else if len(keys) != 1 {
+		t.Fatalf("unexpected number of settings, %v != 1", len(keys))
+	} else if keys[0] != "foo" {
+		t.Fatalf("unexpected key, %s != 'foo'", keys[0])
+	}
+
+	// assert we can query the setting by key
+	if value, err := ss.Setting("foo"); err != nil {
+		t.Fatal(err)
+	} else if value != "bar" {
+		t.Fatalf("unexpected value, %s != 'bar'", value)
+	}
+
+	// assert we can update the setting
+	if err = ss.UpdateSetting("foo", "barbaz"); err != nil {
+		t.Fatal(err)
+	} else if value, err := ss.Setting("foo"); err != nil {
+		t.Fatal(err)
+	} else if value != "barbaz" {
+		t.Fatalf("unexpected value, %s != 'barbaz'", value)
+	}
+}

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -72,6 +72,9 @@ func NewSQLStore(conn gorm.Dialector, migrate bool) (*SQLStore, modules.Consensu
 			&dbSlab{},
 			&dbSector{},
 			&dbShard{},
+
+			// bus.SettingStore tables
+			&dbSetting{},
 		}
 		if err := db.AutoMigrate(tables...); err != nil {
 			return nil, modules.ConsensusChangeID{}, err

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -76,10 +76,6 @@ var defaultAutopilotConfig = autopilot.Config{
 		Upload:   modules.SectorSize * 500,
 		Storage:  modules.SectorSize * 5e3,
 	},
-	Objects: autopilot.ObjectsConfig{
-		MinShards:   2,
-		TotalShards: 2,
-	},
 	Hosts: autopilot.HostsConfig{
 		IgnoreRedundantIPs: true, // ignore for integration tests by default // TODO: add test for IP filter.
 	},

--- a/internal/utils/errors.go
+++ b/internal/utils/errors.go
@@ -6,7 +6,7 @@ import (
 )
 
 // TODO: replace with errors.join (Go 1.20)
-func JoinErrors(errs []error) error {
+func JoinErrors(errs ...error) error {
 	filtered := errs[:0]
 	for _, err := range errs {
 		if err != nil {


### PR DESCRIPTION
This PR adds a `settings` table. It's just a very simple K/V store which I think is the most flexible solution.

It exposes the following routes on the `bus`:
- `GET    /settings`
- `GET    /setting/:key`
- `POST  /setting/:key/:value`

Currently we have only redundancy settings but soon we'll have more; I figured every type of settings could have its own settings object, with sane defaults that we `load()` when the bus loads. So expect `GougingSettings` soon.

I considered adding those to the bus config but since settings can be updated through the API, and since I expect we will end up with a bunch of settings eventually, I figured it was best to keep them out of the bus config but instead load defaults if we find they haven't already been set. Users can then easily overwrite them once with the desired setting.

edit: ended up adding them to the `BusConfig`