### PR TITLE
Active Contracts

### DIFF
--- a/api/params.go
+++ b/api/params.go
@@ -26,9 +26,14 @@ func (t ParamTime) String() string { return url.QueryEscape((time.Time)(t).Forma
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (t *ParamTime) UnmarshalText(b []byte) error { return (*time.Time)(t).UnmarshalText(b) }
 
+// String implements fmt.Stringer.
+func (d Duration) String() string {
+	return strconv.FormatInt(time.Duration(d).Milliseconds(), 10)
+}
+
 // MarshalText implements encoding.TextMarshaler.
 func (d Duration) MarshalText() ([]byte, error) {
-	return []byte(strconv.FormatInt(time.Duration(d).Milliseconds(), 10)), nil
+	return []byte(d.String()), nil
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.

--- a/api/worker.go
+++ b/api/worker.go
@@ -9,9 +9,16 @@ import (
 	"go.sia.tech/siad/types"
 )
 
-type ActiveContractsResponse struct {
+// ContractsRequests is the request type for the /rhp/contracts endpoint.
+type ContractsRequests struct {
+	Contracts   []ContractMetadata `json:"contracts"`
+	HostTimeout time.Duration      `json:"hostTimeout"`
+}
+
+// ContractsResponse is the response type for the /rhp/contracts endpoint.
+type ContractsResponse struct {
 	Contracts []Contract `json:"contracts"`
-	Error     string     `json:"error"`
+	Error     string     `json:"error,omitempty"`
 }
 
 // RHPScanRequest is the request type for the /rhp/scan endpoint.

--- a/api/worker.go
+++ b/api/worker.go
@@ -9,13 +9,7 @@ import (
 	"go.sia.tech/siad/types"
 )
 
-// ContractsRequests is the request type for the /rhp/contracts endpoint.
-type ContractsRequests struct {
-	Contracts   []ContractMetadata `json:"contracts"`
-	HostTimeout time.Duration      `json:"hostTimeout"`
-}
-
-// ContractsResponse is the response type for the /rhp/contracts endpoint.
+// ContractsResponse is the response type for the /rhp/contracts/active endpoint.
 type ContractsResponse struct {
 	Contracts []Contract `json:"contracts"`
 	Error     string     `json:"error,omitempty"`

--- a/api/worker.go
+++ b/api/worker.go
@@ -9,6 +9,11 @@ import (
 	"go.sia.tech/siad/types"
 )
 
+type ActiveContractsResponse struct {
+	Contracts []Contract `json:"contracts"`
+	Error     string     `json:"error"`
+}
+
 // RHPScanRequest is the request type for the /rhp/scan endpoint.
 type RHPScanRequest struct {
 	HostKey consensus.PublicKey `json:"hostKey"`

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -109,6 +109,10 @@ func (ap *Autopilot) Run() error {
 		}
 		ap.logger.Info("autopilot loop starting")
 
+		// initiate a host scan
+		ap.s.tryUpdateTimeout()
+		ap.s.tryPerformHostScan()
+
 		// fetch consensus state
 		cs, err := ap.bus.ConsensusState()
 		if err != nil {
@@ -137,10 +141,6 @@ func (ap *Autopilot) Run() error {
 			ap.logger.Errorf("update contracts failed, err: %v", err)
 		}
 		ap.m.TryPerformMigrations()
-
-		// initiate a host scan
-		ap.s.tryUpdateTimeout()
-		ap.s.tryPerformHostScan()
 	}
 }
 

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -61,11 +61,11 @@ type Bus interface {
 }
 
 type Worker interface {
-	RHPScan(hostKey consensus.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)
+	ActiveContracts(timeout time.Duration) (api.ContractsResponse, error)
+	MigrateSlab(s object.Slab) error
 	RHPForm(endHeight uint64, hk consensus.PublicKey, hostIP string, renterAddress types.UnlockHash, renterFunds types.Currency, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPRenew(fcid types.FileContractID, endHeight uint64, hk consensus.PublicKey, hostIP string, renterAddress types.UnlockHash, renterFunds types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
-	MigrateSlab(s object.Slab) error
-	Contracts(contracts []api.ContractMetadata, timeout time.Duration) (api.ContractsResponse, error)
+	RHPScan(hostKey consensus.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)
 }
 
 type Autopilot struct {

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -65,7 +65,7 @@ type Worker interface {
 	RHPForm(endHeight uint64, hk consensus.PublicKey, hostIP string, renterAddress types.UnlockHash, renterFunds types.Currency, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPRenew(fcid types.FileContractID, endHeight uint64, hk consensus.PublicKey, hostIP string, renterAddress types.UnlockHash, renterFunds types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	MigrateSlab(s object.Slab) error
-	ActiveContracts() (api.ActiveContractsResponse, error)
+	Contracts(contracts []api.ContractMetadata, timeout time.Duration) (api.ContractsResponse, error)
 }
 
 type Autopilot struct {
@@ -107,10 +107,7 @@ func (ap *Autopilot) Run() error {
 			return nil
 		case <-ap.ticker.C:
 		}
-
-		// initiate a host scan
-		ap.s.tryUpdateTimeout()
-		ap.s.tryPerformHostScan()
+		ap.logger.Info("autopilot loop starting")
 
 		// fetch consensus state
 		cs, err := ap.bus.ConsensusState()
@@ -140,6 +137,10 @@ func (ap *Autopilot) Run() error {
 			ap.logger.Errorf("update contracts failed, err: %v", err)
 		}
 		ap.m.TryPerformMigrations()
+
+		// initiate a host scan
+		ap.s.tryUpdateTimeout()
+		ap.s.tryPerformHostScan()
 	}
 }
 

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -65,7 +65,7 @@ type Worker interface {
 	RHPForm(endHeight uint64, hk consensus.PublicKey, hostIP string, renterAddress types.UnlockHash, renterFunds types.Currency, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPRenew(fcid types.FileContractID, endHeight uint64, hk consensus.PublicKey, hostIP string, renterAddress types.UnlockHash, renterFunds types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	MigrateSlab(s object.Slab) error
-	ActiveContracts() (contracts []api.Contract, err error)
+	ActiveContracts() (api.ActiveContractsResponse, error)
 }
 
 type Autopilot struct {

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -378,9 +378,8 @@ func (c *contractor) runContractRenewals(cfg api.AutopilotConfig, blockHeight, c
 			)
 			if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
 				break
-			} else {
-				continue
 			}
+			continue
 		}
 
 		// update the budget
@@ -507,9 +506,8 @@ func (c *contractor) runContractFormations(cfg api.AutopilotConfig, active []api
 			)
 			if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
 				break
-			} else {
-				continue
 			}
+			continue
 		}
 
 		// update the budget

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -142,9 +142,12 @@ func (c *contractor) performContractMaintenance(cfg api.AutopilotConfig, cs api.
 	}
 
 	// fetch all contracts
-	contracts, err := c.ap.worker.ActiveContracts()
+	resp, err := c.ap.worker.ActiveContracts()
 	if err != nil {
 		return err
+	}
+	if resp.Error != "" {
+		c.logger.Error(resp.Error)
 	}
 
 	// fetch gouging settings
@@ -160,6 +163,7 @@ func (c *contractor) performContractMaintenance(cfg api.AutopilotConfig, cs api.
 	}
 
 	// run checks
+	contracts := resp.Contracts
 	toDelete, toIgnore, toRefresh, toRenew, err := c.runContractChecks(cfg, blockHeight, gs, rs, contracts)
 	if err != nil {
 		return fmt.Errorf("failed to run contract checks, err: %v", err)

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -143,14 +143,8 @@ func (c *contractor) performContractMaintenance(cfg api.AutopilotConfig, cs api.
 		return err
 	}
 
-	// fetch active contracts from the bus (without revision)
-	active, err := c.ap.bus.ActiveContracts()
-	if err != nil {
-		return err
-	}
-
-	// fetch all contracts from the worker (includes revision)
-	resp, err := c.ap.worker.Contracts(active, 30*time.Second)
+	// fetch all active contracts from the worker
+	resp, err := c.ap.worker.ActiveContracts(30 * time.Second)
 	if err != nil {
 		return err
 	}

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -114,6 +114,8 @@ func (c *contractor) isStopped() bool {
 }
 
 func (c *contractor) performContractMaintenance(cfg api.AutopilotConfig, cs api.ConsensusState) error {
+	c.logger.Info("performing contract maintenance")
+
 	// No maintenance when syncing.
 	if !cs.Synced {
 		return nil
@@ -141,8 +143,14 @@ func (c *contractor) performContractMaintenance(cfg api.AutopilotConfig, cs api.
 		return err
 	}
 
-	// fetch all contracts
-	resp, err := c.ap.worker.ActiveContracts()
+	// fetch active contracts from the bus (without revision)
+	active, err := c.ap.bus.ActiveContracts()
+	if err != nil {
+		return err
+	}
+
+	// fetch all contracts from the worker (includes revision)
+	resp, err := c.ap.worker.Contracts(active, 30*time.Second)
 	if err != nil {
 		return err
 	}

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -68,6 +68,8 @@ func (m *migrator) fetchSlabsForMigration() ([]object.Slab, error) {
 }
 
 func (m *migrator) performMigrations() {
+	m.logger.Info("performing migrations")
+
 	for {
 		// Fetch slabs for repair
 		slabsToRepair, err := m.fetchSlabsForMigration()

--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -151,7 +151,7 @@ func (s *scanner) tryPerformHostScan() {
 		return
 	}
 
-	s.logger.Debug("host scan started")
+	s.logger.Info("host scan started")
 	s.scanningLastStart = time.Now()
 	s.scanning = true
 	s.mu.Unlock()

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -375,12 +375,7 @@ func (c *TestCluster) WaitForContracts() ([]api.Contract, error) {
 		return nil, err
 	}
 
-	contracts, err := c.Bus.ActiveContracts()
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.Worker.Contracts(contracts, time.Minute)
+	resp, err := c.Worker.ActiveContracts(time.Minute)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -375,7 +375,12 @@ func (c *TestCluster) WaitForContracts() ([]api.Contract, error) {
 		return nil, err
 	}
 
-	resp, err := c.Worker.ActiveContracts()
+	contracts, err := c.Bus.ActiveContracts()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Worker.Contracts(contracts, time.Minute)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -375,7 +375,11 @@ func (c *TestCluster) WaitForContracts() ([]api.Contract, error) {
 		return nil, err
 	}
 
-	return c.Worker.ActiveContracts()
+	resp, err := c.Worker.ActiveContracts()
+	if err != nil {
+		return nil, err
+	}
+	return resp.Contracts, nil
 }
 
 // AddHosts adds n hosts to the cluster. These hosts will be funded and announce

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -101,10 +101,11 @@ func TestNewTestCluster(t *testing.T) {
 
 	// Wait for the contract to be renewed.
 	err = Retry(100, 100*time.Millisecond, func() error {
-		contracts, err := w.ActiveContracts()
+		resp, err := w.ActiveContracts()
 		if err != nil {
 			return err
 		}
+		contracts := resp.Contracts
 		if len(contracts) != 1 {
 			return errors.New("no renewed contract")
 		}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -101,11 +101,7 @@ func TestNewTestCluster(t *testing.T) {
 
 	// Wait for the contract to be renewed.
 	err = Retry(100, 100*time.Millisecond, func() error {
-		active, err := b.ActiveContracts()
-		if err != nil {
-			return err
-		}
-		resp, err := w.Contracts(active, time.Minute)
+		resp, err := w.ActiveContracts(time.Minute)
 		if err != nil {
 			return err
 		}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -101,7 +101,11 @@ func TestNewTestCluster(t *testing.T) {
 
 	// Wait for the contract to be renewed.
 	err = Retry(100, 100*time.Millisecond, func() error {
-		resp, err := w.ActiveContracts()
+		active, err := b.ActiveContracts()
+		if err != nil {
+			return err
+		}
+		resp, err := w.Contracts(active, time.Minute)
 		if err != nil {
 			return err
 		}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -19,6 +19,10 @@ import (
 // TransactionSignature, assuming standard UnlockConditions.
 const BytesPerInput = 241
 
+// ErrInsufficientBalance is returned when there aren't enough unused outputs to
+// cover the requested amount.
+var ErrInsufficientBalance = errors.New("insufficient balance")
+
 // StandardUnlockConditions returns the standard unlock conditions for a single
 // Ed25519 key.
 func StandardUnlockConditions(pk consensus.PublicKey) types.UnlockConditions {
@@ -192,7 +196,7 @@ func (w *SingleAddressWallet) FundTransaction(cs consensus.State, txn *types.Tra
 		}
 	}
 	if outputSum.Cmp(amount) < 0 {
-		return nil, errors.New("insufficient balance")
+		return nil, ErrInsufficientBalance
 	} else if outputSum.Cmp(amount) > 0 {
 		txn.SiacoinOutputs = append(txn.SiacoinOutputs, types.SiacoinOutput{
 			Value:      outputSum.Sub(amount),
@@ -300,7 +304,7 @@ func (w *SingleAddressWallet) Redistribute(cs consensus.State, outputs int, amou
 	// not enough outputs found
 	fee := feePerInput.Mul64(uint64(len(inputs))).Add(outputFees)
 	if SumOutputs(inputs).Cmp(want.Add(fee)) < 0 {
-		return types.Transaction{}, nil, errors.New("insufficient balance")
+		return types.Transaction{}, nil, ErrInsufficientBalance
 	}
 
 	// set the miner fee

--- a/worker/client.go
+++ b/worker/client.go
@@ -188,7 +188,7 @@ func (c *Client) DeleteObject(name string) (err error) {
 // ActiveContracts returns all active contracts from the worker. These contracts
 // decorate a bus contract with the contract's latest revision.
 func (c *Client) ActiveContracts(timeout time.Duration) (resp api.ContractsResponse, err error) {
-	err = c.c.GET(fmt.Sprintf("/rhp/contracts/active?hosttimeout=%s"+api.Duration(timeout).String()), &resp)
+	err = c.c.GET(fmt.Sprintf("/rhp/contracts/active?hosttimeout=%s", api.Duration(timeout)), &resp)
 	return
 }
 

--- a/worker/client.go
+++ b/worker/client.go
@@ -185,13 +185,10 @@ func (c *Client) DeleteObject(name string) (err error) {
 	return
 }
 
-// Contracts returns the requested contracts.
-func (c *Client) Contracts(contracts []api.ContractMetadata, timeout time.Duration) (resp api.ContractsResponse, err error) {
-	req := api.ContractsRequests{
-		Contracts:   contracts,
-		HostTimeout: timeout,
-	}
-	err = c.c.POST("/rhp/contracts", req, &resp)
+// ActiveContracts returns all active contracts from the worker. These contracts
+// decorate a bus contract with the contract's latest revision.
+func (c *Client) ActiveContracts(timeout time.Duration) (resp api.ContractsResponse, err error) {
+	err = c.c.GET(fmt.Sprintf("/rhp/contracts/active?hosttimeout=%s"+api.Duration(timeout).String()), &resp)
 	return
 }
 

--- a/worker/client.go
+++ b/worker/client.go
@@ -187,8 +187,8 @@ func (c *Client) DeleteObject(name string) (err error) {
 
 // ActiveContracts returns all active contracts from the worker. These contracts
 // decorate a bus contract with the contract's latest revision.
-func (c *Client) ActiveContracts() (contracts []api.Contract, err error) {
-	err = c.c.GET("/rhp/contracts/active", &contracts)
+func (c *Client) ActiveContracts() (resp api.ActiveContractsResponse, err error) {
+	err = c.c.GET("/rhp/contracts/active", &resp)
 	return
 }
 

--- a/worker/client.go
+++ b/worker/client.go
@@ -185,10 +185,13 @@ func (c *Client) DeleteObject(name string) (err error) {
 	return
 }
 
-// ActiveContracts returns all active contracts from the worker. These contracts
-// decorate a bus contract with the contract's latest revision.
-func (c *Client) ActiveContracts() (resp api.ActiveContractsResponse, err error) {
-	err = c.c.GET("/rhp/contracts/active", &resp)
+// Contracts returns the requested contracts.
+func (c *Client) Contracts(contracts []api.ContractMetadata, timeout time.Duration) (resp api.ContractsResponse, err error) {
+	req := api.ContractsRequests{
+		Contracts:   contracts,
+		HostTimeout: timeout,
+	}
+	err = c.c.POST("/rhp/contracts", req, &resp)
 	return
 }
 

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -19,7 +19,7 @@ type sectorStore interface {
 	PublicKey() consensus.PublicKey
 	UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte) (consensus.Hash256, error)
 	DownloadSector(ctx context.Context, w io.Writer, root consensus.Hash256, offset, length uint32) error
-	DeleteSectors(roots []consensus.Hash256) error
+	DeleteSectors(ctx context.Context, roots []consensus.Hash256) error
 }
 
 func parallelUploadSlab(ctx context.Context, shards [][]byte, hosts []sectorStore) ([]object.Sector, error) {
@@ -239,7 +239,7 @@ func deleteSlabs(ctx context.Context, slabs []object.Slab, hosts []sectorStore) 
 		go func(h sectorStore) {
 			// NOTE: if host is not storing any sectors, the map lookup will return
 			// nil, making this a no-op
-			err := h.DeleteSectors(rootsBysectorStore[h.PublicKey()])
+			err := h.DeleteSectors(ctx, rootsBysectorStore[h.PublicKey()])
 			if err != nil {
 				errChan <- &HostError{h.PublicKey(), err}
 			} else {

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -47,7 +47,7 @@ func (h *mockHost) DownloadSector(_ context.Context, w io.Writer, root consensus
 	return err
 }
 
-func (h *mockHost) DeleteSectors(roots []consensus.Hash256) error {
+func (h *mockHost) DeleteSectors(_ context.Context, roots []consensus.Hash256) error {
 	for _, root := range roots {
 		delete(h.sectors, root)
 	}


### PR DESCRIPTION
The `worker` currently has an active contracts endpoint that queries the bus for the active contracts and fetches the latest revision from the hosts. This endpoint however will error out as soon as we fail to retrieve a single revision. This is an issue because contract maintenance is blocked by this.

This PR adds a timeout that's applied to every revision fetch from the host. By doing so contract maintenance can continue for hosts that are reachable, the error message is logged by the autopilot so it doesn't go by completely unnoticed.

NOTE: the timeout is only applied to components that use the context, the worker transport for instance is currently not aware  yet of any context and thus won't apply the context to reads for instance. It is applied to the `Dial` which is the most important thing, I figured it's fine to leave it as-is for now