### PR TITLE
Fix nil pointer dereference panic in Session

### DIFF
--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -372,9 +372,7 @@ func (s *Session) Read(ctx context.Context, w io.Writer, sections []rhpv2.RPCRea
 func (s *Session) Reconnect(ctx context.Context, hostIP string, hostKey types.PublicKey, renterKey types.PrivateKey, contractID types.FileContractID) (err error) {
 	defer wrapErr(&err, "Reconnect")
 
-	if s.transport != nil {
-		s.closeTransport()
-	}
+	s.closeTransport()
 
 	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", hostIP)
 	if err != nil {


### PR DESCRIPTION
When force-closing a transport on timeouts we set it to `nil` to trigger a reconnect. To avoid a panic when the caller tries to closet the transport gracefully again, this PR wraps closing a transport in a check. 