### PR TITLE
Fix Slow SQL 

### DIFF
--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -75,6 +75,6 @@ func (m *migrator) performMigrations(cfg api.AutopilotConfig) {
 			m.logger.Errorf("failed to migrate slab %d/%d, err: %v", i+1, len(toMigrate), err)
 			continue
 		}
-		m.logger.Debugf("successfully migrated slab %d/%d", i+1, len(toMigrate))
+		m.logger.Debugf("successfully migrated slab '%v' %d/%d", slab.Key, i+1, len(toMigrate))
 	}
 }

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -248,14 +248,12 @@ func (e *dbBlocklistEntry) AfterCreate(tx *gorm.DB) (err error) {
 		"like_entry":  fmt.Sprintf("%%.%s", e.Entry),
 	}
 
-	err = tx.Exec(`
-	INSERT OR IGNORE INTO host_blocklist_entry_hosts (db_blocklist_entry_id, db_host_id)
-	SELECT @entry_id, id FROM (
-		SELECT id, rtrim(rtrim(net_address, replace(net_address, ':', '')),':') as net_host
-		FROM hosts
-		WHERE net_host == @exact_entry OR net_host LIKE @like_entry
-	)
-	`, params).Error
+	err = tx.Exec(`INSERT OR IGNORE INTO host_blocklist_entry_hosts (db_blocklist_entry_id, db_host_id)
+SELECT @entry_id, id FROM (
+	SELECT id, rtrim(rtrim(net_address, replace(net_address, ':', '')),':') as net_host
+	FROM hosts
+	WHERE net_host == @exact_entry OR net_host LIKE @like_entry
+)`, params).Error
 	return
 }
 

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -69,13 +69,6 @@ func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duratio
 		return nil, modules.ConsensusChangeID{}, err
 	}
 
-	// Disable connection pool.
-	sql, err := db.DB()
-	if err != nil {
-		return nil, modules.ConsensusChangeID{}, err
-	}
-	sql.SetMaxOpenConns(1)
-
 	if migrate {
 		// Create the tables.
 		tables := []interface{}{

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -101,6 +101,11 @@ func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duratio
 		}
 	}
 
+	// Ensure the join table has an index on `db_host_id`.
+	if err := db.Exec("CREATE INDEX IF NOT EXISTS `idx_host_blocklist_entry_hosts` ON `host_blocklist_entry_hosts`(`db_host_id`)").Error; err != nil {
+		return nil, modules.ConsensusChangeID{}, err
+	}
+
 	// Get latest consensus change ID or init db.
 	var ci dbConsensusInfo
 	err = db.Where(&dbConsensusInfo{Model: Model{ID: consensusInfoID}}).

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -68,6 +68,14 @@ func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duratio
 	if err != nil {
 		return nil, modules.ConsensusChangeID{}, err
 	}
+
+	// Disable connection pool.
+	sql, err := db.DB()
+	if err != nil {
+		return nil, modules.ConsensusChangeID{}, err
+	}
+	sql.SetMaxOpenConns(1)
+
 	if migrate {
 		// Create the tables.
 		tables := []interface{}{

--- a/object/object.go
+++ b/object/object.go
@@ -16,6 +16,15 @@ type EncryptionKey struct {
 	entropy *[32]byte
 }
 
+// String implements fmt.Stringer.
+func (k EncryptionKey) String() string {
+	b, err := k.MarshalText()
+	if err != nil {
+		panic("failed to marshal key")
+	}
+	return string(b)
+}
+
 // MarshalText implements the encoding.TextMarshaler interface.
 func (k EncryptionKey) MarshalText() ([]byte, error) {
 	return []byte("key:" + hex.EncodeToString(k.entropy[:])), nil

--- a/object/object.go
+++ b/object/object.go
@@ -18,16 +18,12 @@ type EncryptionKey struct {
 
 // String implements fmt.Stringer.
 func (k EncryptionKey) String() string {
-	b, err := k.MarshalText()
-	if err != nil {
-		panic("failed to marshal key")
-	}
-	return string(b)
+	return "key:" + hex.EncodeToString(k.entropy[:])
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.
 func (k EncryptionKey) MarshalText() ([]byte, error) {
-	return []byte("key:" + hex.EncodeToString(k.entropy[:])), nil
+	return []byte(k.String()), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.


### PR DESCRIPTION
There's a `SLOW SQL` mention that's been bothering me for a while, so I decided to investigate it and found out there's a missing index on a join table. There's a combined `PRIMARY` index and two foreign key constraints but there's no index on `db_host_id`, which we use in the blocklist:

``` 
"SELECT `hosts`.`public_key`,`hosts`.`net_address` FROM `hosts` WHERE last_scan < 1675589085000000000 AND NOT EXISTS (SELECT 1 FROM host_blocklist_entry_hosts hbeh WHERE hbeh.db_host_id = hosts.id) ORDER BY last_scan ASC,`hosts`.`id` LIMIT 1000 OFFSET 5000"
```

Query plan before and after the index is added
```
QUERY PLAN
|--SEARCH TABLE hosts USING INDEX idx_hosts_last_scan (last_scan<?)
`--CORRELATED SCALAR SUBQUERY 1
   `--SCAN TABLE host_blocklist_entry_hosts AS hbeh
```
   
```
QUERY PLAN
|--SEARCH TABLE hosts USING INDEX idx_hosts_last_scan (last_scan<?)
`--CORRELATED SCALAR SUBQUERY 1
   `--SEARCH TABLE host_blocklist_entry_hosts AS hbeh USING COVERING INDEX idx_host_blocklist_entry_hosts (db_host_id=?)
```
   
 Didn't really measure execution time but it goes from >100s (!) to not being caught by the SLOW SQL monitoring which has its threshold at 200ms.
 
 edit: last commit disables the connection pool, I was running into an NDF in the test suite and since we have been running into the database is locked issue even after our WAL mode and all other SQL related fixes it is time to try and disable the connection pool to see if it gets rid of the database locks (?)