### PR TITLE
Establish many2many relation between contracts and contractsets

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -49,7 +49,7 @@ type Bus interface {
 
 	// contractsets
 	SetContractSet(name string, contracts []types.FileContractID) error
-	ContractSetContracts(name string) ([]bus.Contract, error)
+	ContractSet(name string) ([]bus.Contract, error)
 
 	// txpool
 	RecommendedFee() (types.Currency, error)

--- a/bus/client.go
+++ b/bus/client.go
@@ -286,7 +286,7 @@ func (c *Client) ContractSets() (sets []string, err error) {
 }
 
 // HostSet returns the contracts in the given set.
-func (c *Client) ContractSet(name string) (hosts []types.FileContractID, err error) {
+func (c *Client) ContractSet(name string) (hosts []Contract, err error) {
 	err = c.c.GET(fmt.Sprintf("/contractsets/%s", name), &hosts)
 	return
 }
@@ -294,14 +294,6 @@ func (c *Client) ContractSet(name string) (hosts []types.FileContractID, err err
 // SetContractSet assigns a name to the given contracts.
 func (c *Client) SetContractSet(name string, contracts []types.FileContractID) (err error) {
 	err = c.c.PUT(fmt.Sprintf("/contractsets/%s", name), contracts)
-	return
-}
-
-// ContractSetContracts returns the full contract for each contract id in the
-// given set.  The ID and HostIP fields may be empty, depending on whether a
-// contract exists and a host announcement is known.
-func (c *Client) ContractSetContracts(name string) (contracts []Contract, err error) {
-	err = c.c.GET(fmt.Sprintf("/contractsets/%s/contracts", name), &contracts)
 	return
 }
 

--- a/internal/stores/contracts.go
+++ b/internal/stores/contracts.go
@@ -66,9 +66,6 @@ func (dbContract) TableName() string { return "contracts" }
 // TableName implements the gorm.Tabler interface.
 func (dbContractSet) TableName() string { return "contract_sets" }
 
-// TableName implements the gorm.Tabler interface.
-func (dbContractSetEntry) TableName() string { return "contract_set_entries" }
-
 // convert converts a dbContractRHPv2 to a rhpv2.Contract type.
 func (c dbContract) convert() (bus.Contract, error) {
 	return bus.Contract{

--- a/internal/stores/contractsets.go
+++ b/internal/stores/contractsets.go
@@ -1,8 +1,11 @@
 package stores
 
 import (
+	"bytes"
+	"encoding/gob"
 	"errors"
 
+	"go.sia.tech/renterd/bus"
 	"go.sia.tech/siad/types"
 	"gorm.io/gorm"
 )
@@ -11,16 +14,18 @@ type (
 	dbContractSet struct {
 		Model
 
-		Name      string               `gorm:"unique;index"`
-		Contracts []dbContractSetEntry `gorm:"constraint:OnDelete:CASCADE"`
+		Name      string       `gorm:"unique;index"`
+		Contracts []dbContract `gorm:"many2many:contract_set_contracts;constraint:OnDelete:CASCADE"`
 	}
 
-	dbContractSetEntry struct {
-		Model
-		DBContractSetID uint
-		FCID            types.FileContractID `gorm:"NOT NULL;type:bytes;serializer:gob"`
+	dbContractSetContract struct {
+		DBContractID    uint `gorm:"primaryKey"`
+		DBContractSetID uint `gorm:"primaryKey"`
 	}
 )
+
+// TableName implements the gorm.Tabler interface.
+func (dbContractSetContract) TableName() string { return "contract_set_contracts" }
 
 // ContractSets implements the bus.ContractSetStore interface.
 func (s *SQLStore) ContractSets() ([]string, error) {
@@ -32,32 +37,38 @@ func (s *SQLStore) ContractSets() ([]string, error) {
 }
 
 // HostSet implements the bus.ContractSetStore interface.
-func (s *SQLStore) ContractSet(name string) ([]types.FileContractID, error) {
+func (s *SQLStore) ContractSet(name string) ([]bus.Contract, error) {
 	var hostSet dbContractSet
 	err := s.db.Where(&dbContractSet{Name: name}).
-		Preload("Contracts").
+		Preload("Contracts.Host.Announcements").
 		Take(&hostSet).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, ErrContractSetNotFound
 	} else if err != nil {
 		return nil, err
 	}
-	fcids := make([]types.FileContractID, len(hostSet.Contracts))
-	for i, entry := range hostSet.Contracts {
-		fcids[i] = entry.FCID
+	contracts := make([]bus.Contract, len(hostSet.Contracts))
+	for i, c := range hostSet.Contracts {
+		contracts[i], err = c.convert()
+		if err != nil {
+			return nil, err
+		}
 	}
-	return fcids, nil
+	return contracts, nil
 }
 
 // SetContractSet implements the bus.ContractSetStore interface.
 func (s *SQLStore) SetContractSet(name string, contracts []types.FileContractID) error {
-	contractSetEntries := make([]dbContractSetEntry, len(contracts))
+	contractIDs := make([][]byte, len(contracts))
 	for i, fcid := range contracts {
-		contractSetEntries[i] = dbContractSetEntry{
-			FCID: fcid,
+		fcidGob := bytes.NewBuffer(nil)
+		if err := gob.NewEncoder(fcidGob).Encode(fcid); err != nil {
+			return err
 		}
+		contractIDs[i] = fcidGob.Bytes()
 	}
 	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Delete existing set.
 		err := tx.Model(&dbContractSet{}).
 			Where("name", name).
 			Delete(&dbContractSet{}).
@@ -65,9 +76,18 @@ func (s *SQLStore) SetContractSet(name string, contracts []types.FileContractID)
 		if err != nil {
 			return err
 		}
+		// Fetch contracts.
+		var dbContracts []dbContract
+		err = tx.Model(&dbContract{}).
+			Where("fcid in ?", contractIDs).
+			Find(&dbContracts).Error
+		if err != nil {
+			return err
+		}
+		// Create set.
 		return tx.Create(&dbContractSet{
 			Name:      name,
-			Contracts: contractSetEntries,
+			Contracts: dbContracts,
 		}).Error
 	})
 }

--- a/internal/stores/contractsets_test.go
+++ b/internal/stores/contractsets_test.go
@@ -2,15 +2,82 @@ package stores
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 
+	"go.sia.tech/renterd/bus"
+	"go.sia.tech/renterd/internal/consensus"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
+	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/types"
 )
+
+func (s *SQLStore) addTestContract(fcid types.FileContractID, hk consensus.PublicKey) (bus.Contract, error) {
+	uc, _ := types.GenerateDeterministicMultisig(1, 2, "salt")
+	uc.PublicKeys[1].Key = hk[:]
+	uc.Timelock = 192837
+	rev := rhpv2.ContractRevision{
+		Revision: types.FileContractRevision{
+			ParentID:          fcid,
+			UnlockConditions:  uc,
+			NewRevisionNumber: 200,
+			NewFileSize:       4096,
+			NewFileMerkleRoot: crypto.Hash{222},
+			NewWindowStart:    400,
+			NewWindowEnd:      500,
+			NewValidProofOutputs: []types.SiacoinOutput{
+				{
+					Value:      types.NewCurrency64(121),
+					UnlockHash: types.UnlockHash{2, 1, 2},
+				},
+			},
+			NewMissedProofOutputs: []types.SiacoinOutput{
+				{
+					Value:      types.NewCurrency64(323),
+					UnlockHash: types.UnlockHash{2, 3, 2},
+				},
+			},
+			NewUnlockHash: types.UnlockHash{6, 6, 6},
+		},
+		Signatures: [2]types.TransactionSignature{
+			{
+				ParentID:       crypto.Hash(fcid),
+				PublicKeyIndex: 0,
+				Timelock:       100000,
+				CoveredFields:  types.FullCoveredFields,
+				Signature:      []byte("signature1"),
+			},
+			{
+				ParentID:       crypto.Hash(fcid),
+				PublicKeyIndex: 1,
+				Timelock:       200000,
+				CoveredFields:  types.FullCoveredFields,
+				Signature:      []byte("signature2"),
+			},
+		},
+	}
+	return s.AddContract(rev, types.ZeroCurrency, 0)
+}
 
 // TestSQLContractSetStore tests the bus.ContractSetStore methods on the SQLContractStore.
 func TestSQLContractSetStore(t *testing.T) {
 	cs, _, _, err := newTestSQLStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a host.
+	hk1 := consensus.GeneratePrivateKey().PublicKey()
+	err = cs.addTestHost(hk1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add 2 contracts with that host.
+	c1, err := cs.addTestContract(types.FileContractID{1, 2, 3}, hk1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2, err := cs.addTestContract(types.FileContractID{3, 2, 1}, hk1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +97,7 @@ func TestSQLContractSetStore(t *testing.T) {
 	}
 
 	// Add a set.
-	contracts := []types.FileContractID{{1, 2, 3}, {3, 2, 1}}
+	contracts := []types.FileContractID{c1.ID, c2.ID}
 	if err := cs.SetContractSet(setName, contracts); err != nil {
 		t.Fatal(err)
 	}
@@ -47,12 +114,18 @@ func TestSQLContractSetStore(t *testing.T) {
 	if err != nil {
 		t.Fatal("should fail", err)
 	}
-	if !reflect.DeepEqual(set, contracts) {
-		t.Fatal("set mismatch")
+	if len(set) != 2 {
+		t.Fatal("wrong set len", len(set))
+	}
+	if set[0].ID != c1.ID {
+		t.Fatal("wrong contract")
+	}
+	if set[1].ID != c2.ID {
+		t.Fatal("wrong contract")
 	}
 
 	// Remove a contract.
-	contracts = []types.FileContractID{{1, 2, 3}}
+	contracts = []types.FileContractID{c1.ID}
 	if err := cs.SetContractSet(setName, contracts); err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +142,10 @@ func TestSQLContractSetStore(t *testing.T) {
 	if err != nil {
 		t.Fatal("should fail", err)
 	}
-	if !reflect.DeepEqual(set, contracts) {
-		t.Fatal("set mismatch", set, contracts)
+	if len(set) != 1 {
+		t.Fatal("wrong set len", len(set))
+	}
+	if set[0].ID != c1.ID {
+		t.Fatal("wrong contract")
 	}
 }

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -61,7 +61,6 @@ func NewSQLStore(conn gorm.Dialector, migrate bool) (*SQLStore, modules.Consensu
 
 			// bus.ContractSetStore tables
 			&dbContractSet{},
-			&dbContractSetEntry{},
 
 			// bus.ObjectStore tables
 			&dbObject{},

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -219,9 +219,9 @@ func toHostInteraction(m metrics.Metric) (hostdb.Interaction, bool) {
 // A Bus is the source of truth within a renterd system.
 type Bus interface {
 	RecordHostInteraction(hostKey consensus.PublicKey, hi hostdb.Interaction) error
-	ContractSetContracts(name string) ([]bus.Contract, error)
 	ContractsForSlab(shards []object.Sector) ([]bus.Contract, error)
 	Contracts() ([]bus.Contract, error)
+	ContractSet(name string) ([]bus.Contract, error)
 
 	UploadParams() (bus.UploadParams, error)
 	MigrateParams(slab object.Slab) (bus.MigrateParams, error)
@@ -557,12 +557,12 @@ func (w *worker) slabsMigrateHandler(jc jape.Context) {
 		return
 	}
 
-	from, err := w.bus.ContractSetContracts(mp.FromContracts)
+	from, err := w.bus.ContractSet(mp.FromContracts)
 	if jc.Check("couldn't fetch contracts from bus", err) != nil {
 		return
 	}
 
-	to, err := w.bus.ContractSetContracts(mp.ToContracts)
+	to, err := w.bus.ContractSet(mp.ToContracts)
 	if jc.Check("couldn't fetch contracts from bus", err) != nil {
 		return
 	}
@@ -640,7 +640,7 @@ func (w *worker) objectsKeyHandlerPUT(jc jape.Context) {
 	usedContracts := make(map[consensus.PublicKey]types.FileContractID)
 	for {
 		// fetch contracts
-		bcs, err := w.bus.ContractSetContracts(up.ContractSet)
+		bcs, err := w.bus.ContractSet(up.ContractSet)
 		if jc.Check("couldn't fetch contracts from bus", err) != nil {
 			return
 		}


### PR DESCRIPTION
Establishing a relation between contracts and contract sets allows for fetching contracts for a set more efficiently.