### PR TITLE
Update jape dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.12.0
 	go.opentelemetry.io/otel/trace v1.13.0
 	go.sia.tech/core v0.1.8-0.20230222141034-3235e061ee44
-	go.sia.tech/jape v0.8.0
+	go.sia.tech/jape v0.9.0
 	go.sia.tech/siad v1.5.10-0.20221206172719-7f3713a01004
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -711,6 +711,8 @@ go.sia.tech/core v0.1.8-0.20230222141034-3235e061ee44 h1:lOG9iQAH/4UOPpg6hrkwTaR
 go.sia.tech/core v0.1.8-0.20230222141034-3235e061ee44/go.mod h1:6p9xq0pd2WZmju7g8ncSmQRt8HWtsVIOoWKKMXpQCH0=
 go.sia.tech/jape v0.8.0 h1:s/gOJBjgJ3Rl4PQojieFELe+W0gxsXgowLq6zFEZfxA=
 go.sia.tech/jape v0.8.0/go.mod h1:4QqmBB+t3W7cNplXPj++ZqpoUb2PeiS66RLpXmEGap4=
+go.sia.tech/jape v0.9.0 h1:kWgMFqALYhLMJYOwWBgJda5ko/fi4iZzRxHRP7pp8NY=
+go.sia.tech/jape v0.9.0/go.mod h1:4QqmBB+t3W7cNplXPj++ZqpoUb2PeiS66RLpXmEGap4=
 go.sia.tech/mux v1.2.0 h1:ofa1Us9mdymBbGMY2XH/lSpY8itFsKIo/Aq8zwe+GHU=
 go.sia.tech/mux v1.2.0/go.mod h1:Yyo6wZelOYTyvrHmJZ6aQfRoer3o4xyKQ4NmQLJrBSo=
 go.sia.tech/siad v1.5.10-0.20221206172719-7f3713a01004 h1:0tFQh99BL6NQuHiq0brkfVCy/nEq3vyu9DTi1cgnb/E=


### PR DESCRIPTION
Fixes

