### PR TITLE
Blocklist Unique Constraint

### DIFF
--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -278,7 +278,7 @@ func (e *dbBlocklistEntry) AfterCreate(tx *gorm.DB) (err error) {
 	}
 
 	err = tx.Exec(`
-	INSERT INTO host_blocklist_entry_hosts (db_blocklist_entry_id, db_host_id)
+	INSERT OR IGNORE INTO host_blocklist_entry_hosts (db_blocklist_entry_id, db_host_id)
 	SELECT @entry_id, id FROM (
 		SELECT id, rtrim(rtrim(net_address, replace(net_address, ':', '')),':') as net_host
 		FROM hosts

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -494,7 +494,6 @@ func TestRecordScan(t *testing.T) {
 // TestInsertAnnouncements is a test for insertAnnouncements.
 func TestInsertAnnouncements(t *testing.T) {
 	hdb, _, _, err := newTestSQLStore()
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -561,6 +560,20 @@ func TestInsertAnnouncements(t *testing.T) {
 	}
 	if len(announcements) != 7 {
 		t.Fatal("invalid number of announcements")
+	}
+
+	// Add an entry to the blocklist to block host 1
+	entry1 := "foo.bar"
+	err = hdb.AddHostBlocklistEntry(entry1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert multiple announcements for host 1 - this asserts that the UNIQUE
+	// constraint on the blocklist table isn't triggered when inserting multiple
+	// announcements for a host that's on the blocklist
+	if err := insertAnnouncements(hdb.db, []announcement{ann1, ann1}); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Currently when we batch insert announcements for the same host that happens to be blocked by a rule in the blocklist, the unique constraint on the blocklist entry fails. Fixed by using `INSERT OR IGNORE`. Extended `TestInsertAnnouncements` - so it's a regression test for this particular issue.