### PR TITLE
bus/worker: remove unnecessary '/' at beginning of object name

### DIFF
--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -170,6 +170,22 @@ func TestUploadDownload(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// Should be registered in bus.
+		_, entries, err := cluster.Bus.Object("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var found bool
+		for _, entry := range entries {
+			if entry == fmt.Sprintf("/%s", name) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatal("uploaded object not found in bus")
+		}
+
 		// download the data
 		var buffer bytes.Buffer
 		if err := w.DownloadObject(&buffer, name); err != nil {

--- a/internal/testing/migrations_test.go
+++ b/internal/testing/migrations_test.go
@@ -50,7 +50,7 @@ func TestMigrations(t *testing.T) {
 
 	usedHosts := func() []types.PublicKey {
 		t.Helper()
-		obj, _, err := b.Object("/foo")
+		obj, _, err := b.Object("foo")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -693,7 +693,8 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 func (w *worker) objectsKeyHandlerGET(jc jape.Context) {
 	jc.Custom(nil, []string{})
 
-	o, es, err := w.bus.Object(jc.PathParam("key"))
+	key := strings.TrimPrefix(jc.PathParam("key"), "/")
+	o, es, err := w.bus.Object(key)
 	if jc.Check("couldn't get object or entries", err) != nil {
 		return
 	}
@@ -819,7 +820,8 @@ func (w *worker) objectsKeyHandlerPUT(jc jape.Context) {
 		}
 	}
 
-	if jc.Check("couldn't add object", w.bus.AddObject(jc.PathParam("key"), o, usedContracts)) != nil {
+	key := strings.TrimPrefix(jc.PathParam("key"), "/")
+	if jc.Check("couldn't add object", w.bus.AddObject(key, o, usedContracts)) != nil {
 		return
 	}
 }


### PR DESCRIPTION
`objectsKeyHandlerGET` and `objectsKeyHandlerPUT` implicitly added another `/` to the beginning of the object's name within the bus.

That's because when `foo` is passed to an endpoint, the path param is actually `/foo`. So when we passed `foo` to the worker it became `/foo` and the worker calls the bus endpoint which makes it `//foo`.

Same goes for fetching objects from the bus. We need to pass `""` to get the root dir `/` because passing `/` returns the dir `//`. 

I extended the test to make sure the entries are stored with a single slash within the bus as expected.