### PR TITLE
Move finding slab in UpdateSlab out of transaction

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -969,7 +969,7 @@ func (w *worker) rhpActiveContractsHandlerGET(jc jape.Context) {
 			}()
 		}
 		if len(errs) > 0 {
-			return fmt.Errorf("couldn't retrieve contract(s): %w", err)
+			return fmt.Errorf("couldn't retrieve contract(s): %s", errs.Error())
 		}
 		return nil
 	})


### PR DESCRIPTION
To further reduce the number of `database is locked` errors this PR moves reading the slab out of the transaction in `UpdateSlab`.

That shouldn't harm consistency since the update will fail if the slab is deleted between looking it up and applying the transaction. 