### PR TITLE
Query performance improvements

### DIFF
--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -212,6 +212,16 @@ func TestSQLHosts(t *testing.T) {
 	hostKey2 := consensus.GeneratePrivateKey().PublicKey()
 	hostKey3 := consensus.GeneratePrivateKey().PublicKey()
 
+	if err := hdb.addTestHost(hostKey1); err != nil {
+		t.Fatal(err)
+	}
+	if err := hdb.addTestHost(hostKey2); err != nil {
+		t.Fatal(err)
+	}
+	if err := hdb.addTestHost(hostKey3); err != nil {
+		t.Fatal(err)
+	}
+
 	currentTime := time.Now()
 	pastHi := hostdb.Interaction{
 		Timestamp: currentTime.Add(-time.Hour),


### PR DESCRIPTION
Confirmed in production that this gets rid of the `database locked` errors. Apparently it's not a great idea to create transactions which read from one table and write to another with multiple queries on tables that get inserted to a lot such as the interactions ^^