### PR TITLE
Collateral Refresh

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -99,14 +99,14 @@ type WalletPrepareFormRequest struct {
 // WalletPrepareRenewRequest is the request type for the /wallet/prepare/renew
 // endpoint.
 type WalletPrepareRenewRequest struct {
-	Contract       types.FileContractRevision `json:"contract"`
-	EndHeight      uint64                     `json:"endHeight"`
-	HostCollateral types.Currency             `json:"hostCollateral"`
-	HostKey        types.PublicKey            `json:"hostKey"`
-	HostSettings   rhpv2.HostSettings         `json:"hostSettings"`
-	RenterAddress  types.Address              `json:"renterAddress"`
-	RenterFunds    types.Currency             `json:"renterFunds"`
-	RenterKey      types.PrivateKey           `json:"renterKey"`
+	Contract      types.FileContractRevision `json:"contract"`
+	EndHeight     uint64                     `json:"endHeight"`
+	HostKey       types.PublicKey            `json:"hostKey"`
+	HostSettings  rhpv2.HostSettings         `json:"hostSettings"`
+	NewCollateral types.Currency             `json:"newCollateral"`
+	RenterAddress types.Address              `json:"renterAddress"`
+	RenterFunds   types.Currency             `json:"renterFunds"`
+	RenterKey     types.PrivateKey           `json:"renterKey"`
 }
 
 // WalletPrepareRenewResponse is the response type for the /wallet/prepare/renew

--- a/api/bus.go
+++ b/api/bus.go
@@ -87,25 +87,26 @@ type WalletRedistributeRequest struct {
 // WalletPrepareFormRequest is the request type for the /wallet/prepare/form
 // endpoint.
 type WalletPrepareFormRequest struct {
-	RenterKey      types.PrivateKey   `json:"renterKey"`
-	HostKey        types.PublicKey    `json:"hostKey"`
-	RenterFunds    types.Currency     `json:"renterFunds"`
-	RenterAddress  types.Address      `json:"renterAddress"`
-	HostCollateral types.Currency     `json:"hostCollateral"`
 	EndHeight      uint64             `json:"endHeight"`
+	HostCollateral types.Currency     `json:"hostCollateral"`
+	HostKey        types.PublicKey    `json:"hostKey"`
 	HostSettings   rhpv2.HostSettings `json:"hostSettings"`
+	RenterAddress  types.Address      `json:"renterAddress"`
+	RenterFunds    types.Currency     `json:"renterFunds"`
+	RenterKey      types.PrivateKey   `json:"renterKey"`
 }
 
 // WalletPrepareRenewRequest is the request type for the /wallet/prepare/renew
 // endpoint.
 type WalletPrepareRenewRequest struct {
-	Contract      types.FileContractRevision `json:"contract"`
-	RenterKey     types.PrivateKey           `json:"renterKey"`
-	HostKey       types.PublicKey            `json:"hostKey"`
-	RenterFunds   types.Currency             `json:"renterFunds"`
-	RenterAddress types.Address              `json:"renterAddress"`
-	EndHeight     uint64                     `json:"endHeight"`
-	HostSettings  rhpv2.HostSettings         `json:"hostSettings"`
+	Contract       types.FileContractRevision `json:"contract"`
+	EndHeight      uint64                     `json:"endHeight"`
+	HostCollateral types.Currency             `json:"hostCollateral"`
+	HostKey        types.PublicKey            `json:"hostKey"`
+	HostSettings   rhpv2.HostSettings         `json:"hostSettings"`
+	RenterAddress  types.Address              `json:"renterAddress"`
+	RenterFunds    types.Currency             `json:"renterFunds"`
+	RenterKey      types.PrivateKey           `json:"renterKey"`
 }
 
 // WalletPrepareRenewResponse is the response type for the /wallet/prepare/renew

--- a/api/contract.go
+++ b/api/contract.go
@@ -62,4 +62,12 @@ func (c Contract) HostKey() (pk types.PublicKey) {
 }
 
 // RenterFunds returns the funds remaining in the contract's Renter payout.
-func (c Contract) RenterFunds() types.Currency { return c.Revision.ValidRenterPayout() }
+func (c Contract) RenterFunds() types.Currency {
+	return c.Revision.ValidRenterPayout()
+}
+
+// HostCollateral returns the value of the host's collateral.
+func (c Contract) HostCollateral() types.Currency {
+	// TODO: use MissedHostValue
+	return c.Revision.MissedHostOutput().Value
+}

--- a/api/contract.go
+++ b/api/contract.go
@@ -66,8 +66,8 @@ func (c Contract) RenterFunds() types.Currency {
 	return c.Revision.ValidRenterPayout()
 }
 
-// HostCollateral returns the value of the host's collateral.
-func (c Contract) HostCollateral() types.Currency {
+// UnusedCollateral returns the remaining host collateral.
+func (c Contract) UnusedCollateral() types.Currency {
 	// TODO: use MissedHostValue
 	return c.Revision.MissedHostOutput().Value
 }

--- a/api/contract.go
+++ b/api/contract.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"go.sia.tech/core/types"
-	"go.sia.tech/renterd/rhp/v2"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
 )
 
 type (
@@ -68,7 +68,7 @@ func (c Contract) RenterFunds() types.Currency {
 }
 
 // RemainingCollateral returns the remaining collateral in the contract.
-func (c Contract) RemainingCollateral(s rhp.HostSettings) types.Currency {
+func (c Contract) RemainingCollateral(s rhpv2.HostSettings) types.Currency {
 	if c.Revision.MissedHostPayout().Cmp(s.ContractPrice) < 0 {
 		return types.ZeroCurrency
 	}

--- a/api/contract.go
+++ b/api/contract.go
@@ -67,7 +67,7 @@ func (c Contract) RenterFunds() types.Currency {
 	return c.Revision.ValidRenterPayout()
 }
 
-// RemainingCollateral returns the remaining host collateral.
+// RemainingCollateral returns the remaining collateral in the contract.
 func (c Contract) RemainingCollateral(s rhp.HostSettings) types.Currency {
 	if c.Revision.MissedHostPayout().Cmp(s.ContractPrice) < 0 {
 		return types.ZeroCurrency

--- a/api/contract.go
+++ b/api/contract.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/rhp/v2"
 )
 
 type (
@@ -66,7 +67,10 @@ func (c Contract) RenterFunds() types.Currency {
 	return c.Revision.ValidRenterPayout()
 }
 
-// UnusedCollateral returns the remaining host collateral.
-func (c Contract) UnusedCollateral() types.Currency {
-	return c.Revision.MissedHostPayout()
+// RemainingCollateral returns the remaining host collateral.
+func (c Contract) RemainingCollateral(s rhp.HostSettings) types.Currency {
+	if c.Revision.MissedHostPayout().Cmp(s.ContractPrice) < 0 {
+		return types.ZeroCurrency
+	}
+	return c.Revision.MissedHostPayout().Sub(s.ContractPrice)
 }

--- a/api/contract.go
+++ b/api/contract.go
@@ -68,6 +68,5 @@ func (c Contract) RenterFunds() types.Currency {
 
 // UnusedCollateral returns the remaining host collateral.
 func (c Contract) UnusedCollateral() types.Currency {
-	// TODO: use MissedHostValue
-	return c.Revision.MissedHostOutput().Value
+	return c.Revision.MissedHostPayout()
 }

--- a/api/worker.go
+++ b/api/worker.go
@@ -47,12 +47,13 @@ type RHPFormResponse struct {
 
 // RHPRenewRequest is the request type for the /rhp/renew endpoint.
 type RHPRenewRequest struct {
-	ContractID    types.FileContractID `json:"contractID"`
-	EndHeight     uint64               `json:"endHeight"`
-	HostKey       types.PublicKey      `json:"hostKey"`
-	HostIP        string               `json:"hostIP"`
-	RenterAddress types.Address        `json:"renterAddress"`
-	RenterFunds   types.Currency       `json:"renterFunds"`
+	ContractID     types.FileContractID `json:"contractID"`
+	EndHeight      uint64               `json:"endHeight"`
+	HostCollateral types.Currency       `json:"hostCollateral"`
+	HostKey        types.PublicKey      `json:"hostKey"`
+	HostIP         string               `json:"hostIP"`
+	RenterAddress  types.Address        `json:"renterAddress"`
+	RenterFunds    types.Currency       `json:"renterFunds"`
 }
 
 // RHPRenewResponse is the response type for the /rhp/renew endpoint.

--- a/api/worker.go
+++ b/api/worker.go
@@ -47,13 +47,13 @@ type RHPFormResponse struct {
 
 // RHPRenewRequest is the request type for the /rhp/renew endpoint.
 type RHPRenewRequest struct {
-	ContractID     types.FileContractID `json:"contractID"`
-	EndHeight      uint64               `json:"endHeight"`
-	HostCollateral types.Currency       `json:"hostCollateral"`
-	HostKey        types.PublicKey      `json:"hostKey"`
-	HostIP         string               `json:"hostIP"`
-	RenterAddress  types.Address        `json:"renterAddress"`
-	RenterFunds    types.Currency       `json:"renterFunds"`
+	ContractID    types.FileContractID `json:"contractID"`
+	EndHeight     uint64               `json:"endHeight"`
+	HostKey       types.PublicKey      `json:"hostKey"`
+	HostIP        string               `json:"hostIP"`
+	NewCollateral types.Currency       `json:"newCollateral"`
+	RenterAddress types.Address        `json:"renterAddress"`
+	RenterFunds   types.Currency       `json:"renterFunds"`
 }
 
 // RHPRenewResponse is the response type for the /rhp/renew endpoint.

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -30,8 +30,8 @@ type Bus interface {
 	WalletFund(txn *types.Transaction, amount types.Currency) ([]types.Hash256, []types.Transaction, error)
 	WalletOutputs() (resp []wallet.SiacoinElement, err error)
 	WalletPending() (resp []types.Transaction, err error)
-	WalletPrepareForm(renterKey types.PrivateKey, hostKey types.PublicKey, renterFunds types.Currency, renterAddress types.Address, hostCollateral types.Currency, endHeight uint64, hostSettings rhpv2.HostSettings) (txns []types.Transaction, err error)
-	WalletPrepareRenew(contract types.FileContractRevision, renterKey types.PrivateKey, hostKey types.PublicKey, renterFunds types.Currency, renterAddress types.Address, endHeight uint64, hostSettings rhpv2.HostSettings) ([]types.Transaction, types.Currency, error)
+	WalletPrepareForm(renterAddress types.Address, renterKey types.PrivateKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) (txns []types.Transaction, err error)
+	WalletPrepareRenew(contract types.FileContractRevision, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) ([]types.Transaction, types.Currency, error)
 	WalletRedistribute(outputs int, amount types.Currency) (id types.TransactionID, err error)
 	WalletSign(txn *types.Transaction, toSign []types.Hash256, cf types.CoveredFields) error
 
@@ -70,7 +70,7 @@ type Worker interface {
 	ActiveContracts(hostTimeout time.Duration) (api.ContractsResponse, error)
 	MigrateSlab(s object.Slab) error
 	RHPForm(endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds types.Currency, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
-	RHPRenew(fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
+	RHPRenew(fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPScan(hostKey types.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)
 }
 
@@ -156,6 +156,9 @@ func (ap *Autopilot) Run() error {
 				ap.logger.Debug("iteration interrupted, consensus not synced")
 				return
 			}
+
+			// update current period
+			ap.c.updateCurrentPeriod(cfg, cs)
 
 			// perform wallet maintenance
 			err = ap.c.performWalletMaintenance(cfg, cs)

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -31,7 +31,7 @@ type Bus interface {
 	WalletOutputs() (resp []wallet.SiacoinElement, err error)
 	WalletPending() (resp []types.Transaction, err error)
 	WalletPrepareForm(renterAddress types.Address, renterKey types.PrivateKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) (txns []types.Transaction, err error)
-	WalletPrepareRenew(contract types.FileContractRevision, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) ([]types.Transaction, types.Currency, error)
+	WalletPrepareRenew(contract types.FileContractRevision, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, newCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) ([]types.Transaction, types.Currency, error)
 	WalletRedistribute(outputs int, amount types.Currency) (id types.TransactionID, err error)
 	WalletSign(txn *types.Transaction, toSign []types.Hash256, cf types.CoveredFields) error
 
@@ -70,7 +70,7 @@ type Worker interface {
 	ActiveContracts(hostTimeout time.Duration) (api.ContractsResponse, error)
 	MigrateSlab(s object.Slab) error
 	RHPForm(endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds types.Currency, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
-	RHPRenew(fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
+	RHPRenew(fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds, newCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPScan(hostKey types.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)
 }
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1,7 +1,6 @@
 package autopilot
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -361,7 +360,7 @@ func (c *contractor) runContractChecks(cfg api.AutopilotConfig, blockHeight uint
 				"unusable host",
 				"hk", hk,
 				"fcid", contract.ID,
-				"reasons", toString(joinErrors(reasons)),
+				"reasons", errStr(joinErrors(reasons)),
 			)
 
 			toIgnore = append(toIgnore, contract.ID)
@@ -378,7 +377,7 @@ func (c *contractor) runContractChecks(cfg api.AutopilotConfig, blockHeight uint
 				"unusable contract",
 				"hk", hk,
 				"fcid", contract.ID,
-				"reasons", toString(joinErrors(reasons)),
+				"reasons", errStr(joinErrors(reasons)),
 				"refresh", refresh,
 				"renew", renew,
 			)
@@ -952,42 +951,4 @@ func initialContractFundingMinMax(cfg api.AutopilotConfig) (min types.Currency, 
 	min = allowance.Div64(minInitialContractFundingDivisor)
 	max = allowance.Div64(maxInitialContractFundingDivisor)
 	return
-}
-
-func toString(err error) string {
-	if err != nil {
-		return err.Error()
-	}
-	return ""
-}
-
-func containsError(errs []error, err error) bool {
-	for _, e := range errs {
-		if e == err || errors.Unwrap(e) == err {
-			return true
-		}
-	}
-	return false
-}
-
-func joinErrors(errs []error) error {
-	filtered := errs[:0]
-	for _, err := range errs {
-		if err != nil {
-			filtered = append(filtered, err)
-		}
-	}
-
-	switch len(filtered) {
-	case 0:
-		return nil
-	case 1:
-		return filtered[0]
-	default:
-		strs := make([]string, len(filtered))
-		for i := range strs {
-			strs[i] = filtered[i].Error()
-		}
-		return errors.New(strings.Join(strs, ";"))
-	}
 }

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -494,14 +494,6 @@ func (c *contractor) runContractRenewals(cfg api.AutopilotConfig, blockHeight ui
 		timeExtension := endHeight - rev.WindowEnd
 		hostCollateral := renewContractCollateral(settings, renterFunds, fs, timeExtension)
 
-		// check if the added collateral is below the threshold
-		basePrice, baseCollateral := rhpv2.ContractBaseCosts(rev.FileContract, settings, endHeight)
-		_, hostMissedPayout, _ := rhpv2.CalculatePayouts(basePrice, baseCollateral, hostCollateral, settings)
-		if isBelowCollateralThreshold(cfg, settings, hostMissedPayout) {
-			c.logger.Errorw(fmt.Sprintf("renew failed, added host collateral (%v) is below threshold", hostMissedPayout), "hk", hk, "fcid", fcid)
-			continue
-		}
-
 		// renew the contract
 		newRevision, _, err := c.ap.worker.RHPRenew(fcid, endHeight, hk, contract.HostIP, renterAddress, renterFunds, hostCollateral)
 		if err != nil {
@@ -583,8 +575,7 @@ func (c *contractor) runContractRefreshes(cfg api.AutopilotConfig, blockHeight u
 		hostCollateral := renewContractCollateral(settings, renterFunds, contract.FileSize(), 0)
 
 		// check if the added collateral is below the threshold
-		basePrice, baseCollateral := rhpv2.ContractBaseCosts(rev.FileContract, settings, contract.EndHeight())
-		_, hostMissedPayout, _ := rhpv2.CalculatePayouts(basePrice, baseCollateral, hostCollateral, settings)
+		_, hostMissedPayout, _ := rhpv2.CalculatePayouts(rev.FileContract, hostCollateral, settings, contract.EndHeight())
 		if isBelowCollateralThreshold(cfg, settings, hostMissedPayout) {
 			c.logger.Errorw(fmt.Sprintf("renew failed, added host collateral (%v) is below threshold", hostMissedPayout), "hk", hk, "fcid", fcid)
 			continue

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -577,7 +577,7 @@ func (c *contractor) runContractRefreshes(cfg api.AutopilotConfig, blockHeight u
 		// check if the added collateral is below the threshold
 		_, hostMissedPayout, _ := rhpv2.CalculatePayouts(rev.FileContract, hostCollateral, settings, contract.EndHeight())
 		if isBelowCollateralThreshold(cfg, settings, hostMissedPayout) {
-			c.logger.Errorw(fmt.Sprintf("renew failed, added host collateral (%v) is below threshold", hostMissedPayout), "hk", hk, "fcid", fcid)
+			c.logger.Errorw(fmt.Sprintf("refresh failed, refreshed contract collateral (%v) is below threshold", hostMissedPayout), "hk", hk, "fcid", fcid)
 			continue
 		}
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -581,10 +581,6 @@ func (c *contractor) runContractRefreshes(cfg api.AutopilotConfig, blockHeight u
 
 		// calculate the host collateral
 		hostCollateral := renewContractCollateral(settings, renterFunds, contract.FileSize(), 0)
-		if isBelowCollateralThreshold(cfg, settings, hostCollateral) {
-			c.logger.Errorw(fmt.Sprintf("refresh failed, updated host collateral (%v) is below threshold", hostCollateral), "hk", hk, "fcid", fcid)
-			continue
-		}
 
 		// check if the added collateral is below the threshold
 		basePrice, baseCollateral := rhpv2.ContractBaseCosts(rev.FileContract, settings, contract.EndHeight())

--- a/autopilot/contractorspending.go
+++ b/autopilot/contractorspending.go
@@ -1,0 +1,87 @@
+package autopilot
+
+import (
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/api"
+)
+
+func (c *contractor) currentPeriod() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.currPeriod
+}
+
+func (c *contractor) updateCurrentPeriod(cfg api.AutopilotConfig, cs api.ConsensusState) {
+	c.mu.Lock()
+	defer func(prevPeriod uint64) {
+		if c.currPeriod != prevPeriod {
+			c.logger.Debugf("updated current period, %d->%d", prevPeriod, c.currPeriod)
+		}
+		c.mu.Unlock()
+	}(c.currPeriod)
+
+	if c.currPeriod == 0 {
+		c.currPeriod = cs.BlockHeight
+	} else if cs.BlockHeight >= c.currPeriod+cfg.Contracts.Period {
+		c.currPeriod += cfg.Contracts.Period
+	}
+}
+
+func (c *contractor) contractSpending(contract api.Contract, currentPeriod uint64) (api.ContractSpending, error) {
+	ancestors, err := c.ap.bus.AncestorContracts(contract.ID, currentPeriod)
+	if err != nil {
+		return api.ContractSpending{}, err
+	}
+	// compute total spending
+	total := contract.Spending
+	for _, ancestor := range ancestors {
+		total = total.Add(ancestor.Spending)
+	}
+	return total, nil
+}
+
+func (c *contractor) currentPeriodSpending(contracts []api.Contract) (types.Currency, error) {
+	totalCosts := make(map[types.FileContractID]types.Currency)
+	for _, c := range contracts {
+		totalCosts[c.ID] = c.TotalCost
+	}
+
+	// filter contracts in the current period
+	var filtered []api.Contract
+	c.mu.Lock()
+	for _, rev := range contracts {
+		if rev.EndHeight() <= c.currPeriod {
+			filtered = append(filtered, rev)
+		}
+	}
+	c.mu.Unlock()
+
+	// calculate the money spent
+	var spent types.Currency
+	for _, rev := range filtered {
+		remaining := rev.RenterFunds()
+		totalCost := totalCosts[rev.ID]
+		if remaining.Cmp(totalCost) <= 0 {
+			spent = spent.Add(totalCost.Sub(remaining))
+		} else {
+			c.logger.DPanicw("sanity check failed", "remaining", remaining, "totalcost", totalCost)
+		}
+	}
+
+	return spent, nil
+}
+
+func (c *contractor) remainingFunds(cfg api.AutopilotConfig, contracts []api.Contract) (types.Currency, error) {
+	// find out how much we spent in the current period
+	spent, err := c.currentPeriodSpending(contracts)
+	if err != nil {
+		return types.ZeroCurrency, err
+	}
+
+	// figure out remaining funds
+	var remaining types.Currency
+	if cfg.Contracts.Allowance.Cmp(spent) > 0 {
+		remaining = cfg.Contracts.Allowance.Sub(spent)
+	}
+	return remaining, nil
+}

--- a/autopilot/errors.go
+++ b/autopilot/errors.go
@@ -5,13 +5,8 @@ import (
 	"strings"
 )
 
-func containsError(errs []error, err error) bool {
-	for _, e := range errs {
-		if e == err || errors.Unwrap(e) == err {
-			return true
-		}
-	}
-	return false
+func containsError(x, y error) bool {
+	return strings.Contains(x.Error(), y.Error())
 }
 
 func errStr(err error) string {
@@ -19,6 +14,15 @@ func errStr(err error) string {
 		return err.Error()
 	}
 	return ""
+}
+
+func includesError(errs []error, err error) bool {
+	for _, e := range errs {
+		if e == err || errors.Unwrap(e) == err {
+			return true
+		}
+	}
+	return false
 }
 
 func joinErrors(errs []error) error {

--- a/autopilot/errors.go
+++ b/autopilot/errors.go
@@ -1,0 +1,44 @@
+package autopilot
+
+import (
+	"errors"
+	"strings"
+)
+
+func containsError(errs []error, err error) bool {
+	for _, e := range errs {
+		if e == err || errors.Unwrap(e) == err {
+			return true
+		}
+	}
+	return false
+}
+
+func errStr(err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+func joinErrors(errs []error) error {
+	filtered := errs[:0]
+	for _, err := range errs {
+		if err != nil {
+			filtered = append(filtered, err)
+		}
+	}
+
+	switch len(filtered) {
+	case 0:
+		return nil
+	case 1:
+		return filtered[0]
+	default:
+		strs := make([]string, len(filtered))
+		for i := range strs {
+			strs[i] = filtered[i].Error()
+		}
+		return errors.New(strings.Join(strs, ";"))
+	}
+}

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -109,7 +109,7 @@ func isOutOfFunds(cfg api.AutopilotConfig, s rhp.HostSettings, c api.Contract) b
 }
 
 func isOutOfCollateral(cfg api.AutopilotConfig, s rhp.HostSettings, c api.Contract) bool {
-	return isBelowCollateralThreshold(cfg, s, c.UnusedCollateral())
+	return isBelowCollateralThreshold(cfg, s, c.RemainingCollateral(s))
 }
 
 func isBelowCollateralThreshold(cfg api.AutopilotConfig, s rhp.HostSettings, c types.Currency) bool {

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -112,6 +112,9 @@ func isOutOfCollateral(cfg api.AutopilotConfig, s rhpv2.HostSettings, c api.Cont
 	return isBelowCollateralThreshold(cfg, s, c.RemainingCollateral(s))
 }
 
+// isBelowCollateralThreshold returns true if the given collateral is below the
+// minimum contract collateral threshold, which is a percentage of the initial
+// collateral.
 func isBelowCollateralThreshold(cfg api.AutopilotConfig, s rhpv2.HostSettings, c types.Currency) bool {
 	collateral := big.NewRat(0, 1).SetFrac(c.Big(), initialContractCollateral(cfg, s).Big())
 	threshold := big.NewRat(minContractCollateralThresholdNumerator, minContractCollateralThresholdDenominator)

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -116,7 +116,8 @@ func isOutOfCollateral(cfg api.AutopilotConfig, s rhpv2.HostSettings, c api.Cont
 // minimum contract collateral threshold, which is a percentage of the initial
 // collateral.
 func isBelowCollateralThreshold(cfg api.AutopilotConfig, s rhpv2.HostSettings, c types.Currency) bool {
-	collateral := big.NewRat(0, 1).SetFrac(c.Big(), initialContractCollateral(cfg, s).Big())
+	initialCollateral := rhpv2.ContractFormationCollateral(cfg.Contracts.Storage/cfg.Contracts.Amount, cfg.Contracts.Period, s)
+	collateral := big.NewRat(0, 1).SetFrac(c.Big(), initialCollateral.Big())
 	threshold := big.NewRat(minContractCollateralThresholdNumerator, minContractCollateralThresholdDenominator)
 	return collateral.Cmp(threshold) < 0
 }

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -30,11 +30,6 @@ const (
 )
 
 func hostScore(cfg api.AutopilotConfig, h hostdb.Host) float64 {
-	// sanity check - host should have been filtered
-	if h.Settings == nil {
-		return 0
-	}
-
 	// TODO: priceAdjustmentScore
 	// TODO: storageRemainingScore
 	return ageScore(h) *

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -7,7 +7,7 @@ import (
 
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/hostdb"
-	"go.sia.tech/renterd/rhp/v2"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/siad/build"
 	"lukechampine.com/frand"
 )
@@ -72,7 +72,7 @@ func ageScore(h hostdb.Host) float64 {
 	return weight
 }
 
-func collateralScore(cfg api.AutopilotConfig, s rhp.HostSettings) float64 {
+func collateralScore(cfg api.AutopilotConfig, s rhpv2.HostSettings) float64 {
 	// NOTE: This math is copied directly from the old siad hostdb. It would
 	// probably benefit from a thorough review.
 
@@ -167,7 +167,7 @@ func uptimeScore(h hostdb.Host) float64 {
 	return math.Pow(ratio, 200*math.Min(1-ratio, 0.30))
 }
 
-func versionScore(settings rhp.HostSettings) float64 {
+func versionScore(settings rhpv2.HostSettings) float64 {
 	versions := []struct {
 		version string
 		penalty float64

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -312,7 +312,7 @@ func (b *bus) walletPrepareRenewHandler(jc jape.Context) {
 	if jc.Decode(&wprr) != nil {
 		return
 	}
-	fc := rhpv2.PrepareContractRenewal(wprr.Contract, wprr.RenterKey, wprr.HostKey, wprr.RenterFunds, wprr.EndHeight, wprr.HostSettings, wprr.RenterAddress)
+	fc := rhpv2.PrepareContractRenewal(wprr.Contract, wprr.RenterKey, wprr.HostKey, wprr.RenterFunds, wprr.HostCollateral, wprr.EndHeight, wprr.HostSettings, wprr.RenterAddress)
 	cost := rhpv2.ContractRenewalCost(fc, wprr.HostSettings.ContractPrice)
 	finalPayment := wprr.HostSettings.BaseRPCPrice
 	if finalPayment.Cmp(wprr.Contract.ValidRenterPayout()) > 0 {

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -285,9 +285,11 @@ func (b *bus) walletPrepareFormHandler(jc jape.Context) {
 	}
 	if wpfr.HostKey == (types.PublicKey{}) {
 		jc.Error(errors.New("no host key provided"), http.StatusBadRequest)
+		return
 	}
 	if wpfr.RenterKey == nil {
 		jc.Error(errors.New("no renter key provided"), http.StatusBadRequest)
+		return
 	}
 
 	fc := rhpv2.PrepareContractFormation(wpfr.RenterKey, wpfr.HostKey, wpfr.RenterFunds, wpfr.HostCollateral, wpfr.EndHeight, wpfr.HostSettings, wpfr.RenterAddress)
@@ -321,9 +323,11 @@ func (b *bus) walletPrepareRenewHandler(jc jape.Context) {
 	}
 	if wprr.HostKey == (types.PublicKey{}) {
 		jc.Error(errors.New("no host key provided"), http.StatusBadRequest)
+		return
 	}
 	if wprr.RenterKey == nil {
 		jc.Error(errors.New("no renter key provided"), http.StatusBadRequest)
+		return
 	}
 
 	fc := rhpv2.PrepareContractRenewal(wprr.Contract, wprr.RenterKey, wprr.HostKey, wprr.RenterFunds, wprr.HostCollateral, wprr.EndHeight, wprr.HostSettings, wprr.RenterAddress)

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -330,7 +330,7 @@ func (b *bus) walletPrepareRenewHandler(jc jape.Context) {
 		return
 	}
 
-	fc := rhpv2.PrepareContractRenewal(wprr.Contract, wprr.RenterKey, wprr.HostKey, wprr.RenterFunds, wprr.HostCollateral, wprr.EndHeight, wprr.HostSettings, wprr.RenterAddress)
+	fc := rhpv2.PrepareContractRenewal(wprr.Contract, wprr.RenterAddress, wprr.RenterKey, wprr.RenterFunds, wprr.NewCollateral, wprr.HostKey, wprr.HostSettings, wprr.EndHeight)
 	cost := rhpv2.ContractRenewalCost(fc, wprr.HostSettings.ContractPrice)
 	finalPayment := wprr.HostSettings.BaseRPCPrice
 	if finalPayment.Cmp(wprr.Contract.ValidRenterPayout()) > 0 {

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -283,6 +283,13 @@ func (b *bus) walletPrepareFormHandler(jc jape.Context) {
 	if jc.Decode(&wpfr) != nil {
 		return
 	}
+	if wpfr.HostKey == (types.PublicKey{}) {
+		jc.Error(errors.New("no host key provided"), http.StatusBadRequest)
+	}
+	if wpfr.RenterKey == nil {
+		jc.Error(errors.New("no renter key provided"), http.StatusBadRequest)
+	}
+
 	fc := rhpv2.PrepareContractFormation(wpfr.RenterKey, wpfr.HostKey, wpfr.RenterFunds, wpfr.HostCollateral, wpfr.EndHeight, wpfr.HostSettings, wpfr.RenterAddress)
 	cost := rhpv2.ContractFormationCost(fc, wpfr.HostSettings.ContractPrice)
 	txn := types.Transaction{
@@ -312,6 +319,13 @@ func (b *bus) walletPrepareRenewHandler(jc jape.Context) {
 	if jc.Decode(&wprr) != nil {
 		return
 	}
+	if wprr.HostKey == (types.PublicKey{}) {
+		jc.Error(errors.New("no host key provided"), http.StatusBadRequest)
+	}
+	if wprr.RenterKey == nil {
+		jc.Error(errors.New("no renter key provided"), http.StatusBadRequest)
+	}
+
 	fc := rhpv2.PrepareContractRenewal(wprr.Contract, wprr.RenterKey, wprr.HostKey, wprr.RenterFunds, wprr.HostCollateral, wprr.EndHeight, wprr.HostSettings, wprr.RenterAddress)
 	cost := rhpv2.ContractRenewalCost(fc, wprr.HostSettings.ContractPrice)
 	finalPayment := wprr.HostSettings.BaseRPCPrice

--- a/bus/client.go
+++ b/bus/client.go
@@ -173,30 +173,31 @@ func (c *Client) WalletDiscard(txn types.Transaction) error {
 }
 
 // WalletPrepareForm funds and signs a contract transaction.
-func (c *Client) WalletPrepareForm(renterKey types.PrivateKey, hostKey types.PublicKey, renterFunds types.Currency, renterAddress types.Address, hostCollateral types.Currency, endHeight uint64, hostSettings rhpv2.HostSettings) (txns []types.Transaction, err error) {
+func (c *Client) WalletPrepareForm(renterAddress types.Address, renterKey types.PrivateKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) (txns []types.Transaction, err error) {
 	req := api.WalletPrepareFormRequest{
-		RenterKey:      renterKey,
-		HostKey:        hostKey,
-		RenterFunds:    renterFunds,
-		RenterAddress:  renterAddress,
-		HostCollateral: hostCollateral,
 		EndHeight:      endHeight,
+		HostCollateral: hostCollateral,
+		HostKey:        hostKey,
 		HostSettings:   hostSettings,
+		RenterAddress:  renterAddress,
+		RenterFunds:    renterFunds,
+		RenterKey:      renterKey,
 	}
 	err = c.c.POST("/wallet/prepare/form", req, &txns)
 	return
 }
 
 // WalletPrepareRenew funds and signs a contract renewal transaction.
-func (c *Client) WalletPrepareRenew(contract types.FileContractRevision, renterKey types.PrivateKey, hostKey types.PublicKey, renterFunds types.Currency, renterAddress types.Address, endHeight uint64, hostSettings rhpv2.HostSettings) ([]types.Transaction, types.Currency, error) {
+func (c *Client) WalletPrepareRenew(contract types.FileContractRevision, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) ([]types.Transaction, types.Currency, error) {
 	req := api.WalletPrepareRenewRequest{
-		Contract:      contract,
-		RenterKey:     renterKey,
-		HostKey:       hostKey,
-		RenterFunds:   renterFunds,
-		RenterAddress: renterAddress,
-		EndHeight:     endHeight,
-		HostSettings:  hostSettings,
+		Contract:       contract,
+		EndHeight:      endHeight,
+		HostCollateral: hostCollateral,
+		HostKey:        hostKey,
+		HostSettings:   hostSettings,
+		RenterAddress:  renterAddress,
+		RenterFunds:    renterFunds,
+		RenterKey:      renterKey,
 	}
 	var resp api.WalletPrepareRenewResponse
 	err := c.c.POST("/wallet/prepare/renew", req, &resp)

--- a/bus/client.go
+++ b/bus/client.go
@@ -188,16 +188,16 @@ func (c *Client) WalletPrepareForm(renterAddress types.Address, renterKey types.
 }
 
 // WalletPrepareRenew funds and signs a contract renewal transaction.
-func (c *Client) WalletPrepareRenew(contract types.FileContractRevision, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) ([]types.Transaction, types.Currency, error) {
+func (c *Client) WalletPrepareRenew(contract types.FileContractRevision, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, newCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) ([]types.Transaction, types.Currency, error) {
 	req := api.WalletPrepareRenewRequest{
-		Contract:       contract,
-		EndHeight:      endHeight,
-		HostCollateral: hostCollateral,
-		HostKey:        hostKey,
-		HostSettings:   hostSettings,
-		RenterAddress:  renterAddress,
-		RenterFunds:    renterFunds,
-		RenterKey:      renterKey,
+		Contract:      contract,
+		EndHeight:     endHeight,
+		HostKey:       hostKey,
+		HostSettings:  hostSettings,
+		NewCollateral: newCollateral,
+		RenterAddress: renterAddress,
+		RenterFunds:   renterFunds,
+		RenterKey:     renterKey,
 	}
 	var resp api.WalletPrepareRenewResponse
 	err := c.c.POST("/wallet/prepare/renew", req, &resp)

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.17
 require (
 	github.com/klauspost/reedsolomon v1.9.16
 	gitlab.com/NebulousLabs/encoding v0.0.0-20200604091946-456c3dc907fe
-	go.sia.tech/core v0.1.0
+	go.sia.tech/core v0.1.1
 	go.sia.tech/jape v0.7.0
 	go.sia.tech/mux v1.1.0
 	go.sia.tech/siad v1.5.10-0.20221206172719-7f3713a01004
 	go.uber.org/zap v1.24.0
-	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
+	golang.org/x/crypto v0.5.0
 	golang.org/x/sys v0.4.0
 	golang.org/x/term v0.4.0
 	gorm.io/driver/sqlite v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ gitlab.com/NebulousLabs/threadgroup v0.0.0-20200608151952-38921fbef213/go.mod h1
 gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20200618142844-c59a90f49130 h1:0hiQX3a4rmdu/duDhrRxl80zYHZoJDkSbTEFwSlAc74=
 gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20200618142844-c59a90f49130/go.mod h1:SxigdS5Q1ui+OMgGAXt1E/Fg3RB6PvKXMov2O3gvIzs=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
-go.sia.tech/core v0.1.0 h1:QnwEMQKrI7TaGOv+5dgXnrS/MpPrgcH9ytogRenrstA=
-go.sia.tech/core v0.1.0/go.mod h1:toziHOd2kODxC83FQQMm1F/Ip9pR3iTIIgdlhLMx1wI=
+go.sia.tech/core v0.1.1 h1:Llw7/iprRYxuEVQzAq/VkdnAqItW22X2EjcJTiFoC+o=
+go.sia.tech/core v0.1.1/go.mod h1:toziHOd2kODxC83FQQMm1F/Ip9pR3iTIIgdlhLMx1wI=
 go.sia.tech/jape v0.7.0 h1:LJ5aAOlkkqfyoh3qssBZMISTOK2t/8uuGK0CsvfJ20A=
 go.sia.tech/jape v0.7.0/go.mod h1:4QqmBB+t3W7cNplXPj++ZqpoUb2PeiS66RLpXmEGap4=
 go.sia.tech/mux v1.1.0 h1:AH5aHAbYMhi309p4d3iufWgTYR+H7yUTmLaz8FXyH+A=
@@ -207,8 +207,8 @@ golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
-golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.5.0 h1:U/0M97KRkSFvyD/3FSmdP5W5swImpNgle/EHFhOsQPE=
+golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/hostdb/hostdb.go
+++ b/hostdb/hostdb.go
@@ -6,7 +6,7 @@ import (
 
 	"gitlab.com/NebulousLabs/encoding"
 	"go.sia.tech/core/types"
-	"go.sia.tech/renterd/rhp/v2"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
 )
@@ -25,7 +25,7 @@ type hostAnnouncement struct {
 
 type ScanResult struct {
 	Error    string
-	Settings rhp.HostSettings `json:"settings,omitempty"`
+	Settings rhpv2.HostSettings `json:"settings,omitempty"`
 }
 
 const InteractionTypeScan = "scan"
@@ -91,11 +91,11 @@ type HostAddress struct {
 
 // A Host pairs a host's public key with a set of interactions.
 type Host struct {
-	KnownSince   time.Time         `json:"knownSince"`
-	PublicKey    types.PublicKey   `json:"public_key"`
-	NetAddress   string            `json:"netAddress"`
-	Settings     *rhp.HostSettings `json:"settings"`
-	Interactions Interactions      `json:"interactions"`
+	KnownSince   time.Time           `json:"knownSince"`
+	PublicKey    types.PublicKey     `json:"public_key"`
+	NetAddress   string              `json:"netAddress"`
+	Settings     *rhpv2.HostSettings `json:"settings"`
+	Interactions Interactions        `json:"interactions"`
 }
 
 // IsOnline returns whether a host is considered online.

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -10,7 +10,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/hostdb"
-	"go.sia.tech/renterd/rhp/v2"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/siad/modules"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -108,8 +108,8 @@ type (
 )
 
 // convert converts hostSettings to rhp.HostSettings
-func (s hostSettings) convert() rhp.HostSettings {
-	return rhp.HostSettings{
+func (s hostSettings) convert() rhpv2.HostSettings {
+	return rhpv2.HostSettings{
 		AcceptingContracts:         s.AcceptingContracts,
 		MaxDownloadBatchSize:       s.MaxDownloadBatchSize,
 		MaxDuration:                s.MaxDuration,
@@ -136,7 +136,7 @@ func (s hostSettings) convert() rhp.HostSettings {
 	}
 }
 
-func convertHostSettings(settings rhp.HostSettings) hostSettings {
+func convertHostSettings(settings rhpv2.HostSettings) hostSettings {
 	return hostSettings{
 		AcceptingContracts:         settings.AcceptingContracts,
 		MaxDownloadBatchSize:       settings.MaxDownloadBatchSize,

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -11,7 +11,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/hostdb"
-	"go.sia.tech/renterd/rhp/v2"
+	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/siad/modules"
 )
 
@@ -241,7 +241,7 @@ func TestRecordInteractions(t *testing.T) {
 	}
 }
 
-func (s *SQLStore) addTestScan(hk types.PublicKey, t time.Time, err error, settings rhp.HostSettings) error {
+func (s *SQLStore) addTestScan(hk types.PublicKey, t time.Time, err error, settings rhpv2.HostSettings) error {
 	var sr hostdb.ScanResult
 	if err == nil {
 		sr.Settings = settings
@@ -297,13 +297,13 @@ func TestSQLHosts(t *testing.T) {
 
 	// Add a scan for each host.
 	n := time.Now()
-	if err := db.addTestScan(hk1, n.Add(-time.Minute), nil, rhp.HostSettings{}); err != nil {
+	if err := db.addTestScan(hk1, n.Add(-time.Minute), nil, rhpv2.HostSettings{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.addTestScan(hk2, n.Add(-2*time.Minute), nil, rhp.HostSettings{}); err != nil {
+	if err := db.addTestScan(hk2, n.Add(-2*time.Minute), nil, rhpv2.HostSettings{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.addTestScan(hk3, n.Add(-3*time.Minute), nil, rhp.HostSettings{}); err != nil {
+	if err := db.addTestScan(hk3, n.Add(-3*time.Minute), nil, rhpv2.HostSettings{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -380,14 +380,14 @@ func TestRecordScan(t *testing.T) {
 		t.Fatal("creation time not set")
 	}
 
-	scanInteraction := func(hk types.PublicKey, scanTime time.Time, settings rhp.HostSettings, success bool) []hostdb.Interaction {
+	scanInteraction := func(hk types.PublicKey, scanTime time.Time, settings rhpv2.HostSettings, success bool) []hostdb.Interaction {
 		var err string
 		if !success {
 			err = "failure"
 		}
 		result, _ := json.Marshal(struct {
-			Settings rhp.HostSettings `json:"settings"`
-			Error    string           `json:"error"`
+			Settings rhpv2.HostSettings `json:"settings"`
+			Error    string             `json:"error"`
 		}{
 			Settings: settings,
 			Error:    err,
@@ -404,7 +404,7 @@ func TestRecordScan(t *testing.T) {
 
 	// Record a scan.
 	firstScanTime := time.Now().UTC()
-	settings := rhp.HostSettings{NetAddress: "host.com"}
+	settings := rhpv2.HostSettings{NetAddress: "host.com"}
 	if err := hdb.RecordInteractions(scanInteraction(hk, firstScanTime, settings, true)); err != nil {
 		t.Fatal(err)
 	}

--- a/worker/client.go
+++ b/worker/client.go
@@ -47,15 +47,15 @@ func (c *Client) RHPForm(endHeight uint64, hk types.PublicKey, hostIP string, re
 }
 
 // RHPRenew renews an existing contract with a host.
-func (c *Client) RHPRenew(fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error) {
+func (c *Client) RHPRenew(fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds, newCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error) {
 	req := api.RHPRenewRequest{
-		ContractID:     fcid,
-		EndHeight:      endHeight,
-		HostCollateral: hostCollateral,
-		HostKey:        hk,
-		HostIP:         hostIP,
-		RenterAddress:  renterAddress,
-		RenterFunds:    renterFunds,
+		ContractID:    fcid,
+		EndHeight:     endHeight,
+		HostKey:       hk,
+		HostIP:        hostIP,
+		NewCollateral: newCollateral,
+		RenterAddress: renterAddress,
+		RenterFunds:   renterFunds,
 	}
 	var resp api.RHPRenewResponse
 	err := c.c.POST("/rhp/renew", req, &resp)

--- a/worker/client.go
+++ b/worker/client.go
@@ -47,14 +47,15 @@ func (c *Client) RHPForm(endHeight uint64, hk types.PublicKey, hostIP string, re
 }
 
 // RHPRenew renews an existing contract with a host.
-func (c *Client) RHPRenew(fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds types.Currency) (rhpv2.ContractRevision, []types.Transaction, error) {
+func (c *Client) RHPRenew(fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error) {
 	req := api.RHPRenewRequest{
-		ContractID:    fcid,
-		EndHeight:     endHeight,
-		HostKey:       hk,
-		HostIP:        hostIP,
-		RenterAddress: renterAddress,
-		RenterFunds:   renterFunds,
+		ContractID:     fcid,
+		EndHeight:      endHeight,
+		HostCollateral: hostCollateral,
+		HostKey:        hk,
+		HostIP:         hostIP,
+		RenterAddress:  renterAddress,
+		RenterFunds:    renterFunds,
 	}
 	var resp api.RHPRenewResponse
 	err := c.c.POST("/rhp/renew", req, &resp)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -233,7 +233,7 @@ type Bus interface {
 
 	WalletDiscard(txn types.Transaction) error
 	WalletPrepareForm(renterAddress types.Address, renterKey types.PrivateKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) (txns []types.Transaction, err error)
-	WalletPrepareRenew(contract types.FileContractRevision, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) ([]types.Transaction, types.Currency, error)
+	WalletPrepareRenew(contract types.FileContractRevision, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, newCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) ([]types.Transaction, types.Currency, error)
 }
 
 // deriveSubKey can be used to derive a sub-masterkey from the worker's
@@ -495,7 +495,7 @@ func (w *worker) rhpRenewHandler(jc jape.Context) {
 		_ = w.bus.ReleaseContract(rrr.ContractID, lockID) // TODO: log error
 	}()
 
-	hostIP, hostKey, toRenewID, renterFunds, hostCollateral := rrr.HostIP, rrr.HostKey, rrr.ContractID, rrr.RenterFunds, rrr.HostCollateral
+	hostIP, hostKey, toRenewID, renterFunds, newCollateral := rrr.HostIP, rrr.HostKey, rrr.ContractID, rrr.RenterFunds, rrr.NewCollateral
 	renterAddress, endHeight := rrr.RenterAddress, rrr.EndHeight
 	renterKey := w.deriveRenterKey(hostKey)
 
@@ -518,7 +518,7 @@ func (w *worker) rhpRenewHandler(jc jape.Context) {
 		}
 		rev := session.Revision()
 
-		renterTxnSet, finalPayment, err := w.bus.WalletPrepareRenew(rev.Revision, renterAddress, renterKey, renterFunds, hostCollateral, hostKey, hostSettings, endHeight)
+		renterTxnSet, finalPayment, err := w.bus.WalletPrepareRenew(rev.Revision, renterAddress, renterKey, renterFunds, newCollateral, hostKey, hostSettings, endHeight)
 		if err != nil {
 			return err
 		}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -232,8 +232,8 @@ type Bus interface {
 	UpdateSlab(s object.Slab, goodContracts map[types.PublicKey]types.FileContractID) error
 
 	WalletDiscard(txn types.Transaction) error
-	WalletPrepareForm(renterKey types.PrivateKey, hostKey types.PublicKey, renterFunds types.Currency, renterAddress types.Address, hostCollateral types.Currency, endHeight uint64, hostSettings rhpv2.HostSettings) (txns []types.Transaction, err error)
-	WalletPrepareRenew(contract types.FileContractRevision, renterKey types.PrivateKey, hostKey types.PublicKey, renterFunds types.Currency, renterAddress types.Address, endHeight uint64, hostSettings rhpv2.HostSettings) ([]types.Transaction, types.Currency, error)
+	WalletPrepareForm(renterAddress types.Address, renterKey types.PrivateKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) (txns []types.Transaction, err error)
+	WalletPrepareRenew(contract types.FileContractRevision, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) ([]types.Transaction, types.Currency, error)
 }
 
 // deriveSubKey can be used to derive a sub-masterkey from the worker's
@@ -439,27 +439,27 @@ func (w *worker) rhpFormHandler(jc jape.Context) {
 
 	hostIP, hostKey, renterFunds := rfr.HostIP, rfr.HostKey, rfr.RenterFunds
 	renterAddress, endHeight, hostCollateral := rfr.RenterAddress, rfr.EndHeight, rfr.HostCollateral
-	rk := w.deriveRenterKey(hostKey)
+	renterKey := w.deriveRenterKey(hostKey)
 
 	var contract rhpv2.ContractRevision
 	var txnSet []types.Transaction
 	ctx := WithGougingChecker(jc.Request.Context(), gp)
 	err = w.withTransportV2(ctx, hostIP, rfr.HostKey, func(t *rhpv2.Transport) (err error) {
-		settings, err := rhpv2.RPCSettings(ctx, t)
+		hostSettings, err := rhpv2.RPCSettings(ctx, t)
 		if err != nil {
 			return err
 		}
 
-		if errs := PerformGougingChecks(ctx, settings).CanForm(); len(errs) > 0 {
+		if errs := PerformGougingChecks(ctx, hostSettings).CanForm(); len(errs) > 0 {
 			return fmt.Errorf("failed to form contract, gouging check failed: %v", errs)
 		}
 
-		renterTxnSet, err := w.bus.WalletPrepareForm(rk, hostKey, renterFunds, renterAddress, hostCollateral, endHeight, settings)
+		renterTxnSet, err := w.bus.WalletPrepareForm(renterAddress, renterKey, renterFunds, hostCollateral, hostKey, hostSettings, endHeight)
 		if err != nil {
 			return err
 		}
 
-		contract, txnSet, err = rhpv2.RPCFormContract(t, rk, renterTxnSet)
+		contract, txnSet, err = rhpv2.RPCFormContract(t, renterKey, renterTxnSet)
 		if err != nil {
 			w.bus.WalletDiscard(renterTxnSet[len(renterTxnSet)-1])
 			return err
@@ -495,30 +495,30 @@ func (w *worker) rhpRenewHandler(jc jape.Context) {
 		_ = w.bus.ReleaseContract(rrr.ContractID, lockID) // TODO: log error
 	}()
 
-	hostIP, hostKey, toRenewID, renterFunds := rrr.HostIP, rrr.HostKey, rrr.ContractID, rrr.RenterFunds
+	hostIP, hostKey, toRenewID, renterFunds, hostCollateral := rrr.HostIP, rrr.HostKey, rrr.ContractID, rrr.RenterFunds, rrr.HostCollateral
 	renterAddress, endHeight := rrr.RenterAddress, rrr.EndHeight
-	rk := w.deriveRenterKey(hostKey)
+	renterKey := w.deriveRenterKey(hostKey)
 
 	var contract rhpv2.ContractRevision
 	var txnSet []types.Transaction
 	ctx := WithGougingChecker(jc.Request.Context(), gp)
 	err = w.withTransportV2(ctx, hostIP, hostKey, func(t *rhpv2.Transport) error {
-		settings, err := rhpv2.RPCSettings(ctx, t)
+		hostSettings, err := rhpv2.RPCSettings(ctx, t)
 		if err != nil {
 			return err
 		}
 
-		if errs := PerformGougingChecks(ctx, settings).CanForm(); len(errs) > 0 {
+		if errs := PerformGougingChecks(ctx, hostSettings).CanForm(); len(errs) > 0 {
 			return fmt.Errorf("failed to renew contract, gouging check failed: %v", errs)
 		}
 
-		session, err := rhpv2.RPCLock(ctx, t, toRenewID, rk, 5*time.Second)
+		session, err := rhpv2.RPCLock(ctx, t, toRenewID, renterKey, 5*time.Second)
 		if err != nil {
 			return err
 		}
 		rev := session.Revision()
 
-		renterTxnSet, finalPayment, err := w.bus.WalletPrepareRenew(rev.Revision, rk, hostKey, renterFunds, renterAddress, endHeight, settings)
+		renterTxnSet, finalPayment, err := w.bus.WalletPrepareRenew(rev.Revision, renterAddress, renterKey, renterFunds, hostCollateral, hostKey, hostSettings, endHeight)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR refreshes a contract when its remaining collateral drops below a certain threshold. It also changes the initial collateral so it reflects the expected storage instead of basing it solely off of the renter funds. The host collateral now has to be supplied to the worker, which is better because it's consistent with forming a contract and we can check whether the collateral makes sense before trying to renew/refresh.
