### PR TITLE
Fix ContractRenewalCollateral

### DIFF
--- a/rhp/v2/contracts.go
+++ b/rhp/v2/contracts.go
@@ -79,7 +79,10 @@ func ContractRenewalCost(fc types.FileContract, contractFee types.Currency) type
 // renewing a contract. It takes into account the host's max collateral setting
 // and ensures the total collateral does not exceed it.
 func ContractRenewalCollateral(fc types.FileContract, renterFunds types.Currency, host HostSettings, endHeight uint64) types.Currency {
-	extension := endHeight - fc.WindowEnd
+	if endHeight < fc.EndHeight() {
+		panic("endHeight should be at least the current end height of the contract")
+	}
+	extension := endHeight - fc.EndHeight()
 
 	// calculate cost per byte
 	costPerByte := host.UploadBandwidthPrice.Add(host.StoragePrice).Add(host.DownloadBandwidthPrice)


### PR DESCRIPTION
There's an overflow of the currency type and it's caused by an underflow in the calculation of the time extension. The function mistakenly uses `WindowEnd`, confusing it with the contract's end height, which is `WindowStart` 🤯 


```
panic: overflow [recovered]
        panic: overflow [recovered]
        panic: overflow

goroutine 88 [running]:
        /usr/local/go/src/runtime/panic.go:884 +0x212
go.sia.tech/core/types.Currency.Mul64(...)
        /go/pkg/mod/go.sia.tech/core@v0.1.1/types/currency.go:139
go.sia.tech/renterd/rhp/v2.ContractRenewalCollateral({0x267000000, {0x92, 0x2a, 0xfe, 0x4f, 0xaa, 0x50, 0x4, 0x74, 0xe0, ...}, ...}, ...)
        /renterd/rhp/v2/contracts.go:91 +0x278
go.sia.tech/renterd/autopilot.(*contractor).runContractRefreshes(0xc00099b840, {0x11773c0, 0xc0028e5650}, {{0x3e8}, {0x0, 0xc0028e4db0}, {{0xc0004470e4, 0x9}, 0x32, {0x3e25026110000000, ...}, ...}}, ...)
        /renterd/autopilot/contractor.go:580 +0x77b
go.sia.tech/renterd/autopilot.(*contractor).performContractMaintenance(0xc00099b840, {0x11773c0?, 0xc0028e4ea0?}, {{0x3e8}, {0x0, 0xc0028e4db0}, {{0xc0004470e4, 0x9}, 0x32, {0x3e25026110000000, ...}, ...}}, ...)
        /renterd/autopilot/contractor.go:152 +0xa52
go.sia.tech/renterd/autopilot.(*Autopilot).Run.func1(0xc00088f290)
        /renterd/autopilot/autopilot.go:188 +0x4d8
go.sia.tech/renterd/autopilot.(*Autopilot).Run(0xc00088f290)
```