### PR TITLE
Improve locking in rhpRenewHandler

### DIFF
--- a/worker/sessionpool.go
+++ b/worker/sessionpool.go
@@ -88,6 +88,15 @@ func (ss *sharedSession) PublicKey() types.PublicKey {
 	return ss.hostKey
 }
 
+func (ss *sharedSession) RenewContract(ctx context.Context, txnSet []types.Transaction, finalPayment types.Currency) (_ rhpv2.ContractRevision, _ []types.Transaction, err error) {
+	s, err := ss.pool.acquire(ctx, ss)
+	if err != nil {
+		return rhpv2.ContractRevision{}, nil, err
+	}
+	defer ss.pool.release(s)
+	return s.RenewContract(txnSet, finalPayment)
+}
+
 func (ss *sharedSession) Revision(ctx context.Context) (rhpv2.ContractRevision, error) {
 	s, err := ss.pool.acquire(ctx, ss)
 	if err != nil {
@@ -95,6 +104,15 @@ func (ss *sharedSession) Revision(ctx context.Context) (rhpv2.ContractRevision, 
 	}
 	defer ss.pool.release(s)
 	return s.Revision(), nil
+}
+
+func (ss *sharedSession) Settings(ctx context.Context) (rhpv2.HostSettings, error) {
+	s, err := ss.pool.acquire(ctx, ss)
+	if err != nil {
+		return rhpv2.HostSettings{}, err
+	}
+	defer ss.pool.release(s)
+	return s.Settings(), nil
 }
 
 func (ss *sharedSession) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte) (types.Hash256, error) {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -546,7 +546,7 @@ func (w *worker) rhpRenewHandler(jc jape.Context) {
 			if err != nil {
 				return nil, types.Currency{}, nil, err
 			}
-			return txnSet, finalPayment, func() { w.bus.WalletDiscard(ctx, renterTxnSet[len(renterTxnSet)-1]) }, nil
+			return renterTxnSet, finalPayment, func() { w.bus.WalletDiscard(ctx, renterTxnSet[len(renterTxnSet)-1]) }, nil
 		})
 		return nil
 	})


### PR DESCRIPTION
This PR changes the renew endpoint to also make use of the session pool instead of creating a separate transport and manually creating a locked session by calling `withHost`.
