### PR TITLE
gouging: update default gouging settings

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -183,12 +183,12 @@ type GougingParams struct {
 
 // GougingSettings contain some price settings used in price gouging.
 type GougingSettings struct {
-	MinMaxCollateral types.Currency
-	MaxRPCPrice      types.Currency
-	MaxContractPrice types.Currency
-	MaxDownloadPrice types.Currency // per TiB
-	MaxUploadPrice   types.Currency // per TiB
-	MaxStoragePrice  types.Currency // per byte per block
+	MinMaxCollateral types.Currency `json:"minMaxCollateral"`
+	MaxRPCPrice      types.Currency `json:"maxRPCPrice"`
+	MaxContractPrice types.Currency `json:"maxContractPrice"`
+	MaxDownloadPrice types.Currency `json:"maxDownloadPrice"` // per TiB
+	MaxUploadPrice   types.Currency `json:"maxUploadPrice"`   // per TiB
+	MaxStoragePrice  types.Currency `json:"maxStoragePrice"`  // per byte per block
 }
 
 // RedundancySettings contain settings that dictate an object's redundancy.

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -62,12 +62,12 @@ var (
 	}
 
 	defaultGouging = api.GougingSettings{
-		MinMaxCollateral: types.ZeroCurrency,
-		MaxRPCPrice:      types.Siacoins(1),
-		MaxContractPrice: types.Siacoins(1),
-		MaxDownloadPrice: types.Siacoins(1).Mul64(2500),
-		MaxUploadPrice:   types.Siacoins(1).Mul64(2500),
-		MaxStoragePrice:  types.Siacoins(1),
+		MinMaxCollateral: types.Siacoins(10),                   // at least up to 10 SC per contract
+		MaxRPCPrice:      types.Siacoins(1).Div64(1000),        // 1mS per RPC
+		MaxContractPrice: types.Siacoins(10),                   // 10 SC per contract
+		MaxDownloadPrice: types.Siacoins(1).Mul64(1000),        // 1000 SC per 1 TiB
+		MaxUploadPrice:   types.Siacoins(1).Mul64(1000),        // 1000 SC per 1 TiB
+		MaxStoragePrice:  types.Siacoins(1000).Div64(144 * 30), // 1000 SC per month
 	}
 )
 


### PR DESCRIPTION
Updating the default settings since they appeared quite low. I formed a contract with a 2500 SC host.
Especially the `MaxStoragePrice` is reduced from 4320 SC a month to 1000 SC a month.