### PR TITLE
Settings

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -98,9 +98,10 @@ type (
 
 	// A SettingStore stores settings.
 	SettingStore interface {
-		Settings() ([]string, error)
 		Setting(key string) (string, error)
+		Settings() ([]string, error)
 		UpdateSetting(key, value string) error
+		UpdateSettings(settings map[string]string) error
 	}
 )
 
@@ -579,6 +580,13 @@ func (b *bus) settingsHandlerGET(jc jape.Context) {
 	}
 }
 
+func (b *bus) settingsHandlerPUT(jc jape.Context) {
+	var settings map[string]string
+	if jc.Decode(&settings) == nil {
+		jc.Check("couldn't update settings", b.ss.UpdateSettings(settings))
+	}
+}
+
 func (b *bus) settingKeyHandlerGET(jc jape.Context) {
 	if key := jc.PathParam("key"); key == "" {
 		jc.Error(errors.New("param 'key' can not be empty"), http.StatusBadRequest)
@@ -772,6 +780,7 @@ func New(s Syncer, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, cs
 		"GET    /migration/slabs": b.objectsMigrationSlabsHandlerGET,
 
 		"GET    /settings":     b.settingsHandlerGET,
+		"PUT    /settings":     b.settingsHandlerPUT,
 		"GET    /setting/:key": b.settingKeyHandlerGET,
 		"PUT    /setting/:key": b.settingKeyHandlerPUT,
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -377,14 +377,9 @@ func (c *Client) Settings() (settings []string, err error) {
 	return
 }
 
-// UpdateSetting will update or insert the setting for given key with the given value.
-func (c *Client) UpdateSetting(key string, value interface{}) error {
-	v, err := json.Marshal(value)
-	if err != nil {
-		return fmt.Errorf("unable to marshal given setting, err: %v", err)
-	}
-
-	return c.c.POST(fmt.Sprintf("/setting/%s/%s", key, url.QueryEscape(string(v))), nil, nil)
+// UpdateSetting will update the given setting under the given key.
+func (c *Client) UpdateSetting(key string, setting interface{}) error {
+	return c.c.PUT(fmt.Sprintf("/setting/%s", key), setting)
 }
 
 // GougingSettings returns the gouging settings.

--- a/bus/client.go
+++ b/bus/client.go
@@ -379,6 +379,11 @@ func (c *Client) UpdateSetting(key string, value string) error {
 	return c.c.PUT(fmt.Sprintf("/setting/%s", key), value)
 }
 
+// UpdateSettings will bulk update the given settings.
+func (c *Client) UpdateSettings(settings map[string]string) error {
+	return c.c.PUT("/settings", settings)
+}
+
 // GougingSettings returns the gouging settings.
 func (c *Client) GougingSettings() (gs api.GougingSettings, err error) {
 	setting, err := c.Setting(SettingGouging)

--- a/bus/client.go
+++ b/bus/client.go
@@ -363,12 +363,9 @@ func (c *Client) ContractsForSlab(shards []object.Sector, contractSetName string
 }
 
 // Setting returns the value for the setting with given key.
-func (c *Client) Setting(key string, resp interface{}) (err error) {
-	var value string
-	if err := c.c.GET(fmt.Sprintf("/setting/%s", key), &value); err != nil {
-		return err
-	}
-	return json.Unmarshal([]byte(value), &resp)
+func (c *Client) Setting(key string) (value string, err error) {
+	err = c.c.GET(fmt.Sprintf("/setting/%s", key), &value)
+	return
 }
 
 // Settings returns the keys of all settings in the store.
@@ -378,30 +375,46 @@ func (c *Client) Settings() (settings []string, err error) {
 }
 
 // UpdateSetting will update the given setting under the given key.
-func (c *Client) UpdateSetting(key string, setting interface{}) error {
-	return c.c.PUT(fmt.Sprintf("/setting/%s", key), setting)
+func (c *Client) UpdateSetting(key string, value string) error {
+	return c.c.PUT(fmt.Sprintf("/setting/%s", key), value)
 }
 
 // GougingSettings returns the gouging settings.
 func (c *Client) GougingSettings() (gs api.GougingSettings, err error) {
-	err = c.Setting(SettingGouging, &gs)
+	setting, err := c.Setting(SettingGouging)
+	if err != nil {
+		return api.GougingSettings{}, err
+	}
+	err = json.Unmarshal([]byte(setting), &gs)
 	return
 }
 
 // UpdateGougingSettings allows configuring the gouging settings.
 func (c *Client) UpdateGougingSettings(gs api.GougingSettings) error {
-	return c.UpdateSetting(SettingGouging, gs)
+	b, err := json.Marshal(gs)
+	if err != nil {
+		return err
+	}
+	return c.UpdateSetting(SettingGouging, string(b))
 }
 
 // RedundancySettings returns the redundancy settings.
 func (c *Client) RedundancySettings() (rs api.RedundancySettings, err error) {
-	err = c.Setting(SettingRedundancy, &rs)
+	setting, err := c.Setting(SettingRedundancy)
+	if err != nil {
+		return api.RedundancySettings{}, err
+	}
+	err = json.Unmarshal([]byte(setting), &rs)
 	return
 }
 
 // UpdateRedundancySettings allows configuring the redundancy.
 func (c *Client) UpdateRedundancySettings(rs api.RedundancySettings) error {
-	return c.UpdateSetting(SettingRedundancy, rs)
+	b, err := json.Marshal(rs)
+	if err != nil {
+		return err
+	}
+	return c.UpdateSetting(SettingRedundancy, string(b))
 }
 
 // Object returns the object at the given path, or, if path ends in '/', the

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -321,13 +321,13 @@ func TestSQLHosts(t *testing.T) {
 	if len(hostAddresses) != 3 {
 		t.Fatal("wrong number of addresses")
 	}
-	if hostAddresses[0].PublicKey != hk1 {
+	if hostAddresses[0].PublicKey != hk3 {
 		t.Fatal("wrong key")
 	}
 	if hostAddresses[1].PublicKey != hk2 {
 		t.Fatal("wrong key")
 	}
-	if hostAddresses[2].PublicKey != hk3 {
+	if hostAddresses[2].PublicKey != hk1 {
 		t.Fatal("wrong key")
 	}
 

--- a/internal/stores/settingsdb.go
+++ b/internal/stores/settingsdb.go
@@ -42,7 +42,7 @@ func (s *SQLStore) Settings() ([]string, error) {
 	return keys, tx.Error
 }
 
-// Setting implements the bus.SettingStore interface.
+// UpdateSetting implements the bus.SettingStore interface.
 func (s *SQLStore) UpdateSetting(key, value string) error {
 	return s.db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "key"}},
@@ -51,4 +51,20 @@ func (s *SQLStore) UpdateSetting(key, value string) error {
 		Key:   key,
 		Value: value,
 	}).Error
+}
+
+// UpdateSettings implements the bus.SettingStore interface.
+func (s *SQLStore) UpdateSettings(settings map[string]string) error {
+	var dbSettings []dbSetting
+	for key, value := range settings {
+		dbSettings = append(dbSettings, dbSetting{
+			Key:   key,
+			Value: value,
+		})
+	}
+
+	return s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value"}),
+	}).Create(&dbSettings).Error
 }

--- a/object/slab_test.go
+++ b/object/slab_test.go
@@ -2,7 +2,7 @@ package object
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
@@ -99,7 +99,7 @@ func BenchmarkReedSolomon(b *testing.B) {
 				for j := range shards[:r] {
 					shards[j] = shards[j][:0]
 				}
-				if err := ss.Recover(ioutil.Discard, shards); err != nil {
+				if err := ss.Recover(io.Discard, shards); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/rhp/v2/transport.go
+++ b/rhp/v2/transport.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"strings"
 	"sync"
@@ -303,7 +302,7 @@ func (rr *ResponseReader) Read(p []byte) (int, error) {
 func (rr *ResponseReader) VerifyTag() error {
 	// the caller may not have consumed the full message (e.g. if it was padded
 	// to minMessageSize), so make sure the whole thing is written to the MAC
-	if _, err := io.Copy(ioutil.Discard, rr); err != nil {
+	if _, err := io.Copy(io.Discard, rr); err != nil {
 		return err
 	}
 

--- a/worker/client.go
+++ b/worker/client.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -131,10 +130,10 @@ func (c *Client) UploadObject(r io.Reader, name string) (err error) {
 	if err != nil {
 		return err
 	}
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(io.Discard, resp.Body)
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		err, _ := ioutil.ReadAll(resp.Body)
+		err, _ := io.ReadAll(resp.Body)
 		return errors.New(string(err))
 	}
 	return
@@ -152,10 +151,10 @@ func (c *Client) object(path string, w io.Writer, entries *[]string) (err error)
 	if err != nil {
 		return err
 	}
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(io.Discard, resp.Body)
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		err, _ := ioutil.ReadAll(resp.Body)
+		err, _ := io.ReadAll(resp.Body)
 		return errors.New(string(err))
 	}
 	if w != nil {


### PR DESCRIPTION
The settings store allows storing key-value pairs, where the values are always a string. These values can be JSON strings, which is the case for the gouging and redundancy settings. The bus client has methods to get/set both of these. Settings can be updated in bulk by using `POST /settings` and providing a map of key value pairs.

The most important requirements for the settings API are that it needs to be:
- easy to retrieve things like the redundancy settings in a single RT
- easy to update settings