### PR TITLE
Remove UpdatedAt field from Model type

### DIFF
--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -18,7 +18,6 @@ type (
 	Model struct {
 		ID        uint `gorm:"primarykey"`
 		CreatedAt time.Time
-		UpdatedAt time.Time
 	}
 
 	// SQLStore is a helper type for interacting with a SQL-based backend.


### PR DESCRIPTION
Removing the `UpdatedAt` field for now since we haven't used it and we keep getting logging about deadlocked database transactions launched by Gorm for updating that field.