### PR TITLE
ContractSet Setting

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -34,6 +34,7 @@ type (
 
 	// ContractsConfig contains all contracts configuration parameters.
 	ContractsConfig struct {
+		ContractSet string         `json:"contractSet"`
 		Allowance   types.Currency `json:"allowance"`
 		Hosts       uint64         `json:"hosts"`
 		Period      uint64         `json:"period"`
@@ -54,6 +55,7 @@ type (
 func DefaultAutopilotConfig() (c AutopilotConfig) {
 	c.Wallet.DefragThreshold = 1000
 	c.Hosts.ScoreOverrides = make(map[types.PublicKey]float64)
+	c.Contracts.ContractSet = "autopilot"
 	c.Contracts.Allowance = types.Siacoins(1000)
 	c.Contracts.Hosts = 50
 	c.Contracts.Period = 144 * 7 * 6      // 6 weeks

--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -34,9 +34,9 @@ type (
 
 	// ContractsConfig contains all contracts configuration parameters.
 	ContractsConfig struct {
-		ContractSet string         `json:"contractSet"`
+		Set         string         `json:"set"`
+		Amount      uint64         `json:"amount"`
 		Allowance   types.Currency `json:"allowance"`
-		Hosts       uint64         `json:"hosts"`
 		Period      uint64         `json:"period"`
 		RenewWindow uint64         `json:"renewWindow"`
 		Download    uint64         `json:"download"`
@@ -55,9 +55,9 @@ type (
 func DefaultAutopilotConfig() (c AutopilotConfig) {
 	c.Wallet.DefragThreshold = 1000
 	c.Hosts.ScoreOverrides = make(map[types.PublicKey]float64)
-	c.Contracts.ContractSet = "autopilot"
+	c.Contracts.Set = "autopilot"
 	c.Contracts.Allowance = types.Siacoins(1000)
-	c.Contracts.Hosts = 50
+	c.Contracts.Amount = 50
 	c.Contracts.Period = 144 * 7 * 6      // 6 weeks
 	c.Contracts.RenewWindow = 144 * 7 * 2 // 2 weeks
 	c.Contracts.Upload = 1 << 40          // 1 TiB

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -109,6 +109,12 @@ func (ap *Autopilot) SetConfig(c api.AutopilotConfig) error {
 func (ap *Autopilot) Run() error {
 	ap.ticker = time.NewTicker(ap.tickerDuration)
 
+	// update the contract set setting
+	err := ap.bus.UpdateSetting(bus.SettingContractSet, ap.store.Config().Contracts.ContractSet)
+	if err != nil {
+		ap.logger.Errorf("failed to update contract set setting, err: %v", err)
+	}
+
 	ap.wg.Add(1)
 	defer ap.wg.Done()
 	for {

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -110,7 +110,7 @@ func (ap *Autopilot) Run() error {
 	ap.ticker = time.NewTicker(ap.tickerDuration)
 
 	// update the contract set setting
-	err := ap.bus.UpdateSetting(bus.SettingContractSet, ap.store.Config().Contracts.ContractSet)
+	err := ap.bus.UpdateSetting(bus.SettingContractSet, ap.store.Config().Contracts.Set)
 	if err != nil {
 		ap.logger.Errorf("failed to update contract set setting, err: %v", err)
 	}
@@ -135,7 +135,7 @@ func (ap *Autopilot) Run() error {
 			cfg := ap.store.Config()
 
 			// update the contract set setting
-			err := ap.bus.UpdateSetting(bus.SettingContractSet, cfg.Contracts.ContractSet)
+			err := ap.bus.UpdateSetting(bus.SettingContractSet, cfg.Contracts.Set)
 			if err != nil {
 				ap.logger.Errorf("failed to update contract set setting, err: %v", err)
 			}

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -250,7 +250,7 @@ func (c *contractor) performContractMaintenance(cfg api.AutopilotConfig, cs api.
 	if len(contractset) < int(rs.TotalShards) {
 		c.logger.Warnf("contractset does not have enough contracts, %v<%v", len(contractset), rs.TotalShards)
 	}
-	return c.ap.bus.SetContractSet("autopilot", contractset)
+	return c.ap.bus.SetContractSet(cfg.Contracts.ContractSet, contractset)
 }
 
 func (c *contractor) performWalletMaintenance(cfg api.AutopilotConfig, cs api.ConsensusState) error {

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -155,8 +155,8 @@ func (c *contractor) performContractMaintenance(cfg api.AutopilotConfig, cs api.
 	currentPeriod := c.updateCurrentPeriod(cfg, cs)
 	blockHeight := cs.BlockHeight
 
-	// no maintenance if no hosts are requested
-	if cfg.Contracts.Hosts == 0 {
+	// return early if no hosts are requested
+	if cfg.Contracts.Amount == 0 {
 		c.logger.Debug("no hosts requested, skipping contract maintenance")
 		return nil
 	}
@@ -231,8 +231,8 @@ func (c *contractor) performContractMaintenance(cfg api.AutopilotConfig, cs api.
 
 	// check if we need to form contracts and add them to the contract set
 	var formed []types.FileContractID
-	if numContracts < addLeeway(cfg.Contracts.Hosts, leewayPctRequiredContracts) {
-		if formed, err = c.runContractFormations(cfg, active, cfg.Contracts.Hosts-numContracts, blockHeight, currentPeriod, &remaining, address); err != nil {
+	if numContracts < addLeeway(cfg.Contracts.Amount, leewayPctRequiredContracts) {
+		if formed, err = c.runContractFormations(cfg, active, cfg.Contracts.Amount-numContracts, blockHeight, currentPeriod, &remaining, address); err != nil {
 			c.logger.Errorf("failed to form contracts, err: %v", err)
 			// continue - failing to form contracts should not prevent us from updating the contract set
 		}
@@ -250,7 +250,7 @@ func (c *contractor) performContractMaintenance(cfg api.AutopilotConfig, cs api.
 	if len(contractset) < int(rs.TotalShards) {
 		c.logger.Warnf("contractset does not have enough contracts, %v<%v", len(contractset), rs.TotalShards)
 	}
-	return c.ap.bus.SetContractSet(cfg.Contracts.ContractSet, contractset)
+	return c.ap.bus.SetContractSet(cfg.Contracts.Set, contractset)
 }
 
 func (c *contractor) performWalletMaintenance(cfg api.AutopilotConfig, cs api.ConsensusState) error {
@@ -259,7 +259,7 @@ func (c *contractor) performWalletMaintenance(cfg api.AutopilotConfig, cs api.Co
 	l := c.logger
 
 	// no contracts - nothing to do
-	if cfg.Contracts.Hosts == 0 {
+	if cfg.Contracts.Amount == 0 {
 		l.Debug("wallet maintenance skipped, no contracts wanted")
 		return nil
 	}
@@ -287,26 +287,26 @@ func (c *contractor) performWalletMaintenance(cfg api.AutopilotConfig, cs api.Co
 	if err != nil {
 		return err
 	}
-	if uint64(len(outputs)) >= cfg.Contracts.Hosts {
-		l.Debugf("no wallet maintenance needed, plenty of outputs available (%v>=%v)", len(outputs), cfg.Contracts.Hosts)
+	if uint64(len(outputs)) >= cfg.Contracts.Amount {
+		l.Debugf("no wallet maintenance needed, plenty of outputs available (%v>=%v)", len(outputs), cfg.Contracts.Amount)
 		return nil
 	}
 
 	// not enough balance - nothing to do
-	amount := cfg.Contracts.Allowance.Div64(cfg.Contracts.Hosts)
+	amount := cfg.Contracts.Allowance.Div64(cfg.Contracts.Amount)
 	balance, err := b.WalletBalance()
 	if err != nil {
 		return err
 	}
-	if balance.Cmp(amount.Mul64(cfg.Contracts.Hosts)) < 0 {
-		l.Debugf("wallet maintenance skipped, insufficient balance %v < (%v*%v)", balance, cfg.Contracts.Hosts, amount)
+	if balance.Cmp(amount.Mul64(cfg.Contracts.Amount)) < 0 {
+		l.Debugf("wallet maintenance skipped, insufficient balance %v < (%v*%v)", balance, cfg.Contracts.Amount, amount)
 		return nil
 	}
 
 	// redistribute outputs
-	id, err := b.WalletRedistribute(int(cfg.Contracts.Hosts), amount)
+	id, err := b.WalletRedistribute(int(cfg.Contracts.Amount), amount)
 	if err != nil {
-		return fmt.Errorf("failed to redistribute wallet into %d outputs of amount %v, balance %v, err %v", cfg.Contracts.Hosts, amount, balance, err)
+		return fmt.Errorf("failed to redistribute wallet into %d outputs of amount %v, balance %v, err %v", cfg.Contracts.Amount, amount, balance, err)
 	}
 
 	l.Debugf("wallet maintenance succeeded, tx %v", id)
@@ -404,7 +404,7 @@ func (c *contractor) runContractChecks(cfg api.AutopilotConfig, blockHeight uint
 	}
 
 	// apply active contract limit
-	numContractsTooMany := len(contracts) - len(toIgnore) - len(toDelete) - int(cfg.Contracts.Hosts)
+	numContractsTooMany := len(contracts) - len(toIgnore) - len(toDelete) - int(cfg.Contracts.Amount)
 	if numContractsTooMany > 0 {
 		// sort by contract size
 		sort.Slice(contractIds, func(i, j int) bool {
@@ -524,7 +524,7 @@ func (c *contractor) runContractFormations(cfg api.AutopilotConfig, active []api
 	c.logger.Debugw(
 		"run contract formations",
 		"active", len(active),
-		"required", cfg.Contracts.Hosts,
+		"required", cfg.Contracts.Amount,
 		"missing", missing,
 		"budget", budget,
 	)
@@ -910,7 +910,7 @@ func calculateHostCollateral(cfg api.AutopilotConfig, settings rhpv2.HostSetting
 	if !settings.StoragePrice.IsZero() {
 		maxStorage = renterPayout.Div(settings.StoragePrice)
 	}
-	expectedStorage := cfg.Contracts.Storage / cfg.Contracts.Hosts
+	expectedStorage := cfg.Contracts.Storage / cfg.Contracts.Amount
 	hostCollateral := maxStorage.Mul(settings.Collateral)
 
 	// don't add more than 5x the collateral for the expected storage to save on fees
@@ -935,7 +935,7 @@ func addLeeway(n uint64, pct float64) uint64 {
 }
 
 func initialContractFundingMinMax(cfg api.AutopilotConfig) (min types.Currency, max types.Currency) {
-	allowance := cfg.Contracts.Allowance.Div64(cfg.Contracts.Hosts)
+	allowance := cfg.Contracts.Allowance.Div64(cfg.Contracts.Amount)
 	min = allowance.Div64(minInitialContractFundingDivisor)
 	max = allowance.Div64(maxInitialContractFundingDivisor)
 	return

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -86,7 +86,7 @@ func collateralScore(cfg api.AutopilotConfig, s rhp.HostSettings) float64 {
 
 	// convenience variables
 	allowance := cfg.Contracts.Allowance
-	numhosts := cfg.Contracts.Hosts
+	numContracts := cfg.Contracts.Amount
 	duration := cfg.Contracts.Period
 	storage := cfg.Contracts.Storage
 
@@ -100,7 +100,7 @@ func collateralScore(cfg api.AutopilotConfig, s rhp.HostSettings) float64 {
 	collateral = math.Max(1, collateral) // ensure collateral is at least 1
 
 	// calculate the cutoff
-	expectedFundsPerHost := allowance.Div64(numhosts)
+	expectedFundsPerHost := allowance.Div64(numContracts)
 	cutoff, _ := new(big.Rat).SetInt(expectedFundsPerHost.Div64(5).Big()).Float64()
 	cutoff = math.Max(1, cutoff)          // ensure cutoff is at least 1
 	cutoff = math.Min(cutoff, collateral) // ensure cutoff is not greater than collateral

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -50,7 +50,7 @@ func (m *migrator) performMigrations(cfg api.AutopilotConfig) {
 	b := m.ap.bus
 
 	// fetch slabs for migration
-	toMigrate, err := b.SlabsForMigration(cfg.Contracts.ContractSet, migratorBatchSize)
+	toMigrate, err := b.SlabsForMigration(cfg.Contracts.Set, migratorBatchSize)
 	if err != nil {
 		m.logger.Errorf("failed to fetch slabs for migration, err: %v", err)
 		return

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	SettingGouging    = "gouging"
-	SettingRedundancy = "redundancy"
+	SettingContractSet = "contract_set"
+	SettingGouging     = "gouging"
+	SettingRedundancy  = "redundancy"
 )
 
 type (
@@ -660,8 +661,13 @@ func (b *bus) paramsHandlerDownloadGET(jc jape.Context) {
 		return
 	}
 
+	cs, err := b.ss.Setting(SettingContractSet)
+	if jc.Check("could not get contract set setting", err) != nil {
+		return
+	}
+
 	jc.Encode(api.DownloadParams{
-		ContractSet:   "autopilot", // TODO
+		ContractSet:   cs,
 		GougingParams: gp,
 	})
 }
@@ -672,8 +678,13 @@ func (b *bus) paramsHandlerUploadGET(jc jape.Context) {
 		return
 	}
 
+	cs, err := b.ss.Setting(SettingContractSet)
+	if jc.Check("could not get contract set setting", err) != nil {
+		return
+	}
+
 	jc.Encode(api.UploadParams{
-		ContractSet:   "autopilot", // TODO
+		ContractSet:   cs,
 		CurrentHeight: b.cm.TipState().Index.Height,
 		GougingParams: gp,
 	})

--- a/bus/client.go
+++ b/bus/client.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/url"
@@ -257,6 +258,9 @@ func (c *Client) ActiveContracts() (contracts []api.ContractMetadata, err error)
 
 // Contracts returns the contracts for the given set from the contract store.
 func (c *Client) Contracts(set string) (contracts []api.ContractMetadata, err error) {
+	if set == "" {
+		return nil, errors.New("set cannot be empty")
+	}
 	err = c.c.GET(fmt.Sprintf("/contracts/set/%s", set), &contracts)
 	return
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/klauspost/reedsolomon v1.9.16
 	gitlab.com/NebulousLabs/encoding v0.0.0-20200604091946-456c3dc907fe
 	go.sia.tech/core v0.1.0
-	go.sia.tech/jape v0.6.0
+	go.sia.tech/jape v0.7.0
 	go.sia.tech/mux v1.1.0
 	go.sia.tech/siad v1.5.10-0.20221206172719-7f3713a01004
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20200618142844-c59a90f49130/go.mod 
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.sia.tech/core v0.1.0 h1:QnwEMQKrI7TaGOv+5dgXnrS/MpPrgcH9ytogRenrstA=
 go.sia.tech/core v0.1.0/go.mod h1:toziHOd2kODxC83FQQMm1F/Ip9pR3iTIIgdlhLMx1wI=
-go.sia.tech/jape v0.6.0 h1:c/GHB5jloL/iFo+QRZHRNpYm7bke7+ypkAbXb3kGzlU=
-go.sia.tech/jape v0.6.0/go.mod h1:4QqmBB+t3W7cNplXPj++ZqpoUb2PeiS66RLpXmEGap4=
+go.sia.tech/jape v0.7.0 h1:LJ5aAOlkkqfyoh3qssBZMISTOK2t/8uuGK0CsvfJ20A=
+go.sia.tech/jape v0.7.0/go.mod h1:4QqmBB+t3W7cNplXPj++ZqpoUb2PeiS66RLpXmEGap4=
 go.sia.tech/mux v1.1.0 h1:AH5aHAbYMhi309p4d3iufWgTYR+H7yUTmLaz8FXyH+A=
 go.sia.tech/mux v1.1.0/go.mod h1:Yyo6wZelOYTyvrHmJZ6aQfRoer3o4xyKQ4NmQLJrBSo=
 go.sia.tech/siad v1.5.10-0.20221206172719-7f3713a01004 h1:0tFQh99BL6NQuHiq0brkfVCy/nEq3vyu9DTi1cgnb/E=

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -40,7 +40,7 @@ var (
 	defaultAutopilotConfig = api.AutopilotConfig{
 		Contracts: api.ContractsConfig{
 			Allowance:   types.Siacoins(1).Mul64(1e3),
-			Hosts:       5,
+			Amount:      5,
 			Period:      50,
 			RenewWindow: 24,
 
@@ -48,7 +48,7 @@ var (
 			Upload:   modules.SectorSize * 500,
 			Storage:  modules.SectorSize * 5e3,
 
-			ContractSet: "autopilot",
+			Set: "autopilot",
 		},
 		Hosts: api.HostsConfig{
 			IgnoreRedundantIPs: true, // ignore for integration tests by default // TODO: add test for IP filter.

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -47,6 +47,8 @@ var (
 			Download: modules.SectorSize * 500,
 			Upload:   modules.SectorSize * 500,
 			Storage:  modules.SectorSize * 5e3,
+
+			ContractSet: "autopilot",
 		},
 		Hosts: api.HostsConfig{
 			IgnoreRedundantIPs: true, // ignore for integration tests by default // TODO: add test for IP filter.

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -131,7 +131,7 @@ func TestUploadDownload(t *testing.T) {
 	}
 
 	// sanity check the default settings
-	if defaultAutopilotConfig.Contracts.Hosts < uint64(defaultRedundancy.MinShards) {
+	if defaultAutopilotConfig.Contracts.Amount < uint64(defaultRedundancy.MinShards) {
 		t.Fatal("too few hosts to support the redundancy settings")
 	}
 

--- a/internal/testing/gouging_test.go
+++ b/internal/testing/gouging_test.go
@@ -38,7 +38,7 @@ func TestGouging(t *testing.T) {
 	w := cluster.Worker
 
 	// add hosts
-	hosts, err := cluster.AddHostsBlocking(int(cfg.Hosts))
+	hosts, err := cluster.AddHostsBlocking(int(cfg.Amount))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,10 +53,10 @@ func TestGouging(t *testing.T) {
 	waitForContractSet := func() error {
 		t.Helper()
 		return Retry(30, time.Second, func() error {
-			if contracts, err := b.Contracts(cfg.ContractSet); err != nil {
+			if contracts, err := b.Contracts(cfg.Set); err != nil {
 				t.Fatal(err)
-			} else if len(contracts) != int(cfg.Hosts) {
-				return fmt.Errorf("contract set not ready yet, %v!=%v", len(contracts), int(cfg.Hosts))
+			} else if len(contracts) != int(cfg.Amount) {
+				return fmt.Errorf("contract set not ready yet, %v!=%v", len(contracts), int(cfg.Amount))
 			}
 			return nil
 		})
@@ -65,7 +65,7 @@ func TestGouging(t *testing.T) {
 	// helper that waits untail a certain host is removed from the contract set
 	waitForHostRemoval := func(hk types.PublicKey) error {
 		return Retry(30, time.Second, func() error {
-			if contracts, err := b.Contracts(cfg.ContractSet); err != nil {
+			if contracts, err := b.Contracts(cfg.Set); err != nil {
 				t.Fatal(err)
 			} else {
 				for _, c := range contracts {
@@ -112,7 +112,7 @@ func TestGouging(t *testing.T) {
 
 	for _, c := range cases {
 		// fetch current contract set
-		contracts, err := b.Contracts(cfg.ContractSet)
+		contracts, err := b.Contracts(cfg.Set)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/testing/gouging_test.go
+++ b/internal/testing/gouging_test.go
@@ -53,7 +53,7 @@ func TestGouging(t *testing.T) {
 	waitForContractSet := func() error {
 		t.Helper()
 		return Retry(30, time.Second, func() error {
-			if contracts, err := b.Contracts("autopilot"); err != nil {
+			if contracts, err := b.Contracts(cfg.ContractSet); err != nil {
 				t.Fatal(err)
 			} else if len(contracts) != int(cfg.Hosts) {
 				return fmt.Errorf("contract set not ready yet, %v!=%v", len(contracts), int(cfg.Hosts))
@@ -65,7 +65,7 @@ func TestGouging(t *testing.T) {
 	// helper that waits untail a certain host is removed from the contract set
 	waitForHostRemoval := func(hk types.PublicKey) error {
 		return Retry(30, time.Second, func() error {
-			if contracts, err := b.Contracts("autopilot"); err != nil {
+			if contracts, err := b.Contracts(cfg.ContractSet); err != nil {
 				t.Fatal(err)
 			} else {
 				for _, c := range contracts {
@@ -112,7 +112,7 @@ func TestGouging(t *testing.T) {
 
 	for _, c := range cases {
 		// fetch current contract set
-		contracts, err := b.Contracts("autopilot")
+		contracts, err := b.Contracts(cfg.ContractSet)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/testing/migrations_test.go
+++ b/internal/testing/migrations_test.go
@@ -36,7 +36,7 @@ func TestMigrations(t *testing.T) {
 	b := cluster.Bus
 
 	// add hosts
-	hosts, err := cluster.AddHostsBlocking(int(cfg.Contracts.Hosts))
+	hosts, err := cluster.AddHostsBlocking(int(cfg.Contracts.Amount))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -32,6 +32,10 @@ const (
 
 	lockingDurationRenew   = time.Minute
 	lockingDurationFunding = 30 * time.Second
+
+	queryStringParamContractSet = "contractset"
+	queryStringParamMinShards   = "minshards"
+	queryStringParamTotalShards = "totalshards"
 )
 
 // parseRange parses a Range header string as per RFC 7233. Only the first range
@@ -488,9 +492,7 @@ func (w *worker) rhpRenewHandler(jc jape.Context) {
 		return
 	}
 	defer func() {
-		if err := w.bus.ReleaseContract(rrr.ContractID, lockID); err != nil {
-			// TODO: log
-		}
+		_ = w.bus.ReleaseContract(rrr.ContractID, lockID) // TODO: log error
 	}()
 
 	hostIP, hostKey, toRenewID, renterFunds := rrr.HostIP, rrr.HostKey, rrr.ContractID, rrr.RenterFunds
@@ -562,9 +564,7 @@ func (w *worker) rhpFundHandler(jc jape.Context) {
 		return
 	}
 	defer func() {
-		if err := w.bus.ReleaseContract(rfr.ContractID, lockID); err != nil {
-			// TODO: log
-		}
+		_ = w.bus.ReleaseContract(rfr.ContractID, lockID) // TODO: log error
 	}()
 
 	// Get contract revision.
@@ -657,7 +657,7 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 
 	// allow overriding contract set
 	var contractset string
-	if jc.DecodeForm("contractset", &contractset) != nil {
+	if jc.DecodeForm(queryStringParamContractSet, &contractset) != nil {
 		return
 	} else if contractset != "" {
 		up.ContractSet = contractset
@@ -717,7 +717,7 @@ func (w *worker) objectsKeyHandlerGET(jc jape.Context) {
 
 	// allow overriding contract set
 	var contractset string
-	if jc.DecodeForm("contractset", &contractset) != nil {
+	if jc.DecodeForm(queryStringParamContractSet, &contractset) != nil {
 		return
 	} else if contractset != "" {
 		dp.ContractSet = contractset
@@ -777,10 +777,10 @@ func (w *worker) objectsKeyHandlerPUT(jc jape.Context) {
 	rs := up.RedundancySettings
 
 	// allow overriding the redundancy settings
-	if jc.DecodeForm("minshards", &rs.MinShards) != nil {
+	if jc.DecodeForm(queryStringParamMinShards, &rs.MinShards) != nil {
 		return
 	}
-	if jc.DecodeForm("totalshards", &rs.TotalShards) != nil {
+	if jc.DecodeForm(queryStringParamTotalShards, &rs.TotalShards) != nil {
 		return
 	}
 	if jc.Check("invalid redundancy settings", rs.Validate()) != nil {
@@ -789,7 +789,7 @@ func (w *worker) objectsKeyHandlerPUT(jc jape.Context) {
 
 	// allow overriding contract set
 	var contractset string
-	if jc.DecodeForm("contractset", &contractset) != nil {
+	if jc.DecodeForm(queryStringParamContractSet, &contractset) != nil {
 		return
 	} else if contractset != "" {
 		up.ContractSet = contractset

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -655,6 +655,14 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 		return
 	}
 
+	// allow overriding contract set
+	var contractset string
+	if jc.DecodeForm("contractset", &contractset) != nil {
+		return
+	} else if contractset != "" {
+		up.ContractSet = contractset
+	}
+
 	// attach gouging checker to the context
 	ctx := WithGougingChecker(jc.Request.Context(), up.GougingParams)
 
@@ -705,6 +713,14 @@ func (w *worker) objectsKeyHandlerGET(jc jape.Context) {
 	dp, err := w.bus.DownloadParams()
 	if jc.Check("couldn't fetch download parameters from bus", err) != nil {
 		return
+	}
+
+	// allow overriding contract set
+	var contractset string
+	if jc.DecodeForm("contractset", &contractset) != nil {
+		return
+	} else if contractset != "" {
+		dp.ContractSet = contractset
 	}
 
 	// attach gouging checker to the context
@@ -769,6 +785,14 @@ func (w *worker) objectsKeyHandlerPUT(jc jape.Context) {
 	}
 	if jc.Check("invalid redundancy settings", rs.Validate()) != nil {
 		return
+	}
+
+	// allow overriding contract set
+	var contractset string
+	if jc.DecodeForm("contractset", &contractset) != nil {
+		return
+	} else if contractset != "" {
+		up.ContractSet = contractset
 	}
 
 	// attach gouging checker to the context


### PR DESCRIPTION
This PR gets rid of the hardcoded `autopilot` contract set, allowing users to configure a custom contract set name in the autopilot config as well as overriding the contract set on the worker endpoints. The autopilot will update a `bus` setting to configure the default contract set when the autopilot starts up and when the config is updated.