### PR TITLE
Export ChainIndex in rhp

### DIFF
--- a/rhp/v2/rhp.go
+++ b/rhp/v2/rhp.go
@@ -20,6 +20,10 @@ type (
 	PrivateKey = consensus.PrivateKey
 	// A Signature is an Ed25519 signature.
 	Signature = consensus.Signature
+	// A BlockID uniquely identifies a block.
+	BlockID = consensus.BlockID
+	// A ChainIndex pairs a block's height with its ID.
+	ChainIndex = consensus.ChainIndex
 	// ConsensusState represents the full state of the chain as of a particular block.
 	ConsensusState = consensus.State
 )


### PR DESCRIPTION
Need `ChainIndex` to build `ConsensusState` for `RPCFormContract` and `RenewContract` outside of `renterd`. Would it be better to move `consensus` out of `internal` instead of having exports everywhere?