### PR TITLE
Shutdown Timeout

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -191,7 +191,7 @@ func (ap *Autopilot) Run() error {
 			}
 
 			// migration
-			ap.m.TryPerformMigrations(ctx, cfg)
+			ap.m.tryPerformMigrations(ctx, cfg)
 		}()
 	}
 }
@@ -213,6 +213,15 @@ func (ap *Autopilot) Stop() error {
 func (ap *Autopilot) Trigger() bool {
 	select {
 	case ap.triggerChan <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (ap *Autopilot) isStopped() bool {
+	select {
+	case <-ap.stopChan:
 		return true
 	default:
 		return false

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -88,13 +88,13 @@ type Autopilot struct {
 	s *scanner
 
 	tickerDuration time.Duration
-	stopChan       chan struct{}
-	triggerChan    chan struct{}
 	wg             sync.WaitGroup
 
 	startStopMu sync.Mutex
 	running     bool
 	ticker      *time.Ticker
+	triggerChan chan struct{}
+	stopChan    chan struct{}
 }
 
 // Actions returns the autopilot actions that have occurred since the given time.
@@ -212,6 +212,9 @@ func (ap *Autopilot) Shutdown(_ context.Context) error {
 }
 
 func (ap *Autopilot) Trigger() bool {
+	ap.startStopMu.Lock()
+	defer ap.startStopMu.Unlock()
+
 	select {
 	case ap.triggerChan <- struct{}{}:
 		return true

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -196,7 +196,7 @@ func (ap *Autopilot) Run() error {
 	}
 }
 
-func (ap *Autopilot) Stop(ctx context.Context) error {
+func (ap *Autopilot) Shutdown(ctx context.Context) error {
 	doneChan := make(chan struct{})
 	go func() {
 		defer close(doneChan)

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -196,6 +196,7 @@ func (ap *Autopilot) Run() error {
 	}
 }
 
+// Shutdown shuts down the autopilot.
 func (ap *Autopilot) Shutdown(ctx context.Context) error {
 	doneChan := make(chan struct{})
 	go func() {

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -405,6 +405,10 @@ func (c *contractor) runContractFormations(ctx context.Context, cfg api.Autopilo
 	minInitialContractFunds, maxInitialContractFunds := initialContractFundingMinMax(cfg)
 
 	for h := 0; missing > 0 && h < len(candidates); h++ {
+		if c.ap.isStopped() {
+			break
+		}
+
 		host := candidates[h]
 
 		// break if the autopilot is stopped

--- a/autopilot/scanner_test.go
+++ b/autopilot/scanner_test.go
@@ -138,7 +138,7 @@ func newTestScanner(b *mockBus, w *mockWorker) *scanner {
 			trackerNumDataPoints,
 			trackerTimeoutPercentile,
 		),
-		stopChan:        make(chan struct{}),
+
 		scanBatchSize:   40,
 		scanThreads:     3,
 		scanMinInterval: time.Minute,

--- a/autopilot/scanner_test.go
+++ b/autopilot/scanner_test.go
@@ -129,7 +129,9 @@ func TestScanner(t *testing.T) {
 }
 
 func newTestScanner(b *mockBus, w *mockWorker) *scanner {
+	ap := &Autopilot{stopChan: make(chan struct{})}
 	return &scanner{
+		ap:     ap,
 		bus:    b,
 		worker: w,
 		logger: zap.New(zapcore.NewNopCore()).Sugar(),

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -912,6 +912,6 @@ func (b *bus) Handler() http.Handler {
 	}))
 }
 
-func (b *bus) Stop(ctx context.Context) error {
+func (b *bus) Shutdown(ctx context.Context) error {
 	return b.eas.SaveAccounts(ctx, b.accounts.ToPersist())
 }

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -912,6 +912,7 @@ func (b *bus) Handler() http.Handler {
 	}))
 }
 
+// Shutdown shuts down the bus.
 func (b *bus) Shutdown(ctx context.Context) error {
 	return b.eas.SaveAccounts(ctx, b.accounts.ToPersist())
 }

--- a/bus/client_test.go
+++ b/bus/client_test.go
@@ -96,7 +96,7 @@ func newTestClient(dir string) (*bus.Client, func() error, func(context.Context)
 
 	shutdownFn := func(ctx context.Context) error {
 		server.Shutdown(ctx)
-		return cleanup()
+		return cleanup(ctx)
 	}
 	return client, serveFn, shutdownFn, nil
 }

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -333,6 +333,8 @@ func main() {
 
 	// Execute all shutdown functions
 	for shutdowns.Len() > 0 {
-		heap.Pop(shutdowns).(*shutdownEntry).fn(context.Background())
+		if err := heap.Pop(shutdowns).(*shutdownEntry).fn(context.Background()); err != nil {
+			log.Println("Error during shutdown:", err)
+		}
 	}
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1025,7 +1025,7 @@ func (w *worker) Handler() http.Handler {
 	}))
 }
 
-// Shutdown stops the worker.
+// Shutdown shuts down the worker.
 func (w *worker) Shutdown(_ context.Context) error {
 	w.interactionsMu.Lock()
 	if w.interactionsFlushTimer != nil {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1025,9 +1025,8 @@ func (w *worker) Handler() http.Handler {
 	}))
 }
 
-// Stop stops the worker.
-func (w *worker) Stop(_ context.Context) error {
-	// Flush interactions on cleanup.
+// Shutdown stops the worker.
+func (w *worker) Shutdown(_ context.Context) error {
 	w.interactionsMu.Lock()
 	if w.interactionsFlushTimer != nil {
 		w.interactionsFlushTimer.Stop()


### PR DESCRIPTION
This PR improves server shutdowns. It unifies all "cleanup functions" into a function that takes a context and returns an error. I added `node.shutdownTimeout` to the command line options and default it to 5 minutes. I added a small max heap for all of the shutdown functions to allow us to control the order with which our components shut down.

edit: last commit disables the connection pool, I was running into an NDF in the test suite and since we have been running into the `database is locked` issue even after our `WAL` mode and all other SQL related fixes it is time to try and disable the connection pool to see if it gets rid of the database locks (?)