### PR TITLE
Publish ContractSpendingRecorder.Record

### DIFF
--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -298,7 +298,7 @@ func (sw *segWriter) Write(p []byte) (int, error) {
 func (s *Session) Read(ctx context.Context, w io.Writer, sections []rhpv2.RPCReadRequestSection, price types.Currency) (err error) {
 	defer wrapErr(&err, "Read")
 	defer recordRPC(ctx, s.transport, s.revision, rhpv2.RPCReadID, &err)()
-	defer RecordContractSpending(ctx, s.revision.ID(), api.ContractSpending{Downloads: price}, &err)
+	defer recordContractSpending(ctx, s.revision.ID(), api.ContractSpending{Downloads: price}, &err)
 
 	empty := true
 	for _, s := range sections {
@@ -429,7 +429,7 @@ func (s *Session) Read(ctx context.Context, w io.Writer, sections []rhpv2.RPCRea
 func (s *Session) Write(ctx context.Context, actions []rhpv2.RPCWriteAction, price, collateral types.Currency) (err error) {
 	defer wrapErr(&err, "Write")
 	defer recordRPC(ctx, s.transport, s.revision, rhpv2.RPCWriteID, &err)()
-	defer RecordContractSpending(ctx, s.revision.ID(), api.ContractSpending{Uploads: price}, &err)
+	defer recordContractSpending(ctx, s.revision.ID(), api.ContractSpending{Uploads: price}, &err)
 
 	if !s.isRevisable() {
 		return ErrContractFinalized

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -621,7 +621,7 @@ func (w *worker) rhpFundHandler(jc jape.Context) {
 			if !ok {
 				return errors.New("insufficient funds")
 			}
-			w.contractSpendingRecorder.record(rfr.ContractID, api.ContractSpending{FundAccount: cost})
+			w.contractSpendingRecorder.Record(rfr.ContractID, api.ContractSpending{FundAccount: cost})
 			return RPCFundAccount(t, &payment, account.id, pt.UID)
 		})
 	})


### PR DESCRIPTION
+ Removes the panic from a non-existent ContractSpendingRecorder
+ Publishes `Record` in the interface so packages outside renterd can satisfy it.