### PR TITLE
Add pricetable support to bus

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -36,7 +36,6 @@ type Bus interface {
 	RecordInteractions(interactions []hostdb.Interaction) error
 
 	// contracts
-	AcquireContract(id types.FileContractID, priority int, d time.Duration) (uint64, error)
 	ActiveContracts() (contracts []api.ContractMetadata, err error)
 	AddContract(c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64) (api.ContractMetadata, error)
 	AddRenewedContract(c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, renewedFrom types.FileContractID) (api.ContractMetadata, error)
@@ -44,7 +43,6 @@ type Bus interface {
 	Contract(id types.FileContractID) (contract api.ContractMetadata, err error)
 	Contracts(set string) ([]api.ContractMetadata, error)
 	DeleteContracts(ids []types.FileContractID) error
-	ReleaseContract(id types.FileContractID, lockID uint64) error
 	SetContractSet(set string, contracts []types.FileContractID) error
 
 	// txpool

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -536,13 +536,6 @@ func (c *contractor) runContractFormations(cfg api.AutopilotConfig, active []api
 }
 
 func (c *contractor) renewContract(cfg api.AutopilotConfig, currentPeriod uint64, toRenew api.Contract, renterAddress types.Address, renterFunds types.Currency, isRefresh bool) (rhpv2.ContractRevision, error) {
-	// handle contract locking
-	lockID, err := c.ap.bus.AcquireContract(toRenew.ID, contractLockingPriorityRenew, contractLockingDurationRenew)
-	if err != nil {
-		return rhpv2.ContractRevision{}, err
-	}
-	defer c.ap.bus.ReleaseContract(toRenew.ID, lockID)
-
 	// if we are refreshing the contract we use the contract's end height
 	endHeight := c.endHeight(cfg, currentPeriod)
 	if isRefresh {

--- a/rhp/v3/transport.go
+++ b/rhp/v3/transport.go
@@ -24,6 +24,12 @@ func wrapErr(err *error, fnName string) {
 	}
 }
 
+// PriceTablePaymentFunc is a function that can be passed in to RPCPriceTable.
+// It is called after the price table is received from the host and supposed to
+// create a payment for that table and return it. It can also be used to perform
+// gouging checks before paying for the table.
+type PriceTablePaymentFunc func(pt HostPriceTable) (PaymentMethod, error)
+
 // An RPCError may be sent instead of a response object to any RPC.
 type RPCError struct {
 	Type        types.Specifier
@@ -206,7 +212,7 @@ func NewRenterTransport(conn net.Conn, hostKey types.PublicKey) (*Transport, err
 }
 
 // RPCPriceTable calls the UpdatePriceTable RPC.
-func RPCPriceTable(t *Transport, paymentFunc func(pt HostPriceTable) (PaymentMethod, error)) (pt HostPriceTable, err error) {
+func RPCPriceTable(t *Transport, paymentFunc PriceTablePaymentFunc) (pt HostPriceTable, err error) {
 	defer wrapErr(&err, "PriceTable")
 	s := t.DialStream()
 	defer s.Close()

--- a/worker/pricetable.go
+++ b/worker/pricetable.go
@@ -38,10 +38,6 @@ type priceTableUpdate struct {
 // whether it is valid or not.
 func (pts *priceTables) PriceTable(hk types.PublicKey) (rhp.HostPriceTable, bool) {
 	pt := pts.priceTable(hk)
-
-	// TODO: If the pricetable is valid, kick off a non-blocking update
-	// using an EA.
-
 	return pt.convert()
 }
 
@@ -88,11 +84,13 @@ func (pts *priceTables) Update(ctx context.Context, f rhpv3.PriceTablePaymentFun
 	})
 
 	pt.mu.Lock()
+
 	// On success we update the pt.
 	if err == nil {
 		pt.pt = &hpt
 		pt.expiry = time.Now().Add(hpt.Validity)
 	}
+
 	// Signal that the update is over.
 	ongoing.err = err
 	close(ongoing.done)

--- a/worker/pricetable.go
+++ b/worker/pricetable.go
@@ -1,0 +1,157 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/rhp/v3"
+	rhpv3 "go.sia.tech/renterd/rhp/v3"
+)
+
+type priceTables struct {
+	mu          sync.Mutex
+	priceTables map[types.PublicKey]*priceTable
+}
+
+type priceTable struct {
+	pt     *rhp.HostPriceTable
+	hk     types.PublicKey
+	expiry time.Time
+
+	w *worker
+
+	mu            sync.Mutex
+	ongoingUpdate *priceTableUpdate
+}
+
+type priceTableUpdate struct {
+	err  error
+	done chan struct{}
+	pt   *rhp.HostPriceTable
+}
+
+// PriceTable returns a price table for the give host and an bool to indicate
+// whether it is valid or not.
+func (pts *priceTables) PriceTable(hk types.PublicKey) (rhp.HostPriceTable, bool) {
+	pt := pts.priceTable(hk)
+
+	// TODO: If the pricetable is valid, kick off a non-blocking update
+	// using an EA.
+
+	return pt.convert()
+}
+
+// Update updates a price table with the given host. If a revision is provided,
+// the table will be paid for using that revision. Otherwise an ephemeral
+// account will be used. The new table is returned.
+func (pts *priceTables) Update(ctx context.Context, f rhpv3.PriceTablePaymentFunc, hostIP string, hk types.PublicKey) (rhp.HostPriceTable, error) {
+	// Fetch the price table to update.
+	pt := pts.priceTable(hk)
+
+	// Check if there is some update going on already. If not, create one.
+	pt.mu.Lock()
+	ongoing := pt.ongoingUpdate
+	var performUpdate bool
+	if ongoing == nil {
+		ongoing = &priceTableUpdate{
+			done: make(chan struct{}),
+		}
+		pt.ongoingUpdate = ongoing
+		performUpdate = true
+	}
+	pt.mu.Unlock()
+
+	// If this thread is not supposed to perform the update, just block and
+	// return the result.
+	if !performUpdate {
+		select {
+		case <-ctx.Done():
+			return rhp.HostPriceTable{}, errors.New("timeout while blocking for pricetable update")
+		case <-ongoing.done:
+		}
+		if ongoing.err == nil {
+			return *ongoing.pt, nil
+		} else {
+			return rhp.HostPriceTable{}, ongoing.err
+		}
+	}
+
+	// Update price table.
+	var hpt rhpv3.HostPriceTable
+	err := pt.w.withTransportV3(ctx, hostIP, hk, func(t *rhpv3.Transport) (err error) {
+		hpt, err = rhpv3.RPCPriceTable(t, f)
+		return err
+	})
+
+	pt.mu.Lock()
+	// On success we update the pt.
+	if err == nil {
+		pt.pt = &hpt
+		pt.expiry = time.Now().Add(hpt.Validity)
+	}
+	// Signal that the update is over.
+	ongoing.err = err
+	close(ongoing.done)
+	pt.ongoingUpdate = nil
+	pt.mu.Unlock()
+	return hpt, err
+}
+
+// priceTable returns a priceTable from priceTables for the given host or
+// creates a new one.
+func (pts *priceTables) priceTable(hk types.PublicKey) *priceTable {
+	pts.mu.Lock()
+	defer pts.mu.Unlock()
+	pt, exists := pts.priceTables[hk]
+	if !exists {
+		pt = &priceTable{
+			hk: hk,
+		}
+		pts.priceTables[hk] = pt
+	}
+	return pt
+}
+
+// convert turn the priceTable into a rhp.HostPriceTable and also returns
+// whether or not the price table is valid at the given time.
+func (pt *priceTable) convert() (rhp.HostPriceTable, bool) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+	if pt.pt == nil {
+		return rhp.HostPriceTable{}, false
+	}
+	return *pt.pt, time.Now().Before(pt.expiry)
+}
+
+// preparePriceTableContractPayment prepare a payment function to pay for a
+// price table from the given host using the provided revision.
+func (w *worker) preparePriceTableContractPayment(hk types.PublicKey, revision *types.FileContractRevision) rhpv3.PriceTablePaymentFunc {
+	return func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) {
+		// TODO: gouging check on price table
+
+		refundAccount := rhp.Account(w.accounts.deriveAccountKey(hk).PublicKey())
+		rk := w.deriveRenterKey(hk)
+		payment, ok := rhpv3.PayByContract(revision, pt.UpdatePriceTableCost, refundAccount, rk)
+		if !ok {
+			return nil, errors.New("insufficient funds")
+		}
+		return &payment, nil
+	}
+}
+
+// preparePriceTableAccountPayment prepare a payment function to pay for a
+// price table from the given host using the provided revision.
+func (w *worker) preparePriceTableAccountPayment(hk types.PublicKey, revision *types.FileContractRevision) rhpv3.PriceTablePaymentFunc {
+	return func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) {
+		// TODO: gouging check on price table
+
+		accountKey := w.accounts.deriveAccountKey(hk)
+		account := rhpv3.Account(accountKey.PublicKey())
+		payment := rhpv3.PayByEphemeralAccount(account, pt.UpdatePriceTableCost, math.MaxUint64, accountKey)
+		return &payment, nil
+	}
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -938,10 +938,8 @@ func New(masterKey [32]byte, b Bus, sessionReconectTimeout, sessionTTL time.Dura
 		pool:      newSessionPool(sessionReconectTimeout, sessionTTL),
 		masterKey: masterKey,
 		accounts:  nil,
-		priceTables: &priceTables{
-			priceTables: make(map[types.PublicKey]*priceTable),
-		},
 	}
+	w.priceTables = newPriceTables(w.withTransportV3)
 	w.accounts = &accounts{
 		accounts: make(map[rhpv3.Account]*account),
 		workerID: w.id,


### PR DESCRIPTION
This PR allows for workers to keep around price tables and reuse them instead of fetching a new one every time a pricetable is needed. 

Every worker manages its own price tables with hosts. The same way it manages its own ephemeral accounts with hosts.