### PR TITLE
Migrations

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -121,13 +121,25 @@ type ObjectsResponse struct {
 	Object  *object.Object `json:"object,omitempty"`
 }
 
-// AddObjectRequest is the request type for the /object/*key PUT endpoint.
+// AddObjectRequest is the request type for the /object/*key endpoint.
 type AddObjectRequest struct {
 	Object        object.Object                                `json:"object"`
 	UsedContracts map[consensus.PublicKey]types.FileContractID `json:"usedContracts"`
 }
 
-// UpdateBlocklistRequest is the request type for /hosts/blocklist PUT endpoint.
+// MigrationSlabsRequest is the request type for the /slabs/migration endpoint.
+type MigrationSlabsRequest struct {
+	ContractSet string `json:"contractset"`
+	Limit       int    `json:"limit"`
+}
+
+// UpdateSlabRequest is the request type for the /slab endpoint.
+type UpdateSlabRequest struct {
+	Slab          object.Slab                                  `json:"slab"`
+	UsedContracts map[consensus.PublicKey]types.FileContractID `json:"usedContracts"`
+}
+
+// UpdateBlocklistRequest is the request type for /hosts/blocklist endpoint.
 type UpdateBlocklistRequest struct {
 	Add    []string `json:"add"`
 	Remove []string `json:"remove"`
@@ -143,14 +155,6 @@ type DownloadParams struct {
 type UploadParams struct {
 	CurrentHeight uint64
 	ContractSet   string
-	GougingParams
-}
-
-// MigrateParams contains the metadata needed by a worker to migrate a slab.
-type MigrateParams struct {
-	CurrentHeight uint64
-	FromContracts string
-	ToContracts   string
 	GougingParams
 }
 

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -55,7 +55,7 @@ type Bus interface {
 	ConsensusState() (api.ConsensusState, error)
 
 	// objects
-	SlabsForMigration(n int, failureCutoff time.Time, goodContracts []types.FileContractID) ([]object.Slab, error)
+	SlabsForMigration(set string, limit int) ([]object.Slab, error)
 
 	// settings
 	GougingSettings() (gs api.GougingSettings, err error)
@@ -149,10 +149,6 @@ func (ap *Autopilot) Run() error {
 			}
 
 			// migration
-			err = ap.m.UpdateContracts()
-			if err != nil {
-				ap.logger.Errorf("update contracts failed, err: %v", err)
-			}
 			ap.m.TryPerformMigrations()
 		}()
 	}

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -205,7 +205,7 @@ func (c *contractor) performContractMaintenance(cfg api.AutopilotConfig, cs api.
 	}
 
 	// build the new contract set (excluding formed contracts)
-	contractset := buildContractSet(contractIds(contracts), toDelete, toIgnore, contractIds(toRefresh), contractIds(toRenew), renewed)
+	contractset := buildContractSet(contractIds(contractMetadatas(contracts)), toDelete, toIgnore, contractIds(contractMetadatas(toRefresh)), contractIds(contractMetadatas(toRenew)), renewed)
 	numContracts := uint64(len(contractset))
 
 	// check if we need to form contracts and add them to the contract set
@@ -801,7 +801,15 @@ func buildContractSet(active, toDelete, toIgnore, toRefresh, toRenew []types.Fil
 	return contracts
 }
 
-func contractIds(contracts []api.Contract) []types.FileContractID {
+func contractMetadatas(contracts []api.Contract) []api.ContractMetadata {
+	metadatas := make([]api.ContractMetadata, len(contracts))
+	for i, c := range contracts {
+		metadatas[i] = c.ContractMetadata
+	}
+	return metadatas
+}
+
+func contractIds(contracts []api.ContractMetadata) []types.FileContractID {
 	ids := make([]types.FileContractID, len(contracts))
 	for i, c := range contracts {
 		ids[i] = c.ID

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -823,6 +823,11 @@ func calculateHostCollateral(cfg api.AutopilotConfig, settings rhpv2.HostSetting
 		return types.ZeroCurrency, errors.New("contract price + fees exceeds funding")
 	}
 
+	// avoid division by zero
+	if settings.StoragePrice.IsZero() {
+		settings.StoragePrice = types.NewCurrency64(1)
+	}
+
 	// calculate the host collateral
 	renterPayout := renterFunds.Sub(settings.ContractPrice).Sub(txnFee)
 	maxStorage := renterPayout.Div(settings.StoragePrice)

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -61,7 +61,7 @@ func (m *migrator) performMigrations() {
 			return
 		}
 
-		// migrat them one by one
+		// migrate them one by one
 		for i, slab := range toMigrate {
 			err := m.ap.worker.MigrateSlab(slab)
 			if err != nil {

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -63,7 +63,7 @@ func (m *migrator) performMigrations() {
 
 		// migrate the slabs one by one
 		//
-		// TODO: when we support parallel uploads we should parallellize this
+		// TODO: when we support parallel uploads we should parallelize this
 		for i, slab := range toMigrate {
 			err := m.ap.worker.MigrateSlab(slab)
 			if err != nil {

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -27,8 +27,10 @@ func newMigrator(ap *Autopilot) *migrator {
 }
 
 func (m *migrator) TryPerformMigrations() {
+	m.logger.Info("try performing migrations")
 	m.mu.Lock()
 	if m.running {
+		m.logger.Info("migrations still running")
 		m.mu.Unlock()
 		return
 	}

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -27,10 +27,8 @@ func newMigrator(ap *Autopilot) *migrator {
 }
 
 func (m *migrator) TryPerformMigrations() {
-	m.logger.Info("try performing migrations")
 	m.mu.Lock()
 	if m.running {
-		m.logger.Info("migrations still running")
 		m.mu.Unlock()
 		return
 	}
@@ -58,12 +56,14 @@ func (m *migrator) performMigrations() {
 		}
 		m.logger.Debugf("%d slabs to migrate", len(toMigrate))
 
-		// escape early if there's no slabs to migrate
+		// return if there are no slabs to migrate
 		if len(toMigrate) == 0 {
 			return
 		}
 
-		// migrate them one by one
+		// migrate the slabs one by one
+		//
+		// TODO: when we support parallel uploads we should parallellize this
 		for i, slab := range toMigrate {
 			err := m.ap.worker.MigrateSlab(slab)
 			if err != nil {

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -2,20 +2,21 @@ package autopilot
 
 import (
 	"sync"
-	"time"
 
-	"go.sia.tech/renterd/object"
-	"go.sia.tech/siad/types"
 	"go.uber.org/zap"
+)
+
+const (
+	migratorBatchSize   = 100
+	migratorContractset = "autopilot"
 )
 
 type migrator struct {
 	ap     *Autopilot
 	logger *zap.SugaredLogger
 
-	mu            sync.Mutex
-	goodContracts []types.FileContractID
-	running       bool
+	mu      sync.Mutex
+	running bool
 }
 
 func newMigrator(ap *Autopilot) *migrator {
@@ -25,27 +26,6 @@ func newMigrator(ap *Autopilot) *migrator {
 	}
 }
 
-// UpdateContracts updates the set of contracts that the migrator considers
-// good. Missing sectors in slabs will be migrated to these contracts.
-func (m *migrator) UpdateContracts() error {
-	bus := m.ap.bus
-
-	contracts, err := bus.ActiveContracts()
-	if err != nil {
-		return err
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.goodContracts = m.goodContracts[:0]
-	for _, c := range contracts {
-		// TODO: filter out contracts that are not good.
-		m.goodContracts = append(m.goodContracts, c.ID)
-	}
-	return nil
-}
-
-// TryPerformMigrations launches a migration routine unless it's already
-// running. A launched routine runs until there are no more slabs to migrate.
 func (m *migrator) TryPerformMigrations() {
 	m.mu.Lock()
 	if m.running {
@@ -63,28 +43,32 @@ func (m *migrator) TryPerformMigrations() {
 	}()
 }
 
-func (m *migrator) fetchSlabsForMigration() ([]object.Slab, error) {
-	return m.ap.bus.SlabsForMigration(10, time.Now().Add(-time.Hour), m.goodContracts)
-}
-
 func (m *migrator) performMigrations() {
 	m.logger.Info("performing migrations")
+	b := m.ap.bus
 
 	for {
-		// Fetch slabs for repair
-		slabsToRepair, err := m.fetchSlabsForMigration()
+		// fetch slabs for migration
+		toMigrate, err := b.SlabsForMigration(migratorContractset, migratorBatchSize)
 		if err != nil {
-			return // TODO log
+			m.logger.Errorf("failed to fetch slabs for migration, err: %v", err)
+			return
 		}
-		if len(slabsToRepair) == 0 {
-			return // nothing to do
+		m.logger.Debugf("%d slabs to migrate", len(toMigrate))
+
+		// escape early if there's no slabs to migrate
+		if len(toMigrate) == 0 {
+			return
 		}
 
-		// Repair them
-		for _, slab := range slabsToRepair {
-			if err := m.ap.worker.MigrateSlab(slab); err != nil {
-				continue // TODO log
+		// migrat them one by one
+		for i, slab := range toMigrate {
+			err := m.ap.worker.MigrateSlab(slab)
+			if err != nil {
+				m.logger.Errorf("failed to migrate slab %d/%d, err: %v", i+1, len(toMigrate), err)
+				continue
 			}
+			m.logger.Debugf("successfully migrated slab %d/%d", i+1, len(toMigrate))
 		}
 	}
 }

--- a/internal/stores/contracts.go
+++ b/internal/stores/contracts.go
@@ -121,6 +121,13 @@ func gobEncode(i interface{}) []byte {
 	}
 	return buf.Bytes()
 }
+func gobEncodeSlice(i []interface{}) [][]byte {
+	var res [][]byte
+	for _, v := range i {
+		res = append(res, gobEncode(v))
+	}
+	return res
+}
 
 // addContract implements the bus.ContractStore interface.
 func addContract(tx *gorm.DB, c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, renewedFrom types.FileContractID) (dbContract, error) {

--- a/internal/stores/contracts.go
+++ b/internal/stores/contracts.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"go.sia.tech/renterd/api"
@@ -197,6 +198,7 @@ func (s *SQLStore) ActiveContracts() ([]api.ContractMetadata, error) {
 // contracts and moved to the archive. Both new and old contract will be linked
 // to each other through the RenewedFrom and RenewedTo fields respectively.
 func (s *SQLStore) AddRenewedContract(c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, renewedFrom types.FileContractID) (api.ContractMetadata, error) {
+	fmt.Println("renew contract for host", c.HostKey().String())
 	var renewed dbContract
 
 	if err := s.db.Transaction(func(tx *gorm.DB) error {

--- a/internal/stores/contracts_test.go
+++ b/internal/stores/contracts_test.go
@@ -381,6 +381,22 @@ func TestAncestorsContracts(t *testing.T) {
 	}
 }
 
+func (s *SQLStore) addTestContracts(keys []consensus.PublicKey) (fcids []types.FileContractID, contracts []api.ContractMetadata, err error) {
+	cnt, err := s.contractsCount()
+	if err != nil {
+		return nil, nil, err
+	}
+	for i, key := range keys {
+		fcids = append(fcids, types.FileContractID{byte(int(cnt) + i + 1)})
+		contract, err := s.addTestContract(fcids[len(fcids)-1], key)
+		if err != nil {
+			return nil, nil, err
+		}
+		contracts = append(contracts, contract)
+	}
+	return
+}
+
 func (s *SQLStore) addTestContract(fcid types.FileContractID, hk consensus.PublicKey) (api.ContractMetadata, error) {
 	rev := testContractRevision(fcid, hk)
 	return s.AddContract(rev, types.ZeroCurrency, 0)
@@ -389,6 +405,14 @@ func (s *SQLStore) addTestContract(fcid types.FileContractID, hk consensus.Publi
 func (s *SQLStore) addTestRenewedContract(fcid, renewedFrom types.FileContractID, hk consensus.PublicKey, startHeight uint64) (api.ContractMetadata, error) {
 	rev := testContractRevision(fcid, hk)
 	return s.AddRenewedContract(rev, types.ZeroCurrency, startHeight, renewedFrom)
+}
+
+func (s *SQLStore) contractsCount() (cnt int64, err error) {
+	err = s.db.
+		Model(&dbContract{}).
+		Count(&cnt).
+		Error
+	return
 }
 
 func testContractRevision(fcid types.FileContractID, hk consensus.PublicKey) rhpv2.ContractRevision {

--- a/internal/stores/objects.go
+++ b/internal/stores/objects.go
@@ -299,11 +299,6 @@ func (s *SQLStore) Put(key string, o object.Object, usedContracts map[consensus.
 						return err
 					}
 				}
-
-				// Save the sector
-				if err := tx.Save(&sector).Error; err != nil {
-					return err
-				}
 			}
 		}
 		return nil
@@ -450,11 +445,6 @@ func (ss *SQLStore) PutSlab(s object.Slab, goodContracts map[consensus.PublicKey
 					Append(host); err != nil {
 					return err
 				}
-			}
-
-			// save the sector
-			if err := tx.Save(&sector).Error; err != nil {
-				return err
 			}
 		}
 		return nil

--- a/internal/stores/objects.go
+++ b/internal/stores/objects.go
@@ -324,7 +324,7 @@ func deleteObject(tx *gorm.DB, key string) error {
 func (s *SQLStore) get(key string) (dbObject, error) {
 	var obj dbObject
 	tx := s.db.Where(&dbObject{ObjectID: key}).
-		Preload("Slabs.Slab.Shards.DBSector").
+		Preload("Slabs.Slab.Shards.DBSector.Contracts.Host").
 		Take(&obj)
 	if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
 		return dbObject{}, ErrObjectNotFound

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -728,6 +728,14 @@ func TestPutSlab(t *testing.T) {
 		t.Fatal("sector 1 was uploaded to unexpected hosts", hks[0], hks[1])
 	}
 
+	// assert there's still only one entry in the dbslab table
+	var cnt int64
+	if err := db.db.Model(&dbSlab{}).Count(&cnt).Error; err != nil {
+		t.Fatal(err)
+	} else if cnt != 1 {
+		t.Fatalf("unexpected number of entries in dbslab, %v != 1", cnt)
+	}
+
 	// fetch slabs for migration and assert there are none left
 	toMigrate, err = db.SlabsForMigration("autopilot", -1)
 	if err != nil {
@@ -735,6 +743,14 @@ func TestPutSlab(t *testing.T) {
 	}
 	if len(toMigrate) != 0 {
 		t.Fatal("unexpected number of slabs to migrate", len(toMigrate))
+	}
+
+	if obj, err := db.get("foo"); err != nil {
+		t.Fatal(err)
+	} else if len(obj.Slabs) != 1 {
+		t.Fatalf("unexpected number of slabs, %v != 1", len(obj.Slabs))
+	} else if obj.Slabs[0].ID != updated.ID {
+		t.Fatalf("unexpected slab, %v != %v", obj.Slabs[0].ID, updated.ID)
 	}
 }
 

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -139,8 +139,8 @@ func TestSQLObjectStore(t *testing.T) {
 							DBSlabID:   1,
 							DBSectorID: 1,
 							DBSector: dbSector{
-								Root:     obj1.Slabs[0].Shards[0].Root,
-								LastHost: obj1.Slabs[0].Shards[0].Host,
+								Root:       obj1.Slabs[0].Shards[0].Root,
+								LatestHost: obj1.Slabs[0].Shards[0].Host,
 								Contracts: []dbContract{
 									{
 										HostID: 1,
@@ -174,8 +174,8 @@ func TestSQLObjectStore(t *testing.T) {
 							DBSlabID:   2,
 							DBSectorID: 2,
 							DBSector: dbSector{
-								Root:     obj1.Slabs[1].Shards[0].Root,
-								LastHost: obj1.Slabs[1].Shards[0].Host,
+								Root:       obj1.Slabs[1].Shards[0].Root,
+								LatestHost: obj1.Slabs[1].Shards[0].Host,
 								Contracts: []dbContract{
 									{
 										HostID: 2,

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -337,10 +337,8 @@ func TestSlabsForMigration(t *testing.T) {
 	}
 	fcid1, fcid2, fcid3 := fcids[0], fcids[1], fcids[2]
 
-	// add the first two contracts to the autopilot
-	if err = db.SetContractSet("autopilot", []types.FileContractID{fcid1, fcid2}); err != nil {
-		t.Fatal(err)
-	}
+	// select the first two contracts as good contracts
+	goodContracts := []types.FileContractID{fcid1, fcid2}
 
 	// add an object
 	obj := object.Object{
@@ -463,7 +461,7 @@ func TestSlabsForMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	slabs, err := db.SlabsForMigration("autopilot", -1)
+	slabs, err := db.SlabsForMigration(goodContracts, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -672,14 +670,11 @@ func TestPutSlab(t *testing.T) {
 		}
 	}
 
-	// create a contract set using contracts for h1 and h3 (h2 is bad)
-	err = db.SetContractSet("autopilot", []types.FileContractID{fcid1, fcid3})
-	if err != nil {
-		t.Fatal(err)
-	}
+	// select contracts h1 and h3 as good contracts (h2 is bad)
+	goodContracts := []types.FileContractID{fcid1, fcid3}
 
 	// fetch slabs for migration and assert there is only one
-	toMigrate, err := db.SlabsForMigration("autopilot", -1)
+	toMigrate, err := db.SlabsForMigration(goodContracts, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -737,7 +732,7 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// fetch slabs for migration and assert there are none left
-	toMigrate, err = db.SlabsForMigration("autopilot", -1)
+	toMigrate, err = db.SlabsForMigration(goodContracts, -1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -1,6 +1,7 @@
 package stores
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -131,15 +132,17 @@ func TestSQLObjectStore(t *testing.T) {
 			{
 				DBObjectID: 1,
 				Slab: dbSlab{
-					DBSliceID: 1,
-					Key:       obj1Slab0Key,
-					MinShards: 1,
+					DBSliceID:   1,
+					Key:         obj1Slab0Key,
+					MinShards:   1,
+					TotalShards: 1,
 					Shards: []dbShard{
 						{
 							DBSlabID:   1,
 							DBSectorID: 1,
 							DBSector: dbSector{
-								Root: obj1.Slabs[0].Shards[0].Root,
+								Root:     obj1.Slabs[0].Shards[0].Root,
+								LastHost: obj1.Slabs[0].Shards[0].Host,
 								Contracts: []dbContract{
 									{
 										HostID: 1,
@@ -164,15 +167,17 @@ func TestSQLObjectStore(t *testing.T) {
 			{
 				DBObjectID: 1,
 				Slab: dbSlab{
-					DBSliceID: 2,
-					Key:       obj1Slab1Key,
-					MinShards: 2,
+					DBSliceID:   2,
+					Key:         obj1Slab1Key,
+					MinShards:   2,
+					TotalShards: 1,
 					Shards: []dbShard{
 						{
 							DBSlabID:   2,
 							DBSectorID: 2,
 							DBSector: dbSector{
-								Root: obj1.Slabs[1].Shards[0].Root,
+								Root:     obj1.Slabs[1].Shards[0].Root,
+								LastHost: obj1.Slabs[1].Shards[0].Host,
 								Contracts: []dbContract{
 									{
 										HostID: 2,
@@ -197,7 +202,9 @@ func TestSQLObjectStore(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(obj, expectedObj) {
-		t.Fatal("object mismatch")
+		js1, _ := json.MarshalIndent(obj, "", "  ")
+		js2, _ := json.MarshalIndent(expectedObj, "", "  ")
+		t.Fatal("object mismatch", string(js1), string(js2))
 	}
 
 	// Fetch it using Get and verify again.

--- a/internal/stores/objects_test.go
+++ b/internal/stores/objects_test.go
@@ -425,6 +425,27 @@ func TestSlabsForMigration(t *testing.T) {
 					},
 				},
 			},
+			// good slab - reused hosts
+			{
+				Slab: object.Slab{
+					Key:       object.GenerateEncryptionKey(),
+					MinShards: 1,
+					Shards: []object.Sector{
+						{
+							Host: hk1,
+							Root: consensus.Hash256{1},
+						},
+						{
+							Host: hk1,
+							Root: consensus.Hash256{2},
+						},
+						{
+							Host: hk2,
+							Root: consensus.Hash256{3},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -700,6 +721,15 @@ func TestPutSlab(t *testing.T) {
 		t.Fatalf("sector 1 was uploaded to unexpected amount of hosts, %v!=2", len(hks))
 	} else if hks[0] != hk2 || hks[1] != hk3 {
 		t.Fatal("sector 1 was uploaded to unexpected hosts", hks[0], hks[1])
+	}
+
+	// fetch slabs for migration and assert there are none left
+	toMigrate, err = db.SlabsForMigration("autopilot", -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(toMigrate) != 0 {
+		t.Fatal("unexpected number of slabs to migrate", len(toMigrate))
 	}
 }
 

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -7,6 +7,7 @@ import (
 	"go.sia.tech/siad/modules"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 type (
@@ -61,6 +62,7 @@ func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duratio
 	db, err := gorm.Open(conn, &gorm.Config{
 		DisableNestedTransaction: true, // disable nesting transactions
 		PrepareStmt:              true, // caches queries as prepared statements
+		Logger:                   logger.Default.LogMode(logger.Silent),
 	}) // Logger: logger.Default.LogMode(logger.Silent)
 
 	if err != nil {

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -60,10 +60,10 @@ func NewSQLiteConnection(path string) gorm.Dialector {
 // same Dialector multiple times.
 func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duration) (*SQLStore, modules.ConsensusChangeID, error) {
 	db, err := gorm.Open(conn, &gorm.Config{
-		DisableNestedTransaction: true, // disable nesting transactions
-		PrepareStmt:              true, // caches queries as prepared statements
-		Logger:                   logger.Default.LogMode(logger.Silent),
-	}) // Logger: logger.Default.LogMode(logger.Silent)
+		DisableNestedTransaction: true,                                // disable nesting transactions
+		PrepareStmt:              true,                                // caches queries as prepared statements
+		Logger:                   logger.Default.LogMode(logger.Warn), // default log level
+	})
 
 	if err != nil {
 		return nil, modules.ConsensusChangeID{}, err

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -384,6 +384,19 @@ func (c *TestCluster) WaitForContracts() ([]api.Contract, error) {
 	}
 	return resp.Contracts, nil
 }
+func (c *TestCluster) RemoveHost(host *siatest.TestNode) error {
+	if err := host.Close(); err != nil {
+		return err
+	}
+
+	for i, h := range c.hosts {
+		if h == host {
+			c.hosts = append(c.hosts[:i], c.hosts[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
 
 // AddHosts adds n hosts to the cluster. These hosts will be funded and announce
 // themselves on the network, ready to form contracts.

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -68,10 +68,23 @@ var (
 	}
 )
 
+type TestNode struct {
+	*siatest.TestNode
+}
+
+func (n *TestNode) HostKey() (hk consensus.PublicKey) {
+	spk, err := n.HostPublicKey()
+	if err != nil {
+		panic(err)
+	}
+	copy(hk[:], spk.Key)
+	return
+}
+
 // TestCluster is a helper type that allows for easily creating a number of
 // nodes connected to each other and ready for testing.
 type TestCluster struct {
-	hosts []*siatest.TestNode
+	hosts []*TestNode
 
 	Autopilot *autopilot.Client
 	Bus       *bus.Client
@@ -254,7 +267,7 @@ func newTestCluster(dir string, logger *zap.Logger) (*TestCluster, error) {
 }
 
 // addStorageFolderToHosts adds a single storage folder to each host.
-func addStorageFolderToHost(hosts []*siatest.TestNode) error {
+func addStorageFolderToHost(hosts []*TestNode) error {
 	for _, host := range hosts {
 		storage := 512 * modules.SectorSize
 		if err := host.HostStorageFoldersAddPost(host.Dir, storage); err != nil {
@@ -266,7 +279,7 @@ func addStorageFolderToHost(hosts []*siatest.TestNode) error {
 
 // announceHosts adds storage and a registry to each host and announces them to
 // the group
-func announceHosts(hosts []*siatest.TestNode) error {
+func announceHosts(hosts []*TestNode) error {
 	for _, host := range hosts {
 		if err := host.HostModifySettingPost(client.HostParamAcceptingContracts, true); err != nil {
 			return err
@@ -304,7 +317,7 @@ func (c *TestCluster) MineToRenewWindow() error {
 }
 
 // sync blocks until the cluster is synced.
-func (c *TestCluster) sync(hosts []*siatest.TestNode) error {
+func (c *TestCluster) sync(hosts []*TestNode) error {
 	return Retry(100, 100*time.Millisecond, func() error {
 		synced, err := c.synced(hosts)
 		if err != nil {
@@ -318,7 +331,7 @@ func (c *TestCluster) sync(hosts []*siatest.TestNode) error {
 }
 
 // synced returns true if bus and hosts are at the same blockheight.
-func (c *TestCluster) synced(hosts []*siatest.TestNode) (bool, error) {
+func (c *TestCluster) synced(hosts []*TestNode) (bool, error) {
 	cs, err := c.Bus.ConsensusState()
 	if err != nil {
 		return false, err
@@ -350,11 +363,7 @@ func (c *TestCluster) MineBlocks(n int) error {
 func (c *TestCluster) WaitForContracts() ([]api.Contract, error) {
 	needed := make(map[string]struct{})
 	for _, host := range c.hosts {
-		hpk, err := host.HostPublicKey()
-		if err != nil {
-			return nil, err
-		}
-		needed[hpk.String()] = struct{}{}
+		needed[host.HostKey().String()] = struct{}{}
 	}
 
 	//  Wait for the contracts to form.
@@ -384,13 +393,13 @@ func (c *TestCluster) WaitForContracts() ([]api.Contract, error) {
 	}
 	return resp.Contracts, nil
 }
-func (c *TestCluster) RemoveHost(host *siatest.TestNode) error {
+func (c *TestCluster) RemoveHost(host *TestNode) error {
 	if err := host.Close(); err != nil {
 		return err
 	}
 
 	for i, h := range c.hosts {
-		if h == host {
+		if h.HostKey().String() == host.HostKey().String() {
 			c.hosts = append(c.hosts[:i], c.hosts[i+1:]...)
 			break
 		}
@@ -400,17 +409,17 @@ func (c *TestCluster) RemoveHost(host *siatest.TestNode) error {
 
 // AddHosts adds n hosts to the cluster. These hosts will be funded and announce
 // themselves on the network, ready to form contracts.
-func (c *TestCluster) AddHosts(n int) ([]*siatest.TestNode, error) {
+func (c *TestCluster) AddHosts(n int) ([]*TestNode, error) {
 	// Create hosts.
-	var newHosts []*siatest.TestNode
+	var newHosts []*TestNode
 	for i := 0; i < n; i++ {
 		hostDir := filepath.Join(c.dir, "hosts", fmt.Sprint(len(c.hosts)+1))
 		n, err := siatest.NewCleanNodeAsync(sianode.Host(hostDir))
 		if err != nil {
 			return nil, err
 		}
-		c.hosts = append(c.hosts, n)
-		newHosts = append(newHosts, n)
+		c.hosts = append(c.hosts, &TestNode{n})
+		newHosts = append(newHosts, &TestNode{n})
 
 		// Connect gateways.
 		if err := c.Bus.SyncerConnect(string(n.GatewayAddress())); err != nil {
@@ -464,11 +473,7 @@ func (c *TestCluster) AddHosts(n int) ([]*siatest.TestNode, error) {
 		}
 
 		for _, h := range newHosts {
-			hpk, err := h.HostPublicKey()
-			if err != nil {
-				return err
-			}
-			_, err = c.Bus.Host(consensus.PublicKey(hpk.ToPublicKey()))
+			_, err = c.Bus.Host(h.HostKey())
 			if err != nil {
 				return err
 			}

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -361,38 +361,25 @@ func (c *TestCluster) MineBlocks(n int) error {
 }
 
 func (c *TestCluster) WaitForContracts() ([]api.Contract, error) {
-	needed := make(map[string]struct{})
+	// build hosts map
+	hostsmap := make(map[string]struct{})
 	for _, host := range c.hosts {
-		needed[host.HostKey().String()] = struct{}{}
+		hostsmap[host.HostKey().String()] = struct{}{}
 	}
 
-	//  Wait for the contracts to form.
-	if err := Retry(30, time.Second, func() error {
-		contracts, err := c.Bus.ActiveContracts()
-		if err != nil {
-			return err
-		}
-
-		existing := make(map[string]struct{})
-		for _, c := range contracts {
-			existing[c.HostKey.String()] = struct{}{}
-		}
-		for hpk := range needed {
-			if _, exists := existing[hpk]; !exists {
-				return fmt.Errorf("missing contract for host %v", hpk)
-			}
-		}
-		return nil
-	}); err != nil {
+	//  wait for the contracts to form
+	if err := c.waitForHostContracts(hostsmap); err != nil {
 		return nil, err
 	}
 
+	// fetch active contracts
 	resp, err := c.Worker.ActiveContracts(time.Minute)
 	if err != nil {
 		return nil, err
 	}
 	return resp.Contracts, nil
 }
+
 func (c *TestCluster) RemoveHost(host *TestNode) error {
 	if err := host.Close(); err != nil {
 		return err
@@ -492,6 +479,27 @@ func (c *TestCluster) AddHosts(n int) ([]*TestNode, error) {
 	return newHosts, nil
 }
 
+func (c *TestCluster) AddHostsBlocking(n int) ([]*TestNode, error) {
+	// add hosts
+	hosts, err := c.AddHosts(n)
+	if err != nil {
+		return nil, err
+	}
+
+	// build hosts map
+	hostsmap := make(map[string]struct{})
+	for _, host := range hosts {
+		hostsmap[host.HostKey().String()] = struct{}{}
+	}
+
+	// wait for contracts to form
+	if err := c.waitForHostContracts(hostsmap); err != nil {
+		return nil, err
+	}
+
+	return hosts, nil
+}
+
 // Shutdown shuts down a TestCluster. Cleanups are performed in reverse order.
 func (c *TestCluster) Shutdown(ctx context.Context) error {
 	for i := len(c.cleanups) - 1; i >= 0; i-- {
@@ -511,4 +519,28 @@ func (c *TestCluster) Shutdown(ctx context.Context) error {
 // Sync blocks until the whole cluster has reached the same block height.
 func (c *TestCluster) Sync() error {
 	return c.sync(c.hosts)
+}
+
+// waitForHostContracts will fetch the active contracts from the bus and wait
+// until we have a contract with every host in the given hosts map
+func (c *TestCluster) waitForHostContracts(hosts map[string]struct{}) error {
+	return Retry(30, time.Second, func() error {
+		contracts, err := c.Bus.ActiveContracts()
+		if err != nil {
+			return err
+		}
+
+		existing := make(map[string]struct{})
+		for _, c := range contracts {
+			existing[c.HostKey.String()] = struct{}{}
+		}
+
+		for hpk := range hosts {
+			if _, exists := existing[hpk]; !exists {
+				c.MineBlocks(1)
+				return fmt.Errorf("missing contract for host %v", hpk)
+			}
+		}
+		return nil
+	})
 }

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -149,12 +149,7 @@ func TestUploadDownload(t *testing.T) {
 	rs := defaultRedundancy
 
 	// add hosts
-	if _, err := cluster.AddHosts(int(rs.TotalShards)); err != nil {
-		t.Fatal(err)
-	}
-
-	// wait for contracts to form
-	if _, err := cluster.WaitForContracts(); err != nil {
+	if _, err := cluster.AddHostsBlocking(int(rs.TotalShards)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/testing/gouging_test.go
+++ b/internal/testing/gouging_test.go
@@ -50,8 +50,8 @@ func TestGouging(t *testing.T) {
 	}
 
 	// helper that waits until the contract set is ready
-	t.Helper()
 	waitForContractSet := func() error {
+		t.Helper()
 		return Retry(30, time.Second, func() error {
 			if contracts, err := b.Contracts("autopilot"); err != nil {
 				t.Fatal(err)
@@ -63,8 +63,8 @@ func TestGouging(t *testing.T) {
 	}
 
 	// helper that waits untail a certain host is removed from the contract set
-	t.Helper()
 	waitForHostRemoval := func(hk consensus.PublicKey) error {
+		t.Helper()
 		return Retry(30, time.Second, func() error {
 			if contracts, err := b.Contracts("autopilot"); err != nil {
 				t.Fatal(err)

--- a/internal/testing/gouging_test.go
+++ b/internal/testing/gouging_test.go
@@ -38,7 +38,7 @@ func TestGouging(t *testing.T) {
 	w := cluster.Worker
 
 	// add hosts
-	hosts, err := cluster.AddHosts(int(cfg.Hosts))
+	hosts, err := cluster.AddHostsBlocking(int(cfg.Hosts))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/gouging_test.go
+++ b/internal/testing/gouging_test.go
@@ -11,7 +11,6 @@ import (
 	"go.sia.tech/renterd/internal/consensus"
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/siad/node/api/client"
-	"go.sia.tech/siad/siatest"
 	"go.sia.tech/siad/types"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -45,9 +44,9 @@ func TestGouging(t *testing.T) {
 	}
 
 	// build a hosts map
-	hostsmap := make(map[string]*siatest.TestNode)
+	hostsmap := make(map[string]*TestNode)
 	for _, h := range hosts {
-		hostsmap[hostPK(h).String()] = h
+		hostsmap[h.HostKey().String()] = h
 	}
 
 	// helper that waits until the contract set is ready
@@ -147,12 +146,4 @@ func TestGouging(t *testing.T) {
 	if err := w.DownloadObject(&buffer, name); err == nil {
 		t.Fatal("expected download to fail")
 	}
-}
-
-func hostPK(node *siatest.TestNode) consensus.PublicKey {
-	pk, err := node.HostPublicKey()
-	if err != nil {
-		panic(err)
-	}
-	return consensus.PublicKey(pk.ToPublicKey())
 }

--- a/internal/testing/migrations_test.go
+++ b/internal/testing/migrations_test.go
@@ -1,0 +1,116 @@
+package testing
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.sia.tech/renterd/internal/consensus"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"lukechampine.com/frand"
+)
+
+func TestMigrations(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// create a new test cluster
+	cluster, err := newTestCluster(t.TempDir(), zap.New(zapcore.NewNopCore()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := cluster.Shutdown(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// convenience variables
+	cfg := defaultAutopilotConfig.Contracts
+	w := cluster.Worker
+	b := cluster.Bus
+
+	// add hosts
+	hosts, err := cluster.AddHosts(int(cfg.Hosts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// wait until we have contracts
+	if _, err := cluster.WaitForContracts(); err != nil {
+		t.Fatal(err)
+	}
+
+	// add an object
+	data := make([]byte, rhpv2.SectorSize*4)
+	frand.Read(data)
+	if err := w.UploadObject(bytes.NewReader(data), "foo"); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Helper()
+	usedHosts := func() []consensus.PublicKey {
+		obj, _, err := b.Object("/foo")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		hostmap := make(map[consensus.PublicKey]struct{})
+		for _, slab := range obj.Slabs {
+			for _, sector := range slab.Shards {
+				hostmap[sector.Host] = struct{}{}
+			}
+		}
+
+		hks := make([]consensus.PublicKey, 0, len(hostmap))
+		for hk := range hostmap {
+			hks = append(hks, hk)
+		}
+
+		return hks
+	}
+
+	t.Helper()
+	isUsed := func(hk consensus.PublicKey, usedHosts []consensus.PublicKey) bool {
+		for _, h := range usedHosts {
+			if h == hk {
+				return true
+			}
+		}
+		return false
+	}
+
+	// remove one (random) host from the cluster
+	hks := usedHosts()
+	var hk consensus.PublicKey
+	for _, h := range hosts {
+		hpk, err := h.HostPublicKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		copy(hk[:], hpk.Key)
+		if isUsed(hk, hks) {
+			if err := cluster.RemoveHost(h); err != nil {
+				t.Fatal(err)
+			}
+			break
+		}
+	}
+
+	// assert we migrated away from the bad host
+	if err := Retry(30, time.Second, func() error {
+		hks := usedHosts()
+		if isUsed(hk, hks) {
+			return errors.New("host is still used")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/testing/migrations_test.go
+++ b/internal/testing/migrations_test.go
@@ -53,8 +53,8 @@ func TestMigrations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Helper()
 	usedHosts := func() []consensus.PublicKey {
+		t.Helper()
 		obj, _, err := b.Object("/foo")
 		if err != nil {
 			t.Fatal(err)
@@ -75,8 +75,8 @@ func TestMigrations(t *testing.T) {
 		return hks
 	}
 
-	t.Helper()
 	isUsed := func(hk consensus.PublicKey, usedHosts []consensus.PublicKey) bool {
+		t.Helper()
 		for _, h := range usedHosts {
 			if h == hk {
 				return true

--- a/internal/testing/migrations_test.go
+++ b/internal/testing/migrations_test.go
@@ -89,13 +89,7 @@ func TestMigrations(t *testing.T) {
 	hks := usedHosts()
 	var hk consensus.PublicKey
 	for _, h := range hosts {
-		hpk, err := h.HostPublicKey()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		copy(hk[:], hpk.Key)
-		if isUsed(hk, hks) {
+		if hk = h.HostKey(); isUsed(hk, hks) {
 			if err := cluster.RemoveHost(h); err != nil {
 				t.Fatal(err)
 			}

--- a/worker/client.go
+++ b/worker/client.go
@@ -114,7 +114,7 @@ func (c *Client) RHPUpdateRegistry(hostKey consensus.PublicKey, hostIP string, k
 
 // MigrateSlab migrates the specified slab.
 func (c *Client) MigrateSlab(slab object.Slab) error {
-	return c.c.POST("/slabs/migrate", slab, nil)
+	return c.c.POST("/slab/migrate", slab, nil)
 }
 
 // UploadObject uploads the data in r, creating an object with the given name.

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
-	"math"
 	"testing"
 
 	"go.sia.tech/renterd/internal/consensus"
@@ -62,94 +60,6 @@ func newMockHost() *mockHost {
 		publicKey:  consensus.GeneratePrivateKey().PublicKey(),
 		sectors:    make(map[consensus.Hash256][]byte),
 	}
-}
-
-func TestSlabs(t *testing.T) {
-	ctx := context.Background()
-
-	// generate data
-	data := frand.Bytes(1000000)
-
-	// upload slabs
-	var hosts []sectorStore
-	for i := 0; i < 10; i++ {
-		hosts = append(hosts, newMockHost())
-	}
-	s, _, err := uploadSlab(ctx, bytes.NewReader(data), 3, 10, hosts)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// download various ranges
-	checkDownload := func(offset, length uint32) {
-		t.Helper()
-		var buf bytes.Buffer
-		err := downloadSlab(ctx, &buf, object.SlabSlice{Slab: s, Offset: offset, Length: length}, hosts)
-		if err != nil {
-			t.Error(err)
-			return
-		}
-		exp := data[offset:][:length]
-		got := buf.Bytes()
-		if !bytes.Equal(got, exp) {
-			if len(got) > 20 {
-				t.Errorf("download(%v, %v):\nexpected: %x...%x (%v)\ngot:      %x...%x (%v)",
-					offset, length,
-					exp[:20], exp[len(exp)-20:], len(exp),
-					got[:20], got[len(got)-20:], len(got))
-			} else {
-				t.Errorf("download(%v, %v):\nexpected: %x (%v)\ngot:      %x (%v)",
-					offset, length, exp, len(exp), got, len(got))
-			}
-		}
-	}
-	checkDownload(0, 0)
-	checkDownload(0, 1)
-	checkDownload(rhpv2.LeafSize*10, rhpv2.LeafSize*20)
-	checkDownload(0, uint32(len(data)/2))
-	checkDownload(0, uint32(len(data)))
-	checkDownload(uint32(len(data)/2), uint32(len(data)/2))
-	checkDownload(84923, uint32(len(data[84923:])-53219))
-
-	checkDownloadFail := func(offset, length uint32) {
-		t.Helper()
-		var buf bytes.Buffer
-		if err := downloadSlab(ctx, &buf, object.SlabSlice{Slab: s, Offset: offset, Length: length}, hosts); err == nil {
-			t.Error("expected error, got nil")
-		}
-	}
-	checkDownloadFail(0, math.MaxUint32)
-	checkDownloadFail(math.MaxUint32, 1)
-
-	// migrate to 5 new hosts
-	from := hosts[5:]
-	to := hosts[5:]
-	for i := 0; i < 5; i++ {
-		to = append(to, newMockHost())
-	}
-	old := fmt.Sprint(s)
-	if err := migrateSlab(ctx, &s, from, to); err != nil {
-		t.Fatal(err)
-	}
-	if fmt.Sprint(s) == old {
-		t.Error("no change to s after migration")
-	}
-	checkDownload(0, 0)
-	checkDownload(0, 1)
-	checkDownload(rhpv2.LeafSize*10, rhpv2.LeafSize*20)
-	checkDownload(0, uint32(len(data)/2))
-	checkDownload(0, uint32(len(data)))
-	checkDownload(uint32(len(data)/2), uint32(len(data)/2))
-	checkDownload(84923, uint32(len(data[84923:])-53219))
-
-	// delete
-	if err := deleteSlabs(ctx, []object.Slab{s}, to); err != nil {
-		t.Fatal(err)
-	}
-
-	// downloads should now fail
-	checkDownloadFail(0, uint32(len(data)))
-	checkDownloadFail(0, 1)
 }
 
 func TestMultipleObjects(t *testing.T) {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -591,8 +591,7 @@ func (w *worker) slabsMigrateHandler(jc jape.Context) {
 		}
 	}
 
-	err = w.bus.UpdateSlab(slab, usedContracts)
-	if jc.Check("couldn't update slab", err) != nil {
+	if jc.Check("couldn't update slab", w.bus.UpdateSlab(slab, usedContracts)) != nil {
 		return
 	}
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -199,7 +199,7 @@ type Bus interface {
 	AddObject(key string, o object.Object, usedContracts map[consensus.PublicKey]types.FileContractID) error
 	DeleteObject(key string) error
 
-	UpdateSlab(s object.Slab, usedContracts map[consensus.PublicKey]types.FileContractID) error
+	UpdateSlab(s object.Slab, goodContracts map[consensus.PublicKey]types.FileContractID) error
 
 	WalletDiscard(txn types.Transaction) error
 	WalletPrepareForm(renterKey consensus.PrivateKey, hostKey consensus.PublicKey, renterFunds types.Currency, renterAddress types.UnlockHash, hostCollateral types.Currency, endHeight uint64, hostSettings rhpv2.HostSettings) (txns []types.Transaction, err error)
@@ -550,7 +550,7 @@ func (w *worker) rhpRegistryUpdateHandler(jc jape.Context) {
 	}
 }
 
-func (w *worker) slabsMigrateHandler(jc jape.Context) {
+func (w *worker) slabMigrateHandler(jc jape.Context) {
 	var slab object.Slab
 	if jc.Decode(&slab) != nil {
 		return
@@ -821,7 +821,7 @@ func New(masterKey [32]byte, b Bus, sessionReconectTimeout, sessionTTL time.Dura
 		"POST   /rhp/registry/read":    w.rhpRegistryReadHandler,
 		"POST   /rhp/registry/update":  w.rhpRegistryUpdateHandler,
 
-		"POST   /slabs/migrate": w.slabsMigrateHandler,
+		"POST   /slab/migrate": w.slabMigrateHandler,
 
 		"GET    /objects/*key": w.objectsKeyHandlerGET,
 		"PUT    /objects/*key": w.objectsKeyHandlerPUT,


### PR DESCRIPTION
This PR adds migrations. 

It changes a couple of things, but nothing major:
- move away from `fromContracts` and `toContracts`
- we can get rid of `MigrationParams`
- we can migrate using the contract set name (seeing as we merged contract set store and contract store)
- we can reuse the upload code for migrations

I added two fields: 
- `LastHost`: something we really need to figure out what slabs to migrate (contact me in PM if you want to hear why)
- `TotalShards`: something we don't really need, but it saves an inner query and I figured it's not too bad..


