### PR TITLE
Pricetable Gouging

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -191,8 +191,10 @@ type UploadParams struct {
 // GougingParams contains the metadata needed by a worker to perform gouging
 // checks.
 type GougingParams struct {
+	ConsensusState     ConsensusState
 	GougingSettings    GougingSettings
 	RedundancySettings RedundancySettings
+	TransactionFee     types.Currency
 }
 
 // GougingSettings contain some price settings used in price gouging.

--- a/api/bus.go
+++ b/api/bus.go
@@ -205,6 +205,8 @@ type GougingSettings struct {
 	MaxDownloadPrice types.Currency `json:"maxDownloadPrice"` // per TiB
 	MaxUploadPrice   types.Currency `json:"maxUploadPrice"`   // per TiB
 	MaxStoragePrice  types.Currency `json:"maxStoragePrice"`  // per byte per block
+
+	HostBlockHeightLeeway int `json:"hostBlockHeightLeeway"`
 }
 
 // RedundancySettings contain settings that dictate an object's redundancy.

--- a/api/worker.go
+++ b/api/worker.go
@@ -24,7 +24,7 @@ type RHPScanRequest struct {
 // RHPPriceTableRequest is the request type for the /rhp/pricetable endpoint.
 type RHPPriceTableRequest struct {
 	HostKey    types.PublicKey `json:"hostKey"`
-	SiamuxAddr string          `json:"hostIP"`
+	SiamuxAddr string          `json:"siamuxAddr"`
 	Timeout    time.Duration   `json:"timeout"`
 }
 

--- a/api/worker.go
+++ b/api/worker.go
@@ -21,6 +21,13 @@ type RHPScanRequest struct {
 	Timeout time.Duration   `json:"timeout"`
 }
 
+// RHPPriceTableRequest is the request type for the /rhp/pricetable endpoint.
+type RHPPriceTableRequest struct {
+	HostKey    types.PublicKey `json:"hostKey"`
+	SiamuxAddr string          `json:"hostIP"`
+	Timeout    time.Duration   `json:"timeout"`
+}
+
 // RHPScanResponse is the response type for the /rhp/scan endpoint.
 type RHPScanResponse struct {
 	Ping      ParamDuration      `json:"ping"`

--- a/api/worker.go
+++ b/api/worker.go
@@ -25,7 +25,6 @@ type RHPScanRequest struct {
 type RHPPriceTableRequest struct {
 	HostKey    types.PublicKey `json:"hostKey"`
 	SiamuxAddr string          `json:"siamuxAddr"`
-	Timeout    time.Duration   `json:"timeout"`
 }
 
 // RHPScanResponse is the response type for the /rhp/scan endpoint.

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -78,7 +78,7 @@ type Worker interface {
 	MigrateSlab(ctx context.Context, s object.Slab) error
 	RHPForm(ctx context.Context, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds types.Currency, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, amount types.Currency) (err error)
-	RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (rhpv3.HostPriceTable, error)
+	RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string) (rhpv3.HostPriceTable, error)
 	RHPRenew(ctx context.Context, fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds, newCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPScan(ctx context.Context, hostKey types.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)
 }

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
+	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/jape"
 	"go.sia.tech/renterd/api"
@@ -77,6 +78,7 @@ type Worker interface {
 	MigrateSlab(ctx context.Context, s object.Slab) error
 	RHPForm(ctx context.Context, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds types.Currency, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, amount types.Currency) (err error)
+	RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (rhpv3.HostPriceTable, error)
 	RHPRenew(ctx context.Context, fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds, newCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPScan(ctx context.Context, hostKey types.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)
 }

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -22,6 +22,10 @@ import (
 )
 
 const (
+	// contractHostPriceTableTimeout is the amount of time we wait to receive a
+	// price table from the host
+	contractHostPriceTableTimeout = 10 * time.Second
+
 	// contractHostTimeout is the amount of time we wait to receive the latest
 	// revision from the host
 	contractHostTimeout = 30 * time.Second
@@ -325,7 +329,7 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 		}
 
 		// fetch price table
-		pt, err := c.ap.worker.RHPPriceTable(ctx, host.PublicKey, host.Settings.SiamuxAddr(), 30*time.Second)
+		pt, err := c.ap.worker.RHPPriceTable(ctx, host.PublicKey, host.Settings.SiamuxAddr(), contractHostPriceTableTimeout)
 		if err != nil {
 			c.logger.Errorf("could not fetch price table for host %v: %v", host.PublicKey, err)
 			continue
@@ -745,7 +749,7 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 		if h.Settings == nil {
 			continue // host has not been scanned yet
 		}
-		pt, err := c.ap.worker.RHPPriceTable(ctx, h.PublicKey, h.Settings.SiamuxAddr(), 30*time.Second)
+		pt, err := c.ap.worker.RHPPriceTable(ctx, h.PublicKey, h.Settings.SiamuxAddr(), contractHostPriceTableTimeout)
 		if err != nil {
 			c.logger.Errorf("could not fetch price table for host %v: %v", h.PublicKey, err)
 			continue

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -324,8 +324,15 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 			continue
 		}
 
+		// fetch price table
+		pt, err := c.ap.worker.RHPPriceTable(ctx, host.PublicKey, host.Settings.SiamuxAddr(), 30*time.Second)
+		if err != nil {
+			c.logger.Errorf("could not fetch price table for host %v: %v", host.PublicKey, err)
+			continue
+		}
+
 		// decide whether the host is still good
-		usable, reasons := isUsableHost(cfg, gs, rs, f, host.Host, minScore, contract.FileSize())
+		usable, reasons := isUsableHost(cfg, gs, rs, &pt, f, host.Host, minScore, contract.FileSize())
 		if !usable {
 			c.logger.Infow("unusable host", "hk", hk, "fcid", fcid, "reasons", errStr(joinErrors(reasons)))
 			toIgnore = append(toIgnore, fcid)
@@ -735,7 +742,15 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 		if _, exclude := exclude[h.PublicKey]; exclude {
 			continue
 		}
-		if usable, _ := isUsableHost(cfg, gs, rs, ipFilter, h, minScore, storedData[h.PublicKey]); !usable {
+		if h.Settings == nil {
+			continue // host has not been scanned yet
+		}
+		pt, err := c.ap.worker.RHPPriceTable(ctx, h.PublicKey, h.Settings.SiamuxAddr(), 30*time.Second)
+		if err != nil {
+			c.logger.Errorf("could not fetch price table for host %v: %v", h.PublicKey, err)
+			continue
+		}
+		if usable, _ := isUsableHost(cfg, gs, rs, &pt, ipFilter, h, minScore, storedData[h.PublicKey]); !usable {
 			continue
 		}
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.sia.tech/core/consensus"
 	rhpv2 "go.sia.tech/core/rhp/v2"
+	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/hostdb"
@@ -114,6 +115,12 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 	c.logger.Debugf("fetched %d active contracts, took %v", len(resp.Contracts), time.Since(start))
 	active := resp.Contracts
 
+	// fetch recommended txn fee
+	fee, err := c.ap.bus.RecommendedFee(ctx)
+	if err != nil {
+		return err
+	}
+
 	// fetch gouging settings
 	gs, err := c.ap.bus.GougingSettings(ctx)
 	if err != nil {
@@ -150,7 +157,7 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 	}
 
 	// run checks
-	toDelete, toIgnore, toRefresh, toRenew, err := c.runContractChecks(ctx, cfg, cs.BlockHeight, gs, rs, active, minScore)
+	toDelete, toIgnore, toRefresh, toRenew, err := c.runContractChecks(ctx, cfg, cs, gs, rs, active, minScore, fee)
 	if err != nil {
 		return fmt.Errorf("failed to run contract checks, err: %v", err)
 	}
@@ -188,7 +195,7 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 	// check if we need to form contracts and add them to the contract set
 	var formed []types.FileContractID
 	if numContracts < addLeeway(cfg.Contracts.Amount, leewayPctRequiredContracts) {
-		if formed, err = c.runContractFormations(ctx, cfg, hosts, active, cfg.Contracts.Amount-numContracts, cs.BlockHeight, &remaining, address, minScore); err != nil {
+		if formed, err = c.runContractFormations(ctx, cfg, hosts, active, cfg.Contracts.Amount-numContracts, cs.BlockHeight, &remaining, address, minScore, fee); err != nil {
 			c.logger.Errorf("failed to form contracts, err: %v", err) // continue
 		}
 	}
@@ -279,7 +286,7 @@ func (c *contractor) performWalletMaintenance(ctx context.Context, cfg api.Autop
 	return nil
 }
 
-func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotConfig, blockHeight uint64, gs api.GougingSettings, rs api.RedundancySettings, contracts []api.Contract, minScore float64) (toDelete, toIgnore []types.FileContractID, toRefresh, toRenew []contractInfo, _ error) {
+func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotConfig, cs api.ConsensusState, gs api.GougingSettings, rs api.RedundancySettings, contracts []api.Contract, minScore float64, txnFee types.Currency) (toDelete, toIgnore []types.FileContractID, toRefresh, toRenew []contractInfo, _ error) {
 	if c.ap.isStopped() {
 		return
 	}
@@ -329,14 +336,14 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 		}
 
 		// fetch price table
-		pt, err := c.ap.worker.RHPPriceTable(ctx, host.PublicKey, host.Settings.SiamuxAddr(), contractHostPriceTableTimeout)
+		pt, err := c.priceTable(ctx, host.PublicKey, host.Settings.SiamuxAddr())
 		if err != nil {
 			c.logger.Errorf("could not fetch price table for host %v: %v", host.PublicKey, err)
 			continue
 		}
 
 		// decide whether the host is still good
-		usable, reasons := isUsableHost(cfg, gs, rs, &pt, f, host.Host, minScore, contract.FileSize())
+		usable, reasons := isUsableHost(cfg, gs, rs, cs, &pt, f, host.Host, minScore, contract.FileSize(), txnFee)
 		if !usable {
 			c.logger.Infow("unusable host", "hk", hk, "fcid", fcid, "reasons", errStr(joinErrors(reasons)))
 			toIgnore = append(toIgnore, fcid)
@@ -348,12 +355,12 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 
 		// decide whether the contract is still good
 		ci := contractInfo{contract: contract, settings: settings}
-		renterFunds, err := c.renewFundingEstimate(ctx, cfg, blockHeight, ci)
+		renterFunds, err := c.renewFundingEstimate(ctx, cfg, cs.BlockHeight, ci)
 		if err != nil {
 			c.logger.Errorw(fmt.Sprintf("failed to compute renterFunds for contract: %v", err))
 		}
 
-		usable, refresh, renew, reasons := isUsableContract(cfg, ci, blockHeight, renterFunds)
+		usable, refresh, renew, reasons := isUsableContract(cfg, ci, cs.BlockHeight, renterFunds)
 		if !usable {
 			c.logger.Infow(
 				"unusable contract",
@@ -410,7 +417,7 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 	return toDelete, toIgnore, toRefresh, toRenew, nil
 }
 
-func (c *contractor) runContractFormations(ctx context.Context, cfg api.AutopilotConfig, hosts []hostdb.Host, active []api.Contract, missing, blockHeight uint64, budget *types.Currency, renterAddress types.Address, minScore float64) ([]types.FileContractID, error) {
+func (c *contractor) runContractFormations(ctx context.Context, cfg api.AutopilotConfig, hosts []hostdb.Host, active []api.Contract, missing, blockHeight uint64, budget *types.Currency, renterAddress types.Address, minScore float64, txnFee types.Currency) ([]types.FileContractID, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "runContractFormations")
 	defer span.End()
 
@@ -440,12 +447,6 @@ func (c *contractor) runContractFormations(ctx context.Context, cfg api.Autopilo
 		used[contract.HostKey()] = struct{}{}
 	}
 
-	// fetch recommended txn fee
-	fee, err := c.ap.bus.RecommendedFee(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// fetch candidate hosts
 	wanted := int(addLeeway(missing, leewayPctCandidateHosts))
 	candidates, err := c.candidateHosts(ctx, cfg, hosts, used, make(map[types.PublicKey]uint64), wanted, minScore)
@@ -468,7 +469,7 @@ func (c *contractor) runContractFormations(ctx context.Context, cfg api.Autopilo
 			break
 		}
 
-		formedContract, proceed, err := c.formContract(ctx, host, fee, minInitialContractFunds, maxInitialContractFunds, blockHeight, budget, renterAddress, cfg)
+		formedContract, proceed, err := c.formContract(ctx, host, txnFee, minInitialContractFunds, maxInitialContractFunds, blockHeight, budget, renterAddress, cfg)
 		if err == nil {
 			// add contract to contract set
 			formed = append(formed, formedContract.ID)
@@ -715,6 +716,18 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 		return nil, nil
 	}
 
+	// fetch consensus state
+	cs, err := c.ap.bus.ConsensusState(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch recommended fee
+	txnFee, err := c.ap.bus.RecommendedFee(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// fetch gouging settings
 	gs, err := c.ap.bus.GougingSettings(ctx)
 	if err != nil {
@@ -749,12 +762,14 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 		if h.Settings == nil {
 			continue // host has not been scanned yet
 		}
-		pt, err := c.ap.worker.RHPPriceTable(ctx, h.PublicKey, h.Settings.SiamuxAddr(), contractHostPriceTableTimeout)
+
+		pt, err := c.priceTable(ctx, h.PublicKey, h.Settings.SiamuxAddr())
 		if err != nil {
 			c.logger.Errorf("could not fetch price table for host %v: %v", h.PublicKey, err)
 			continue
 		}
-		if usable, _ := isUsableHost(cfg, gs, rs, &pt, ipFilter, h, minScore, storedData[h.PublicKey]); !usable {
+
+		if usable, _ := isUsableHost(cfg, gs, rs, cs, &pt, ipFilter, h, minScore, storedData[h.PublicKey], txnFee); !usable {
 			continue
 		}
 
@@ -987,6 +1002,12 @@ func (c *contractor) formContract(ctx context.Context, host hostdb.Host, fee, mi
 		"collateral", hostCollateral.String(),
 	)
 	return formedContract, true, nil
+}
+
+func (c *contractor) priceTable(ctx context.Context, hk types.PublicKey, siamuxAddr string) (rhpv3.HostPriceTable, error) {
+	ctx, cancel := context.WithTimeout(ctx, contractHostPriceTableTimeout)
+	defer cancel()
+	return c.ap.worker.RHPPriceTable(ctx, hk, siamuxAddr)
 }
 
 func buildContractSet(active []api.Contract, toDelete, toIgnore []types.FileContractID, toRefresh, toRenew []contractInfo, renewed []api.ContractMetadata) []types.FileContractID {

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
+	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/hostdb"
@@ -56,7 +57,7 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 	}
 	if settings, bad, reason := hasBadSettings(cfg, h); bad {
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostBadSettings, reason))
-	} else if gouging, reason := isGouging(gs, rs, settings); gouging {
+	} else if gouging, reason := isGouging(gs, rs, settings, nil); gouging { // TODO pass pricetable
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostPriceGouging, reason))
 	} else if score := hostScore(cfg, h, storedData, rs.Redundancy()); score < minScore {
 		reasons = append(reasons, fmt.Errorf("%w: %v < %v", errLowScore, score, minScore))
@@ -141,28 +142,28 @@ func isUpForRenewal(cfg api.AutopilotConfig, r types.FileContractRevision, block
 	return blockHeight+cfg.Contracts.RenewWindow >= r.EndHeight()
 }
 
-func isGouging(gs api.GougingSettings, rs api.RedundancySettings, settings rhpv2.HostSettings) (bool, string) {
-	return worker.IsGouging(gs, settings, rs.MinShards, rs.TotalShards)
+func isGouging(gs api.GougingSettings, rs api.RedundancySettings, hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable) (bool, string) {
+	return worker.IsGouging(gs, hs, pt, rs.MinShards, rs.TotalShards)
 }
 
-func hasBadSettings(cfg api.AutopilotConfig, h hostdb.Host) (rhpv2.HostSettings, bool, string) {
+func hasBadSettings(cfg api.AutopilotConfig, h hostdb.Host) (*rhpv2.HostSettings, bool, string) {
 	settings := h.Settings
 	if settings == nil {
-		return rhpv2.HostSettings{}, true, "no settings"
+		return nil, true, "no settings"
 	}
 	if !settings.AcceptingContracts {
-		return *settings, true, "not accepting contracts"
+		return nil, true, "not accepting contracts"
 	}
 	if cfg.Contracts.Period+cfg.Contracts.RenewWindow > settings.MaxDuration {
-		return *settings, true, fmt.Sprintf("max duration too low, %v > %v", cfg.Contracts.Period+cfg.Contracts.RenewWindow, settings.MaxDuration)
+		return nil, true, fmt.Sprintf("max duration too low, %v > %v", cfg.Contracts.Period+cfg.Contracts.RenewWindow, settings.MaxDuration)
 	}
 	maxBaseRPCPrice := settings.DownloadBandwidthPrice.Mul64(maxBaseRPCPriceVsBandwidth)
 	if settings.BaseRPCPrice.Cmp(maxBaseRPCPrice) > 0 {
-		return *settings, true, fmt.Sprintf("base RPC price too high, %v > %v", settings.BaseRPCPrice, maxBaseRPCPrice)
+		return nil, true, fmt.Sprintf("base RPC price too high, %v > %v", settings.BaseRPCPrice, maxBaseRPCPrice)
 	}
 	maxSectorAccessPrice := settings.DownloadBandwidthPrice.Mul64(maxSectorAccessPriceVsBandwidth)
 	if settings.SectorAccessPrice.Cmp(maxSectorAccessPrice) > 0 {
-		return *settings, true, fmt.Sprintf("sector access price too high, %v > %v", settings.BaseRPCPrice, maxBaseRPCPrice)
+		return nil, true, fmt.Sprintf("sector access price too high, %v > %v", settings.BaseRPCPrice, maxBaseRPCPrice)
 	}
-	return *settings, false, ""
+	return settings, false, ""
 }

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -57,7 +57,7 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 	}
 	if settings, bad, reason := hasBadSettings(cfg, h); bad {
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostBadSettings, reason))
-	} else if gouging, reason := isGouging(gs, rs, settings, pt); gouging {
+	} else if gouging, reason := worker.IsGouging(gs, rs, settings, pt); gouging {
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostPriceGouging, reason))
 	} else if score := hostScore(cfg, h, storedData, rs.Redundancy()); score < minScore {
 		reasons = append(reasons, fmt.Errorf("%w: %v < %v", errLowScore, score, minScore))
@@ -140,10 +140,6 @@ func isBelowCollateralThreshold(expectedCollateral, actualCollateral types.Curre
 
 func isUpForRenewal(cfg api.AutopilotConfig, r types.FileContractRevision, blockHeight uint64) bool {
 	return blockHeight+cfg.Contracts.RenewWindow >= r.EndHeight()
-}
-
-func isGouging(gs api.GougingSettings, rs api.RedundancySettings, hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable) (bool, string) {
-	return worker.IsGouging(gs, hs, pt, rs.MinShards, rs.TotalShards)
 }
 
 func hasBadSettings(cfg api.AutopilotConfig, h hostdb.Host) (*rhpv2.HostSettings, bool, string) {

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -46,7 +46,7 @@ var (
 
 // isUsableHost returns whether the given host is usable along with a list of
 // reasons why it was deemed unusable.
-func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.RedundancySettings, f *ipFilter, h hostdb.Host, minScore float64, storedData uint64) (bool, []error) {
+func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.RedundancySettings, pt *rhpv3.HostPriceTable, f *ipFilter, h hostdb.Host, minScore float64, storedData uint64) (bool, []error) {
 	var reasons []error
 
 	if !h.IsOnline() {
@@ -57,7 +57,7 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 	}
 	if settings, bad, reason := hasBadSettings(cfg, h); bad {
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostBadSettings, reason))
-	} else if gouging, reason := isGouging(gs, rs, settings, nil); gouging { // TODO pass pricetable
+	} else if gouging, reason := isGouging(gs, rs, settings, pt); gouging {
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostPriceGouging, reason))
 	} else if score := hostScore(cfg, h, storedData, rs.Redundancy()); score < minScore {
 		reasons = append(reasons, fmt.Errorf("%w: %v < %v", errLowScore, score, minScore))

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -46,7 +46,7 @@ var (
 
 // isUsableHost returns whether the given host is usable along with a list of
 // reasons why it was deemed unusable.
-func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.RedundancySettings, pt *rhpv3.HostPriceTable, f *ipFilter, h hostdb.Host, minScore float64, storedData uint64) (bool, []error) {
+func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.RedundancySettings, cs api.ConsensusState, pt *rhpv3.HostPriceTable, f *ipFilter, h hostdb.Host, minScore float64, storedData uint64, txnFee types.Currency) (bool, []error) {
 	var reasons []error
 
 	if !h.IsOnline() {
@@ -57,7 +57,7 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 	}
 	if settings, bad, reason := hasBadSettings(cfg, h); bad {
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostBadSettings, reason))
-	} else if gouging, reason := worker.IsGouging(gs, rs, settings, pt); gouging {
+	} else if gouging, reason := worker.IsGouging(gs, rs, cs, settings, pt, txnFee, cfg.Contracts.Period, cfg.Contracts.RenewWindow); gouging {
 		reasons = append(reasons, fmt.Errorf("%w: %v", errHostPriceGouging, reason))
 	} else if score := hostScore(cfg, h, storedData, rs.Redundancy()); score < minScore {
 		reasons = append(reasons, fmt.Errorf("%w: %v < %v", errLowScore, score, minScore))

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -778,9 +778,16 @@ func (b *bus) gougingParams(ctx context.Context) (api.GougingParams, error) {
 		panic(err)
 	}
 
+	cs := api.ConsensusState{
+		BlockHeight: b.cm.TipState(ctx).Index.Height,
+		Synced:      b.cm.Synced(ctx),
+	}
+
 	return api.GougingParams{
+		ConsensusState:     cs,
 		GougingSettings:    gs,
 		RedundancySettings: rs,
+		TransactionFee:     b.tp.RecommendedFee(),
 	}, nil
 }
 

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -162,6 +162,7 @@ func main() {
 	flagCurrencyVar(&busCfg.MaxDownloadPrice, "bus.maxDownloadPrice", types.Siacoins(2500), "max allowed price to download one TiB")
 	flagCurrencyVar(&busCfg.MaxUploadPrice, "bus.maxUploadPrice", types.Siacoins(2500), "max allowed price to upload one TiB")
 	flagCurrencyVar(&busCfg.MaxStoragePrice, "bus.maxStoragePrice", types.Siacoins(1), "max allowed price to store one byte per block")
+	flag.IntVar(&busCfg.HostBlockHeightLeeway, "bus.hostBlockHeightLeeway", 3, "amount of leeway given to host block height before it is considered gouging")
 	flag.DurationVar(&workerCfg.BusFlushInterval, "worker.busFlushInterval", 5*time.Second, "time after which the worker flushes buffered data to bus for persisting")
 	flag.StringVar(&workerCfg.WorkerConfig.ID, "worker.id", "worker", "unique identifier of worker")
 	flag.StringVar(&workerCfg.remoteAddr, "worker.remoteAddr", "", "URL of remote worker service")

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -57,18 +57,20 @@ var (
 		},
 	}
 
-	defaultRedundancy = api.RedundancySettings{
+	testRedundancySettings = api.RedundancySettings{
 		MinShards:   2,
 		TotalShards: 3,
 	}
 
-	defaultGouging = api.GougingSettings{
+	testGougingSettings = api.GougingSettings{
 		MinMaxCollateral: types.Siacoins(10),                   // at least up to 10 SC per contract
 		MaxRPCPrice:      types.Siacoins(1).Div64(1000),        // 1mS per RPC
 		MaxContractPrice: types.Siacoins(10),                   // 10 SC per contract
 		MaxDownloadPrice: types.Siacoins(1).Mul64(1000),        // 1000 SC per 1 TiB
 		MaxUploadPrice:   types.Siacoins(1).Mul64(1000),        // 1000 SC per 1 TiB
 		MaxStoragePrice:  types.Siacoins(1000).Div64(144 * 30), // 1000 SC per month
+
+		HostBlockHeightLeeway: 120, // amount of leeway given to host block height
 	}
 )
 
@@ -192,8 +194,8 @@ func newTestClusterWithFunding(dir, dbName string, funding bool, logger *zap.Log
 		GatewayAddr:        "127.0.0.1:0",
 		Miner:              miner,
 		PersistInterval:    testPersistInterval,
-		GougingSettings:    defaultGouging,
-		RedundancySettings: defaultRedundancy,
+		GougingSettings:    testGougingSettings,
+		RedundancySettings: testRedundancySettings,
 	}, busDir, wk, logger)
 	if err != nil {
 		return nil, err

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -134,7 +134,7 @@ func TestUploadDownload(t *testing.T) {
 	}
 
 	// sanity check the default settings
-	if defaultAutopilotConfig.Contracts.Amount < uint64(defaultRedundancy.MinShards) {
+	if defaultAutopilotConfig.Contracts.Amount < uint64(testRedundancySettings.MinShards) {
 		t.Fatal("too few hosts to support the redundancy settings")
 	}
 
@@ -150,7 +150,7 @@ func TestUploadDownload(t *testing.T) {
 	}()
 
 	w := cluster.Worker
-	rs := defaultRedundancy
+	rs := testRedundancySettings
 
 	// add hosts
 	if _, err := cluster.AddHostsBlocking(int(rs.TotalShards)); err != nil {

--- a/worker/client.go
+++ b/worker/client.go
@@ -75,13 +75,7 @@ func (c *Client) RHPFund(ctx context.Context, contractID types.FileContractID, h
 }
 
 // RHPPriceTable fetches a price table for a host.
-func (c *Client) RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (pt rhpv3.HostPriceTable, err error) {
-	if timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
-
+func (c *Client) RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string) (pt rhpv3.HostPriceTable, err error) {
 	req := api.RHPPriceTableRequest{
 		HostKey:    hostKey,
 		SiamuxAddr: siamuxAddr,

--- a/worker/client.go
+++ b/worker/client.go
@@ -74,6 +74,17 @@ func (c *Client) RHPFund(ctx context.Context, contractID types.FileContractID, h
 	return
 }
 
+// RHPPriceTable fetches a price table for a host.
+func (c *Client) RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (pt rhpv3.HostPriceTable, err error) {
+	req := api.RHPPriceTableRequest{
+		HostKey:    hostKey,
+		SiamuxAddr: siamuxAddr,
+		Timeout:    timeout,
+	}
+	err = c.c.WithContext(ctx).POST("/rhp/pricetable", req, &pt)
+	return
+}
+
 // RHPReadRegistry reads a registry value.
 func (c *Client) RHPReadRegistry(ctx context.Context, hostKey types.PublicKey, hostIP string, key rhpv3.RegistryKey, payment rhpv3.PayByEphemeralAccountRequest) (resp rhpv3.RegistryValue, err error) {
 	req := api.RHPRegistryReadRequest{

--- a/worker/client.go
+++ b/worker/client.go
@@ -76,10 +76,15 @@ func (c *Client) RHPFund(ctx context.Context, contractID types.FileContractID, h
 
 // RHPPriceTable fetches a price table for a host.
 func (c *Client) RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (pt rhpv3.HostPriceTable, err error) {
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
 	req := api.RHPPriceTableRequest{
 		HostKey:    hostKey,
 		SiamuxAddr: siamuxAddr,
-		Timeout:    timeout,
 	}
 	err = c.c.WithContext(ctx).POST("/rhp/pricetable", req, &pt)
 	return

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
+	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/siad/modules"
@@ -16,7 +17,8 @@ const keyGougingChecker contextKey = "GougingChecker"
 
 type (
 	GougingChecker interface {
-		Check(rhpv2.HostSettings) GougingResults
+		CheckHS(*rhpv2.HostSettings) GougingResults
+		CheckPT(*rhpv3.HostPriceTable) GougingResults
 	}
 
 	GougingResults struct {
@@ -34,11 +36,15 @@ type (
 	contextKey string
 )
 
-func PerformGougingChecks(ctx context.Context, hs rhpv2.HostSettings) GougingResults {
-	if gc, ok := ctx.Value(keyGougingChecker).(GougingChecker); ok {
-		return gc.Check(hs)
+func PerformGougingChecks(ctx context.Context, hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable) (results GougingResults) {
+	gc, ok := ctx.Value(keyGougingChecker).(GougingChecker)
+	if !ok {
+		panic("no gouging checker attached to the context") // developer error
 	}
-	panic("no gouging checker attached to the context") // developer error
+
+	results.merge(gc.CheckHS(hs))
+	results.merge(gc.CheckPT(pt))
+	return
 }
 
 func WithGougingChecker(ctx context.Context, gp api.GougingParams) context.Context {
@@ -49,29 +55,51 @@ func WithGougingChecker(ctx context.Context, gp api.GougingParams) context.Conte
 	})
 }
 
-func IsGouging(gs api.GougingSettings, hs rhpv2.HostSettings, minShards, totalShards int) (bool, string) {
-	errs := filterErrors(
-		checkDownloadGouging(gs, hs, minShards, totalShards),
-		checkFormContractGouging(gs, hs),
-		checkUploadGouging(gs, hs, minShards, totalShards),
-	)
-	if len(errs) == 0 {
+func IsGouging(gs api.GougingSettings, hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable, minShards, totalShards int) (bool, string) {
+	var hsErrs []error
+	if hs != nil {
+		hsErrs = filterErrors(
+			checkDownloadGougingHS(gs, hs, minShards, totalShards),
+			checkFormContractGougingHS(gs, hs),
+			checkUploadGougingHS(gs, hs, minShards, totalShards),
+		)
+	}
+
+	var ptErrs []error
+	if pt != nil {
+		ptErrs = filterErrors(
+			checkDownloadGougingPT(gs, pt, minShards, totalShards),
+			checkFormContractGougingPT(gs, pt),
+			checkUploadGougingPT(gs, pt, minShards, totalShards),
+		)
+	}
+
+	if len(hsErrs)+len(ptErrs) == 0 {
 		return false, ""
 	}
-
-	var reasons []string
-	for _, err := range errs {
-		reasons = append(reasons, err.Error())
-	}
-	return true, strings.Join(reasons, ", ")
+	return true, joinErrors(append(hsErrs, ptErrs...)...).Error()
 }
 
-func (gc gougingChecker) Check(hs rhpv2.HostSettings) GougingResults {
-	return GougingResults{
-		downloadErr:     checkDownloadGouging(gc.settings, hs, gc.minShards, gc.totalShards),
-		formContractErr: checkFormContractGouging(gc.settings, hs),
-		uploadErr:       checkUploadGouging(gc.settings, hs, gc.minShards, gc.totalShards),
+func (gc gougingChecker) CheckHS(hs *rhpv2.HostSettings) (results GougingResults) {
+	if hs != nil {
+		results = GougingResults{
+			downloadErr:     checkDownloadGougingHS(gc.settings, hs, gc.minShards, gc.totalShards),
+			formContractErr: checkFormContractGougingHS(gc.settings, hs),
+			uploadErr:       checkUploadGougingHS(gc.settings, hs, gc.minShards, gc.totalShards),
+		}
 	}
+	return
+}
+
+func (gc gougingChecker) CheckPT(pt *rhpv3.HostPriceTable) (results GougingResults) {
+	if pt != nil {
+		results = GougingResults{
+			downloadErr:     checkDownloadGougingPT(gc.settings, pt, gc.minShards, gc.totalShards),
+			formContractErr: checkFormContractGougingPT(gc.settings, pt),
+			uploadErr:       checkUploadGougingPT(gc.settings, pt, gc.minShards, gc.totalShards),
+		}
+	}
+	return
 }
 
 func (gr GougingResults) CanDownload() (errs []error) {
@@ -92,14 +120,20 @@ func (gr GougingResults) CanUpload() []error {
 	)
 }
 
-func checkDownloadGouging(gs api.GougingSettings, hs rhpv2.HostSettings, minShards, totalShards int) error {
+func (gr *GougingResults) merge(other GougingResults) {
+	gr.downloadErr = joinErrors(gr.downloadErr, other.downloadErr)
+	gr.uploadErr = joinErrors(gr.uploadErr, other.uploadErr)
+	gr.formContractErr = joinErrors(gr.formContractErr, other.formContractErr)
+}
+
+func checkDownloadGougingHS(gs api.GougingSettings, hs *rhpv2.HostSettings, minShards, totalShards int) error {
 	// check base rpc price
 	if !gs.MaxRPCPrice.IsZero() && hs.BaseRPCPrice.Cmp(gs.MaxRPCPrice) > 0 {
 		return fmt.Errorf("rpc price exceeds max: %v>%v", hs.BaseRPCPrice, gs.MaxRPCPrice)
 	}
 
 	// check download cost
-	dpptb, overflow := downloadPricePerTB(hs)
+	dpptb, overflow := downloadPricePerTB(hs.BaseRPCPrice, hs.SectorAccessPrice, hs.DownloadBandwidthPrice)
 	if overflow {
 		return fmt.Errorf("overflow detected when computing download price per TiB")
 	}
@@ -115,7 +149,35 @@ func checkDownloadGouging(gs api.GougingSettings, hs rhpv2.HostSettings, minShar
 	return nil
 }
 
-func checkUploadGouging(gs api.GougingSettings, hs rhpv2.HostSettings, minShards, totalShards int) error {
+func checkDownloadGougingPT(gs api.GougingSettings, pt *rhpv3.HostPriceTable, minShards, totalShards int) error {
+	// check base rpc price
+	if !gs.MaxRPCPrice.IsZero() && gs.MaxRPCPrice.Cmp(pt.InitBaseCost) < 0 {
+		return fmt.Errorf("init base cost exceeds max: %v>%v", pt.InitBaseCost, gs.MaxRPCPrice)
+	}
+
+	// check ReadLengthCost - should be 1H as it's unused by hosts
+	if types.NewCurrency64(1).Cmp(pt.ReadLengthCost) < 0 {
+		return fmt.Errorf("ReadLengthCost of host is %v but should be %v", pt.ReadLengthCost, types.NewCurrency64(1))
+	}
+
+	// check download cost
+	dpptb, overflow := downloadPricePerTB(pt.InitBaseCost, pt.ReadBaseCost.Add(pt.ReadLengthCost.Mul64(modules.SectorSize)), pt.DownloadBandwidthCost)
+	if overflow {
+		return fmt.Errorf("overflow detected when computing download price per TiB")
+	}
+	downloadPriceTotalShards, overflow := dpptb.Mul64WithOverflow(uint64(totalShards))
+	if overflow {
+		return fmt.Errorf("overflow detected when multiplying %v * %v in download gouging", dpptb, totalShards)
+	}
+	downloadPrice := downloadPriceTotalShards.Div64(uint64(minShards))
+	if !gs.MaxDownloadPrice.IsZero() && downloadPrice.Cmp(gs.MaxDownloadPrice) > 0 {
+		return fmt.Errorf("cost per TiB exceeds max dl price: %v>%v", downloadPrice, gs.MaxDownloadPrice)
+	}
+
+	return nil
+}
+
+func checkUploadGougingHS(gs api.GougingSettings, hs *rhpv2.HostSettings, minShards, totalShards int) error {
 	// check base rpc price
 	if !gs.MaxRPCPrice.IsZero() && hs.BaseRPCPrice.Cmp(gs.MaxRPCPrice) > 0 {
 		return fmt.Errorf("rpc price exceeds max: %v>%v", hs.BaseRPCPrice, gs.MaxRPCPrice)
@@ -127,7 +189,7 @@ func checkUploadGouging(gs api.GougingSettings, hs rhpv2.HostSettings, minShards
 	}
 
 	// check upload cost
-	upptb, overflow := uploadPricePerTB(hs)
+	upptb, overflow := uploadPricePerTB(hs.BaseRPCPrice, hs.SectorAccessPrice, hs.UploadBandwidthPrice)
 	if overflow {
 		return fmt.Errorf("overflow detected when computing upload price per TiB")
 	}
@@ -143,7 +205,40 @@ func checkUploadGouging(gs api.GougingSettings, hs rhpv2.HostSettings, minShards
 	return nil
 }
 
-func checkFormContractGouging(gs api.GougingSettings, hs rhpv2.HostSettings) error {
+func checkUploadGougingPT(gs api.GougingSettings, pt *rhpv3.HostPriceTable, minShards, totalShards int) error {
+	// check base rpc price
+	if !gs.MaxRPCPrice.IsZero() && gs.MaxRPCPrice.Cmp(pt.InitBaseCost) < 0 {
+		return fmt.Errorf("init base cost exceeds max: %v>%v", pt.InitBaseCost, gs.MaxRPCPrice)
+	}
+
+	// check WriteLengthCost - should be 1H as it's unused by hosts
+	if types.NewCurrency64(1).Cmp(pt.WriteLengthCost) < 0 {
+		return fmt.Errorf("WriteLengthCost of %v exceeds 1H", pt.WriteLengthCost)
+	}
+
+	// check MemoryTimeCost - should be 1H as it's unused by hosts
+	if types.NewCurrency64(1).Cmp(pt.MemoryTimeCost) < 0 {
+		return fmt.Errorf("MemoryTimeCost of %v exceeds 1H", pt.WriteLengthCost)
+	}
+
+	// check upload cost
+	upptb, overflow := uploadPricePerTB(pt.InitBaseCost, pt.WriteBaseCost.Add(pt.WriteLengthCost.Mul64(modules.SectorSize)), pt.UploadBandwidthCost)
+	if overflow {
+		return fmt.Errorf("overflow detected when computing upload price per TiB")
+	}
+	uploadPriceTotalShards, overflow := upptb.Mul64WithOverflow(uint64(totalShards))
+	if overflow {
+		return fmt.Errorf("overflow detected when multiplying %v * %v in upload gouging", upptb, totalShards)
+	}
+	uploadPrice := uploadPriceTotalShards.Div64(uint64(minShards))
+	if !gs.MaxUploadPrice.IsZero() && uploadPrice.Cmp(gs.MaxUploadPrice) > 0 {
+		return fmt.Errorf("cost per TiB exceeds max ul price: %v>%v", uploadPrice, gs.MaxUploadPrice)
+	}
+
+	return nil
+}
+
+func checkFormContractGougingHS(gs api.GougingSettings, hs *rhpv2.HostSettings) error {
 	// check base rpc price
 	if !gs.MaxRPCPrice.IsZero() && hs.BaseRPCPrice.Cmp(gs.MaxRPCPrice) > 0 {
 		return fmt.Errorf("rpc price exceeds max: %v>%v", hs.BaseRPCPrice, gs.MaxRPCPrice)
@@ -164,12 +259,34 @@ func checkFormContractGouging(gs api.GougingSettings, hs rhpv2.HostSettings) err
 	return nil
 }
 
-func uploadPricePerTB(hs rhpv2.HostSettings) (types.Currency, bool) {
-	uploadPrice, overflow := hs.UploadBandwidthPrice.Mul64WithOverflow(modules.SectorSize)
+func checkFormContractGougingPT(gs api.GougingSettings, pt *rhpv3.HostPriceTable) error {
+	// check base rpc price
+	if !gs.MaxRPCPrice.IsZero() && gs.MaxRPCPrice.Cmp(pt.InitBaseCost) < 0 {
+		return fmt.Errorf("init base cost exceeds max: %v>%v", pt.InitBaseCost, gs.MaxRPCPrice)
+	}
+
+	// check contract price
+	if !gs.MaxContractPrice.IsZero() && pt.ContractPrice.Cmp(gs.MaxContractPrice) > 0 {
+		return fmt.Errorf("contract price exceeds max: %v>%v", pt.ContractPrice, gs.MaxContractPrice)
+	}
+
+	// check MaxCollateral
+	if pt.MaxCollateral.IsZero() {
+		return errors.New("MaxCollateral of host is 0")
+	}
+	if pt.MaxCollateral.Cmp(gs.MinMaxCollateral) < 0 {
+		return fmt.Errorf("MaxCollateral is below minimum: %v<%v", pt.MaxCollateral, gs.MinMaxCollateral)
+	}
+
+	return nil
+}
+
+func uploadPricePerTB(baseRPCPrice, sectorAccessPrice, UploadBandwidthPrice types.Currency) (types.Currency, bool) {
+	uploadPrice, overflow := UploadBandwidthPrice.Mul64WithOverflow(modules.SectorSize)
 	if overflow {
 		return types.ZeroCurrency, true
 	}
-	sectorPrice, overflow := hs.SectorAccessPrice.AddWithOverflow(hs.BaseRPCPrice)
+	sectorPrice, overflow := sectorAccessPrice.AddWithOverflow(baseRPCPrice)
 	if overflow {
 		return types.ZeroCurrency, true
 	}
@@ -180,12 +297,12 @@ func uploadPricePerTB(hs rhpv2.HostSettings) (types.Currency, bool) {
 	return sectorPrice.Mul64WithOverflow(1 << 40 / modules.SectorSize) // sectors per TiB
 }
 
-func downloadPricePerTB(hs rhpv2.HostSettings) (types.Currency, bool) {
-	downloadPrice, overflow := hs.DownloadBandwidthPrice.Mul64WithOverflow(modules.SectorSize)
+func downloadPricePerTB(baseRPCPrice, sectorAccessPrice, downloadBandwidthPrice types.Currency) (types.Currency, bool) {
+	downloadPrice, overflow := downloadBandwidthPrice.Mul64WithOverflow(modules.SectorSize)
 	if overflow {
 		return types.ZeroCurrency, true
 	}
-	sectorPrice, overflow := hs.SectorAccessPrice.AddWithOverflow(hs.BaseRPCPrice)
+	sectorPrice, overflow := sectorAccessPrice.AddWithOverflow(baseRPCPrice)
 	if overflow {
 		return types.ZeroCurrency, true
 	}
@@ -204,4 +321,26 @@ func filterErrors(errs ...error) []error {
 		}
 	}
 	return filtered
+}
+
+func joinErrors(errs ...error) error {
+	filtered := errs[:0]
+	for _, err := range errs {
+		if err != nil {
+			filtered = append(filtered, err)
+		}
+	}
+
+	switch len(filtered) {
+	case 0:
+		return nil
+	case 1:
+		return filtered[0]
+	default:
+		strs := make([]string, len(filtered))
+		for i := range strs {
+			strs[i] = filtered[i].Error()
+		}
+		return errors.New(strings.Join(strs, ";"))
+	}
 }

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -14,10 +14,6 @@ import (
 )
 
 const (
-	// blockHeightLeeway is the amount of leeway we will allow in the host's
-	// blockheight field on the price table
-	blockHeightLeeway = 3
-
 	keyGougingChecker contextKey = "GougingChecker"
 )
 
@@ -288,8 +284,13 @@ func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, txnFee t
 			return fmt.Errorf("consensus not synced and host block height is lower, %v < %v", pt.HostBlockHeight, cs.BlockHeight)
 		}
 	} else {
-		if !(cs.BlockHeight-blockHeightLeeway <= pt.HostBlockHeight && pt.HostBlockHeight <= cs.BlockHeight+blockHeightLeeway) {
-			return fmt.Errorf("consensus is synced and host block height is not within range, %v %v %v", cs.BlockHeight, pt.HostBlockHeight, blockHeightLeeway)
+		var min uint64
+		if cs.BlockHeight >= uint64(gs.HostBlockHeightLeeway) {
+			min = cs.BlockHeight - uint64(gs.HostBlockHeightLeeway)
+		}
+		max := cs.BlockHeight + uint64(gs.HostBlockHeightLeeway)
+		if !(min <= pt.HostBlockHeight && pt.HostBlockHeight <= max) {
+			return fmt.Errorf("consensus is synced and host block height is not within range, %v-%v %v", min, max, pt.HostBlockHeight)
 		}
 	}
 

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -299,6 +299,11 @@ func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, txnFee t
 		return fmt.Errorf("TxnFeeMaxRecommended %v exceeds %v", pt.TxnFeeMaxRecommended, txnFee.Mul64(5))
 	}
 
+	// check TxnFeeMinRecommended - expect it to be lower or equal than the max
+	if pt.TxnFeeMinRecommended.Cmp(pt.TxnFeeMaxRecommended) > 0 {
+		return fmt.Errorf("TxnFeeMinRecommended is greater than TxnFeeMaxRecommended, %v>%v", pt.TxnFeeMinRecommended, pt.TxnFeeMaxRecommended)
+	}
+
 	return nil
 }
 

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -483,6 +483,8 @@ func RPCPriceTable(t *rhpv3.Transport, paymentFunc PriceTablePaymentFunc) (pt rh
 		return rhpv3.HostPriceTable{}, err
 	} else if payment, err := paymentFunc(pt); err != nil {
 		return rhpv3.HostPriceTable{}, err
+	} else if payment == nil {
+		return pt, nil // intended not to pay
 	} else if err := processPayment(s, payment); err != nil {
 		return rhpv3.HostPriceTable{}, err
 	} else if err := s.ReadResponse(&rhpv3.RPCPriceTableResponse{}, 0); err != nil {

--- a/worker/sessionpool.go
+++ b/worker/sessionpool.go
@@ -103,7 +103,7 @@ func (ss *sharedSession) RenewContract(ctx context.Context, prepareFn func(rev t
 	}
 	defer ss.pool.release(s)
 
-	if errs := PerformGougingChecks(ctx, s.settings).CanUpload(); len(errs) > 0 {
+	if errs := PerformGougingChecks(ctx, &s.settings, nil).CanUpload(); len(errs) > 0 {
 		return rhpv2.ContractRevision{}, nil, fmt.Errorf("failed reneww contract, gouging check failed: %v", errs)
 	}
 
@@ -129,7 +129,7 @@ func (ss *sharedSession) UploadSector(ctx context.Context, sector *[rhpv2.Sector
 		return types.Hash256{}, err
 	}
 	defer ss.pool.release(s)
-	if errs := PerformGougingChecks(ctx, s.settings).CanUpload(); len(errs) > 0 {
+	if errs := PerformGougingChecks(ctx, &s.settings, nil).CanUpload(); len(errs) > 0 {
 		return types.Hash256{}, fmt.Errorf("failed to upload sector, gouging check failed: %v", errs)
 	}
 	return s.appendSector(ctx, sector, currentHeight)
@@ -141,7 +141,7 @@ func (ss *sharedSession) DownloadSector(ctx context.Context, w io.Writer, root t
 		return err
 	}
 	defer ss.pool.release(s)
-	if errs := PerformGougingChecks(ctx, s.settings).CanDownload(); len(errs) > 0 {
+	if errs := PerformGougingChecks(ctx, &s.settings, nil).CanDownload(); len(errs) > 0 {
 		return fmt.Errorf("failed to download sector, gouging check failed: %v", errs)
 	}
 	return s.readSector(ctx, w, root, offset, length)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -474,15 +474,8 @@ func (w *worker) rhpPriceTableHandler(jc jape.Context) {
 		return
 	}
 
-	ctx := jc.Request.Context()
-	if rptr.Timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(jc.Request.Context(), rptr.Timeout)
-		defer cancel()
-	}
-
 	var pt rhpv3.HostPriceTable
-	if jc.Check("could not get price table", w.withTransportV3(ctx, rptr.SiamuxAddr, rptr.HostKey, func(t *rhpv3.Transport) (err error) {
+	if jc.Check("could not get price table", w.withTransportV3(jc.Request.Context(), rptr.SiamuxAddr, rptr.HostKey, func(t *rhpv3.Transport) (err error) {
 		pt, err = RPCPriceTable(t, func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) { return nil, nil })
 		return
 	})) != nil {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -497,7 +497,7 @@ func (w *worker) rhpFormHandler(jc jape.Context) {
 			return err
 		}
 
-		if errs := PerformGougingChecks(ctx, hostSettings).CanForm(); len(errs) > 0 {
+		if errs := PerformGougingChecks(ctx, &hostSettings, nil).CanForm(); len(errs) > 0 {
 			return fmt.Errorf("failed to form contract, gouging check failed: %v", errs)
 		}
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -468,6 +468,30 @@ func (w *worker) rhpScanHandler(jc jape.Context) {
 	})
 }
 
+func (w *worker) rhpPriceTableHandler(jc jape.Context) {
+	var rptr api.RHPPriceTableRequest
+	if jc.Decode(&rptr) != nil {
+		return
+	}
+
+	ctx := jc.Request.Context()
+	if rptr.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(jc.Request.Context(), rptr.Timeout)
+		defer cancel()
+	}
+
+	var pt rhpv3.HostPriceTable
+	if jc.Check("could not get price table", w.withTransportV3(ctx, rptr.SiamuxAddr, rptr.HostKey, func(t *rhpv3.Transport) (err error) {
+		pt, err = RPCPriceTable(t, func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) { return nil, nil })
+		return
+	})) != nil {
+		return
+	}
+
+	jc.Encode(pt)
+}
+
 func (w *worker) rhpFormHandler(jc jape.Context) {
 	ctx := jc.Request.Context()
 	var rfr api.RHPFormRequest
@@ -1041,6 +1065,7 @@ func (w *worker) Handler() http.Handler {
 		"POST   /rhp/form":             w.rhpFormHandler,
 		"POST   /rhp/renew":            w.rhpRenewHandler,
 		"POST   /rhp/fund":             w.rhpFundHandler,
+		"POST   /rhp/pricetable":       w.rhpPriceTableHandler,
 		"POST   /rhp/registry/read":    w.rhpRegistryReadHandler,
 		"POST   /rhp/registry/update":  w.rhpRegistryUpdateHandler,
 


### PR DESCRIPTION
This PR adds gouging checks that use a price table rather than host settings. It does so by extending the gouging checker to check for gouging for both host settings and a host price table. For the time being, nobody is passing a price table but #169 will be updated to do so once this is merged.