### PR TITLE
Inline dbAnnouncement into dbHost

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -442,7 +442,7 @@ func (c *contractor) runContractFormations(cfg api.AutopilotConfig, blockHeight,
 		}
 
 		// fetch host settings
-		scan, err := c.ap.worker.RHPScan(candidate, host.NetAddress(), 0)
+		scan, err := c.ap.worker.RHPScan(candidate, host.NetAddress, 0)
 		if err != nil {
 			c.logger.Debugw(
 				fmt.Sprintf("failed scan, err: %v", err),
@@ -477,7 +477,7 @@ func (c *contractor) runContractFormations(cfg api.AutopilotConfig, blockHeight,
 		}
 
 		// form contract
-		contract, err := c.formContract(cfg, currentPeriod, candidate, host.NetAddress(), settings, renterAddress, renterFunds, hostCollateral)
+		contract, err := c.formContract(cfg, currentPeriod, candidate, host.NetAddress, settings, renterAddress, renterFunds, hostCollateral)
 		if err != nil {
 			// TODO: keep track of consecutive failures and break at some point
 			c.logger.Errorw(
@@ -589,7 +589,7 @@ func (c *contractor) refreshFundingEstimate(cfg api.AutopilotConfig, contract ap
 	}
 
 	// fetch host settings
-	scan, err := c.ap.worker.RHPScan(contract.HostKey(), host.NetAddress(), 0)
+	scan, err := c.ap.worker.RHPScan(contract.HostKey(), host.NetAddress, 0)
 	if err != nil {
 		c.logger.Debugw(
 			fmt.Sprintf("failed scan, err: %v", err),
@@ -628,7 +628,7 @@ func (c *contractor) renewFundingEstimate(cfg api.AutopilotConfig, currentPeriod
 	}
 
 	// fetch host settings
-	scan, err := c.ap.worker.RHPScan(contract.HostKey(), host.NetAddress(), 0)
+	scan, err := c.ap.worker.RHPScan(contract.HostKey(), host.NetAddress, 0)
 	if err != nil {
 		c.logger.Debugw(
 			fmt.Sprintf("failed scan, err: %v", err),

--- a/autopilot/host.go
+++ b/autopilot/host.go
@@ -21,14 +21,14 @@ func (h *Host) IsHost(host string) bool {
 	if h.PublicKey.String() == host {
 		return true
 	}
-	if h.NetAddress() == host {
+	if h.NetAddress == host {
 		return true
 	}
 	_, ipNet, err := net.ParseCIDR(host)
 	if err != nil {
 		return false
 	}
-	ip, err := net.ResolveIPAddr("ip", h.NetAddress())
+	ip, err := net.ResolveIPAddr("ip", h.NetAddress)
 	if err != nil {
 		return false
 	}

--- a/autopilot/host_test.go
+++ b/autopilot/host_test.go
@@ -59,16 +59,17 @@ func TestHost(t *testing.T) {
 	}
 
 	// assert is host returns expected outcome
-	if h.IsHost("foo") || !h.IsHost(hk.String()) || !h.IsHost(h.NetAddress()) {
+	if h.IsHost("foo") || !h.IsHost(hk.String()) || !h.IsHost(h.NetAddress) {
 		t.Fatal("unexpected")
 	}
 }
 
 func newTestHost(hk consensus.PublicKey, settings *rhpv2.HostSettings) hostdb.Host {
 	return hostdb.Host{
-		Announcements: []hostdb.Announcement{{Timestamp: time.Now(), NetAddress: randomIP().String()}},
-		Interactions:  []hostdb.Interaction{newTestScan(settings, true)},
-		PublicKey:     hk,
+		NetAddress:   randomIP().String(),
+		KnownSince:   time.Now(),
+		Interactions: []hostdb.Interaction{newTestScan(settings, true)},
+		PublicKey:    hk,
 	}
 }
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -42,7 +42,7 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 	}
 
 	// sanity check - should never happen but this would cause a zero score
-	if len(h.Announcements) == 0 {
+	if h.NetAddress == "" {
 		reasons = append(reasons, "not announced")
 	}
 

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -41,8 +41,8 @@ func hostScore(cfg api.AutopilotConfig, h Host) float64 {
 }
 
 func ageScore(h Host) float64 {
-	// sanity check to avoid panic - host should have been filtered
-	if len(h.Announcements) == 0 {
+	// sanity check
+	if h.KnownSince.IsZero() {
 		return 0
 	}
 
@@ -61,7 +61,7 @@ func ageScore(h Host) float64 {
 		{1 * day, 3},
 	}
 
-	age := time.Since(h.Announcements[0].Timestamp)
+	age := time.Since(h.KnownSince)
 	weight := 1.0
 	for _, w := range weights {
 		if age >= w.age {

--- a/autopilot/hostscore_test.go
+++ b/autopilot/hostscore_test.go
@@ -28,7 +28,7 @@ func TestHostScore(t *testing.T) {
 	}
 
 	// assert age affects the score
-	h1.Announcements[0].Timestamp = time.Now().Add(-1 * day)
+	h1.KnownSince = time.Now().Add(-1 * day)
 	if hostScore(cfg, h1) <= hostScore(cfg, h2) {
 		t.Fatal("unexpected")
 	}

--- a/autopilot/ipfilter.go
+++ b/autopilot/ipfilter.go
@@ -30,7 +30,7 @@ func newIPFilter() *ipFilter {
 
 func (f *ipFilter) isRedundantIP(h Host) bool {
 	// lookup all IP addresses for the given host
-	host, _, err := net.SplitHostPort(h.NetAddress())
+	host, _, err := net.SplitHostPort(h.NetAddress)
 	if err != nil {
 		return true
 	}

--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -208,7 +208,7 @@ func (s *scanner) performHostScans() error {
 	for _, h := range hosts {
 		reqChan <- scanReq{
 			hostKey: h.PublicKey,
-			hostIP:  h.NetAddress(),
+			hostIP:  h.NetAddress,
 		}
 	}
 	close(reqChan)

--- a/hostdb/hostdb.go
+++ b/hostdb/hostdb.go
@@ -63,15 +63,8 @@ type Interaction struct {
 
 // A Host pairs a host's public key with a set of interactions.
 type Host struct {
-	PublicKey     consensus.PublicKey
-	Announcements []Announcement
-	Interactions  []Interaction
-}
-
-// NetAddress returns the host's last announced NetAddress, if available.
-func (h *Host) NetAddress() string {
-	if len(h.Announcements) == 0 {
-		return ""
-	}
-	return h.Announcements[len(h.Announcements)-1].NetAddress
+	KnownSince   time.Time
+	PublicKey    consensus.PublicKey
+	NetAddress   string
+	Interactions []Interaction
 }

--- a/internal/stores/contracts.go
+++ b/internal/stores/contracts.go
@@ -224,7 +224,7 @@ func (s *SQLStore) ActiveContracts() ([]api.ContractMetadata, error) {
 	var dbContracts []dbContract
 	err := s.db.
 		Model(&dbContract{}).
-		Preload("Host.Announcements").
+		Preload("Host").
 		Find(&dbContracts).
 		Error
 	if err != nil {
@@ -370,7 +370,7 @@ func (s *SQLStore) contracts(set string) ([]dbContract, error) {
 	var cs dbContractSet
 	err := s.db.
 		Where(&dbContractSet{Name: set}).
-		Preload("Contracts.Host.Announcements").
+		Preload("Contracts.Host").
 		Take(&cs).
 		Error
 
@@ -386,7 +386,7 @@ func (s *SQLStore) contracts(set string) ([]dbContract, error) {
 func contract(tx *gorm.DB, id types.FileContractID) (dbContract, error) {
 	var contract dbContract
 	err := tx.Where(&dbContract{FCID: id}).
-		Preload("Host.Announcements").
+		Preload("Host").
 		Take(&contract).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return contract, ErrContractNotFound
@@ -397,6 +397,7 @@ func contract(tx *gorm.DB, id types.FileContractID) (dbContract, error) {
 func removeContract(tx *gorm.DB, id types.FileContractID) error {
 	var contract dbContract
 	if err := tx.Where(&dbContract{FCID: id}).
+		Preload("Host").
 		Take(&contract).Error; err != nil {
 		return err
 	}

--- a/internal/stores/contracts.go
+++ b/internal/stores/contracts.go
@@ -397,7 +397,6 @@ func contract(tx *gorm.DB, id types.FileContractID) (dbContract, error) {
 func removeContract(tx *gorm.DB, id types.FileContractID) error {
 	var contract dbContract
 	if err := tx.Where(&dbContract{FCID: id}).
-		Preload("Host").
 		Take(&contract).Error; err != nil {
 		return err
 	}

--- a/internal/stores/contracts.go
+++ b/internal/stores/contracts.go
@@ -89,7 +89,7 @@ func (dbContractSet) TableName() string { return "contract_sets" }
 func (c dbContract) convert() api.ContractMetadata {
 	return api.ContractMetadata{
 		ID:          c.FCID,
-		HostIP:      c.Host.NetAddress(),
+		HostIP:      c.Host.NetAddress,
 		HostKey:     c.Host.PublicKey,
 		StartHeight: c.StartHeight,
 		RenewedFrom: c.RenewedFrom,

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -141,17 +141,6 @@ func (db *SQLStore) RecordInteraction(hostKey consensus.PublicKey, hi hostdb.Int
 	})
 }
 
-// hosts returns all hosts int he db.
-func (db *SQLStore) hosts() ([]dbHost, error) {
-	var hosts []dbHost
-	tx := db.db.Preload("Interactions").
-		Find(&hosts)
-	if tx.Error != nil {
-		return nil, tx.Error
-	}
-	return hosts, nil
-}
-
 // ProcessConsensusChange implements consensus.Subscriber.
 func (db *SQLStore) ProcessConsensusChange(cc modules.ConsensusChange) {
 	height := cc.InitialHeight()

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -307,3 +307,15 @@ func TestSQLHosts(t *testing.T) {
 func (s *SQLStore) addTestHost(hk consensus.PublicKey) error {
 	return s.db.FirstOrCreate(&dbHost{}, &dbHost{PublicKey: hk}).Error
 }
+
+// hosts returns all hosts in the db. Only used in testing since preloading all
+// interactions for all hosts is expensive in production.
+func (db *SQLStore) hosts() ([]dbHost, error) {
+	var hosts []dbHost
+	tx := db.db.Preload("Interactions").
+		Find(&hosts)
+	if tx.Error != nil {
+		return nil, tx.Error
+	}
+	return hosts, nil
+}

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -108,35 +108,31 @@ func TestSQLHostDB(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Read the announcement and verify it.
-	var announcements []dbAnnouncement
-	tx = hdb.db.Find(&announcements)
+	// Read the host and verify that the announcement related fields were
+	// set.
+	var h dbHost
+	tx = hdb.db.Where("last_announcement = ? AND net_address = ?", a.Timestamp, a.NetAddress).Find(&h)
 	if tx.Error != nil {
-		t.Fatal(err)
+		t.Fatal(tx.Error)
 	}
-	if len(announcements) != 1 {
-		t.Fatalf("wrong number of announcements %v != %v", len(announcements), 1)
-	}
-	if !reflect.DeepEqual(announcements[0].convert(), a) {
-		t.Fatal("announcement mismatch", announcements[0], a)
+	if h.PublicKey != hk {
+		t.Fatal("wrong host returned")
 	}
 
-	// Read the host using SelectHosts. Even without manually adding it
-	// there should be an entry which was created upon inserting the first
-	// interaction. We should also be able to preload the interactions.
+	// Same thing again but with hosts.
 	hosts, err := hdb.hosts()
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := hosts[0]
 	if len(hosts) != 1 {
-		t.Fatalf("invalid number of hosts %v != %v", len(hosts), 1)
+		t.Fatal("wrong number of hosts", len(hosts))
 	}
-	if len(h.Interactions) != 2 {
-		t.Fatalf("wrong number of interactions %v != %v", len(h.Interactions), 2)
-	}
-	if len(h.Announcements) != 1 {
-		t.Fatalf("wrong number of announcements %v != %v", len(h.Announcements), 1)
+	h1 := hosts[0]
+	h1.Interactions = h.Interactions // ignore for comparison
+	if !reflect.DeepEqual(h1, h) {
+		fmt.Println(h1)
+		fmt.Println(h)
+		t.Fatal("mismatch")
 	}
 
 	// Same thing again but with Host.
@@ -144,11 +140,11 @@ func TestSQLHostDB(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(h2.Interactions) != 2 {
-		t.Fatalf("wrong number of interactions %v != %v", len(h2.Interactions), 2)
+	if h2.NetAddress != h.NetAddress {
+		t.Fatal("wrong net address")
 	}
-	if len(h2.Announcements) != 1 {
-		t.Fatalf("wrong number of announcements %v != %v", len(h2.Announcements), 1)
+	if h2.KnownSince.IsZero() {
+		t.Fatal("known since not set")
 	}
 
 	// Insert another announcement for an unknown host.
@@ -164,8 +160,11 @@ func TestSQLHostDB(t *testing.T) {
 	if len(h3.Interactions) != 0 {
 		t.Fatalf("wrong number of interactions %v != %v", len(h2.Interactions), 2)
 	}
-	if len(h3.Announcements) != 1 {
-		t.Fatalf("wrong number of announcements %v != %v", len(h2.Announcements), 1)
+	if h3.NetAddress != a.NetAddress {
+		t.Fatal("wrong net address")
+	}
+	if h3.KnownSince.IsZero() {
+		t.Fatal("known since not set")
 	}
 
 	// Apply a consensus change to make sure the ccid is updated.

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -69,7 +69,6 @@ func NewSQLStore(conn gorm.Dialector, migrate bool) (*SQLStore, modules.Consensu
 			// bus.HostDB tables
 			&dbHost{},
 			&dbInteraction{},
-			&dbAnnouncement{},
 			&dbConsensusInfo{},
 
 			// bus.ObjectStore tables


### PR DESCRIPTION
At this time syncing renterd from scratch results in a database that contains around 80k hosts and around 350k announcements. Since we never use any of them but the most recent one, they take up quite a lot of space without being of any use to us.
Additionally they slow down all host related queries because when we return a host through the API we include all of its announcements. So when we fetch all hosts, we slow things down quite a bit by querying for all the announcements as well even though we only need the most recent one per host.

To clean this up, this PR inlines only the necessary info into the host table and gets rid of the announcements.