### PR TITLE
Autopilot Trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,13 +40,13 @@ jobs:
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/testing/..."
-          args: "-tags='testing';-timeout=300s"
+          args: "-tags='testing';-timeout=600s"
       - name: Test Integration
         if: matrix.os != 'windows-latest' || matrix.go-version != '1.18'
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/testing/..."
-          args: "-race;-tags='testing';-timeout=300s"
+          args: "-race;-tags='testing';-timeout=600s"
       - name: Check Endpoints
         uses: SiaFoundation/action-golang-analysis@HEAD
         with:

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -112,14 +112,14 @@ func (ap *Autopilot) Run() error {
 		case <-ap.stopChan:
 			return nil
 		case <-ap.triggerChan:
-			ap.logger.Info("autopilot loop triggered")
+			ap.logger.Info("autopilot iteration triggered")
 			ap.ticker.Reset(ap.tickerDuration)
 		case <-ap.ticker.C:
-			ap.logger.Info("autopilot loop starting")
+			ap.logger.Info("autopilot iteration starting")
 		}
 
 		func() {
-			defer ap.logger.Info("autopilot loop ended")
+			defer ap.logger.Info("autopilot iteration ended")
 
 			// initiate a host scan
 			ap.s.tryUpdateTimeout()
@@ -128,13 +128,13 @@ func (ap *Autopilot) Run() error {
 			// fetch consensus state
 			cs, err := ap.bus.ConsensusState()
 			if err != nil {
-				ap.logger.Errorf("loop interrupted, could not fetch consensus state, err: %v", err)
+				ap.logger.Errorf("iteration interrupted, could not fetch consensus state, err: %v", err)
 				return
 			}
 
 			// do not continue if we are not synced
 			if !cs.Synced {
-				ap.logger.Info("consensus not synced")
+				ap.logger.Debug("iteration interrupted, consensus not synced")
 				return
 			}
 

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -79,9 +80,11 @@ type Autopilot struct {
 	m *migrator
 	s *scanner
 
-	ticker   *time.Ticker
-	stopChan chan struct{}
-	wg       sync.WaitGroup
+	ticker         *time.Ticker
+	tickerDuration time.Duration
+	stopChan       chan struct{}
+	triggerChan    chan struct{}
+	wg             sync.WaitGroup
 }
 
 // Actions returns the autopilot actions that have occurred since the given time.
@@ -100,56 +103,78 @@ func (ap *Autopilot) SetConfig(c api.AutopilotConfig) error {
 }
 
 func (ap *Autopilot) Run() error {
+	ap.ticker = time.NewTicker(ap.tickerDuration)
+
 	ap.wg.Add(1)
 	defer ap.wg.Done()
 	for {
 		select {
 		case <-ap.stopChan:
 			return nil
+		case <-ap.triggerChan:
+			ap.logger.Info("autopilot loop triggered")
+			ap.ticker.Reset(ap.tickerDuration)
 		case <-ap.ticker.C:
-		}
-		ap.logger.Info("autopilot loop starting")
-
-		// initiate a host scan
-		ap.s.tryUpdateTimeout()
-		ap.s.tryPerformHostScan()
-
-		// fetch consensus state
-		cs, err := ap.bus.ConsensusState()
-		if err != nil {
-			ap.logger.Errorf("loop interrupted, could not fetch consensus state, err: %v", err)
-			continue
+			ap.logger.Info("autopilot loop starting")
 		}
 
-		// do not continue if we are not synced
-		if !cs.Synced {
-			continue
-		}
+		func() {
+			defer ap.logger.Info("autopilot loop ended")
 
-		// fetch config to ensure its not updated during maintenance
-		cfg := ap.store.Config()
+			// initiate a host scan
+			ap.s.tryUpdateTimeout()
+			ap.s.tryPerformHostScan()
 
-		// perform maintenance
-		err = ap.c.performContractMaintenance(cfg, cs)
-		if err != nil {
-			ap.logger.Errorf("contract maintenance failed, err: %v", err)
-			continue
-		}
+			// fetch consensus state
+			cs, err := ap.bus.ConsensusState()
+			if err != nil {
+				ap.logger.Errorf("loop interrupted, could not fetch consensus state, err: %v", err)
+				return
+			}
 
-		// migration
-		err = ap.m.UpdateContracts()
-		if err != nil {
-			ap.logger.Errorf("update contracts failed, err: %v", err)
-		}
-		ap.m.TryPerformMigrations()
+			// do not continue if we are not synced
+			if !cs.Synced {
+				ap.logger.Info("consensus not synced")
+				return
+			}
+
+			// fetch config to ensure its not updated during maintenance
+			cfg := ap.store.Config()
+
+			// perform maintenance
+			err = ap.c.performContractMaintenance(cfg, cs)
+			if err != nil {
+				ap.logger.Errorf("contract maintenance failed, err: %v", err)
+				return
+			}
+
+			// migration
+			err = ap.m.UpdateContracts()
+			if err != nil {
+				ap.logger.Errorf("update contracts failed, err: %v", err)
+			}
+			ap.m.TryPerformMigrations()
+		}()
 	}
 }
 
 func (ap *Autopilot) Stop() error {
-	ap.ticker.Stop()
+	if ap.ticker != nil {
+		ap.ticker.Stop()
+	}
 	close(ap.stopChan)
+	close(ap.triggerChan)
 	ap.wg.Wait()
 	return nil
+}
+
+func (ap *Autopilot) Trigger() bool {
+	select {
+	case ap.triggerChan <- struct{}{}:
+		return true
+	default:
+		return false
+	}
 }
 
 func (ap *Autopilot) actionsHandler(jc jape.Context) {
@@ -173,12 +198,17 @@ func (ap *Autopilot) configHandlerPUT(jc jape.Context) {
 	if jc.Check("failed to set config", ap.SetConfig(c)) != nil {
 		return
 	}
+	ap.Trigger() // trigger the autopilot loop
 }
 
 func (ap *Autopilot) statusHandlerGET(jc jape.Context) {
 	jc.Encode(api.AutopilotStatusResponseGET{
 		CurrentPeriod: ap.c.currentPeriod(),
 	})
+}
+
+func (ap *Autopilot) triggerHandlerPOST(jc jape.Context) {
+	jc.Encode(fmt.Sprintf("triggered: %t", ap.Trigger()))
 }
 
 // NewServer returns an HTTP handler that serves the renterd autopilot api.
@@ -188,6 +218,8 @@ func NewServer(ap *Autopilot) http.Handler {
 		"GET    /config":  ap.configHandlerGET,
 		"PUT    /config":  ap.configHandlerPUT,
 		"GET    /status":  ap.statusHandlerGET,
+
+		"POST    /debug/trigger": ap.triggerHandlerPOST,
 	})
 }
 
@@ -199,8 +231,9 @@ func New(store Store, bus Bus, worker Worker, logger *zap.Logger, heartbeat time
 		store:  store,
 		worker: worker,
 
-		ticker:   time.NewTicker(heartbeat),
-		stopChan: make(chan struct{}),
+		tickerDuration: heartbeat,
+		stopChan:       make(chan struct{}),
+		triggerChan:    make(chan struct{}),
 	}
 
 	scanner, err := newScanner(

--- a/autopilot/client.go
+++ b/autopilot/client.go
@@ -38,3 +38,8 @@ func (c *Client) Status() (uint64, error) {
 	err := c.c.GET("/status", &resp)
 	return resp.CurrentPeriod, err
 }
+
+func (c *Client) Trigger() (res string, err error) {
+	err = c.c.POST("/debug/trigger", nil, &res)
+	return
+}

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -145,7 +145,7 @@ func main() {
 	flag.StringVar(&workerCfg.apiPassword, "worker.apiPassword", "", "API password for remote worker service")
 	flag.DurationVar(&workerCfg.SessionTTL, "worker.sessionTTL", 2*time.Minute, "the time a host session is valid for before being refreshed")
 	flag.BoolVar(&autopilotCfg.enabled, "autopilot.enabled", true, "enable the autopilot")
-	flag.DurationVar(&autopilotCfg.Heartbeat, "autopilot.heartbeat", time.Minute, "interval at which autopilot loop runs")
+	flag.DurationVar(&autopilotCfg.Heartbeat, "autopilot.heartbeat", 10*time.Minute, "interval at which autopilot loop runs")
 	flag.DurationVar(&autopilotCfg.ScannerInterval, "autopilot.scannerInterval", 24*time.Hour, "interval at which hosts are scanned")
 	flag.Uint64Var(&autopilotCfg.ScannerBatchSize, "autopilot.scannerBatchSize", 1000, "size of the batch with which hosts are scanned")
 	flag.Uint64Var(&autopilotCfg.ScannerNumThreads, "autopilot.scannerNumThreads", 100, "number of threads that scan hosts")


### PR DESCRIPTION
I have been debugging the autopilot today and feel it is necessary at times to be able to trigger the autopilot loop. There are other debug related tools/requirements like this such as `pprof` for instance. I have added the route as `/debug/trigger`, which is meant to be the first in a (small) series of debug endpoints we add to the autopilot.

The trigger itself is quite straightforward. It will trigger the autopilot loop and reset the ticker to ensure we don't run it again only moments after. I also trigger the loop when we update the autopilot config, which makes sense I think, maybe we should be a little smarter about that but I figured it's probably fine like this for now (?)