### PR TITLE
Add in-memory contract locking to bus for multi-worker setups

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -41,7 +41,7 @@ type ContractAcquireRequest struct {
 // ContractAcquireResponse is the response type for the /contract/:id/acquire
 // endpoint.
 type ContractAcquireResponse struct {
-	Locked bool `json:"locked"`
+	LockID uint64 `json:"lockID"`
 }
 
 type HostsScanPubkeyHandlerPOSTRequest struct {

--- a/api/bus.go
+++ b/api/bus.go
@@ -39,13 +39,13 @@ type ContractAcquireRequest struct {
 	Priority int           `json:"priority"`
 }
 
-// ContractAcquireRequest is the request type for the /contract/release
+// ContractAcquireRequest is the request type for the /contract/:id/release
 // endpoint.
 type ContractReleaseRequest struct {
 	LockID uint64 `json:"lockID"`
 }
 
-// ContractAcquireResponse is the response type for the /contract/acquire
+// ContractAcquireResponse is the response type for the /contract/:id/acquire
 // endpoint.
 type ContractAcquireResponse struct {
 	LockID uint64 `json:"lockID"`

--- a/api/bus.go
+++ b/api/bus.go
@@ -32,13 +32,21 @@ type ContractsIDRenewedRequest struct {
 	TotalCost   types.Currency         `json:"totalCost"`
 }
 
-// ContractAcquireRequest is the request type for the /contract/:id/acquire
+// ContractAcquireRequest is the request type for the /contract/acquire
 // endpoint.
 type ContractAcquireRequest struct {
-	Duration time.Duration
+	ContractID types.FileContractID `json:"contractID"`
+	Duration   time.Duration        `json:"duration"`
 }
 
-// ContractAcquireResponse is the response type for the /contract/:id/acquire
+// ContractAcquireRequest is the request type for the /contract/release
+// endpoint.
+type ContractReleaseRequest struct {
+	ContractID types.FileContractID `json:"contractID"`
+	LockID     uint64               `json:"lockID"`
+}
+
+// ContractAcquireResponse is the response type for the /contract/acquire
 // endpoint.
 type ContractAcquireResponse struct {
 	LockID uint64 `json:"lockID"`

--- a/api/bus.go
+++ b/api/bus.go
@@ -36,6 +36,7 @@ type ContractsIDRenewedRequest struct {
 // endpoint.
 type ContractAcquireRequest struct {
 	Duration time.Duration `json:"duration"`
+	Priority int           `json:"priority"`
 }
 
 // ContractAcquireRequest is the request type for the /contract/release

--- a/api/bus.go
+++ b/api/bus.go
@@ -35,15 +35,13 @@ type ContractsIDRenewedRequest struct {
 // ContractAcquireRequest is the request type for the /contract/acquire
 // endpoint.
 type ContractAcquireRequest struct {
-	ContractID types.FileContractID `json:"contractID"`
-	Duration   time.Duration        `json:"duration"`
+	Duration time.Duration `json:"duration"`
 }
 
 // ContractAcquireRequest is the request type for the /contract/release
 // endpoint.
 type ContractReleaseRequest struct {
-	ContractID types.FileContractID `json:"contractID"`
-	LockID     uint64               `json:"lockID"`
+	LockID uint64 `json:"lockID"`
 }
 
 // ContractAcquireResponse is the response type for the /contract/acquire

--- a/api/bus.go
+++ b/api/bus.go
@@ -35,8 +35,8 @@ type ContractsIDRenewedRequest struct {
 // ContractAcquireRequest is the request type for the /contract/acquire
 // endpoint.
 type ContractAcquireRequest struct {
-	Duration time.Duration `json:"duration"`
-	Priority int           `json:"priority"`
+	Duration Duration `json:"duration"`
+	Priority int      `json:"priority"`
 }
 
 // ContractAcquireRequest is the request type for the /contract/:id/release

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -36,7 +36,7 @@ type Bus interface {
 	RecordInteractions(interactions []hostdb.Interaction) error
 
 	// contracts
-	AcquireContract(id types.FileContractID, d time.Duration) (uint64, error)
+	AcquireContract(id types.FileContractID, priority int, d time.Duration) (uint64, error)
 	ActiveContracts() (contracts []api.ContractMetadata, err error)
 	AddContract(c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64) (api.ContractMetadata, error)
 	AddRenewedContract(c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, renewedFrom types.FileContractID) (api.ContractMetadata, error)

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -36,7 +36,7 @@ type Bus interface {
 	RecordInteractions(interactions []hostdb.Interaction) error
 
 	// contracts
-	AcquireContract(id types.FileContractID, d time.Duration) (bool, error)
+	AcquireContract(id types.FileContractID, d time.Duration) (uint64, error)
 	ActiveContracts() (contracts []api.ContractMetadata, err error)
 	AddContract(c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64) (api.ContractMetadata, error)
 	AddRenewedContract(c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, renewedFrom types.FileContractID) (api.ContractMetadata, error)
@@ -44,7 +44,7 @@ type Bus interface {
 	Contract(id types.FileContractID) (contract api.ContractMetadata, err error)
 	Contracts(set string) ([]api.ContractMetadata, error)
 	DeleteContracts(ids []types.FileContractID) error
-	ReleaseContract(id types.FileContractID) error
+	ReleaseContract(id types.FileContractID, lockID uint64) error
 	SetContractSet(set string, contracts []types.FileContractID) error
 
 	// txpool

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -23,6 +23,10 @@ const (
 	// lock when renewing a contract
 	contractLockingDurationRenew = 30 * time.Second
 
+	// contractLockingPriorityRenew is the priority used when locking a
+	// contract for renew.
+	contractLockingPriorityRenew = 10
+
 	// estimatedFileContractTransactionSetSize is the estimated blockchain size
 	// of a transaction set between a renter and a host that contains a file
 	// contract.
@@ -533,7 +537,7 @@ func (c *contractor) runContractFormations(cfg api.AutopilotConfig, active []api
 
 func (c *contractor) renewContract(cfg api.AutopilotConfig, currentPeriod uint64, toRenew api.Contract, renterAddress types.UnlockHash, renterFunds types.Currency, isRefresh bool) (rhpv2.ContractRevision, error) {
 	// handle contract locking
-	lockID, err := c.ap.bus.AcquireContract(toRenew.ID, contractLockingDurationRenew)
+	lockID, err := c.ap.bus.AcquireContract(toRenew.ID, contractLockingPriorityRenew, contractLockingDurationRenew)
 	if err != nil {
 		return rhpv2.ContractRevision{}, err
 	}

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -533,14 +533,11 @@ func (c *contractor) runContractFormations(cfg api.AutopilotConfig, active []api
 
 func (c *contractor) renewContract(cfg api.AutopilotConfig, currentPeriod uint64, toRenew api.Contract, renterAddress types.UnlockHash, renterFunds types.Currency, isRefresh bool) (rhpv2.ContractRevision, error) {
 	// handle contract locking
-	locked, err := c.ap.bus.AcquireContract(toRenew.ID, contractLockingDurationRenew)
+	lockID, err := c.ap.bus.AcquireContract(toRenew.ID, contractLockingDurationRenew)
 	if err != nil {
 		return rhpv2.ContractRevision{}, err
 	}
-	if !locked {
-		return rhpv2.ContractRevision{}, errors.New("contract is currently locked")
-	}
-	defer c.ap.bus.ReleaseContract(toRenew.ID)
+	defer c.ap.bus.ReleaseContract(toRenew.ID, lockID)
 
 	// if we are refreshing the contract we use the contract's end height
 	endHeight := c.endHeight(cfg, currentPeriod)

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -458,7 +458,7 @@ func (b *bus) contractAcquireHandlerPOST(jc jape.Context) {
 		return
 	}
 
-	lockID, err := b.contractLocks.Acquire(jc.Request.Context(), req.Priority, id, req.Duration)
+	lockID, err := b.contractLocks.Acquire(jc.Request.Context(), req.Priority, id, time.Duration(req.Duration))
 	if jc.Check("failed to acquire contract", err) != nil {
 		return
 	}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -458,7 +458,7 @@ func (b *bus) contractAcquireHandlerPOST(jc jape.Context) {
 		return
 	}
 
-	lockID, err := b.contractLocks.Acquire(jc.Request.Context(), id, req.Duration)
+	lockID, err := b.contractLocks.Acquire(jc.Request.Context(), req.Priority, id, req.Duration)
 	if jc.Check("failed to acquire contract", err) != nil {
 		return
 	}

--- a/bus/client.go
+++ b/bus/client.go
@@ -320,9 +320,8 @@ func (c *Client) DeleteContract(id types.FileContractID) (err error) {
 // released manually before that time.
 func (c *Client) AcquireContract(fcid types.FileContractID, d time.Duration) (lockID uint64, err error) {
 	var resp api.ContractAcquireResponse
-	err = c.c.POST("/contract/acquire", api.ContractAcquireRequest{
-		ContractID: fcid,
-		Duration:   d,
+	err = c.c.POST(fmt.Sprintf("/contract/%s/acquire", fcid), api.ContractAcquireRequest{
+		Duration: d,
 	}, &resp)
 	lockID = resp.LockID
 	return
@@ -330,8 +329,8 @@ func (c *Client) AcquireContract(fcid types.FileContractID, d time.Duration) (lo
 
 // ReleaseContract releases a contract that was previously acquired using AcquireContract.
 func (c *Client) ReleaseContract(fcid types.FileContractID, lockID uint64) (err error) {
-	err = c.c.POST("/contract/release", api.ContractReleaseRequest{
-		ContractID: fcid,
+	err = c.c.POST(fmt.Sprintf("/contract/%s/release", fcid), api.ContractReleaseRequest{
+		LockID: lockID,
 	}, nil)
 	return
 }

--- a/bus/client.go
+++ b/bus/client.go
@@ -318,10 +318,11 @@ func (c *Client) DeleteContract(id types.FileContractID) (err error) {
 
 // AcquireContract acquires a contract for a given amount of time unless
 // released manually before that time.
-func (c *Client) AcquireContract(fcid types.FileContractID, d time.Duration) (lockID uint64, err error) {
+func (c *Client) AcquireContract(fcid types.FileContractID, priority int, d time.Duration) (lockID uint64, err error) {
 	var resp api.ContractAcquireResponse
 	err = c.c.POST(fmt.Sprintf("/contract/%s/acquire", fcid), api.ContractAcquireRequest{
 		Duration: d,
+		Priority: priority,
 	}, &resp)
 	lockID = resp.LockID
 	return

--- a/bus/client.go
+++ b/bus/client.go
@@ -318,10 +318,10 @@ func (c *Client) DeleteContract(id types.FileContractID) (err error) {
 
 // AcquireContract acquires a contract for a given amount of time unless
 // released manually before that time.
-func (c *Client) AcquireContract(fcid types.FileContractID, d time.Duration) (locked bool, err error) {
+func (c *Client) AcquireContract(fcid types.FileContractID, d time.Duration) (lockID uint64, err error) {
 	var resp api.ContractAcquireResponse
 	err = c.c.POST(fmt.Sprintf("/contract/%s/acquire", fcid), api.ContractAcquireRequest{Duration: d}, &resp)
-	locked = resp.Locked
+	lockID = resp.LockID
 	return
 }
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -321,7 +321,7 @@ func (c *Client) DeleteContract(id types.FileContractID) (err error) {
 func (c *Client) AcquireContract(fcid types.FileContractID, priority int, d time.Duration) (lockID uint64, err error) {
 	var resp api.ContractAcquireResponse
 	err = c.c.POST(fmt.Sprintf("/contract/%s/acquire", fcid), api.ContractAcquireRequest{
-		Duration: d,
+		Duration: api.Duration(d),
 		Priority: priority,
 	}, &resp)
 	lockID = resp.LockID

--- a/bus/client.go
+++ b/bus/client.go
@@ -320,14 +320,19 @@ func (c *Client) DeleteContract(id types.FileContractID) (err error) {
 // released manually before that time.
 func (c *Client) AcquireContract(fcid types.FileContractID, d time.Duration) (lockID uint64, err error) {
 	var resp api.ContractAcquireResponse
-	err = c.c.POST(fmt.Sprintf("/contract/%s/acquire", fcid), api.ContractAcquireRequest{Duration: d}, &resp)
+	err = c.c.POST("/contract/acquire", api.ContractAcquireRequest{
+		ContractID: fcid,
+		Duration:   d,
+	}, &resp)
 	lockID = resp.LockID
 	return
 }
 
 // ReleaseContract releases a contract that was previously acquired using AcquireContract.
-func (c *Client) ReleaseContract(fcid types.FileContractID) (err error) {
-	err = c.c.POST(fmt.Sprintf("/contract/%s/release", fcid), nil, nil)
+func (c *Client) ReleaseContract(fcid types.FileContractID, lockID uint64) (err error) {
+	err = c.c.POST("/contract/release", api.ContractReleaseRequest{
+		ContractID: fcid,
+	}, nil)
 	return
 }
 

--- a/bus/contractlocking.go
+++ b/bus/contractlocking.go
@@ -1,0 +1,122 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"time"
+
+	"go.sia.tech/siad/types"
+	"lukechampine.com/frand"
+)
+
+type contractLocks struct {
+	mu    sync.Mutex
+	locks map[types.FileContractID]*contractLock
+}
+
+type contractLock struct {
+	mu          sync.Mutex    // locks contractLock fields
+	lockChan    chan struct{} // locks the contract
+	lockedUntil time.Time
+	heldBy      uint64
+	references  uint64
+}
+
+func newContractLocks() *contractLocks {
+	return &contractLocks{
+		locks: make(map[types.FileContractID]*contractLock),
+	}
+}
+
+func (l *contractLocks) lockForContractID(id types.FileContractID) *contractLock {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	lock, exists := l.locks[id]
+	if !exists {
+		lock = &contractLock{
+			lockChan:    make(chan struct{}, 1),
+			lockedUntil: time.Now().Add(time.Hour),
+		}
+		l.locks[id] = lock
+	}
+	return lock
+}
+
+var ErrAcquireContractTimeout = errors.New("acquiring the lock timed out")
+
+// Acquire acquires a contract lock for the given id and provided duration. If
+// acquiring the lock doesn't finish before the context is closed,
+// ErrAcquireContractTimeout is returned.
+func (l *contractLocks) Acquire(ctx context.Context, id types.FileContractID, d time.Duration) (uint64, error) {
+	lock := l.lockForContractID(id)
+
+	setAcquired := func() {
+		lock.lockedUntil = time.Now().Add(d)
+		lock.heldBy = frand.Uint64n(math.MaxUint64)
+	}
+
+	lock.mu.Lock()
+	lockChan := lock.lockChan                        // remember lockChan to wait on
+	previousHolder := lock.heldBy                    // remember previous holder
+	lock.references++                                // update the number of threads waiting
+	t := time.NewTimer(time.Until(lock.lockedUntil)) // prepare a timer for expiring locks
+	lock.mu.Unlock()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// We hit a timeout. Abort.
+			lock.mu.Lock()
+			lock.references--
+			lock.mu.Unlock()
+			return 0, ErrAcquireContractTimeout
+		case <-t.C:
+			// The lock has expired. That leaves us with 2 options
+			// after acquiring the mutext.
+			//   1. the holder hasn't changed. So we are the first
+			//   thread that acquired the mutex after the lock has
+			//   expired. We are free to acquire the lock in this
+			//   case and have to swap out the channel and remove
+			//   the reference of the original holder.
+			//   2. the holder has changed. In that case we were too
+			//   slow and another thread has acquired the lock and
+			//   swapped out the lockChan in the meantime. In that
+			//   case we grab the new channel, update the timer and
+			//   retry.
+			lock.mu.Lock()
+			if lock.heldBy == previousHolder {
+				setAcquired()
+				// Create a new lockChan and acquire it right away.
+				lockChan = make(chan struct{}, 1)
+				lockChan <- struct{}{}
+				lock.lockChan = lockChan
+				heldBy := lock.heldBy
+				// Remove the reference of the previous, expired
+				// holder.
+				lock.references--
+				lock.mu.Unlock()
+				return heldBy, nil
+			} else {
+				lockChan = lock.lockChan
+				previousHolder = lock.heldBy
+				t.Reset(time.Until(lock.lockedUntil))
+			}
+			lock.mu.Unlock()
+			continue
+			// The lock was acquired successfully.
+		case lockChan <- struct{}{}: // lock acquired
+			lock.mu.Lock()
+			setAcquired()
+			heldBy := lock.heldBy
+			lock.mu.Unlock()
+			return heldBy, nil
+
+		}
+	}
+}
+
+func (l *contractLock) Release(id types.FileContractID, lockID uint64) error {
+	panic("not implemeneted")
+}

--- a/bus/contractlocking.go
+++ b/bus/contractlocking.go
@@ -176,7 +176,7 @@ func (l *contractLocks) Release(id types.FileContractID, lockID uint64) error {
 		return nil // nothing to do
 	}
 	if lock.heldByID != lockID {
-		return fmt.Errorf("can't unlock lock due to id mismatch %v != %v", lockID, lock.heldByID)
+		return fmt.Errorf("failed to unlock lock held by lockID %v with lockID %v - potentially due to a timeout", lock.heldByID, lockID)
 	}
 
 	// Stop the timer on the lock.

--- a/bus/contractlocking_test.go
+++ b/bus/contractlocking_test.go
@@ -57,6 +57,7 @@ func TestContractAcquire(t *testing.T) {
 	var lockIDs []uint64
 	var lockIDsMu sync.Mutex
 	var wg sync.WaitGroup
+	start := time.Now()
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
@@ -76,6 +77,12 @@ func TestContractAcquire(t *testing.T) {
 		t.Fatal("wrong number of lock ids")
 	}
 	verify(fcid, lockIDs[len(lockIDs)-1], 100*time.Millisecond, 50*time.Millisecond)
+
+	// Acquiring the lock should take 10 threads with a 100ms lock duration
+	// a total of at least 900ms.
+	if time.Since(start) < 900*time.Millisecond {
+		t.Fatal("not enough time has passed")
+	}
 
 	// Test timing out while trying to acquire a lock.
 	fcid = types.FileContractID{4}

--- a/bus/contractlocking_test.go
+++ b/bus/contractlocking_test.go
@@ -1,0 +1,98 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"go.sia.tech/siad/types"
+)
+
+// TestContractAcquire is a unit test for contractLocks.Acquire.
+func TestContractAcquire(t *testing.T) {
+	locks := newContractLocks()
+
+	verify := func(fcid types.FileContractID, references, lockID uint64, lockedDuration time.Duration, delta time.Duration) {
+		t.Helper()
+		if lockID == 0 {
+			t.Fatal("invalid lock id")
+		}
+		lock := locks.lockForContractID(fcid)
+		if lock.heldBy != lockID {
+			t.Fatal("heldBy not set")
+		}
+		lockedUntil := time.Now().Add(lockedDuration)
+		if lock.lockedUntil.Before(lockedUntil.Add(-delta)) || lock.lockedUntil.After(lockedUntil.Add(delta)) {
+			t.Fatal("locked_until not set correctly")
+		}
+		if lock.references != references {
+			t.Fatal("wrong references")
+		}
+	}
+
+	// Acquire contract.
+	fcid := types.FileContractID{1}
+	lockID, err := locks.Acquire(context.Background(), fcid, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verify(fcid, 1, lockID, time.Minute, 3*time.Second)
+
+	// Acquire another contract but this time it has been acquired already
+	// and the lock expired.
+	fcid = types.FileContractID{2}
+	_, err = locks.Acquire(context.Background(), fcid, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(5 * time.Millisecond) // wait for lock to expire
+
+	lockID, err = locks.Acquire(context.Background(), fcid, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verify(fcid, 1, lockID, time.Minute, 3*time.Second)
+
+	// Same thing again but with multiple locks that expire.
+	fcid = types.FileContractID{3}
+	var lockIDs []uint64
+	var lockIDsMu sync.Mutex
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lockID, err = locks.Acquire(context.Background(), fcid, 100*time.Millisecond)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			lockIDsMu.Lock()
+			lockIDs = append(lockIDs, lockID)
+			lockIDsMu.Unlock()
+		}()
+	}
+	wg.Wait()
+	if len(lockIDs) != 10 {
+		t.Fatal("wrong number of lock ids")
+	}
+	verify(fcid, 1, lockIDs[len(lockIDs)-1], 100*time.Millisecond, 50*time.Millisecond)
+
+	// Test timing out while trying to acquire a lock.
+	fcid = types.FileContractID{4}
+	lockID, err = locks.Acquire(context.Background(), fcid, time.Hour)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = locks.Acquire(ctx, fcid, 100*time.Millisecond)
+	if !errors.Is(err, ErrAcquireContractTimeout) {
+		t.Fatal("acquire should time out", err)
+		return
+	}
+	verify(fcid, 1, lockID, time.Hour, time.Second)
+}

--- a/bus/contractlocking_test.go
+++ b/bus/contractlocking_test.go
@@ -61,7 +61,7 @@ func TestContractAcquire(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			lockID, err = locks.Acquire(context.Background(), fcid, 100*time.Millisecond)
+			lockID, err := locks.Acquire(context.Background(), fcid, 100*time.Millisecond)
 			if err != nil {
 				t.Error(err)
 				return

--- a/bus/contractlocking_test.go
+++ b/bus/contractlocking_test.go
@@ -31,7 +31,7 @@ func TestContractAcquire(t *testing.T) {
 
 	// Acquire contract.
 	fcid := types.FileContractID{1}
-	lockID, err := locks.Acquire(context.Background(), fcid, time.Minute)
+	lockID, err := locks.Acquire(context.Background(), 0, fcid, time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,13 +40,13 @@ func TestContractAcquire(t *testing.T) {
 	// Acquire another contract but this time it has been acquired already
 	// and the lock expired.
 	fcid = types.FileContractID{2}
-	_, err = locks.Acquire(context.Background(), fcid, time.Millisecond)
+	_, err = locks.Acquire(context.Background(), 0, fcid, time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(5 * time.Millisecond) // wait for lock to expire
 
-	lockID, err = locks.Acquire(context.Background(), fcid, time.Minute)
+	lockID, err = locks.Acquire(context.Background(), 0, fcid, time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestContractAcquire(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			lockID, err := locks.Acquire(context.Background(), fcid, 100*time.Millisecond)
+			lockID, err := locks.Acquire(context.Background(), 0, fcid, 100*time.Millisecond)
 			if err != nil {
 				t.Error(err)
 				return
@@ -86,14 +86,14 @@ func TestContractAcquire(t *testing.T) {
 
 	// Test timing out while trying to acquire a lock.
 	fcid = types.FileContractID{4}
-	lockID, err = locks.Acquire(context.Background(), fcid, time.Hour)
+	lockID, err = locks.Acquire(context.Background(), 0, fcid, time.Hour)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err = locks.Acquire(ctx, fcid, 100*time.Millisecond)
+	_, err = locks.Acquire(ctx, 0, fcid, 100*time.Millisecond)
 	if !errors.Is(err, ErrAcquireContractTimeout) {
 		t.Fatal("acquire should time out", err)
 		return
@@ -118,7 +118,7 @@ func TestContractRelease(t *testing.T) {
 
 	// Acquire contract.
 	fcid := types.FileContractID{1}
-	lockID, err := locks.Acquire(context.Background(), fcid, time.Minute)
+	lockID, err := locks.Acquire(context.Background(), 0, fcid, time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func TestContractRelease(t *testing.T) {
 		}
 	}()
 
-	lockID, err = locks.Acquire(context.Background(), fcid, time.Minute)
+	lockID, err = locks.Acquire(context.Background(), 0, fcid, time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/bus/contractlocking_test.go
+++ b/bus/contractlocking_test.go
@@ -15,13 +15,13 @@ import (
 func TestContractAcquire(t *testing.T) {
 	locks := newContractLocks()
 
-	verify := func(fcid types.FileContractID, lockID uint64, lockedDuration time.Duration, delta time.Duration) {
+	verify := func(fcid types.FileContractID, lockID uint64) {
 		t.Helper()
 		if lockID == 0 {
 			t.Fatal("invalid lock id")
 		}
 		lock := locks.lockForContractID(fcid, false)
-		if lock.heldBy != lockID {
+		if lock.heldByID != lockID {
 			t.Fatal("heldBy not set")
 		}
 	}
@@ -32,7 +32,7 @@ func TestContractAcquire(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	verify(fcid, lockID, time.Minute, 3*time.Second)
+	verify(fcid, lockID)
 
 	// Acquire another contract but this time it has been acquired already
 	// and the lock expired.
@@ -47,7 +47,7 @@ func TestContractAcquire(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	verify(fcid, lockID, time.Minute, 3*time.Second)
+	verify(fcid, lockID)
 
 	// Same thing again but with multiple locks that expire. The first lock
 	// is acquired in the same thread to guarantee it's the first and the
@@ -86,7 +86,7 @@ func TestContractAcquire(t *testing.T) {
 	if !sort.IsSorted(sort.Reverse(sort.IntSlice(threadIndices))) {
 		t.Fatal("threads didn't finish in order or priority", threadIndices)
 	}
-	verify(fcid, lockIDs[len(lockIDs)-1], 100*time.Millisecond, 50*time.Millisecond)
+	verify(fcid, lockIDs[len(lockIDs)-1])
 
 	// Acquiring the lock should take 10 threads with a 100ms lock duration
 	// a total of at least 900ms.
@@ -108,7 +108,7 @@ func TestContractAcquire(t *testing.T) {
 		t.Fatal("acquire should time out", err)
 		return
 	}
-	verify(fcid, lockID, time.Hour, time.Second)
+	verify(fcid, lockID)
 }
 
 // TestContractRelease is a unit test for contractLocks.Release.
@@ -118,7 +118,7 @@ func TestContractRelease(t *testing.T) {
 	verify := func(fcid types.FileContractID, lockID uint64, lockedUntil time.Time, delta time.Duration) {
 		t.Helper()
 		lock := locks.lockForContractID(fcid, false)
-		if lock.heldBy != lockID {
+		if lock.heldByID != lockID {
 			t.Fatalf("heldBy not set")
 		}
 	}


### PR DESCRIPTION
Until we have EA uploads we need some sort of locking for when we use contracts. This PR adds an in-memory locking structure to the Bus that achieves exactly that. 