### PR TITLE
Custom Gorm Logger + Worker/Bus Loggers

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -18,6 +18,7 @@ import (
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	rhpv3 "go.sia.tech/renterd/rhp/v3"
 	"go.sia.tech/renterd/wallet"
+	"go.uber.org/zap"
 )
 
 const (
@@ -124,6 +125,7 @@ type bus struct {
 	os  ObjectStore
 	ss  SettingStore
 
+	logger        *zap.SugaredLogger
 	accounts      *accounts
 	contractLocks *contractLocks
 }
@@ -794,7 +796,7 @@ func (b *bus) accountsUpdateHandlerPOST(jc jape.Context) {
 }
 
 // New returns a new Bus.
-func New(s Syncer, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, cs ContractStore, os ObjectStore, ss SettingStore, eas EphemeralAccountStore, gs api.GougingSettings, rs api.RedundancySettings) (http.Handler, func() error, error) {
+func New(s Syncer, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, cs ContractStore, os ObjectStore, ss SettingStore, eas EphemeralAccountStore, gs api.GougingSettings, rs api.RedundancySettings, l *zap.Logger) (http.Handler, func() error, error) {
 	b := &bus{
 		s:             s,
 		cm:            cm,
@@ -805,6 +807,7 @@ func New(s Syncer, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, cs
 		os:            os,
 		ss:            ss,
 		contractLocks: newContractLocks(),
+		logger:        l.Sugar().Named("bus"),
 	}
 
 	if err := b.setGougingSettings(gs); err != nil {

--- a/bus/client_test.go
+++ b/bus/client_test.go
@@ -14,6 +14,8 @@ import (
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/bus"
 	"go.sia.tech/renterd/internal/node"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 var defaultSettings = api.RedundancySettings{
@@ -76,7 +78,7 @@ func newTestClient(dir string) (*bus.Client, func() error, func(context.Context)
 		GatewayAddr:        "127.0.0.1:0",
 		Miner:              node.NewMiner(client),
 		RedundancySettings: defaultSettings,
-	}, filepath.Join(dir, "bus"), types.GeneratePrivateKey())
+	}, filepath.Join(dir, "bus"), types.GeneratePrivateKey(), zap.New(zapcore.NewNopCore()))
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -222,7 +222,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		workerLog := filepath.Join(workerDir, fmt.Sprintf("worker_%s.log", workerCfg.WorkerConfig.ID))
+		workerLog := filepath.Join(workerDir, workerCfg.WorkerConfig.ID)
 		l, closeFn, err := node.NewLogger(workerLog)
 		if err != nil {
 			log.Fatal(err)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -311,9 +311,14 @@ func NewLogger(path string) (*zap.Logger, func(), error) {
 		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), zapcore.DebugLevel),
 	)
 
-	return zap.New(
+	logger := zap.New(
 		core,
 		zap.AddCaller(),
 		zap.AddStacktrace(zapcore.ErrorLevel),
-	), closeFn, nil
+	)
+
+	return logger, func() {
+		_ = logger.Sync() // ignore Error
+		closeFn()
+	}, nil
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -177,7 +177,7 @@ func (tp txpool) UnconfirmedParents(txn types.Transaction) ([]types.Transaction,
 	return parents, nil
 }
 
-func NewBus(cfg BusConfig, dir string, walletKey types.PrivateKey) (http.Handler, func() error, error) {
+func NewBus(cfg BusConfig, dir string, walletKey types.PrivateKey, logger *zap.Logger) (http.Handler, func() error, error) {
 	gatewayDir := filepath.Join(dir, "gateway")
 	if err := os.MkdirAll(gatewayDir, 0700); err != nil {
 		return nil, nil, err
@@ -231,7 +231,8 @@ func NewBus(cfg BusConfig, dir string, walletKey types.PrivateKey) (http.Handler
 	}
 	dbConn := stores.NewSQLiteConnection(filepath.Join(dbDir, "db.sqlite"))
 
-	sqlStore, ccid, err := stores.NewSQLStore(dbConn, true, cfg.PersistInterval)
+	sqlLogger := stores.NewLogger(logger.Named("db"), nil)
+	sqlStore, ccid, err := stores.NewSQLStore(dbConn, true, cfg.PersistInterval, sqlLogger)
 	if err != nil {
 		return nil, nil, err
 	} else if err := cs.ConsensusSetSubscribe(sqlStore, ccid, nil); err != nil {

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -137,7 +137,7 @@ func TestSQLHostDB(t *testing.T) {
 
 	// Connect to the same DB again.
 	conn2 := NewEphemeralSQLiteConnection(dbName)
-	hdb2, ccid, err := NewSQLStore(conn2, false, time.Second)
+	hdb2, ccid, err := NewSQLStore(conn2, false, time.Second, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/stores/logger.go
+++ b/internal/stores/logger.go
@@ -1,0 +1,109 @@
+package stores
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+type LoggerConfig struct {
+	IgnoreRecordNotFoundError bool
+	LogLevel                  logger.LogLevel
+	SlowThreshold             time.Duration
+}
+
+type gormLogger struct {
+	LoggerConfig
+	logger *zap.SugaredLogger
+}
+
+func NewLogger(l *zap.Logger, config *LoggerConfig) logger.Interface {
+	l = l.WithOptions(zap.AddCallerSkip(1))
+
+	if config == nil {
+		config = &LoggerConfig{
+			IgnoreRecordNotFoundError: true,
+			LogLevel:                  logger.Warn,
+			SlowThreshold:             200 * time.Millisecond,
+		}
+	}
+	return &gormLogger{
+		LoggerConfig: *config,
+		logger:       l.Sugar(),
+	}
+}
+
+func (l *gormLogger) LogMode(level logger.LogLevel) logger.Interface {
+	newlogger := *l
+	newlogger.LogLevel = level
+	return &newlogger
+}
+
+func (l gormLogger) Info(ctx context.Context, msg string, args ...interface{}) {
+	if l.LogLevel < logger.Info {
+		return
+	}
+	l.logger.Infof(msg, args...)
+}
+
+func (l gormLogger) Warn(ctx context.Context, msg string, args ...interface{}) {
+	if l.LogLevel < logger.Warn {
+		return
+	}
+	l.logger.Warnf(msg, args...)
+}
+
+func (l gormLogger) Error(ctx context.Context, msg string, args ...interface{}) {
+	if l.LogLevel < logger.Error {
+		return
+	}
+	l.logger.Errorf(msg, args...)
+}
+
+func (l gormLogger) Trace(ctx context.Context, start time.Time, fc func() (sql string, rowsAffected int64), err error) {
+	if l.LogLevel <= logger.Silent {
+		return
+	}
+
+	hideError := errors.Is(err, gorm.ErrRecordNotFound) && l.IgnoreRecordNotFoundError
+	if err != nil && !hideError && l.LogLevel >= logger.Error {
+		var log func(string, ...interface{})
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			log = l.logger.Debugw
+		} else {
+			log = l.logger.Errorw
+		}
+
+		sql, rows := fc()
+		if rows == -1 {
+			log(err.Error(), "elapsed", elapsedMS(start), "sql", sql)
+		} else {
+			log(err.Error(), "elapsed", elapsedMS(start), "rows", rows, "sql", sql)
+		}
+		return
+	}
+
+	if l.SlowThreshold != 0 && time.Since(start) > l.SlowThreshold && l.LogLevel >= logger.Warn {
+		sql, rows := fc()
+		if rows == -1 {
+			l.logger.Warnw(fmt.Sprintf("SLOW SQL >= %v", l.SlowThreshold), "elapsed", elapsedMS(start), "sql", sql)
+		} else {
+			l.logger.Warnw(fmt.Sprintf("SLOW SQL >= %v", l.SlowThreshold), "elapsed", elapsedMS(start), "rows", rows, "sql", sql)
+		}
+		return
+	}
+
+	if l.LogLevel >= logger.Info {
+		sql, rows := fc()
+		l.logger.Debugw("trace", "elapsed", elapsedMS(start), "rows", rows, "sql", sql)
+	}
+}
+
+func elapsedMS(t time.Time) string {
+	return fmt.Sprintf("%.3fms", float64(time.Since(t).Nanoseconds())/1e6)
+}

--- a/internal/stores/logger.go
+++ b/internal/stores/logger.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -19,12 +21,10 @@ type LoggerConfig struct {
 
 type gormLogger struct {
 	LoggerConfig
-	logger *zap.SugaredLogger
+	l *zap.SugaredLogger
 }
 
 func NewSQLLogger(l *zap.Logger, config *LoggerConfig) logger.Interface {
-	l = l.WithOptions(zap.AddCallerSkip(3))
-
 	if config == nil {
 		config = &LoggerConfig{
 			IgnoreRecordNotFoundError: true,
@@ -34,7 +34,7 @@ func NewSQLLogger(l *zap.Logger, config *LoggerConfig) logger.Interface {
 	}
 	return &gormLogger{
 		LoggerConfig: *config,
-		logger:       l.Sugar(),
+		l:            l.Sugar(),
 	}
 }
 
@@ -48,35 +48,36 @@ func (l gormLogger) Info(ctx context.Context, msg string, args ...interface{}) {
 	if l.LogLevel < logger.Info {
 		return
 	}
-	l.logger.Infof(msg, args...)
+	l.logger().Infof(msg, args...)
 }
 
 func (l gormLogger) Warn(ctx context.Context, msg string, args ...interface{}) {
 	if l.LogLevel < logger.Warn {
 		return
 	}
-	l.logger.Warnf(msg, args...)
+	l.logger().Warnf(msg, args...)
 }
 
 func (l gormLogger) Error(ctx context.Context, msg string, args ...interface{}) {
 	if l.LogLevel < logger.Error {
 		return
 	}
-	l.logger.Errorf(msg, args...)
+	l.logger().Errorf(msg, args...)
 }
 
 func (l gormLogger) Trace(ctx context.Context, start time.Time, fc func() (sql string, rowsAffected int64), err error) {
 	if l.LogLevel <= logger.Silent {
 		return
 	}
+	ll := l.logger()
 
 	hideError := errors.Is(err, gorm.ErrRecordNotFound) && l.IgnoreRecordNotFoundError
 	if err != nil && !hideError && l.LogLevel >= logger.Error {
 		var log func(string, ...interface{})
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			log = l.logger.Debugw
+			log = ll.Debugw
 		} else {
-			log = l.logger.Errorw
+			log = ll.Errorw
 		}
 
 		sql, rows := fc()
@@ -91,17 +92,30 @@ func (l gormLogger) Trace(ctx context.Context, start time.Time, fc func() (sql s
 	if l.SlowThreshold != 0 && time.Since(start) > l.SlowThreshold && l.LogLevel >= logger.Warn {
 		sql, rows := fc()
 		if rows == -1 {
-			l.logger.Warnw(fmt.Sprintf("SLOW SQL >= %v", l.SlowThreshold), "elapsed", elapsedMS(start), "sql", sql)
+			ll.Warnw(fmt.Sprintf("SLOW SQL >= %v", l.SlowThreshold), "elapsed", elapsedMS(start), "sql", sql)
 		} else {
-			l.logger.Warnw(fmt.Sprintf("SLOW SQL >= %v", l.SlowThreshold), "elapsed", elapsedMS(start), "rows", rows, "sql", sql)
+			ll.Warnw(fmt.Sprintf("SLOW SQL >= %v", l.SlowThreshold), "elapsed", elapsedMS(start), "rows", rows, "sql", sql)
 		}
 		return
 	}
 
 	if l.LogLevel >= logger.Info {
 		sql, rows := fc()
-		l.logger.Debugw("trace", "elapsed", elapsedMS(start), "rows", rows, "sql", sql)
+		ll.Debugw("trace", "elapsed", elapsedMS(start), "rows", rows, "sql", sql)
 	}
+}
+
+func (l *gormLogger) logger() *zap.SugaredLogger {
+	for i := 2; i < 15; i++ {
+		_, file, _, ok := runtime.Caller(i)
+		switch {
+		case !ok:
+		case strings.Contains(file, "gorm"):
+		default:
+			return l.l.WithOptions(zap.AddCallerSkip(i))
+		}
+	}
+	return l.l
 }
 
 func elapsedMS(t time.Time) string {

--- a/internal/stores/logger.go
+++ b/internal/stores/logger.go
@@ -22,8 +22,8 @@ type gormLogger struct {
 	logger *zap.SugaredLogger
 }
 
-func NewLogger(l *zap.Logger, config *LoggerConfig) logger.Interface {
-	l = l.WithOptions(zap.AddCallerSkip(1))
+func NewSQLLogger(l *zap.Logger, config *LoggerConfig) logger.Interface {
+	l = l.WithOptions(zap.AddCallerSkip(3))
 
 	if config == nil {
 		config = &LoggerConfig{

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -2,14 +2,12 @@ package stores
 
 import (
 	"fmt"
-	"log"
-	"os"
 	"time"
 
 	"go.sia.tech/siad/modules"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
+	glogger "gorm.io/gorm/logger"
 )
 
 type (
@@ -61,17 +59,7 @@ func NewSQLiteConnection(path string) gorm.Dialector {
 // NewSQLStore uses a given Dialector to connect to a SQL database.  NOTE: Only
 // pass migrate=true for the first instance of SQLHostDB if you connect via the
 // same Dialector multiple times.
-func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duration) (*SQLStore, modules.ConsensusChangeID, error) {
-	logger := logger.New(
-		log.New(os.Stdout, "\r\n", log.LstdFlags),
-		logger.Config{
-			SlowThreshold:             200 * time.Millisecond,
-			LogLevel:                  logger.Warn,
-			IgnoreRecordNotFoundError: true,
-			Colorful:                  false,
-		},
-	)
-
+func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duration, logger glogger.Interface) (*SQLStore, modules.ConsensusChangeID, error) {
 	db, err := gorm.Open(conn, &gorm.Config{
 		DisableNestedTransaction: true,   // disable nesting transactions
 		PrepareStmt:              true,   // caches queries as prepared statements

--- a/internal/stores/sql_test.go
+++ b/internal/stores/sql_test.go
@@ -2,9 +2,13 @@ package stores
 
 import (
 	"encoding/hex"
+	"os"
 	"time"
 
 	"go.sia.tech/siad/modules"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"gorm.io/gorm/logger"
 	"lukechampine.com/frand"
 )
 
@@ -14,9 +18,29 @@ const testPersistInterval = time.Second
 func newTestSQLStore() (*SQLStore, string, modules.ConsensusChangeID, error) {
 	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
 	conn := NewEphemeralSQLiteConnection(dbName)
-	sqlStore, ccid, err := NewSQLStore(conn, true, time.Second)
+	sqlStore, ccid, err := NewSQLStore(conn, true, time.Second, newTestLogger())
 	if err != nil {
 		return nil, "", modules.ConsensusChangeID{}, err
 	}
 	return sqlStore, dbName, ccid, nil
+}
+
+// newTestLogger creates a console logger used for testing.
+func newTestLogger() logger.Interface {
+	config := zap.NewProductionEncoderConfig()
+	config.EncodeTime = zapcore.RFC3339TimeEncoder
+	config.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	config.StacktraceKey = ""
+	consoleEncoder := zapcore.NewConsoleEncoder(config)
+
+	l := zap.New(
+		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), zapcore.DebugLevel),
+		zap.AddCaller(),
+		zap.AddStacktrace(zapcore.ErrorLevel),
+	)
+	return NewLogger(l, &LoggerConfig{
+		IgnoreRecordNotFoundError: false,
+		LogLevel:                  logger.Warn,
+		SlowThreshold:             100 * time.Millisecond,
+	})
 }

--- a/internal/stores/sql_test.go
+++ b/internal/stores/sql_test.go
@@ -38,7 +38,7 @@ func newTestLogger() logger.Interface {
 		zap.AddCaller(),
 		zap.AddStacktrace(zapcore.ErrorLevel),
 	)
-	return NewLogger(l, &LoggerConfig{
+	return NewSQLLogger(l, &LoggerConfig{
 		IgnoreRecordNotFoundError: false,
 		LogLevel:                  logger.Warn,
 		SlowThreshold:             100 * time.Millisecond,

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -177,7 +177,7 @@ func newTestClusterWithFunding(dir string, funding bool, logger *zap.Logger) (*T
 		PersistInterval:    testPersistInterval,
 		GougingSettings:    defaultGouging,
 		RedundancySettings: defaultRedundancy,
-	}, busDir, wk)
+	}, busDir, wk, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -194,7 +194,7 @@ func newTestClusterWithFunding(dir string, funding bool, logger *zap.Logger) (*T
 		InteractionFlushInterval: testInteractionsFlushInterval,
 		SessionReconnectTimeout:  10 * time.Second,
 		SessionTTL:               2 * time.Minute,
-	}, busClient, wk)
+	}, busClient, wk, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -26,7 +27,7 @@ func TestNewTestCluster(t *testing.T) {
 		t.SkipNow()
 	}
 
-	cluster, err := newTestCluster(t.TempDir(), zap.New(zapcore.NewNopCore()))
+	cluster, err := newTestCluster(t.TempDir(), newTestLogger())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +137,7 @@ func TestUploadDownload(t *testing.T) {
 	}
 
 	// create a test cluster
-	cluster, err := newTestCluster(t.TempDir(), zap.New(zapcore.NewNopCore()))
+	cluster, err := newTestCluster(t.TempDir(), newTestLogger())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,4 +303,19 @@ func TestEphemeralAccounts(t *testing.T) {
 	if !reflect.DeepEqual(accounts, accounts2) {
 		t.Fatal("worker's accounts weren't persisted")
 	}
+}
+
+// newTestLogger creates a console logger used for testing.
+func newTestLogger() *zap.Logger {
+	config := zap.NewProductionEncoderConfig()
+	config.EncodeTime = zapcore.RFC3339TimeEncoder
+	config.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	config.StacktraceKey = ""
+	consoleEncoder := zapcore.NewConsoleEncoder(config)
+
+	return zap.New(
+		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), zapcore.ErrorLevel),
+		zap.AddCaller(),
+		zap.AddStacktrace(zapcore.ErrorLevel),
+	)
 }

--- a/internal/testing/gouging_test.go
+++ b/internal/testing/gouging_test.go
@@ -12,8 +12,6 @@ import (
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
 	"go.sia.tech/siad/node/api/client"
 	stypes "go.sia.tech/siad/types"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"lukechampine.com/frand"
 )
 
@@ -23,7 +21,7 @@ func TestGouging(t *testing.T) {
 	}
 
 	// create a new test cluster
-	cluster, err := newTestCluster(t.TempDir(), zap.New(zapcore.NewNopCore()))
+	cluster, err := newTestCluster(t.TempDir(), newTestLogger())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/migrations_test.go
+++ b/internal/testing/migrations_test.go
@@ -9,8 +9,6 @@ import (
 
 	"go.sia.tech/core/types"
 	rhpv2 "go.sia.tech/renterd/rhp/v2"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"lukechampine.com/frand"
 )
 
@@ -20,7 +18,7 @@ func TestMigrations(t *testing.T) {
 	}
 
 	// create a new test cluster
-	cluster, err := newTestCluster(t.TempDir(), zap.New(zapcore.NewNopCore()))
+	cluster, err := newTestCluster(t.TempDir(), newTestLogger())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -970,7 +970,7 @@ func New(masterKey [32]byte, id string, b Bus, sessionReconectTimeout, sessionTT
 		masterKey:                 masterKey,
 		interactionsFlushInterval: interactionsFlushInterval,
 		uploadSectorTimeout:       uploadSectorTimeout,
-		logger:                    l.Sugar().Named(id),
+		logger:                    l.Sugar().Named("worker").Named(id),
 	}
 	w.priceTables = newPriceTables(w.withTransportV3)
 	w.accounts = newAccounts(w.id, w.deriveSubKey("accountkey"), b)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -970,7 +970,7 @@ func New(masterKey [32]byte, id string, b Bus, sessionReconectTimeout, sessionTT
 		masterKey:                 masterKey,
 		interactionsFlushInterval: interactionsFlushInterval,
 		uploadSectorTimeout:       uploadSectorTimeout,
-		logger:                    l.Sugar().Named(fmt.Sprintf("worker_%s", id)),
+		logger:                    l.Sugar().Named(id),
 	}
 	w.priceTables = newPriceTables(w.withTransportV3)
 	w.accounts = newAccounts(w.id, w.deriveSubKey("accountkey"), b)


### PR DESCRIPTION
This PR passes a custom logger to `Gorm`, a zap logger to ensure the `sql` logs are consistent with the other log output. While I was at it I added a logger to the worker and bus as well. 

It looks pretty good now, the slow sql logs are neatly in line with all other logs:
![Screenshot 2023-02-03 at 11 48 29](https://user-images.githubusercontent.com/684818/216585054-41a38a7b-4773-47e8-a4d4-9e0c177db4a4.png)

We now have full control over the logs, I made it so the default config ignores not found errors. I also made sure the loggers we use in unit tests and integration tests still show sql logs, I've even made the slow sql a little more strict there.