### PR TITLE
Fix Scanpool Race 

### DIFF
--- a/autopilot/scanner_test.go
+++ b/autopilot/scanner_test.go
@@ -95,8 +95,8 @@ func TestScanner(t *testing.T) {
 	}
 
 	// reset the scanner
-	w = &mockWorker{blockChan: make(chan struct{})}
-	s = newTestScanner(b, w)
+	w.blockChan = make(chan struct{})
+	s.scanningLastStart = time.Time{}
 
 	// start another scan
 	if errChan = s.tryPerformHostScan(); errChan == nil {

--- a/autopilot/scanner_test.go
+++ b/autopilot/scanner_test.go
@@ -127,7 +127,7 @@ func TestScanner(t *testing.T) {
 }
 
 func newTestScanner(b *mockBus, w *mockWorker) *scanner {
-	s := &scanner{
+	return &scanner{
 		bus:    b,
 		worker: w,
 		logger: zap.New(zapcore.NewNopCore()).Sugar(),
@@ -138,8 +138,7 @@ func newTestScanner(b *mockBus, w *mockWorker) *scanner {
 			trackerMinTimeout,
 		),
 		stopChan:        make(chan struct{}),
+		scanThreads:     3,
 		scanMinInterval: time.Second,
 	}
-	s.pool = &scanPool{numThreads: 3, s: s}
-	return s
 }


### PR DESCRIPTION
Turns out there was a data race in the scanner pool. I ran the integration tests in a loop to try and reproduce it and caught it. The handling of the channels and threads in `performHostScan` was a bit sloppy and was mainly due to the `scanPool` object. Instead of adding more locking I decided to just inline the scan pool which makes everything a lot simpler.

race: https://github.com/SiaFoundation/renterd/actions/runs/3687188966/jobs/6240446150
fix: https://github.com/SiaFoundation/renterd/actions/runs/3687664093/jobs/6241531530