### PR TITLE
Fix Renew Panic

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -548,7 +548,7 @@ func (w *worker) rhpRenewHandler(jc jape.Context) {
 			}
 			return renterTxnSet, finalPayment, func() { w.bus.WalletDiscard(ctx, renterTxnSet[len(renterTxnSet)-1]) }, nil
 		})
-		return nil
+		return err
 	})
 	if jc.Check("couldn't renew contract", err) != nil {
 		return


### PR DESCRIPTION
small bug that got through, leading to renew panics when trying to fetch a contract's `HostKey`

```
2023/02/21 13:50:11 http: panic serving 127.0.0.1:62922: runtime error: index out of range [1] with length 0
goroutine 1574 [running]:
net/http.(*conn).serve.func1()
        /opt/homebrew/Cellar/go/1.19.5/libexec/src/net/http/server.go:1850 +0xe4
panic({0x103b6f400, 0xc0009a0360})
        /opt/homebrew/Cellar/go/1.19.5/libexec/src/runtime/panic.go:890 +0x258
go.sia.tech/core/rhp/v2.ContractRevision.HostKey(...)
        /Users/peterjan/go/pkg/mod/go.sia.tech/core@v0.1.7/rhp/v2/rhp.go:38
go.sia.tech/renterd/internal/stores.addContract(_, {{{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...}, ...}, ...}, ...)
        /Users/peterjan/code/siafoundation/renterd/internal/stores/metadata.go:795 +0x770
```