### PR TITLE
Handle SIGTERM

### DIFF
--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"go.sia.tech/core/types"
@@ -290,7 +291,7 @@ func main() {
 	log.Println("bus: Listening on", syncerAddress)
 
 	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, os.Interrupt)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
 	select {
 	case <-signalCh:
 		log.Println("Shutting down...")


### PR DESCRIPTION
Added support for graceful shutdown upon receiving a SIGTERM as docker uses a SIGTERM followed by a SIGKILL after a grace period to shut down containers.

https://docs.docker.com/engine/reference/commandline/stop/