### PR TITLE
Allowlist

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -9,6 +9,15 @@ import (
 	"go.sia.tech/renterd/object"
 )
 
+var (
+	// ErrHostNotFound is returned if the requested host is not found.
+	ErrHostNotFound = errors.New("host doesn't exist in hostdb")
+
+	// ErrSettingNotFound is returned if a requested setting is not present in the
+	// database.
+	ErrSettingNotFound = errors.New("setting not found")
+)
+
 // ConsensusState holds the current blockheight and whether we are synced or not.
 type ConsensusState struct {
 	BlockHeight uint64
@@ -223,7 +232,3 @@ func (rs RedundancySettings) Validate() error {
 	}
 	return nil
 }
-
-// ErrSettingNotFound is returned if a requested setting is not present in the
-// database.
-var ErrSettingNotFound = errors.New("setting not found")

--- a/api/bus.go
+++ b/api/bus.go
@@ -10,9 +10,6 @@ import (
 )
 
 var (
-	// ErrHostNotFound is returned if the requested host is not found.
-	ErrHostNotFound = errors.New("host doesn't exist in hostdb")
-
 	// ErrSettingNotFound is returned if a requested setting is not present in the
 	// database.
 	ErrSettingNotFound = errors.New("setting not found")

--- a/api/bus.go
+++ b/api/bus.go
@@ -139,6 +139,12 @@ type UpdateSlabRequest struct {
 	UsedContracts map[types.PublicKey]types.FileContractID `json:"usedContracts"`
 }
 
+// UpdateAllowlistRequest is the request type for /hosts/allowlist endpoint.
+type UpdateAllowlistRequest struct {
+	Add    []types.PublicKey `json:"add"`
+	Remove []types.PublicKey `json:"remove"`
+}
+
 // UpdateBlocklistRequest is the request type for /hosts/blocklist endpoint.
 type UpdateBlocklistRequest struct {
 	Add    []string `json:"add"`

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -39,7 +39,7 @@ type Bus interface {
 	WalletSign(ctx context.Context, txn *types.Transaction, toSign []types.Hash256, cf types.CoveredFields) error
 
 	// hostdb
-	Host(ctx context.Context, hostKey types.PublicKey) (hostdb.Host, error)
+	Host(ctx context.Context, hostKey types.PublicKey) (hostdb.HostInfo, error)
 	Hosts(ctx context.Context, offset, limit int) ([]hostdb.Host, error)
 	HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) ([]hostdb.HostAddress, error)
 	RecordInteractions(ctx context.Context, interactions []hostdb.Interaction) error

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -137,8 +137,7 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 	// min score to pass checks.
 	var minScore float64
 	if len(hosts) > 0 {
-		redundancy := rs.TotalShards / rs.MinShards
-		minScore, err = c.managedFindMinAllowedHostScores(ctx, cfg, hosts, storedData, float64(redundancy))
+		minScore, err = c.managedFindMinAllowedHostScores(ctx, cfg, hosts, storedData, rs.Redundancy())
 		if err != nil {
 			return fmt.Errorf("failed to determine min score for contract check: %w", err)
 		}
@@ -318,6 +317,7 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 
 		// if the host is blocked we ignore it, it might be unblocked later
 		if host.Blocked {
+			c.logger.Infow("blocked host", "hk", hk, "fcid", fcid, "reasons", errHostBlocked.Error())
 			toIgnore = append(toIgnore, fcid)
 			continue
 		}
@@ -678,7 +678,7 @@ func (c *contractor) managedFindMinAllowedHostScores(ctx context.Context, cfg ap
 		return 0, err
 	}
 	if len(hosts) == 0 {
-		c.logger.Debug("min host score is 0 because there are no candidate hosts")
+		c.logger.Warn("min host score is 0 because there are no candidate hosts")
 		return 0, nil
 	}
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -135,10 +135,13 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 	}
 
 	// min score to pass checks.
-	redundancy := rs.TotalShards / rs.MinShards
-	minScore, err := c.managedFindMinAllowedHostScores(ctx, cfg, hosts, storedData, float64(redundancy))
-	if err != nil {
-		return fmt.Errorf("failed to determine min score for contract check: %w", err)
+	var minScore float64
+	if len(hosts) > 0 {
+		redundancy := rs.TotalShards / rs.MinShards
+		minScore, err = c.managedFindMinAllowedHostScores(ctx, cfg, hosts, storedData, float64(redundancy))
+		if err != nil {
+			return fmt.Errorf("failed to determine min score for contract check: %w", err)
+		}
 	}
 
 	// run checks
@@ -313,8 +316,14 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 			continue
 		}
 
+		// if the host is blocked we ignore it, it might be unblocked later
+		if host.Blocked {
+			toIgnore = append(toIgnore, fcid)
+			continue
+		}
+
 		// decide whether the host is still good
-		usable, reasons := isUsableHost(cfg, gs, rs, f, host, minScore, contract.FileSize())
+		usable, reasons := isUsableHost(cfg, gs, rs, f, host.Host, minScore, contract.FileSize())
 		if !usable {
 			c.logger.Infow("unusable host", "hk", hk, "fcid", fcid, "reasons", errStr(joinErrors(reasons)))
 			toIgnore = append(toIgnore, fcid)
@@ -669,7 +678,8 @@ func (c *contractor) managedFindMinAllowedHostScores(ctx context.Context, cfg ap
 		return 0, err
 	}
 	if len(hosts) == 0 {
-		return 0, errors.New("no hosts returned in candidateHosts")
+		c.logger.Debug("min host score is 0 because there are no candidate hosts")
+		return 0, nil
 	}
 
 	// Find the minimum score that a host is allowed to have to be considered

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -680,7 +680,7 @@ func (c *contractor) managedFindMinAllowedHostScores(ctx context.Context, cfg ap
 		return 0, err
 	}
 	if len(hosts) == 0 {
-		c.logger.Warn("min host score is 0 because there are no candidate hosts")
+		c.logger.Warn("min host score is set to the smallest non-zero float because there are no candidate hosts")
 		return math.SmallestNonzeroFloat64, nil
 	}
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -141,6 +141,8 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 		if err != nil {
 			return fmt.Errorf("failed to determine min score for contract check: %w", err)
 		}
+	} else {
+		c.logger.Warn("could not calculate min score, no hosts found")
 	}
 
 	// run checks
@@ -679,7 +681,7 @@ func (c *contractor) managedFindMinAllowedHostScores(ctx context.Context, cfg ap
 	}
 	if len(hosts) == 0 {
 		c.logger.Warn("min host score is 0 because there are no candidate hosts")
-		return 0, nil
+		return math.SmallestNonzeroFloat64, nil
 	}
 
 	// Find the minimum score that a host is allowed to have to be considered

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -28,6 +28,7 @@ const (
 )
 
 var (
+	errHostBlocked      = errors.New("host is blocked")
 	errHostOffline      = errors.New("host is offline")
 	errLowScore         = errors.New("host's score is below minimum")
 	errHostRedundantIP  = errors.New("host has redundant IP")

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -74,12 +74,9 @@ type (
 		RemoveOfflineHosts(ctx context.Context, minRecentScanFailures uint64, maxDowntime time.Duration) (uint64, error)
 
 		HostAllowlist(ctx context.Context) ([]types.PublicKey, error)
-		AddHostAllowlistEntries(ctx context.Context, entries []types.PublicKey) error
-		RemoveHostAllowlistEntries(ctx context.Context, entries []types.PublicKey) error
-
 		HostBlocklist(ctx context.Context) ([]string, error)
-		AddHostBlocklistEntries(ctx context.Context, entries []string) error
-		RemoveHostBlocklistEntries(ctx context.Context, entries []string) error
+		UpdateHostAllowlistEntries(ctx context.Context, add, remove []types.PublicKey) error
+		UpdateHostBlocklistEntries(ctx context.Context, add, remove []string) error
 	}
 
 	// A MetadataStore stores information about contracts and objects.
@@ -481,10 +478,7 @@ func (b *bus) hostsAllowlistHandlerPUT(jc jape.Context) {
 	ctx := jc.Request.Context()
 	var req api.UpdateAllowlistRequest
 	if jc.Decode(&req) == nil {
-		if jc.Check("couldn't add allowlist entries", b.hdb.AddHostAllowlistEntries(ctx, req.Add)) != nil {
-			return
-		}
-		if jc.Check("couldn't remove allowlist entries", b.hdb.RemoveHostAllowlistEntries(ctx, req.Remove)) != nil {
+		if jc.Check("couldn't update allowlist entries", b.hdb.UpdateHostAllowlistEntries(ctx, req.Add, req.Remove)) != nil {
 			return
 		}
 	}
@@ -501,10 +495,7 @@ func (b *bus) hostsBlocklistHandlerPUT(jc jape.Context) {
 	ctx := jc.Request.Context()
 	var req api.UpdateBlocklistRequest
 	if jc.Decode(&req) == nil {
-		if jc.Check("couldn't add blocklist entries", b.hdb.AddHostBlocklistEntries(ctx, req.Add)) != nil {
-			return
-		}
-		if jc.Check("couldn't remove blocklist entries", b.hdb.RemoveHostBlocklistEntries(ctx, req.Remove)) != nil {
+		if jc.Check("couldn't update blocklist entries", b.hdb.UpdateHostBlocklistEntries(ctx, req.Add, req.Remove)) != nil {
 			return
 		}
 	}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -67,7 +67,7 @@ type (
 
 	// A HostDB stores information about hosts.
 	HostDB interface {
-		Host(ctx context.Context, hostKey types.PublicKey) (hostdb.Host, error)
+		Host(ctx context.Context, hostKey types.PublicKey) (hostdb.HostInfo, error)
 		Hosts(ctx context.Context, offset, limit int) ([]hostdb.Host, error)
 		HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) ([]hostdb.HostAddress, error)
 		RecordInteractions(ctx context.Context, interactions []hostdb.Interaction) error

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -74,12 +74,12 @@ type (
 		RemoveOfflineHosts(ctx context.Context, minRecentScanFailures uint64, maxDowntime time.Duration) (uint64, error)
 
 		HostAllowlist(ctx context.Context) ([]types.PublicKey, error)
-		AddHostAllowlistEntry(ctx context.Context, entry types.PublicKey) error
-		RemoveHostAllowlistEntry(ctx context.Context, entry types.PublicKey) error
+		AddHostAllowlistEntries(ctx context.Context, entries []types.PublicKey) error
+		RemoveHostAllowlistEntries(ctx context.Context, entries []types.PublicKey) error
 
 		HostBlocklist(ctx context.Context) ([]string, error)
-		AddHostBlocklistEntry(ctx context.Context, entry string) error
-		RemoveHostBlocklistEntry(ctx context.Context, entry string) error
+		AddHostBlocklistEntries(ctx context.Context, entries []string) error
+		RemoveHostBlocklistEntries(ctx context.Context, entries []string) error
 	}
 
 	// A MetadataStore stores information about contracts and objects.
@@ -481,15 +481,11 @@ func (b *bus) hostsAllowlistHandlerPUT(jc jape.Context) {
 	ctx := jc.Request.Context()
 	var req api.UpdateAllowlistRequest
 	if jc.Decode(&req) == nil {
-		for _, entry := range req.Add {
-			if jc.Check(fmt.Sprintf("couldn't add allowlist entry '%s'", entry), b.hdb.AddHostAllowlistEntry(ctx, entry)) != nil {
-				return
-			}
+		if jc.Check("couldn't add allowlist entries", b.hdb.AddHostAllowlistEntries(ctx, req.Add)) != nil {
+			return
 		}
-		for _, entry := range req.Remove {
-			if jc.Check(fmt.Sprintf("couldn't remove allowlist entry '%s'", entry), b.hdb.RemoveHostAllowlistEntry(ctx, entry)) != nil {
-				return
-			}
+		if jc.Check("couldn't remove allowlist entries", b.hdb.RemoveHostAllowlistEntries(ctx, req.Remove)) != nil {
+			return
 		}
 	}
 }
@@ -505,15 +501,11 @@ func (b *bus) hostsBlocklistHandlerPUT(jc jape.Context) {
 	ctx := jc.Request.Context()
 	var req api.UpdateBlocklistRequest
 	if jc.Decode(&req) == nil {
-		for _, entry := range req.Add {
-			if jc.Check(fmt.Sprintf("couldn't add blocklist entry '%s'", entry), b.hdb.AddHostBlocklistEntry(ctx, entry)) != nil {
-				return
-			}
+		if jc.Check("couldn't add blocklist entries", b.hdb.AddHostBlocklistEntries(ctx, req.Add)) != nil {
+			return
 		}
-		for _, entry := range req.Remove {
-			if jc.Check(fmt.Sprintf("couldn't remove blocklist entry '%s'", entry), b.hdb.RemoveHostBlocklistEntry(ctx, entry)) != nil {
-				return
-			}
+		if jc.Check("couldn't remove blocklist entries", b.hdb.RemoveHostBlocklistEntries(ctx, req.Remove)) != nil {
+			return
 		}
 	}
 }

--- a/bus/client.go
+++ b/bus/client.go
@@ -242,6 +242,18 @@ func (c *Client) RemoveOfflineHosts(ctx context.Context, minRecentScanFailures u
 	return
 }
 
+// HostAllowlist returns the allowlist.
+func (c *Client) HostAllowlist(ctx context.Context) (allowlist []types.PublicKey, err error) {
+	err = c.c.WithContext(ctx).GET("/hosts/allowlist", &allowlist)
+	return
+}
+
+// UpdateHostAllowlist updates the host allowlist, adding and removing the given entries.
+func (c *Client) UpdateHostAllowlist(ctx context.Context, add, remove []types.PublicKey) (err error) {
+	err = c.c.WithContext(ctx).PUT("/hosts/allowlist", api.UpdateAllowlistRequest{Add: add, Remove: remove})
+	return
+}
+
 // HostBlocklist returns a host blocklist.
 func (c *Client) HostBlocklist(ctx context.Context) (blocklist []string, err error) {
 	err = c.c.WithContext(ctx).GET("/hosts/blocklist", &blocklist)

--- a/bus/client.go
+++ b/bus/client.go
@@ -212,7 +212,7 @@ func (c *Client) WalletPending(ctx context.Context) (resp []types.Transaction, e
 }
 
 // Host returns information about a particular host known to the server.
-func (c *Client) Host(ctx context.Context, hostKey types.PublicKey) (h hostdb.Host, err error) {
+func (c *Client) Host(ctx context.Context, hostKey types.PublicKey) (h hostdb.HostInfo, err error) {
 	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/host/%s", hostKey), &h)
 	return
 }

--- a/hostdb/hostdb.go
+++ b/hostdb/hostdb.go
@@ -98,6 +98,12 @@ type Host struct {
 	Interactions Interactions        `json:"interactions"`
 }
 
+// HostInfo extends the host type with a field indicating whether it is blocked or not.
+type HostInfo struct {
+	Host
+	Blocked bool `json:"blocked"`
+}
+
 // IsOnline returns whether a host is considered online.
 func (h Host) IsOnline() bool {
 	if h.Interactions.TotalScans == 0 {

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -66,7 +66,15 @@ type (
 		LastAnnouncement time.Time
 		NetAddress       string `gorm:"index"`
 
+		Allowlist []dbAllowlistEntry `gorm:"many2many:host_allowlist_entry_hosts;constraint:OnDelete:CASCADE"`
 		Blocklist []dbBlocklistEntry `gorm:"many2many:host_blocklist_entry_hosts;constraint:OnDelete:CASCADE"`
+	}
+
+	// dbAllowlistEntry defines a table that stores the host blocklist.
+	dbAllowlistEntry struct {
+		Model
+		Entry publicKey `gorm:"unique;index;NOT NULL;size:32"`
+		Hosts []dbHost  `gorm:"many2many:host_allowlist_entry_hosts;constraint:OnDelete:CASCADE"`
 	}
 
 	// dbBlocklistEntry defines a table that stores the host blocklist.
@@ -183,6 +191,9 @@ func (dbHost) TableName() string { return "hosts" }
 func (dbInteraction) TableName() string { return "host_interactions" }
 
 // TableName implements the gorm.Tabler interface.
+func (dbAllowlistEntry) TableName() string { return "host_allowlist_entries" }
+
+// TableName implements the gorm.Tabler interface.
 func (dbBlocklistEntry) TableName() string { return "host_blocklist_entries" }
 
 // convert converts a host into a hostdb.Host.
@@ -216,6 +227,27 @@ func (h dbHost) convert() hostdb.Host {
 }
 
 func (h *dbHost) AfterCreate(tx *gorm.DB) (err error) {
+	// fetch allowlist and filter the entries that apply to this host
+	var dbAllowlist []dbAllowlistEntry
+	if err := tx.
+		Model(&dbAllowlistEntry{}).
+		Find(&dbAllowlist).
+		Error; err != nil {
+		return err
+	}
+	allowlist := dbAllowlist[:0]
+	for _, entry := range dbAllowlist {
+		if entry.Entry == h.PublicKey {
+			allowlist = append(allowlist, entry)
+		}
+	}
+
+	// update the association on the host
+	if err := tx.Model(h).Association("Allowlist").Replace(&allowlist); err != nil {
+		return err
+	}
+
+	// fetch blocklist and filter the entries that apply to this host
 	var dbBlocklist []dbBlocklistEntry
 	if err := tx.
 		Model(&dbBlocklistEntry{}).
@@ -223,14 +255,15 @@ func (h *dbHost) AfterCreate(tx *gorm.DB) (err error) {
 		Error; err != nil {
 		return err
 	}
-
-	filtered := dbBlocklist[:0]
+	blocklist := dbBlocklist[:0]
 	for _, entry := range dbBlocklist {
 		if entry.blocks(h) {
-			filtered = append(filtered, entry)
+			blocklist = append(blocklist, entry)
 		}
 	}
-	return tx.Model(h).Association("Blocklist").Replace(&filtered)
+
+	// update the association on the host
+	return tx.Model(h).Association("Blocklist").Replace(&blocklist)
 }
 
 func (h *dbHost) BeforeCreate(tx *gorm.DB) (err error) {
@@ -241,7 +274,30 @@ func (h *dbHost) BeforeCreate(tx *gorm.DB) (err error) {
 	return nil
 }
 
-func (e *dbBlocklistEntry) AfterCreate(tx *gorm.DB) (err error) {
+func (e *dbAllowlistEntry) AfterCreate(tx *gorm.DB) error {
+	// NOTE: the ID is zero here if we ignore a conflict on create
+	if e.ID == 0 {
+		return nil
+	}
+
+	// insert entries into the allowlist
+	return tx.Exec(`INSERT OR IGNORE INTO host_allowlist_entry_hosts (db_allowlist_entry_id, db_host_id)
+SELECT ?, id FROM (
+	SELECT id
+	FROM hosts
+	WHERE public_key = ?
+)`, e.ID, publicKey(e.Entry)).Error
+}
+
+func (e *dbAllowlistEntry) BeforeCreate(tx *gorm.DB) (err error) {
+	tx.Statement.AddClause(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "entry"}},
+		DoNothing: true,
+	})
+	return nil
+}
+
+func (e *dbBlocklistEntry) AfterCreate(tx *gorm.DB) error {
 	// NOTE: the ID is zero here if we ignore a conflict on create
 	if e.ID == 0 {
 		return nil
@@ -253,13 +309,13 @@ func (e *dbBlocklistEntry) AfterCreate(tx *gorm.DB) (err error) {
 		"like_entry":  fmt.Sprintf("%%.%s", e.Entry),
 	}
 
-	err = tx.Exec(`INSERT OR IGNORE INTO host_blocklist_entry_hosts (db_blocklist_entry_id, db_host_id)
+	// insert entries into the blocklist
+	return tx.Exec(`INSERT OR IGNORE INTO host_blocklist_entry_hosts (db_blocklist_entry_id, db_host_id)
 SELECT @entry_id, id FROM (
 	SELECT id, rtrim(rtrim(net_address, replace(net_address, ':', '')),':') as net_host
 	FROM hosts
 	WHERE net_host == @exact_entry OR net_host LIKE @like_entry
 )`, params).Error
-	return
 }
 
 func (e *dbBlocklistEntry) BeforeCreate(tx *gorm.DB) (err error) {
@@ -284,7 +340,7 @@ func (ss *SQLStore) Host(ctx context.Context, hostKey types.PublicKey) (hostdb.H
 	var h dbHost
 
 	tx := ss.db.
-		Scopes(ExcludeBlockedHosts).
+		Scopes(ss.blocklist).
 		Where(&dbHost{PublicKey: publicKey(hostKey)}).
 		Take(&h)
 	if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
@@ -306,7 +362,7 @@ func (ss *SQLStore) HostsForScanning(ctx context.Context, maxLastScan time.Time,
 	var hostAddresses []hostdb.HostAddress
 
 	err := ss.db.
-		Scopes(ExcludeBlockedHosts).
+		Scopes(ss.blocklist).
 		Model(&dbHost{}).
 		Where("last_scan < ?", maxLastScan.UnixNano()).
 		Offset(offset).
@@ -338,7 +394,7 @@ func (ss *SQLStore) Hosts(ctx context.Context, offset, limit int) ([]hostdb.Host
 	var fullHosts []dbHost
 
 	err := ss.db.
-		Scopes(ExcludeBlockedHosts).
+		Scopes(ss.blocklist).
 		Offset(offset).
 		Limit(limit).
 		FindInBatches(&fullHosts, hostRetrievalBatchSize, func(tx *gorm.DB, batch int) error {
@@ -365,17 +421,42 @@ func (ss *SQLStore) RemoveOfflineHosts(ctx context.Context, minRecentFailures ui
 	return
 }
 
-func (ss *SQLStore) AddHostBlocklistEntry(ctx context.Context, entry string) error {
+func (ss *SQLStore) AddHostAllowlistEntry(ctx context.Context, entry types.PublicKey) (err error) {
+	defer ss.updateHasAllowlist(&err)
+	return ss.db.Create(&dbAllowlistEntry{Entry: publicKey(entry)}).Error
+}
+
+func (ss *SQLStore) RemoveHostAllowlistEntry(ctx context.Context, entry types.PublicKey) (err error) {
+	defer ss.updateHasAllowlist(&err)
+	return ss.db.Where(&dbAllowlistEntry{Entry: publicKey(entry)}).Delete(&dbAllowlistEntry{}).Error
+}
+
+func (ss *SQLStore) AddHostBlocklistEntry(ctx context.Context, entry string) (err error) {
+	defer ss.updateHasBlocklist(&err)
 	return ss.db.Create(&dbBlocklistEntry{Entry: entry}).Error
 }
 
-func (db *SQLStore) RemoveHostBlocklistEntry(ctx context.Context, entry string) (err error) {
-	err = db.db.Where(&dbBlocklistEntry{Entry: entry}).Delete(&dbBlocklistEntry{}).Error
+func (ss *SQLStore) RemoveHostBlocklistEntry(ctx context.Context, entry string) (err error) {
+	defer ss.updateHasBlocklist(&err)
+	err = ss.db.Where(&dbBlocklistEntry{Entry: entry}).Delete(&dbBlocklistEntry{}).Error
 	return
 }
 
-func (db *SQLStore) HostBlocklist(ctx context.Context) (blocklist []string, err error) {
-	err = db.db.
+func (ss *SQLStore) HostAllowlist(ctx context.Context) (allowlist []types.PublicKey, err error) {
+	var pubkeys []publicKey
+	err = ss.db.
+		Model(&dbAllowlistEntry{}).
+		Pluck("entry", &pubkeys).
+		Error
+
+	for _, pubkey := range pubkeys {
+		allowlist = append(allowlist, types.PublicKey(pubkey))
+	}
+	return
+}
+
+func (ss *SQLStore) HostBlocklist(ctx context.Context) (blocklist []string, err error) {
+	err = ss.db.
 		Model(&dbBlocklistEntry{}).
 		Pluck("entry", &blocklist).
 		Error
@@ -384,7 +465,7 @@ func (db *SQLStore) HostBlocklist(ctx context.Context) (blocklist []string, err 
 
 // RecordHostInteraction records an interaction with a host. If the host is not in
 // the store, a new entry is created for it.
-func (db *SQLStore) RecordInteractions(ctx context.Context, interactions []hostdb.Interaction) error {
+func (ss *SQLStore) RecordInteractions(ctx context.Context, interactions []hostdb.Interaction) error {
 	if len(interactions) == 0 {
 		return nil // nothing to do
 	}
@@ -404,7 +485,7 @@ func (db *SQLStore) RecordInteractions(ctx context.Context, interactions []hostd
 	// transaction since we don't need it to be perfectly
 	// consistent.
 	var hosts []dbHost
-	if err := db.db.Where("public_key IN ?", hks).
+	if err := ss.db.Where("public_key IN ?", hks).
 		Find(&hosts).Error; err != nil {
 		return err
 	}
@@ -415,7 +496,7 @@ func (db *SQLStore) RecordInteractions(ctx context.Context, interactions []hostd
 
 	// Write the interactions and update to the hosts atmomically within a
 	// single transaction.
-	return db.db.Transaction(func(tx *gorm.DB) error {
+	return ss.db.Transaction(func(tx *gorm.DB) error {
 		// Apply all the interactions to the hosts.
 		dbInteractions := make([]dbInteraction, 0, len(interactions))
 		for _, interaction := range interactions {
@@ -496,7 +577,7 @@ func (db *SQLStore) RecordInteractions(ctx context.Context, interactions []hostd
 }
 
 // ProcessConsensusChange implements consensus.Subscriber.
-func (db *SQLStore) ProcessConsensusChange(cc modules.ConsensusChange) {
+func (ss *SQLStore) ProcessConsensusChange(cc modules.ConsensusChange) {
 	height := uint64(cc.InitialHeight())
 	for range cc.RevertedBlocks {
 		height--
@@ -516,31 +597,40 @@ func (db *SQLStore) ProcessConsensusChange(cc modules.ConsensusChange) {
 		height++
 	}
 
-	db.unappliedAnnouncements = append(db.unappliedAnnouncements, newAnnouncements...)
-	db.unappliedCCID = cc.ID
+	ss.unappliedAnnouncements = append(ss.unappliedAnnouncements, newAnnouncements...)
+	ss.unappliedCCID = cc.ID
 
 	// Apply new announcements
-	if time.Since(db.lastAnnouncementSave) > db.persistInterval || len(db.unappliedAnnouncements) >= announcementBatchSoftLimit {
-		err := db.db.Transaction(func(tx *gorm.DB) error {
-			if len(db.unappliedAnnouncements) > 0 {
-				if err := insertAnnouncements(tx, db.unappliedAnnouncements); err != nil {
+	if time.Since(ss.lastAnnouncementSave) > ss.persistInterval || len(ss.unappliedAnnouncements) >= announcementBatchSoftLimit {
+		err := ss.db.Transaction(func(tx *gorm.DB) error {
+			if len(ss.unappliedAnnouncements) > 0 {
+				if err := insertAnnouncements(tx, ss.unappliedAnnouncements); err != nil {
 					return err
 				}
 			}
-			return updateCCID(tx, db.unappliedCCID)
+			return updateCCID(tx, ss.unappliedCCID)
 		})
 		if err != nil {
 			// NOTE: print error. If we failed due to a temporary error
-			println(fmt.Sprintf("failed to apply %v announcements - should never happen", len(db.unappliedAnnouncements)))
+			println(fmt.Sprintf("failed to apply %v announcements - should never happen", len(ss.unappliedAnnouncements)))
 		}
 
-		db.unappliedAnnouncements = db.unappliedAnnouncements[:0]
-		db.lastAnnouncementSave = time.Now()
+		ss.unappliedAnnouncements = ss.unappliedAnnouncements[:0]
+		ss.lastAnnouncementSave = time.Now()
 	}
 }
 
-func ExcludeBlockedHosts(db *gorm.DB) *gorm.DB {
-	return db.Where("NOT EXISTS (SELECT 1 FROM host_blocklist_entry_hosts hbeh WHERE hbeh.db_host_id = hosts.id)")
+func (ss *SQLStore) blocklist(db *gorm.DB) *gorm.DB {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	if ss.hasAllowlist {
+		db = db.Where("EXISTS (SELECT 1 FROM host_allowlist_entry_hosts hbeh WHERE hbeh.db_host_id = hosts.id)")
+	}
+	if ss.hasBlocklist {
+		db = db.Where("NOT EXISTS (SELECT 1 FROM host_blocklist_entry_hosts hbeh WHERE hbeh.db_host_id = hosts.id)")
+	}
+	return db
 }
 
 func updateCCID(tx *gorm.DB, newCCID modules.ConsensusChangeID) error {

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -702,8 +702,11 @@ func TestSQLHostAllowlist(t *testing.T) {
 
 	isAllowed := func(hk types.PublicKey) bool {
 		t.Helper()
-		_, err := hdb.Host(ctx, hk)
-		return err == nil
+		host, err := hdb.Host(ctx, hk)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return !host.Blocked
 	}
 
 	// add three hosts
@@ -842,16 +845,11 @@ func TestSQLHostBlocklist(t *testing.T) {
 
 	isBlocked := func(hk types.PublicKey) bool {
 		t.Helper()
-		hosts, err := hdb.Hosts(ctx, 0, -1)
+		host, err := hdb.Host(ctx, hk)
 		if err != nil {
 			t.Fatal(err)
 		}
-		for _, host := range hosts {
-			if host.PublicKey == hk {
-				return false
-			}
-		}
-		return true
+		return host.Blocked
 	}
 
 	// add three hosts

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -653,7 +653,7 @@ func TestInsertAnnouncements(t *testing.T) {
 
 	// Add an entry to the blocklist to block host 1
 	entry1 := "foo.bar"
-	err = hdb.AddHostBlocklistEntry(context.Background(), entry1)
+	err = hdb.AddHostBlocklistEntries(context.Background(), []string{entry1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -728,11 +728,7 @@ func TestSQLHostAllowlist(t *testing.T) {
 	}
 
 	// assert we can add entries to the allowlist
-	err = hdb.AddHostAllowlistEntry(ctx, hk1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = hdb.AddHostAllowlistEntry(ctx, hk2)
+	err = hdb.AddHostAllowlistEntries(ctx, []types.PublicKey{hk1, hk2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -749,7 +745,7 @@ func TestSQLHostAllowlist(t *testing.T) {
 	}
 
 	// assert adding the same entry is a no-op
-	err = hdb.AddHostAllowlistEntry(ctx, hk1)
+	err = hdb.AddHostAllowlistEntries(ctx, []types.PublicKey{hk1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -758,7 +754,7 @@ func TestSQLHostAllowlist(t *testing.T) {
 	}
 
 	// assert we can remove an entry
-	err = hdb.RemoveHostAllowlistEntry(ctx, hk2)
+	err = hdb.RemoveHostAllowlistEntries(ctx, []types.PublicKey{hk2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -775,7 +771,7 @@ func TestSQLHostAllowlist(t *testing.T) {
 	}
 
 	// assert removing a non-existing entry is a no-op
-	err = hdb.RemoveHostAllowlistEntry(ctx, hk2)
+	err = hdb.RemoveHostAllowlistEntries(ctx, []types.PublicKey{hk2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -795,7 +791,7 @@ func TestSQLHostAllowlist(t *testing.T) {
 	}
 
 	// remove the allowlist entry for h1
-	err = hdb.RemoveHostAllowlistEntry(ctx, hk1)
+	err = hdb.RemoveHostAllowlistEntries(ctx, []types.PublicKey{hk1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -875,13 +871,7 @@ func TestSQLHostBlocklist(t *testing.T) {
 	}
 
 	// assert we can add entries to the blocklist
-	entry1 := "foo.bar.com"
-	err = hdb.AddHostBlocklistEntry(ctx, entry1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	entry2 := "bar.com"
-	err = hdb.AddHostBlocklistEntry(ctx, entry2)
+	err = hdb.AddHostBlocklistEntries(ctx, []string{"foo.bar.com", "bar.com"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -903,7 +893,7 @@ func TestSQLHostBlocklist(t *testing.T) {
 	}
 
 	// assert adding the same entry is a no-op
-	err = hdb.AddHostBlocklistEntry(ctx, entry1)
+	err = hdb.AddHostBlocklistEntries(ctx, []string{"foo.bar.com", "bar.com"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -912,7 +902,7 @@ func TestSQLHostBlocklist(t *testing.T) {
 	}
 
 	// assert we can remove an entry
-	err = hdb.RemoveHostBlocklistEntry(ctx, entry1)
+	err = hdb.RemoveHostBlocklistEntries(ctx, []string{"foo.bar.com"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -929,12 +919,12 @@ func TestSQLHostBlocklist(t *testing.T) {
 	}
 
 	// assert removing a non-existing entry is a no-op
-	err = hdb.RemoveHostBlocklistEntry(ctx, entry1)
+	err = hdb.RemoveHostBlocklistEntries(ctx, []string{"foo.bar.com"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	// remove the other entry and assert the delete cascaded properly
-	err = hdb.RemoveHostBlocklistEntry(ctx, entry2)
+	err = hdb.RemoveHostBlocklistEntries(ctx, []string{"bar.com"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -949,8 +939,7 @@ func TestSQLHostBlocklist(t *testing.T) {
 	}
 
 	// block the second host
-	entry3 := "baz.com"
-	err = hdb.AddHostBlocklistEntry(ctx, entry3)
+	err = hdb.AddHostBlocklistEntries(ctx, []string{"baz.com"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1006,8 +995,7 @@ func TestSQLHostBlocklist(t *testing.T) {
 	}
 
 	// add another entry that blocks multiple hosts
-	entry4 := "com"
-	err = hdb.AddHostBlocklistEntry(ctx, entry4)
+	err = hdb.AddHostBlocklistEntries(ctx, []string{"com"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1018,7 +1006,7 @@ func TestSQLHostBlocklist(t *testing.T) {
 	}
 
 	// add host 5 to the allowlist
-	err = hdb.AddHostAllowlistEntry(ctx, hk5)
+	err = hdb.AddHostAllowlistEntries(ctx, []types.PublicKey{hk5})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1029,7 +1017,7 @@ func TestSQLHostBlocklist(t *testing.T) {
 	}
 
 	// add a rule to block host 5
-	err = hdb.AddHostBlocklistEntry(ctx, "foo.baz.commmmm")
+	err = hdb.AddHostBlocklistEntries(ctx, []string{"foo.baz.commmmm"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -385,7 +385,7 @@ func (s *SQLStore) Objects(ctx context.Context, path string) ([]string, error) {
 	}
 
 	concat := func(a, b string) string {
-		if s.isSQLite() {
+		if isSQLite(s.db) {
 			return fmt.Sprintf("%s || %s", a, b)
 		}
 		return fmt.Sprintf("CONCAT(%s, %s)", a, b)

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -177,14 +177,14 @@ func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duratio
 	return ss, ccid, nil
 }
 
-func (s *SQLStore) isSQLite() bool {
-	switch s.db.Dialector.(type) {
+func isSQLite(db *gorm.DB) bool {
+	switch db.Dialector.(type) {
 	case *sqlite.Dialector:
 		return true
 	case *mysql.Dialector:
 		return false
 	default:
-		panic(fmt.Sprintf("unknown dialector: %t", s.db.Dialector))
+		panic(fmt.Sprintf("unknown dialector: %t", db.Dialector))
 	}
 }
 

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -3,6 +3,7 @@ package stores
 import (
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"go.sia.tech/siad/modules"
@@ -30,6 +31,10 @@ type (
 		persistInterval        time.Duration
 		unappliedAnnouncements []announcement
 		unappliedCCID          modules.ConsensusChangeID
+
+		mu           sync.Mutex
+		hasAllowlist bool
+		hasBlocklist bool
 	}
 )
 
@@ -102,6 +107,7 @@ func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duratio
 			&dbConsensusInfo{},
 			&dbHost{},
 			&dbInteraction{},
+			&dbAllowlistEntry{},
 			&dbBlocklistEntry{},
 
 			// bus.SettingStore tables
@@ -138,24 +144,35 @@ func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duratio
 
 	// Get latest consensus change ID or init db.
 	var ci dbConsensusInfo
-	err = db.Where(&dbConsensusInfo{Model: Model{ID: consensusInfoID}}).
+	if err := db.
+		Where(&dbConsensusInfo{Model: Model{ID: consensusInfoID}}).
 		Attrs(dbConsensusInfo{
-			Model: Model{
-				ID: consensusInfoID,
-			},
-			CCID: modules.ConsensusChangeBeginning[:],
+			Model: Model{ID: consensusInfoID},
+			CCID:  modules.ConsensusChangeBeginning[:],
 		}).
-		FirstOrCreate(&ci).Error
-	if err != nil {
+		FirstOrCreate(&ci).
+		Error; err != nil {
 		return nil, modules.ConsensusChangeID{}, err
 	}
 	var ccid modules.ConsensusChangeID
 	copy(ccid[:], ci.CCID)
 
+	// Check allowlist and blocklist counts
+	allowlistCnt, err := tableCount(db, &dbAllowlistEntry{})
+	if err != nil {
+		return nil, modules.ConsensusChangeID{}, err
+	}
+	blocklistCnt, err := tableCount(db, &dbBlocklistEntry{})
+	if err != nil {
+		return nil, modules.ConsensusChangeID{}, err
+	}
+
 	ss := &SQLStore{
 		db:                   db,
 		lastAnnouncementSave: time.Now(),
 		persistInterval:      persistInterval,
+		hasAllowlist:         allowlistCnt > 0,
+		hasBlocklist:         blocklistCnt > 0,
 	}
 	return ss, ccid, nil
 }
@@ -169,6 +186,43 @@ func (s *SQLStore) isSQLite() bool {
 	default:
 		panic(fmt.Sprintf("unknown dialector: %t", s.db.Dialector))
 	}
+}
+
+func (ss *SQLStore) updateHasAllowlist(err *error) {
+	if *err != nil {
+		return
+	}
+
+	cnt, cErr := tableCount(ss.db, &dbAllowlistEntry{})
+	if cErr != nil {
+		*err = cErr
+		return
+	}
+
+	ss.mu.Lock()
+	ss.hasAllowlist = cnt > 0
+	ss.mu.Unlock()
+}
+
+func (ss *SQLStore) updateHasBlocklist(err *error) {
+	if *err != nil {
+		return
+	}
+
+	cnt, cErr := tableCount(ss.db, &dbBlocklistEntry{})
+	if cErr != nil {
+		*err = cErr
+		return
+	}
+
+	ss.mu.Lock()
+	ss.hasBlocklist = cnt > 0
+	ss.mu.Unlock()
+}
+
+func tableCount(db *gorm.DB, model interface{}) (cnt int64, err error) {
+	err = db.Model(model).Count(&cnt).Error
+	return
 }
 
 // Close closes the underlying database connection of the store.

--- a/internal/testing/blocklist_test.go
+++ b/internal/testing/blocklist_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestBlocklist(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	ctx := context.Background()
 
 	// create a new test cluster

--- a/internal/testing/blocklist_test.go
+++ b/internal/testing/blocklist_test.go
@@ -1,0 +1,125 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/api"
+	"go.sia.tech/siad/build"
+)
+
+func TestBlocklist(t *testing.T) {
+	ctx := context.Background()
+
+	// create a new test cluster
+	cluster, err := newTestCluster(t.TempDir(), newTestLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := cluster.Shutdown(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	b := cluster.Bus
+
+	// add hosts
+	_, err = cluster.AddHostsBlocking(3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// wait until we have 3 contracts in the set
+	var contracts []api.ContractMetadata
+	if err := build.Retry(5, time.Second, func() (err error) {
+		contracts, err = b.Contracts(ctx, "autopilot")
+		if err != nil {
+			t.Fatal(err)
+		} else if len(contracts) != 3 {
+			err = fmt.Errorf("unexpected number of contracts, %v != 3", len(contracts))
+			return
+		}
+		return
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// add h1 and h2 to the allowlist
+	hk1 := contracts[0].HostKey
+	hk2 := contracts[1].HostKey
+	hk3 := contracts[2].HostKey
+	err = b.UpdateHostAllowlist(ctx, []types.PublicKey{hk1, hk2}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert h3 is no longer in the contract set
+	if err := build.Retry(5, time.Second, func() error {
+		contracts, err := b.Contracts(ctx, "autopilot")
+		if err != nil {
+			t.Fatal(err)
+		} else if len(contracts) != 2 {
+			return fmt.Errorf("unexpected number of contracts, %v != 2", len(contracts))
+		}
+		for _, c := range contracts {
+			if c.HostKey == hk3 {
+				return fmt.Errorf("unexpected contract for host %v", hk3)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// add h1 to the blocklist
+	h1, err := b.Host(context.Background(), hk1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.UpdateHostBlocklist(ctx, []string{h1.NetAddress}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert h1 is no longer in the contract set
+	if err := build.Retry(5, time.Second, func() error {
+		contracts, err := b.Contracts(ctx, "autopilot")
+		if err != nil {
+			t.Fatal(err)
+		} else if len(contracts) != 1 {
+			return fmt.Errorf("unexpected number of contracts, %v != 1", len(contracts))
+		}
+		for _, c := range contracts {
+			if c.HostKey == hk1 {
+				return fmt.Errorf("unexpected contract for host %v", hk1)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// clear the allowlist and blocklist and assert we have 3 contracts again
+	err = b.UpdateHostAllowlist(ctx, nil, []types.PublicKey{hk1, hk2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.UpdateHostBlocklist(ctx, nil, []string{h1.NetAddress})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := build.Retry(5, time.Second, func() error {
+		contracts, err := b.Contracts(ctx, "autopilot")
+		if err != nil {
+			t.Fatal(err)
+		} else if len(contracts) != 3 {
+			return fmt.Errorf("unexpected number of contracts, %v != 3", len(contracts))
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -225,7 +225,7 @@ type Bus interface {
 	RecordInteractions(ctx context.Context, interactions []hostdb.Interaction) error
 	RecordContractSpending(ctx context.Context, records []api.ContractSpendingRecord) error
 
-	Host(ctx context.Context, hostKey types.PublicKey) (hostdb.Host, error)
+	Host(ctx context.Context, hostKey types.PublicKey) (hostdb.HostInfo, error)
 
 	DownloadParams(ctx context.Context) (api.DownloadParams, error)
 	GougingParams(ctx context.Context) (api.GougingParams, error)


### PR DESCRIPTION
This PR adds an allow list. 

How to implement allowlist and blocklists is definitely debatable. Since the blocklist is already defined in a separate table, adding another table seems like the most straightforward solution to me, so I added a new entity called `dbAllowlistEntry`.

I think if both the allowlist and blocklist were to use the same type to define an entry, it would make more sense to consolidate both entries in one single table. But we specify a blocklist entry using strings to match the host's net address where an allowlist entry is specified using the pubkey of the specific host.

The API is pretty straightforward:
`GET|PUT /hosts/allowlist`
`GET|PUT /hosts/blocklist`

For the time being, hosts that are blocked or not allowed (if an allowlist is being used) are essentially hidden from all host related endpoints. There is no way in telling whether a host is not present in the database or if it's being obscured. This is easy to add but we don't need it at this point.

The rules are as follows:
- if a host is on the blocklist it is blocked
- if a host is on the allowlist it is allowed if and only if it is not blocked
- the allowlist is applied only if it has entries
- the blocklist is applied only if it has entries
- as soon as there's an entry in the allowlist, it serves as a projection over the entire host database

I feel this keeps it simple for now while at the same time allowing more complex scenarios in the future. I considered inversing the logic where the allowlist can overrule the blocklist. With this type of logic you could block a certain domain but allow specific hosts from that domain. Another potential use case is allowing hosts from a certain region based on their geo location, and allowing the blocklist to override certain domains. The most immediate use case for now though is to simply specify a list of hosts to potentially form contracts with.

- - - - 

I added some state on the store that keeps track of whether the allowlist and blocklist should be applied or not. This greatly simplifies the logic when applying the blocklist scope. I think this is fine as a trade-off and more importantly if a user decides he's not interested in using the blocklist feature, his database queries won't be complicated and slowed down by it as we simply ignore it all together.