### PR TITLE
Improve host scoring by including MaxCollateral and RemainingStorage

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -36,6 +36,7 @@ type (
 	HostsConfig struct {
 		IgnoreRedundantIPs bool                        `json:"ignoreRedundantIPs"`
 		MaxDowntimeHours   uint64                      `json:"maxDowntimeHours"`
+		MinMaxCollateral   types.Currency              `json:"minMaxCollateral"`
 		ScoreOverrides     map[types.PublicKey]float64 `json:"scoreOverrides"`
 	}
 

--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -36,7 +36,6 @@ type (
 	HostsConfig struct {
 		IgnoreRedundantIPs bool                        `json:"ignoreRedundantIPs"`
 		MaxDowntimeHours   uint64                      `json:"maxDowntimeHours"`
-		MinMaxCollateral   types.Currency              `json:"minMaxCollateral"`
 		ScoreOverrides     map[types.PublicKey]float64 `json:"scoreOverrides"`
 	}
 

--- a/api/bus.go
+++ b/api/bus.go
@@ -197,6 +197,12 @@ type RedundancySettings struct {
 	TotalShards int
 }
 
+// Redundancy returns the effective storage redundancy of the
+// RedundancySettings.
+func (rs RedundancySettings) Redundancy() float64 {
+	return float64(rs.TotalShards) / float64(rs.MinShards)
+}
+
 // Validate returns an error if the redundancy settings are not considered
 // valid.
 func (rs RedundancySettings) Validate() error {

--- a/api/bus.go
+++ b/api/bus.go
@@ -183,6 +183,7 @@ type GougingParams struct {
 
 // GougingSettings contain some price settings used in price gouging.
 type GougingSettings struct {
+	MinMaxCollateral types.Currency
 	MaxRPCPrice      types.Currency
 	MaxContractPrice types.Currency
 	MaxDownloadPrice types.Currency // per TiB

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -676,7 +676,7 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 			continue
 		}
 
-		score := hostScore(cfg, h)
+		score := hostScore(cfg, h, 0, float64(rs.TotalShards)/float64(rs.MinShards))
 		if score == 0 {
 			c.logger.DPanicw("sanity check failed", "score", score, "hk", h.PublicKey)
 			continue

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -678,7 +678,6 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 
 		score := hostScore(cfg, h, 0, float64(rs.TotalShards)/float64(rs.MinShards))
 		if score == 0 {
-			c.logger.DPanicw("sanity check failed", "score", score, "hk", h.PublicKey)
 			continue
 		}
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -117,8 +117,21 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 		return err
 	}
 
+	// compile map of stored data per host
+	storedData := make(map[types.PublicKey]uint64)
+	for _, c := range active {
+		storedData[c.HostKey()] += c.FileSize()
+	}
+
+	// min score to pass checks.
+	redundancy := rs.TotalShards / rs.MinShards
+	minScore, err := c.managedFindMinAllowedHostScores(ctx, cfg, storedData, float64(redundancy))
+	if err != nil {
+		return fmt.Errorf("failed to determine min score for contract check: %w", err)
+	}
+
 	// run checks
-	toDelete, toIgnore, toRefresh, toRenew, err := c.runContractChecks(ctx, cfg, cs.BlockHeight, gs, rs, active)
+	toDelete, toIgnore, toRefresh, toRenew, err := c.runContractChecks(ctx, cfg, cs.BlockHeight, gs, rs, active, minScore)
 	if err != nil {
 		return fmt.Errorf("failed to run contract checks, err: %v", err)
 	}
@@ -156,7 +169,7 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 	// check if we need to form contracts and add them to the contract set
 	var formed []types.FileContractID
 	if numContracts < addLeeway(cfg.Contracts.Amount, leewayPctRequiredContracts) {
-		if formed, err = c.runContractFormations(ctx, cfg, active, cfg.Contracts.Amount-numContracts, cs.BlockHeight, &remaining, address); err != nil {
+		if formed, err = c.runContractFormations(ctx, cfg, active, cfg.Contracts.Amount-numContracts, cs.BlockHeight, &remaining, address, minScore); err != nil {
 			c.logger.Errorf("failed to form contracts, err: %v", err) // continue
 		}
 	}
@@ -247,7 +260,7 @@ func (c *contractor) performWalletMaintenance(ctx context.Context, cfg api.Autop
 	return nil
 }
 
-func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotConfig, blockHeight uint64, gs api.GougingSettings, rs api.RedundancySettings, contracts []api.Contract) (toDelete, toIgnore []types.FileContractID, toRefresh, toRenew []contractInfo, _ error) {
+func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotConfig, blockHeight uint64, gs api.GougingSettings, rs api.RedundancySettings, contracts []api.Contract, minScore float64) (toDelete, toIgnore []types.FileContractID, toRefresh, toRenew []contractInfo, _ error) {
 	if c.ap.isStopped() {
 		return
 	}
@@ -290,7 +303,7 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 		}
 
 		// decide whether the host is still good
-		usable, reasons := isUsableHost(cfg, gs, rs, f, host)
+		usable, reasons := isUsableHost(cfg, gs, rs, f, host, minScore, contract.FileSize())
 		if !usable {
 			c.logger.Infow("unusable host", "hk", hk, "fcid", fcid, "reasons", errStr(joinErrors(reasons)))
 			toIgnore = append(toIgnore, fcid)
@@ -364,7 +377,7 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 	return toDelete, toIgnore, toRefresh, toRenew, nil
 }
 
-func (c *contractor) runContractFormations(ctx context.Context, cfg api.AutopilotConfig, active []api.Contract, missing, blockHeight uint64, budget *types.Currency, renterAddress types.Address) ([]types.FileContractID, error) {
+func (c *contractor) runContractFormations(ctx context.Context, cfg api.AutopilotConfig, active []api.Contract, missing, blockHeight uint64, budget *types.Currency, renterAddress types.Address, minScore float64) ([]types.FileContractID, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "runContractFormations")
 	defer span.End()
 
@@ -389,9 +402,9 @@ func (c *contractor) runContractFormations(ctx context.Context, cfg api.Autopilo
 	}()
 
 	// create a map of used hosts
-	used := make(map[types.PublicKey]bool)
+	used := make(map[types.PublicKey]struct{})
 	for _, contract := range active {
-		used[contract.HostKey()] = true
+		used[contract.HostKey()] = struct{}{}
 	}
 
 	// fetch recommended txn fee
@@ -402,7 +415,7 @@ func (c *contractor) runContractFormations(ctx context.Context, cfg api.Autopilo
 
 	// fetch candidate hosts
 	wanted := int(addLeeway(missing, leewayPctCandidateHosts))
-	candidates, err := c.candidateHosts(ctx, cfg, used, wanted)
+	candidates, err := c.candidateHosts(ctx, cfg, used, make(map[types.PublicKey]uint64), wanted, minScore)
 	if err != nil {
 		return nil, err
 	}
@@ -633,7 +646,34 @@ func (c *contractor) renewFundingEstimate(ctx context.Context, cfg api.Autopilot
 	return cappedEstimatedCost, nil
 }
 
-func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig, used map[types.PublicKey]bool, wanted int) ([]hostdb.Host, error) {
+func (c *contractor) managedFindMinAllowedHostScores(ctx context.Context, cfg api.AutopilotConfig, storedData map[types.PublicKey]uint64, redundancy float64) (float64, error) {
+	// Pull a new set of hosts from the hostdb that could be used as a new set
+	// to match the allowance. The lowest scoring host of these new hosts will
+	// be used as a baseline for determining whether our existing contracts are
+	// worthwhile.
+	numContracts := cfg.Contracts.Amount
+	buffer := 50
+	hosts, err := c.candidateHosts(ctx, cfg, make(map[types.PublicKey]struct{}), storedData, int(numContracts)+int(buffer), 1) // 1 to avoid 0 score hosts
+	if err != nil {
+		return 0, err
+	}
+	if len(hosts) == 0 {
+		return 0, errors.New("no hosts returned in candidateHosts")
+	}
+
+	// Find the minimum score that a host is allowed to have to be considered
+	// good for upload.
+	lowestScore := hostScore(cfg, hosts[0], 0, redundancy)
+	for i := 1; i < len(hosts); i++ {
+		score := hostScore(cfg, hosts[i], 0, redundancy)
+		if score < lowestScore {
+			lowestScore = score
+		}
+	}
+	return lowestScore / 500, nil
+}
+
+func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig, exclude map[types.PublicKey]struct{}, storedData map[types.PublicKey]uint64, wanted int, minScore float64) ([]hostdb.Host, error) {
 	c.logger.Debugf("looking for %d candidate hosts", wanted)
 
 	// nothing to do
@@ -662,17 +702,17 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 		return nil, err
 	}
 
-	c.logger.Debugf("found %d candidate hosts", len(hosts)-len(used))
+	c.logger.Debugf("found %d candidate hosts", len(hosts)-len(exclude))
 
 	// collect scores for all usable hosts
 	start := time.Now()
 	scores := make([]float64, 0, len(hosts))
 	scored := make([]hostdb.Host, 0, len(hosts))
 	for _, h := range hosts {
-		if used[h.PublicKey] {
+		if _, exclude := exclude[h.PublicKey]; exclude {
 			continue
 		}
-		if usable, _ := isUsableHost(cfg, gs, rs, ipFilter, h); !usable {
+		if usable, _ := isUsableHost(cfg, gs, rs, ipFilter, h, minScore, storedData[h.PublicKey]); !usable {
 			continue
 		}
 
@@ -685,7 +725,7 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 		scores = append(scores, score)
 	}
 
-	c.logger.Debugf("scored %d candidate hosts, took %v", len(hosts)-len(used), time.Since(start))
+	c.logger.Debugf("scored %d candidate hosts, took %v", len(hosts)-len(exclude), time.Since(start))
 
 	// select hosts
 	var selected []hostdb.Host

--- a/autopilot/host_test.go
+++ b/autopilot/host_test.go
@@ -70,8 +70,10 @@ func newTestHost(hk types.PublicKey, settings *rhpv2.HostSettings) hostdb.Host {
 func newTestHostSettings() *rhpv2.HostSettings {
 	return &rhpv2.HostSettings{
 		AcceptingContracts: true,
+		MaxCollateral:      types.Siacoins(10000),
 		MaxDuration:        144 * 7 * 12, // 12w
 		Version:            "1.5.10",
+		RemainingStorage:   1 << 42, // 4 TiB
 	}
 }
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -160,5 +160,11 @@ func hasBadSettings(cfg api.AutopilotConfig, h hostdb.Host) (rhpv2.HostSettings,
 	if settings.SectorAccessPrice.Cmp(maxSectorAccessPrice) > 0 {
 		return *settings, true, fmt.Sprintf("sector access price too high, %v > %v", settings.BaseRPCPrice, maxBaseRPCPrice)
 	}
+	if settings.MaxCollateral.IsZero() {
+		return *settings, true, "max collateral of host is 0"
+	}
+	if settings.MaxCollateral.Cmp(cfg.Hosts.MinMaxCollateral) < 0 {
+		return *settings, true, fmt.Sprintf("max collateral of host is below the minimum: %v < %v", settings.MaxCollateral, cfg.Hosts.MinMaxCollateral)
+	}
 	return *settings, false, ""
 }

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -57,7 +57,7 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostBadSettings, reason))
 	} else if gouging, reason := isGouging(gs, rs, settings); gouging {
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostPriceGouging, reason))
-	} else if score := hostScore(cfg, h, storedData, float64(rs.TotalShards)/float64(rs.MinShards)); score < minScore {
+	} else if score := hostScore(cfg, h, storedData, rs.Redundancy()); score < minScore {
 		reasons = append(reasons, fmt.Errorf("%w: %v < %v", errLowScore, score, minScore))
 	}
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -50,9 +50,6 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 	if !h.IsOnline() {
 		reasons = append(reasons, errHostOffline)
 	}
-	if hostScore(cfg, h, storedData, float64(rs.TotalShards)/float64(rs.MinShards)) < minScore {
-		reasons = append(reasons, errLowScore)
-	}
 	if !cfg.Hosts.IgnoreRedundantIPs && f.isRedundantIP(h) {
 		reasons = append(reasons, errHostRedundantIP)
 	}
@@ -60,6 +57,8 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostBadSettings, reason))
 	} else if gouging, reason := isGouging(gs, rs, settings); gouging {
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostPriceGouging, reason))
+	} else if hostScore(cfg, h, storedData, float64(rs.TotalShards)/float64(rs.MinShards)) < minScore {
+		reasons = append(reasons, errLowScore)
 	}
 
 	// sanity check - should never happen but this would cause a zero score

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -160,11 +160,5 @@ func hasBadSettings(cfg api.AutopilotConfig, h hostdb.Host) (rhpv2.HostSettings,
 	if settings.SectorAccessPrice.Cmp(maxSectorAccessPrice) > 0 {
 		return *settings, true, fmt.Sprintf("sector access price too high, %v > %v", settings.BaseRPCPrice, maxBaseRPCPrice)
 	}
-	if settings.MaxCollateral.IsZero() {
-		return *settings, true, "max collateral of host is 0"
-	}
-	if settings.MaxCollateral.Cmp(cfg.Hosts.MinMaxCollateral) < 0 {
-		return *settings, true, fmt.Sprintf("max collateral of host is below the minimum: %v < %v", settings.MaxCollateral, cfg.Hosts.MinMaxCollateral)
-	}
 	return *settings, false, ""
 }

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -57,8 +57,8 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostBadSettings, reason))
 	} else if gouging, reason := isGouging(gs, rs, settings); gouging {
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostPriceGouging, reason))
-	} else if hostScore(cfg, h, storedData, float64(rs.TotalShards)/float64(rs.MinShards)) < minScore {
-		reasons = append(reasons, errLowScore)
+	} else if score := hostScore(cfg, h, storedData, float64(rs.TotalShards)/float64(rs.MinShards)); score < minScore {
+		reasons = append(reasons, fmt.Errorf("%w: %v < %v", errLowScore, score, minScore))
 	}
 
 	// sanity check - should never happen but this would cause a zero score

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -34,7 +34,7 @@ func hostScore(cfg api.AutopilotConfig, h hostdb.Host, storedData uint64, expect
 	return ageScore(h) *
 		collateralScore(cfg, *h.Settings, expectedRedundancy) *
 		interactionScore(h) *
-		storageRemainingScore(cfg, *h.Settings, 0, 3) *
+		storageRemainingScore(cfg, *h.Settings, storedData, expectedRedundancy) *
 		uptimeScore(h) *
 		versionScore(*h.Settings)
 }

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -104,8 +104,8 @@ func ageScore(h hostdb.Host) float64 {
 }
 
 func collateralScore(cfg api.AutopilotConfig, s rhpv2.HostSettings, expectedRedundancy float64) float64 {
-	// Ignore hosts which have set their max collateral too low.
-	if s.MaxCollateral.IsZero() || s.MaxCollateral.Cmp(cfg.Hosts.MinMaxCollateral) < 0 {
+	// Ignore hosts which have set their max collateral to 0.
+	if s.MaxCollateral.IsZero() {
 		return 0
 	}
 

--- a/autopilot/hostscore_test.go
+++ b/autopilot/hostscore_test.go
@@ -21,13 +21,14 @@ func TestHostScore(t *testing.T) {
 	h2 := newHost(newTestHostSettings())
 
 	// assert both hosts score equal
-	if hostScore(cfg, h1) != hostScore(cfg, h2) {
+	redundancy := 3.0
+	if hostScore(cfg, h1, 0, redundancy) != hostScore(cfg, h2, 0, redundancy) {
 		t.Fatal("unexpected")
 	}
 
 	// assert age affects the score
 	h1.KnownSince = time.Now().Add(-1 * day)
-	if hostScore(cfg, h1) <= hostScore(cfg, h2) {
+	if hostScore(cfg, h1, 0, redundancy) <= hostScore(cfg, h2, 0, redundancy) {
 		t.Fatal("unexpected")
 	}
 
@@ -36,21 +37,21 @@ func TestHostScore(t *testing.T) {
 	settings.Collateral = types.NewCurrency64(1)
 	settings.MaxCollateral = types.NewCurrency64(10)
 	h1 = newHost(settings) // reset
-	if hostScore(cfg, h1) <= hostScore(cfg, h2) {
+	if hostScore(cfg, h1, 0, redundancy) <= hostScore(cfg, h2, 0, redundancy) {
 		t.Fatal("unexpected")
 	}
 
 	// assert interactions affect the score
 	h1 = newHost(newTestHostSettings()) // reset
 	h1.Interactions.SuccessfulInteractions++
-	if hostScore(cfg, h1) <= hostScore(cfg, h2) {
+	if hostScore(cfg, h1, 0, redundancy) <= hostScore(cfg, h2, 0, redundancy) {
 		t.Fatal("unexpected")
 	}
 
 	// assert uptime affects the score
 	h2 = newHost(newTestHostSettings()) // reset
 	h2.Interactions.SecondToLastScanSuccess = false
-	if hostScore(cfg, h1) <= hostScore(cfg, h2) || ageScore(h1) != ageScore(h2) {
+	if hostScore(cfg, h1, 0, redundancy) <= hostScore(cfg, h2, 0, redundancy) || ageScore(h1) != ageScore(h2) {
 		t.Fatal("unexpected")
 	}
 
@@ -58,7 +59,27 @@ func TestHostScore(t *testing.T) {
 	h2Settings := newTestHostSettings()
 	h2Settings.Version = "1.5.6" // lower
 	h2 = newHost(h2Settings)     // reset
-	if hostScore(cfg, h1) <= hostScore(cfg, h2) {
+	if hostScore(cfg, h1, 0, redundancy) <= hostScore(cfg, h2, 0, redundancy) {
+		t.Fatal("unexpected")
+	}
+
+	// asseret remaining storage affects the score.
+	h1 = newHost(newTestHostSettings()) // reset
+	h2.Settings.RemainingStorage = 100
+	if hostScore(cfg, h1, 0, redundancy) <= hostScore(cfg, h2, 0, redundancy) {
+		t.Fatal("unexpected")
+	}
+
+	// assert MaxCollateral affects the score.
+	h2 = newHost(newTestHostSettings()) // reset
+	h2.Settings.MaxCollateral = types.ZeroCurrency
+	if hostScore(cfg, h1, 0, redundancy) <= hostScore(cfg, h2, 0, redundancy) {
+		t.Fatal("unexpected")
+	}
+	h2 = newHost(newTestHostSettings()) // reset
+	h1.Settings.MaxCollateral = newTestHostSettings().MaxCollateral.Mul64(2)
+	cfg.Hosts.MinMaxCollateral = newTestHostSettings().MaxCollateral.Mul64(2)
+	if hostScore(cfg, h1, 0, redundancy) <= hostScore(cfg, h2, 0, redundancy) {
 		t.Fatal("unexpected")
 	}
 }

--- a/autopilot/hostscore_test.go
+++ b/autopilot/hostscore_test.go
@@ -76,12 +76,6 @@ func TestHostScore(t *testing.T) {
 	if hostScore(cfg, h1, 0, redundancy) <= hostScore(cfg, h2, 0, redundancy) {
 		t.Fatal("unexpected")
 	}
-	h2 = newHost(newTestHostSettings()) // reset
-	h1.Settings.MaxCollateral = newTestHostSettings().MaxCollateral.Mul64(2)
-	cfg.Hosts.MinMaxCollateral = newTestHostSettings().MaxCollateral.Mul64(2)
-	if hostScore(cfg, h1, 0, redundancy) <= hostScore(cfg, h2, 0, redundancy) {
-		t.Fatal("unexpected")
-	}
 }
 
 func TestRandSelectByWeight(t *testing.T) {

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -61,6 +61,7 @@ var (
 	}
 
 	defaultGouging = api.GougingSettings{
+		MinMaxCollateral: types.ZeroCurrency,
 		MaxRPCPrice:      types.Siacoins(1),
 		MaxContractPrice: types.Siacoins(1),
 		MaxDownloadPrice: types.Siacoins(1).Mul64(2500),

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -137,6 +138,13 @@ func checkFormContractGouging(gs api.GougingSettings, hs rhpv2.HostSettings) err
 		return fmt.Errorf("contract price exceeds max: %v>%v", hs.ContractPrice, gs.MaxContractPrice)
 	}
 
+	// check MaxCollateral
+	if hs.MaxCollateral.IsZero() {
+		return errors.New("MaxCollateral of host is 0")
+	}
+	if hs.MaxCollateral.Cmp(gs.MinMaxCollateral) < 0 {
+		return fmt.Errorf("MaxCollateral is below minimum: %v<%v", hs.MaxCollateral, gs.MinMaxCollateral)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This PR adds gouging checks for `MaxCollateral`, adds a score adjustment mechanism for remaining storage on hosts and extends the contract maintenance with a score check against a minimal score threshold.

That way we should be a lot less likely to select hosts with insufficient storage for contract formation and we will be able to avoid hosts which are not willing to put a minimum amount of collateral into contracts.