```
2023-02-22T16:29:15.658948337Z http: panic serving 172.21.0.1:59028: unsupported type *string
2023-02-22T16:29:15.659003630Z goroutine 3896 [running]:
2023-02-22T16:29:15.659016683Z net/http.(*conn).serve.func1()
2023-02-22T16:29:15.659025683Z 	/usr/local/go/src/net/http/server.go:1850 +0xbf
2023-02-22T16:29:15.659034418Z panic({0xf427a0, 0xc00192eea0})
2023-02-22T16:29:15.659042643Z 	/usr/local/go/src/runtime/panic.go:890 +0x262
2023-02-22T16:29:15.659051770Z go.sia.tech/jape.Context.DecodeForm({{0x124cd48, 0xc00010ef60}, 0xc00012ac00, {0xc001ec5b80, 0x1, 0x1}}, {0x10bd43e, 0xb}, {0xf24e80, 0xc00192ee90})
2023-02-22T16:29:15.659061880Z 	/go/pkg/mod/go.sia.tech/jape@v0.8.0/server.go:123 +0x4ad
2023-02-22T16:29:15.659071800Z go.sia.tech/renterd/worker.(*worker).objectsKeyHandlerPUT(0xc000036580, {{0x124cd48, 0xc00010ef60}, 0xc00012ac00, {0xc001ec5b80, 0x1, 0x1}})
2023-02-22T16:29:15.659081170Z 	/renterd/worker/worker.go:840 +0x425
2023-02-22T16:29:15.659090423Z go.sia.tech/jape.Adapt.func1.1({0x124cd48, 0xc00010ef60}, 0xc00012ac00)
2023-02-22T16:29:15.659096560Z 	/go/pkg/mod/go.sia.tech/jape@v0.8.0/server.go:177 +0xf6
2023-02-22T16:29:15.659102645Z net/http.HandlerFunc.ServeHTTP(0x124d300?, {0x124cd48?, 0xc00010ef60?}, 0x123ee80?)
2023-02-22T16:29:15.659126830Z 	/usr/local/go/src/net/http/server.go:2109 +0x2f
2023-02-22T16:29:15.659132895Z go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*Handler).ServeHTTP(0xc001f04180, {0x124bed8?, 0xc0038ae1c0}, 0xc00012ab00)
2023-02-22T16:29:15.659138953Z 	/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.39.0/handler.go:213 +0x1251
2023-02-22T16:29:15.659144715Z go.sia.tech/jape.Adapt.func1.2({{0x124bed8, 0xc0038ae1c0}, 0xc00425b700, {0xc001ec5b80, 0x1, 0x1}})
2023-02-22T16:29:15.659150443Z 	/go/pkg/mod/go.sia.tech/jape@v0.8.0/server.go:180 +0x1a8
2023-02-22T16:29:15.659156120Z go.sia.tech/jape.adaptor.func1({0x124bed8?, 0xc0038ae1c0?}, 0xc00190e000?, {0xc001ec5b80?, 0x1c?, 0x1000000000000?})
2023-02-22T16:29:15.659161895Z 	/go/pkg/mod/go.sia.tech/jape@v0.8.0/server.go:141 +0x6a
2023-02-22T16:29:15.659167535Z github.com/julienschmidt/httprouter.(*Router).ServeHTTP(0xc00053d5c0, {0x124bed8, 0xc0038ae1c0}, 0xc00425b700)
2023-02-22T16:29:15.659173290Z 	/go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:387 +0x81c
2023-02-22T16:29:15.659179198Z go.sia.tech/jape.BasicAuth.func1.1({0x124bed8, 0xc0038ae1c0}, 0x0?)
2023-02-22T16:29:15.659184868Z 	/go/pkg/mod/go.sia.tech/jape@v0.8.0/server.go:194 +0xa3
2023-02-22T16:29:15.659190465Z net/http.HandlerFunc.ServeHTTP(0x0?, {0x124bed8?, 0xc0038ae1c0?}, 0xc0038ae1c0?)
2023-02-22T16:29:15.659196083Z 	/usr/local/go/src/net/http/server.go:2109 +0x2f
2023-02-22T16:29:15.659201680Z main.treeMux.ServeHTTP({{0x1246680?, 0xc001aad380?}, 0x0?}, {0x124bed8, 0xc0038ae1c0}, 0xc00425b700)
2023-02-22T16:29:15.659209128Z 	/renterd/cmd/renterd/web.go:53 +0x29b
2023-02-22T16:29:15.659214978Z main.treeMux.ServeHTTP({{0x1244e60?, 0xc0004f7600?}, 0xc000512780?}, {0x124bed8, 0xc0038ae1c0}, 0xc00425b700)
2023-02-22T16:29:15.659220821Z 	/renterd/cmd/renterd/web.go:49 +0x268
2023-02-22T16:29:15.659229851Z net/http.serverHandler.ServeHTTP({0x12497a0?}, {0x124bed8, 0xc0038ae1c0}, 0xc00425b700)
2023-02-22T16:29:15.659239196Z 	/usr/local/go/src/net/http/server.go:2947 +0x30c
2023-02-22T16:29:15.659245241Z net/http.(*conn).serve(0xc005ca8820, {0x124d300, 0xc001ec00c0})
2023-02-22T16:29:15.659250851Z 	/usr/local/go/src/net/http/server.go:1991 +0x607
2023-02-22T16:29:15.659256541Z created by net/http.(*Server).Serve
2023-02-22T16:29:15.659262136Z 	/usr/local/go/src/net/http/server.go:3102 +0x4db
2023-02-22T16:29:46.074130657Z http: panic serving 172.21.0.1:48900: unsupported type *string
2023-02-22T16:29:46.074704444Z goroutine 3900 [running]:
2023-02-22T16:29:46.075058999Z net/http.(*conn).serve.func1()
2023-02-22T16:29:46.075364225Z 	/usr/local/go/src/net/http/server.go:1850 +0xbf
2023-02-22T16:29:46.075680151Z panic({0xf427a0, 0xc00195c440})
2023-02-22T16:29:46.075919272Z 	/usr/local/go/src/runtime/panic.go:890 +0x262
2023-02-22T16:29:46.076257552Z go.sia.tech/jape.Context.DecodeForm({{0x124cd48, 0xc00228c8a0}, 0xc00207e300, {0xc0004a0540, 0x1, 0x1}}, {0x10bd43e, 0xb}, {0xf24e80, 0xc00195c430})
2023-02-22T16:29:46.076547883Z 	/go/pkg/mod/go.sia.tech/jape@v0.8.0/server.go:123 +0x4ad
2023-02-22T16:29:46.076995723Z go.sia.tech/renterd/worker.(*worker).objectsKeyHandlerPUT(0xc000036580, {{0x124cd48, 0xc00228c8a0}, 0xc00207e300, {0xc0004a0540, 0x1, 0x1}})
2023-02-22T16:29:46.077324107Z 	/renterd/worker/worker.go:840 +0x425
2023-02-22T16:29:46.077595661Z go.sia.tech/jape.Adapt.func1.1({0x124cd48, 0xc00228c8a0}, 0xc00207e300)
2023-02-22T16:29:46.077828445Z 	/go/pkg/mod/go.sia.tech/jape@v0.8.0/server.go:177 +0xf6
2023-02-22T16:29:46.077922152Z net/http.HandlerFunc.ServeHTTP(0x124d300?, {0x124cd48?, 0xc00228c8a0?}, 0x123ee80?)
2023-02-22T16:29:46.078051117Z 	/usr/local/go/src/net/http/server.go:2109 +0x2f
2023-02-22T16:29:46.078073881Z go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*Handler).ServeHTTP(0xc001f04180, {0x124bed8?, 0xc003cae1c0}, 0xc00207e200)
2023-02-22T16:29:46.078136250Z 	/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.39.0/handler.go:213 +0x1251
2023-02-22T16:29:46.078155949Z go.sia.tech/jape.Adapt.func1.2({{0x124bed8, 0xc003cae1c0}, 0xc00207e100, {0xc0004a0540, 0x1, 0x1}})
2023-02-22T16:29:46.078172605Z 	/go/pkg/mod/go.sia.tech/jape@v0.8.0/server.go:180 +0x1a8
2023-02-22T16:29:46.078223046Z go.sia.tech/jape.adaptor.func1({0x124bed8?, 0xc003cae1c0?}, 0xc0020b0000?, {0xc0004a0540?, 0x1c?, 0x1000000000000?})
2023-02-22T16:29:46.078240898Z 	/go/pkg/mod/go.sia.tech/jape@v0.8.0/server.go:141 +0x6a
2023-02-22T16:29:46.078257014Z github.com/julienschmidt/httprouter.(*Router).ServeHTTP(0xc00053d5c0, {0x124bed8, 0xc003cae1c0}, 0xc00207e100)
2023-02-22T16:29:46.078776104Z 	/go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:387 +0x81c
2023-02-22T16:29:46.079075416Z go.sia.tech/jape.BasicAuth.func1.1({0x124bed8, 0xc003cae1c0}, 0x203000?)
2023-02-22T16:29:46.079299345Z 	/go/pkg/mod/go.sia.tech/jape@v0.8.0/server.go:194 +0xa3
2023-02-22T16:29:46.079632409Z net/http.HandlerFunc.ServeHTTP(0xc002e45480?, {0x124bed8?, 0xc003cae1c0?}, 0x0?)
2023-02-22T16:29:46.079665862Z 	/usr/local/go/src/net/http/server.go:2109 +0x2f
2023-02-22T16:29:46.079685213Z main.treeMux.ServeHTTP({{0x1246680?, 0xc001aad380?}, 0x0?}, {0x124bed8, 0xc003cae1c0}, 0xc00207e100)
2023-02-22T16:29:46.079718378Z 	/renterd/cmd/renterd/web.go:53 +0x29b
2023-02-22T16:29:46.079737946Z main.treeMux.ServeHTTP({{0x1244e60?, 0xc0004f7600?}, 0xc000512780?}, {0x124bed8, 0xc003cae1c0}, 0xc00207e100)
2023-02-22T16:29:46.079755782Z 	/renterd/cmd/renterd/web.go:49 +0x268
2023-02-22T16:29:46.079771586Z net/http.serverHandler.ServeHTTP({0x12497a0?}, {0x124bed8, 0xc003cae1c0}, 0xc00207e100)
2023-02-22T16:29:46.079787218Z 	/usr/local/go/src/net/http/server.go:2947 +0x30c
2023-02-22T16:29:46.079803161Z net/http.(*conn).serve(0xc005ca8a00, {0x124d300, 0xc001ec00c0})
2023-02-22T16:29:46.079851218Z 	/usr/local/go/src/net/http/server.go:1991 +0x607
2023-02-22T16:29:46.079870546Z created by net/http.(*Server).Serve
2023-02-22T16:29:46.079886117Z 	/usr/local/go/src/net/http/server.go:3102 +0x4db
```