### PR TITLE
Fix uploads failing when contracts renew mid-upload

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -859,7 +859,7 @@ func (c *contractor) refreshContract(ctx context.Context, ci contractInfo, cfg a
 	newCollateral := rhpv2.ContractRenewalCollateral(rev.FileContract, expectedStorage, settings, blockHeight, contract.EndHeight())
 
 	// do not refresh if the contract's updated collateral will fall below the threshold anyway
-	_, hostMissedPayout, _ := rhpv2.CalculateHostPayouts(rev.FileContract, newCollateral, settings, contract.EndHeight())
+	_, hostMissedPayout, _, _ := rhpv2.CalculateHostPayouts(rev.FileContract, newCollateral, settings, contract.EndHeight())
 	if isBelowCollateralThreshold(newCollateral, hostMissedPayout) {
 		err := fmt.Errorf("refresh failed, refreshed contract collateral (%v) is below threshold", hostMissedPayout)
 		c.logger.Errorw(err.Error(), "hk", hk, "fcid", fcid, "newCollateral", newCollateral.String(), "hostMissedPayout", hostMissedPayout.String(), "maxCollateral", settings.MaxCollateral)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.12.0
 	go.opentelemetry.io/otel/sdk v1.12.0
 	go.opentelemetry.io/otel/trace v1.13.0
-	go.sia.tech/core v0.1.7
+	go.sia.tech/core v0.1.8-0.20230222141034-3235e061ee44
 	go.sia.tech/jape v0.8.0
 	go.sia.tech/siad v1.5.10-0.20221206172719-7f3713a01004
 	go.uber.org/zap v1.24.0
@@ -62,7 +62,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.12.0 // indirect
 	go.opentelemetry.io/otel/metric v0.36.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
-	go.sia.tech/mux v1.1.1 // indirect
+	go.sia.tech/mux v1.2.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/net v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -707,12 +707,12 @@ go.opentelemetry.io/otel/trace v1.13.0/go.mod h1:muCvmmO9KKpvuXSf3KKAXXB2ygNYHQ+
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
-go.sia.tech/core v0.1.7 h1:fpf+29kxgheQcKpINUJNKXPQfVJm6jfZ+SKibN+ETDo=
-go.sia.tech/core v0.1.7/go.mod h1:RXV2UsXnLhJEYVNjJA89jVwKXAhUtTq8yMlopumjXyE=
+go.sia.tech/core v0.1.8-0.20230222141034-3235e061ee44 h1:lOG9iQAH/4UOPpg6hrkwTaRMZMuDhTGTF2ctzJsuki0=
+go.sia.tech/core v0.1.8-0.20230222141034-3235e061ee44/go.mod h1:6p9xq0pd2WZmju7g8ncSmQRt8HWtsVIOoWKKMXpQCH0=
 go.sia.tech/jape v0.8.0 h1:s/gOJBjgJ3Rl4PQojieFELe+W0gxsXgowLq6zFEZfxA=
 go.sia.tech/jape v0.8.0/go.mod h1:4QqmBB+t3W7cNplXPj++ZqpoUb2PeiS66RLpXmEGap4=
-go.sia.tech/mux v1.1.1 h1:g4itlrPi4Dk4Wlg1BY/6CIgEYyCY12MVShM5a7ff4RY=
-go.sia.tech/mux v1.1.1/go.mod h1:Yyo6wZelOYTyvrHmJZ6aQfRoer3o4xyKQ4NmQLJrBSo=
+go.sia.tech/mux v1.2.0 h1:ofa1Us9mdymBbGMY2XH/lSpY8itFsKIo/Aq8zwe+GHU=
+go.sia.tech/mux v1.2.0/go.mod h1:Yyo6wZelOYTyvrHmJZ6aQfRoer3o4xyKQ4NmQLJrBSo=
 go.sia.tech/siad v1.5.10-0.20221206172719-7f3713a01004 h1:0tFQh99BL6NQuHiq0brkfVCy/nEq3vyu9DTi1cgnb/E=
 go.sia.tech/siad v1.5.10-0.20221206172719-7f3713a01004/go.mod h1:ifu7TjXlL9s+47DSmqeMz8LOvthALMysZkJ3Df0daAY=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -159,45 +159,76 @@ func TestUploadDownload(t *testing.T) {
 	small := make([]byte, rhpv2.SectorSize/12)
 	large := make([]byte, rhpv2.SectorSize*3)
 
-	for _, data := range [][]byte{small, large} {
-		// prepare some data - make sure it's more than one sector
-		if _, err := frand.Read(data); err != nil {
-			t.Fatal(err)
-		}
+	uploadDownload := func() {
+		t.Helper()
+		for _, data := range [][]byte{small, large} {
+			// prepare some data - make sure it's more than one sector
+			if _, err := frand.Read(data); err != nil {
+				t.Fatal(err)
+			}
 
-		// upload the data
-		name := fmt.Sprintf("data_%v", len(data))
-		if err := w.UploadObject(context.Background(), bytes.NewReader(data), name); err != nil {
-			t.Fatal(err)
-		}
+			// upload the data
+			name := fmt.Sprintf("data_%v", len(data))
+			if err := w.UploadObject(context.Background(), bytes.NewReader(data), name); err != nil {
+				t.Fatal(err)
+			}
 
-		// Should be registered in bus.
-		_, entries, err := cluster.Bus.Object(context.Background(), "")
+			// Should be registered in bus.
+			_, entries, err := cluster.Bus.Object(context.Background(), "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var found bool
+			for _, entry := range entries {
+				if entry == fmt.Sprintf("/%s", name) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatal("uploaded object not found in bus")
+			}
+
+			// download the data
+			var buffer bytes.Buffer
+			if err := w.DownloadObject(context.Background(), &buffer, name); err != nil {
+				t.Fatal(err)
+			}
+
+			// assert it matches
+			if !bytes.Equal(data, buffer.Bytes()) {
+				t.Fatal("unexpected")
+			}
+		}
+	}
+
+	// Run uploads once.
+	uploadDownload()
+
+	// Renew contracts.
+	if err := cluster.MineToRenewWindow(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the contract to be renewed.
+	err = Retry(100, 100*time.Millisecond, func() error {
+		cms, err := cluster.Bus.ActiveContracts(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
-		var found bool
-		for _, entry := range entries {
-			if entry == fmt.Sprintf("/%s", name) {
-				found = true
-				break
+		for _, cm := range cms {
+			if cm.RenewedFrom == (types.FileContractID{}) {
+				return errors.New("found contract that wasn't renewed")
 			}
 		}
-		if !found {
-			t.Fatal("uploaded object not found in bus")
-		}
-
-		// download the data
-		var buffer bytes.Buffer
-		if err := w.DownloadObject(context.Background(), &buffer, name); err != nil {
-			t.Fatal(err)
-		}
-
-		// assert it matches
-		if !bytes.Equal(data, buffer.Bytes()) {
-			t.Fatal("unexpected")
-		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	// Run uploads again.
+	uploadDownload()
 
 	// Check that the spending was recorded.
 	err = Retry(100, testBusFlushInterval, func() error {

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -211,7 +211,7 @@ func TestUploadDownload(t *testing.T) {
 	}
 
 	// Wait for the contract to be renewed.
-	err = Retry(100, 100*time.Millisecond, func() error {
+	err = Retry(100, time.Second, func() error {
 		cms, err := cluster.Bus.ActiveContracts(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -148,6 +148,7 @@ func updateRevisionOutputs(rev *types.FileContractRevision, cost, collateral typ
 // Contract.
 type Session struct {
 	transport   *rhpv2.Transport
+	renewedFrom types.FileContractID
 	revision    rhpv2.ContractRevision
 	key         types.PrivateKey
 	appendRoots []types.Hash256
@@ -814,6 +815,8 @@ func (s *Session) RenewContract(txnSet []types.Transaction, finalPayment types.C
 	txn.Signatures = append(renterContractSignatures, hostSigs.ContractSignatures...)
 	signedTxnSet := append(resp.Parents, append(parents, txn)...)
 
+	// update revision
+	s.renewedFrom = s.revision.ID()
 	s.revision.Revision = initRevision
 	s.revision.Signatures[0].Signature = renterRevisionSig.Signature
 	s.revision.Signatures[1].Signature = hostSigs.RevisionSignature.Signature

--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -814,6 +814,10 @@ func (s *Session) RenewContract(txnSet []types.Transaction, finalPayment types.C
 	txn.Signatures = append(renterContractSignatures, hostSigs.ContractSignatures...)
 	signedTxnSet := append(resp.Parents, append(parents, txn)...)
 
+	s.revision.Revision = initRevision
+	s.revision.Signatures[0].Signature = renterRevisionSig.Signature
+	s.revision.Signatures[1].Signature = hostSigs.RevisionSignature.Signature
+
 	return rhpv2.ContractRevision{
 		Revision:   initRevision,
 		Signatures: [2]types.TransactionSignature{renterRevisionSig, hostSigs.RevisionSignature},

--- a/worker/sessionpool.go
+++ b/worker/sessionpool.go
@@ -185,7 +185,7 @@ func (sp *sessionPool) acquire(ctx context.Context, ss *sharedSession) (_ *Sessi
 
 	// if contract of session was renewed, update the sharedSession.
 	if s.renewedFrom != (types.FileContractID{}) && ss.contractID == s.renewedFrom {
-		ss.contractID = s.Revision().ID()
+		ss.contractID = s.renewedTo
 	}
 
 	// reuse existing transport if possible

--- a/worker/sessionpool.go
+++ b/worker/sessionpool.go
@@ -193,7 +193,10 @@ func (sp *sessionPool) acquire(ctx context.Context, ss *sharedSession) (_ *Sessi
 				goto reconnect
 			}
 		}
-		if s.Revision().ID() != ss.contractID {
+		// if contract of session was renewed, update the sharedSession.
+		if s.renewedFrom != (types.FileContractID{}) && ss.contractID == s.renewedFrom {
+			ss.contractID = s.Revision().ID()
+		} else if s.Revision().ID() != ss.contractID {
 			// connected, but not locking the correct contract
 			if s.Revision().ID() != (types.FileContractID{}) {
 				if err := s.Unlock(); err != nil {


### PR DESCRIPTION
Uploads in renterd appear to fail if contracts get renewed mid-upload. The reason is the error `Lock: contract cannot be revised further`.

After investigating a bit it seems like every upload fetches a `sharedSession` and acquires/releases the session multiple times. Between theses calls it's possible for another `sharedSession` to renew the associated contract.
Unfortunately the `contractID` within a `sharedSession` never gets updated so the slow, ongoing upload is stuck with the `contractID` of the renewed contract.
What's even worse is that the `if s.Revision().ID() != ss.contractID` - check in `(*SessionPool).acquire` will try to reconnect on every `acquire` since the contract IDs no longer match.

As a solution, I propose a `renewedFrom` field in the `Session`. That way, a `sharedSession` can verify whether its contract has been updated and if so, update its own contract id to the new one.