### PR TITLE
Introduce healthCutoff to UnhealthySlabs

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -129,8 +129,9 @@ type AddObjectRequest struct {
 
 // MigrationSlabsRequest is the request type for the /slabs/migration endpoint.
 type MigrationSlabsRequest struct {
-	ContractSet string `json:"contractset"`
-	Limit       int    `json:"limit"`
+	ContractSet  string  `json:"contractset"`
+	HealthCutoff float64 `json:"healthCutoff"`
+	Limit        int     `json:"limit"`
 }
 
 // UpdateSlabRequest is the request type for the /slab endpoint.

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -268,7 +268,7 @@ func (ap *Autopilot) triggerHandlerPOST(jc jape.Context) {
 }
 
 // New initializes an Autopilot.
-func New(store Store, bus Bus, worker Worker, logger *zap.Logger, heartbeat time.Duration, scannerScanInterval time.Duration, scannerBatchSize, scannerNumThreads uint64) (*Autopilot, error) {
+func New(store Store, bus Bus, worker Worker, logger *zap.Logger, heartbeat time.Duration, scannerScanInterval time.Duration, scannerBatchSize, scannerNumThreads uint64, migrationHealthCutoff float64) (*Autopilot, error) {
 	ap := &Autopilot{
 		bus:    bus,
 		logger: logger.Sugar().Named("autopilot"),
@@ -292,7 +292,7 @@ func New(store Store, bus Bus, worker Worker, logger *zap.Logger, heartbeat time
 
 	ap.s = scanner
 	ap.c = newContractor(ap)
-	ap.m = newMigrator(ap)
+	ap.m = newMigrator(ap, migrationHealthCutoff)
 
 	return ap, nil
 }

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -62,7 +62,7 @@ type Bus interface {
 	ConsensusState(ctx context.Context) (api.ConsensusState, error)
 
 	// objects
-	SlabsForMigration(ctx context.Context, set string, limit int) ([]object.Slab, error)
+	SlabsForMigration(ctx context.Context, healthCutoff float64, set string, limit int) ([]object.Slab, error)
 
 	// settings
 	UpdateSetting(ctx context.Context, key string, value string) error

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -12,6 +12,8 @@ import (
 
 const (
 	migratorBatchSize = math.MaxInt // TODO: change once we have a fix for the infinite loop
+
+	slabsForMigrationHealthCutoff = 0.75
 )
 
 type migrator struct {
@@ -55,7 +57,7 @@ func (m *migrator) performMigrations(cfg api.AutopilotConfig) {
 	defer span.End()
 
 	// fetch slabs for migration
-	toMigrate, err := b.SlabsForMigration(ctx, cfg.Contracts.Set, migratorBatchSize)
+	toMigrate, err := b.SlabsForMigration(ctx, slabsForMigrationHealthCutoff, cfg.Contracts.Set, migratorBatchSize)
 	if err != nil {
 		m.logger.Errorf("failed to fetch slabs for migration, err: %v", err)
 		return

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -12,22 +12,22 @@ import (
 
 const (
 	migratorBatchSize = math.MaxInt // TODO: change once we have a fix for the infinite loop
-
-	slabsForMigrationHealthCutoff = 0.75
 )
 
 type migrator struct {
-	ap     *Autopilot
-	logger *zap.SugaredLogger
+	ap           *Autopilot
+	logger       *zap.SugaredLogger
+	healthCutoff float64
 
 	mu      sync.Mutex
 	running bool
 }
 
-func newMigrator(ap *Autopilot) *migrator {
+func newMigrator(ap *Autopilot, healthCutoff float64) *migrator {
 	return &migrator{
-		ap:     ap,
-		logger: ap.logger.Named("migrator"),
+		ap:           ap,
+		logger:       ap.logger.Named("migrator"),
+		healthCutoff: healthCutoff,
 	}
 }
 
@@ -57,7 +57,7 @@ func (m *migrator) performMigrations(cfg api.AutopilotConfig) {
 	defer span.End()
 
 	// fetch slabs for migration
-	toMigrate, err := b.SlabsForMigration(ctx, slabsForMigrationHealthCutoff, cfg.Contracts.Set, migratorBatchSize)
+	toMigrate, err := b.SlabsForMigration(ctx, m.healthCutoff, cfg.Contracts.Set, migratorBatchSize)
 	if err != nil {
 		m.logger.Errorf("failed to fetch slabs for migration, err: %v", err)
 		return

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -95,7 +95,7 @@ type (
 		UpdateObject(ctx context.Context, key string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
 		RemoveObject(ctx context.Context, key string) error
 
-		UnhealthySlabs(ctx context.Context, set string, limit int) ([]object.Slab, error)
+		UnhealthySlabs(ctx context.Context, healthCutoff float64, set string, limit int) ([]object.Slab, error)
 		UpdateSlab(ctx context.Context, s object.Slab, usedContracts map[types.PublicKey]types.FileContractID) error
 	}
 
@@ -635,7 +635,7 @@ func (b *bus) slabHandlerPUT(jc jape.Context) {
 func (b *bus) slabsMigrationHandlerPOST(jc jape.Context) {
 	var msr api.MigrationSlabsRequest
 	if jc.Decode(&msr) == nil {
-		if slabs, err := b.ms.UnhealthySlabs(jc.Request.Context(), msr.ContractSet, msr.Limit); jc.Check("couldn't fetch slabs for migration", err) == nil {
+		if slabs, err := b.ms.UnhealthySlabs(jc.Request.Context(), msr.HealthCutoff, msr.ContractSet, msr.Limit); jc.Check("couldn't fetch slabs for migration", err) == nil {
 			jc.Encode(slabs)
 		}
 	}

--- a/bus/client.go
+++ b/bus/client.go
@@ -481,8 +481,8 @@ func (c *Client) DeleteObject(ctx context.Context, name string) (err error) {
 // SlabsForMigration returns up to 'limit' slabs which require migration. A slab
 // needs to be migrated if it has sectors on contracts that are not part of the
 // given 'set'.
-func (c *Client) SlabsForMigration(ctx context.Context, set string, limit int) (slabs []object.Slab, err error) {
-	err = c.c.WithContext(ctx).POST("/slabs/migration", api.MigrationSlabsRequest{ContractSet: set, Limit: limit}, &slabs)
+func (c *Client) SlabsForMigration(ctx context.Context, healthCutoff float64, set string, limit int) (slabs []object.Slab, err error) {
+	err = c.c.WithContext(ctx).POST("/slabs/migration", api.MigrationSlabsRequest{ContractSet: set, HealthCutoff: healthCutoff, Limit: limit}, &slabs)
 	return
 }
 

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -159,6 +159,7 @@ func main() {
 	flag.DurationVar(&workerCfg.UploadSectorTimeout, "worker.uploadSectorTimeout", 5*time.Second, "timeout applied to sector uploads when uploading a slab")
 	flag.BoolVar(&autopilotCfg.enabled, "autopilot.enabled", true, "enable the autopilot")
 	flag.DurationVar(&autopilotCfg.Heartbeat, "autopilot.heartbeat", 10*time.Minute, "interval at which autopilot loop runs")
+	flag.Float64Var(&autopilotCfg.MigrationHealthCutoff, "autopilot.migrationHealthCutoff", 0.75, "health threshold below which slabs are migrated to new hosts")
 	flag.DurationVar(&autopilotCfg.ScannerInterval, "autopilot.scannerInterval", 24*time.Hour, "interval at which hosts are scanned")
 	flag.Uint64Var(&autopilotCfg.ScannerBatchSize, "autopilot.scannerBatchSize", 1000, "size of the batch with which hosts are scanned")
 	flag.Uint64Var(&autopilotCfg.ScannerNumThreads, "autopilot.scannerNumThreads", 100, "number of threads that scan hosts")

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -53,10 +53,11 @@ type BusConfig struct {
 }
 
 type AutopilotConfig struct {
-	Heartbeat         time.Duration
-	ScannerInterval   time.Duration
-	ScannerBatchSize  uint64
-	ScannerNumThreads uint64
+	Heartbeat             time.Duration
+	MigrationHealthCutoff float64
+	ScannerInterval       time.Duration
+	ScannerBatchSize      uint64
+	ScannerNumThreads     uint64
 }
 
 type ShutdownFn = func(context.Context) error
@@ -284,7 +285,7 @@ func NewWorker(cfg WorkerConfig, b worker.Bus, walletKey types.PrivateKey, l *za
 }
 
 func NewAutopilot(cfg AutopilotConfig, s autopilot.Store, b autopilot.Bus, w autopilot.Worker, l *zap.Logger) (http.Handler, func() error, ShutdownFn, error) {
-	ap, err := autopilot.New(s, b, w, l, cfg.Heartbeat, cfg.ScannerInterval, cfg.ScannerBatchSize, cfg.ScannerNumThreads)
+	ap, err := autopilot.New(s, b, w, l, cfg.Heartbeat, cfg.ScannerInterval, cfg.ScannerBatchSize, cfg.ScannerNumThreads, cfg.MigrationHealthCutoff)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -701,12 +701,12 @@ func (ss *SQLStore) UpdateSlab(ctx context.Context, s object.Slab, usedContracts
 // so they are restored to full health.
 //
 // TODO: consider that we don't want to migrate slabs above a given health.
-func (s *SQLStore) UnhealthySlabs(ctx context.Context, set string, limit int) ([]object.Slab, error) {
+func (s *SQLStore) UnhealthySlabs(ctx context.Context, healthCutoff float64, set string, limit int) ([]object.Slab, error) {
 	var dbBatch []dbSlab
 	var slabs []object.Slab
 
 	if err := s.db.
-		Select("slabs.*, COUNT(DISTINCT(c.host_id)) as num_good_sectors, slabs.total_shards as num_required_sectors, slabs.total_shards-COUNT(DISTINCT(c.host_id)) as num_bad_sectors").
+		Select("slabs.*, (COUNT(DISTINCT(c.host_id)) - slabs.min_shards) / (slabs.total_shards - slabs.min_shards) as health").
 		Model(&dbSlab{}).
 		Joins("INNER JOIN shards sh ON sh.db_slab_id = slabs.id").
 		Joins("INNER JOIN sectors s ON sh.db_sector_id = s.id").
@@ -716,8 +716,8 @@ func (s *SQLStore) UnhealthySlabs(ctx context.Context, set string, limit int) ([
 		Joins("INNER JOIN contract_sets cs ON cs.id = csc.db_contract_set_id").
 		Where("cs.name = ?", set).
 		Group("slabs.id").
-		Having("num_good_sectors < num_required_sectors").
-		Order("num_bad_sectors DESC").
+		Having("health < ?", healthCutoff).
+		Order("health ASC").
 		Limit(limit).
 		Preload("Shards.DBSector").
 		FindInBatches(&dbBatch, slabRetrievalBatchSize, func(tx *gorm.DB, batch int) error {

--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -706,7 +706,7 @@ func (s *SQLStore) UnhealthySlabs(ctx context.Context, healthCutoff float64, set
 	var slabs []object.Slab
 
 	if err := s.db.
-		Select("slabs.*, (COUNT(DISTINCT(c.host_id)) - slabs.min_shards) / (slabs.total_shards - slabs.min_shards) as health").
+		Select("slabs.*, CAST(COUNT(DISTINCT(c.host_id) - slabs.min_shards) AS FLOAT) / (slabs.total_shards - slabs.min_shards) as health").
 		Model(&dbSlab{}).
 		Joins("INNER JOIN shards sh ON sh.db_slab_id = slabs.id").
 		Joins("INNER JOIN sectors s ON sh.db_sector_id = s.id").
@@ -716,7 +716,7 @@ func (s *SQLStore) UnhealthySlabs(ctx context.Context, healthCutoff float64, set
 		Joins("INNER JOIN contract_sets cs ON cs.id = csc.db_contract_set_id").
 		Where("cs.name = ?", set).
 		Group("slabs.id").
-		Having("health < ?", healthCutoff).
+		Having("health <= ?", healthCutoff).
 		Order("health ASC").
 		Limit(limit).
 		Preload("Shards.DBSector").

--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -706,7 +706,7 @@ func (s *SQLStore) UnhealthySlabs(ctx context.Context, healthCutoff float64, set
 	var slabs []object.Slab
 
 	if err := s.db.
-		Select("slabs.*, CAST(COUNT(DISTINCT(c.host_id) - slabs.min_shards) AS FLOAT) / (slabs.total_shards - slabs.min_shards) as health").
+		Select("slabs.*, CAST((COUNT(DISTINCT(c.host_id)) - slabs.min_shards) AS FLOAT) / Cast(slabs.total_shards - slabs.min_shards AS FLOAT) AS health").
 		Model(&dbSlab{}).
 		Joins("INNER JOIN shards sh ON sh.db_slab_id = slabs.id").
 		Joins("INNER JOIN sectors s ON sh.db_sector_id = s.id").

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -940,7 +940,7 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	slabs, err := db.UnhealthySlabs(ctx, 1.0, "autopilot", -1)
+	slabs, err := db.UnhealthySlabs(ctx, 0.99, "autopilot", -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -958,7 +958,7 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatal("slabs are not returned in the correct order")
 	}
 
-	slabs, err = db.UnhealthySlabs(ctx, 0.5, "autopilot", -1)
+	slabs, err = db.UnhealthySlabs(ctx, 0.49, "autopilot", -1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -940,7 +940,7 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	slabs, err := db.UnhealthySlabs(ctx, "autopilot", -1)
+	slabs, err := db.UnhealthySlabs(ctx, 1.0, "autopilot", -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1159,7 +1159,7 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// fetch slabs for migration and assert there is only one
-	toMigrate, err := db.UnhealthySlabs(ctx, "autopilot", -1)
+	toMigrate, err := db.UnhealthySlabs(ctx, 1.0, "autopilot", -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1217,7 +1217,7 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// fetch slabs for migration and assert there are none left
-	toMigrate, err = db.UnhealthySlabs(ctx, "autopilot", -1)
+	toMigrate, err = db.UnhealthySlabs(ctx, 1.0, "autopilot", -1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -957,6 +957,22 @@ func TestUnhealthySlabs(t *testing.T) {
 	if reflect.DeepEqual(slabs, expected) {
 		t.Fatal("slabs are not returned in the correct order")
 	}
+
+	slabs, err = db.UnhealthySlabs(ctx, 0.5, "autopilot", -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slabs) != 2 {
+		t.Fatalf("unexpected amount of slabs to migrate, %v!=4", len(slabs))
+	}
+
+	expected = []object.SlabSlice{
+		obj.Slabs[4],
+		obj.Slabs[2],
+	}
+	if reflect.DeepEqual(slabs, expected) {
+		t.Fatal("slabs are not returned in the correct order")
+	}
 }
 
 // TestContractSectors is a test for the contract_sectors join table. It

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -1175,7 +1175,7 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// fetch slabs for migration and assert there is only one
-	toMigrate, err := db.UnhealthySlabs(ctx, 1.0, "autopilot", -1)
+	toMigrate, err := db.UnhealthySlabs(ctx, 0.99, "autopilot", -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1233,7 +1233,7 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// fetch slabs for migration and assert there are none left
-	toMigrate, err = db.UnhealthySlabs(ctx, 1.0, "autopilot", -1)
+	toMigrate, err = db.UnhealthySlabs(ctx, 0.99, "autopilot", -1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -229,10 +229,11 @@ func newTestClusterWithFunding(dir, dbName string, funding bool, logger *zap.Log
 
 	// Create autopilot.
 	ap, aStartFn, aStopFn, err := node.NewAutopilot(node.AutopilotConfig{
-		Heartbeat:         time.Second,
-		ScannerInterval:   time.Second,
-		ScannerBatchSize:  10,
-		ScannerNumThreads: 1,
+		Heartbeat:             time.Second,
+		MigrationHealthCutoff: 0.99,
+		ScannerInterval:       time.Second,
+		ScannerBatchSize:      10,
+		ScannerNumThreads:     1,
 	}, autopilotStore, busClient, workerClient, logger)
 	if err != nil {
 		return nil, err

--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -878,7 +878,6 @@ func (s *Session) withTransport(ctx context.Context, fn func(t *rhpv2.Transport)
 			err = ctx.Err()
 		}
 		s.transport = nil
-		fmt.Println("err", err, ctx.Err())
 	}
 	return
 }

--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -878,6 +878,7 @@ func (s *Session) withTransport(ctx context.Context, fn func(t *rhpv2.Transport)
 			err = ctx.Err()
 		}
 		s.transport = nil
+		fmt.Println("err", err, ctx.Err())
 	}
 	return
 }

--- a/worker/sessionpool.go
+++ b/worker/sessionpool.go
@@ -248,20 +248,6 @@ func (sp *sessionPool) unlockContract(ctx context.Context, ss *sharedSession) {
 	}
 }
 
-func (sp *sessionPool) forceClose(ss *sharedSession) {
-	sp.mu.Lock()
-	s, ok := ss.pool.hosts[ss.hostKey]
-	sp.mu.Unlock()
-	if !ok {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.transport != nil {
-		s.transport.Close()
-	}
-}
-
 // Close gracefully closes all of the sessions in the pool.
 func (sp *sessionPool) Close() error {
 	for hostKey, sess := range sp.hosts {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -399,7 +399,7 @@ func (w *worker) withHosts(ctx context.Context, contracts []api.ContractMetadata
 		// apply a pessimistic timeout, ensuring unlocking the contract or force
 		// closing the session does not deadlock and keep this goroutine around
 		// forever
-		ctx, cancel := context.WithTimeout(ctx, time.Hour)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
 		defer cancel()
 
 		var wg sync.WaitGroup

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -420,10 +420,9 @@ func (w *worker) withHosts(ctx context.Context, contracts []api.ContractMetadata
 	go func() {
 		select {
 		case <-done:
-			w.unlockHosts(hosts)
 		case <-ctx.Done():
-			w.unlockHosts(hosts)
 		}
+		w.unlockHosts(hosts)
 	}()
 	defer func() {
 		close(done)


### PR DESCRIPTION
I noticed on my node that we sometimes temporarily lose contracts from the contract set for minor reasons. e.g. the contract being up for a refresh and not refreshing since there are no unspent outputs in the wallet.

In that case GiBs of data are downloaded and migrated simply because the contract is unavailable for 10 minutes. To avoid that I'm introducing a health threshold which allows us to only fetch slabs for migration which are below a certain health threshold. e.g. if 25% of the redundancy shards are lost. 