### PR TITLE
Contractor Redundant Calls

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -40,7 +40,6 @@ type Bus interface {
 	AddContract(c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64) (api.ContractMetadata, error)
 	AddRenewedContract(c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, renewedFrom types.FileContractID) (api.ContractMetadata, error)
 	AncestorContracts(id types.FileContractID, minStartHeight uint64) ([]api.ArchivedContract, error)
-	Contract(id types.FileContractID) (contract api.ContractMetadata, err error)
 	Contracts(set string) ([]api.ContractMetadata, error)
 	DeleteContracts(ids []types.FileContractID) error
 	SetContractSet(set string, contracts []types.FileContractID) error

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -47,7 +47,6 @@ type (
 	contractInfo struct {
 		contract api.Contract
 		settings rhpv2.HostSettings
-		host     hostdb.Host
 	}
 )
 
@@ -262,7 +261,7 @@ func (c *contractor) runContractChecks(cfg api.AutopilotConfig, blockHeight uint
 		settings := *host.Settings
 
 		// decide whether the contract is still good
-		usable, refresh, renew, reasons := isUsableContract(cfg, *host.Settings, contract, blockHeight)
+		usable, refresh, renew, reasons := isUsableContract(cfg, settings, contract, blockHeight)
 		if !usable {
 			c.logger.Infow(
 				"unusable contract",
@@ -276,13 +275,11 @@ func (c *contractor) runContractChecks(cfg api.AutopilotConfig, blockHeight uint
 				renewIndices[contract.ID] = len(toRenew)
 				toRenew = append(toRenew, contractInfo{
 					contract: contract,
-					host:     host,
 					settings: settings,
 				})
 			} else if refresh {
 				toRefresh = append(toRefresh, contractInfo{
 					contract: contract,
-					host:     host,
 					settings: settings,
 				})
 			} else {


### PR DESCRIPTION
The contractor has some redundant `bus` calls that I wanted to get rid of. This PR changes some method signatures and adds a small helper type that combines host/contract info and passes it around.

- redundant host/settings call in renew/refresh funding estimates
- redundant host/contract call in `runContractChecks`
- redundant host call in `runContractFormations`
