### PR TITLE
Add excluded hosts to ipFilter in candidateHosts

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -715,6 +715,7 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 	scored := make([]hostdb.Host, 0, len(hosts))
 	for _, h := range hosts {
 		if _, exclude := exclude[h.PublicKey]; exclude {
+			ipFilter.isRedundantIP(h) // add excluded hosts to ipFilter too
 			continue
 		}
 		if usable, _ := isUsableHost(cfg, gs, rs, ipFilter, h, minScore, storedData[h.PublicKey]); !usable {


### PR DESCRIPTION
I noticed on a fresh set of contracts that one of the contracts was ignored due to being in a redundant ip range.
Seems like the reason for that was that excluded hosts never have `isUsableHost` called on them. So `isRedundantIP` is also never called and the subnet never gets registered in the filter.

So my node formed a contract and during the next contract maintenance realised that it now has 2 contracts from the same subnet.