### PR TITLE
Autopilot Loop State

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -193,7 +193,7 @@ func (ap *Autopilot) Run() error {
 			ap.s.tryPerformHostScan(ctx)
 
 			// do not continue if we are not synced
-			if !ap.state.cs.Synced {
+			if !ap.isSynced() {
 				ap.logger.Debug("iteration interrupted, consensus not synced")
 				return
 			}

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -82,18 +82,21 @@ func newContractor(ap *Autopilot) *contractor {
 	}
 }
 
-func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.AutopilotConfig, cs api.ConsensusState) error {
+func (c *contractor) performContractMaintenance(ctx context.Context) error {
 	ctx, span := tracing.Tracer.Start(ctx, "contractor.performContractMaintenance")
 	defer span.End()
 
-	if c.ap.isStopped() || !cs.Synced {
+	if c.ap.isStopped() || !c.ap.isSynced() {
 		return nil // skip contract maintenance if we're not synced
 	}
 
 	c.logger.Info("performing contract maintenance")
 
+	// convenience variables
+	state := c.ap.state
+
 	// no maintenance if no hosts are requested
-	if cfg.Contracts.Amount == 0 {
+	if state.cfg.Contracts.Amount == 0 {
 		c.logger.Debug("no hosts requested, skipping contract maintenance")
 		return nil
 	}
@@ -116,24 +119,6 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 	c.logger.Debugf("fetched %d active contracts, took %v", len(resp.Contracts), time.Since(start))
 	active := resp.Contracts
 
-	// fetch recommended txn fee
-	fee, err := c.ap.bus.RecommendedFee(ctx)
-	if err != nil {
-		return err
-	}
-
-	// fetch gouging settings
-	gs, err := c.ap.bus.GougingSettings(ctx)
-	if err != nil {
-		return err
-	}
-
-	// fetch redundancy settings
-	rs, err := c.ap.bus.RedundancySettings(ctx)
-	if err != nil {
-		return err
-	}
-
 	// fetch all hosts
 	hosts, err := c.ap.bus.Hosts(ctx, 0, -1)
 	if err != nil {
@@ -149,7 +134,7 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 	// min score to pass checks.
 	var minScore float64
 	if len(hosts) > 0 {
-		minScore, err = c.managedFindMinAllowedHostScores(ctx, cfg, hosts, storedData, rs.Redundancy())
+		minScore, err = c.managedFindMinAllowedHostScores(ctx, hosts, storedData)
 		if err != nil {
 			return fmt.Errorf("failed to determine min score for contract check: %w", err)
 		}
@@ -158,7 +143,7 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 	}
 
 	// run checks
-	toDelete, toIgnore, toRefresh, toRenew, err := c.runContractChecks(ctx, cfg, cs, gs, rs, active, minScore, fee)
+	toDelete, toIgnore, toRefresh, toRenew, err := c.runContractChecks(ctx, active, minScore)
 	if err != nil {
 		return fmt.Errorf("failed to run contract checks, err: %v", err)
 	}
@@ -172,19 +157,19 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 	}
 
 	// calculate remaining funds
-	remaining, err := c.remainingFunds(cfg, active)
+	remaining, err := c.remainingFunds(active)
 	if err != nil {
 		return err
 	}
 
 	// run renewals
-	renewed, err := c.runContractRenewals(ctx, cfg, cs.BlockHeight, &remaining, address, toRenew)
+	renewed, err := c.runContractRenewals(ctx, &remaining, address, toRenew)
 	if err != nil {
 		c.logger.Errorf("failed to renew contracts, err: %v", err) // continue
 	}
 
 	// run contract refreshes
-	refreshed, err := c.runContractRefreshes(ctx, cfg, cs.BlockHeight, &remaining, address, toRefresh)
+	refreshed, err := c.runContractRefreshes(ctx, &remaining, address, toRefresh)
 	if err != nil {
 		c.logger.Errorf("failed to refresh contracts, err: %v", err) // continue
 	}
@@ -195,8 +180,8 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 
 	// check if we need to form contracts and add them to the contract set
 	var formed []types.FileContractID
-	if numContracts < addLeeway(cfg.Contracts.Amount, leewayPctRequiredContracts) {
-		if formed, err = c.runContractFormations(ctx, cfg, cs, gs, rs, hosts, active, cfg.Contracts.Amount-numContracts, &remaining, address, minScore, fee); err != nil {
+	if numContracts < addLeeway(state.cfg.Contracts.Amount, leewayPctRequiredContracts) {
+		if formed, err = c.runContractFormations(ctx, hosts, active, state.cfg.Contracts.Amount-numContracts, &remaining, address, minScore); err != nil {
 			c.logger.Errorf("failed to form contracts, err: %v", err) // continue
 		}
 	}
@@ -211,19 +196,19 @@ func (c *contractor) performContractMaintenance(ctx context.Context, cfg api.Aut
 
 	// update contract set
 	if !c.ap.isStopped() {
-		if len(contractset) < int(rs.TotalShards) {
-			c.logger.Warnf("contractset does not have enough contracts, %v<%v", len(contractset), rs.TotalShards)
+		if len(contractset) < int(state.rs.TotalShards) {
+			c.logger.Warnf("contractset does not have enough contracts, %v<%v", len(contractset), state.rs.TotalShards)
 		}
-		return c.ap.bus.SetContractSet(ctx, cfg.Contracts.Set, contractset)
+		return c.ap.bus.SetContractSet(ctx, state.cfg.Contracts.Set, contractset)
 	}
 	return nil
 }
 
-func (c *contractor) performWalletMaintenance(ctx context.Context, cfg api.AutopilotConfig, cs api.ConsensusState) error {
+func (c *contractor) performWalletMaintenance(ctx context.Context) error {
 	ctx, span := tracing.Tracer.Start(ctx, "contractor.performWalletMaintenance")
 	defer span.End()
 
-	if c.ap.isStopped() || !cs.Synced {
+	if c.ap.isStopped() || !c.ap.isSynced() {
 		return nil // skip contract maintenance if we're not synced
 	}
 
@@ -232,6 +217,7 @@ func (c *contractor) performWalletMaintenance(ctx context.Context, cfg api.Autop
 	l := c.logger
 
 	// no contracts - nothing to do
+	cfg := c.ap.state.cfg
 	if cfg.Contracts.Amount == 0 {
 		l.Debug("wallet maintenance skipped, no contracts wanted")
 		return nil
@@ -287,7 +273,7 @@ func (c *contractor) performWalletMaintenance(ctx context.Context, cfg api.Autop
 	return nil
 }
 
-func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotConfig, cs api.ConsensusState, gs api.GougingSettings, rs api.RedundancySettings, contracts []api.Contract, minScore float64, txnFee types.Currency) (toDelete, toIgnore []types.FileContractID, toRefresh, toRenew []contractInfo, _ error) {
+func (c *contractor) runContractChecks(ctx context.Context, contracts []api.Contract, minScore float64) (toDelete, toIgnore []types.FileContractID, toRefresh, toRenew []contractInfo, _ error) {
 	if c.ap.isStopped() {
 		return
 	}
@@ -308,6 +294,9 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 
 	// create a new ip filter
 	f := newIPFilter(c.logger)
+
+	// convenience variables
+	state := c.ap.state
 
 	// state variables
 	contractIds := make([]types.FileContractID, 0, len(contracts))
@@ -344,7 +333,7 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 		}
 
 		// decide whether the host is still good
-		usable, reasons := isUsableHost(cfg, gs, rs, cs, &pt, f, host.Host, minScore, contract.FileSize(), txnFee)
+		usable, reasons := isUsableHost(state.cfg, state.gs, state.rs, state.cs, &pt, f, host.Host, minScore, contract.FileSize(), state.fee)
 		if !usable {
 			c.logger.Infow("unusable host", "hk", hk, "fcid", fcid, "reasons", errStr(joinErrors(reasons)))
 			toIgnore = append(toIgnore, fcid)
@@ -356,12 +345,12 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 
 		// decide whether the contract is still good
 		ci := contractInfo{contract: contract, settings: settings}
-		renterFunds, err := c.renewFundingEstimate(ctx, cfg, cs.BlockHeight, ci)
+		renterFunds, err := c.renewFundingEstimate(ctx, ci)
 		if err != nil {
 			c.logger.Errorw(fmt.Sprintf("failed to compute renterFunds for contract: %v", err))
 		}
 
-		usable, refresh, renew, reasons := isUsableContract(cfg, ci, cs.BlockHeight, renterFunds)
+		usable, refresh, renew, reasons := isUsableContract(state.cfg, ci, state.cs.BlockHeight, renterFunds)
 		if !usable {
 			c.logger.Infow(
 				"unusable contract",
@@ -396,7 +385,7 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 	}
 
 	// apply active contract limit
-	numContractsTooMany := len(contracts) - len(toIgnore) - len(toDelete) - int(cfg.Contracts.Amount)
+	numContractsTooMany := len(contracts) - len(toIgnore) - len(toDelete) - int(state.cfg.Contracts.Amount)
 	if numContractsTooMany > 0 {
 		// sort by contract size
 		sort.Slice(contractIds, func(i, j int) bool {
@@ -418,7 +407,7 @@ func (c *contractor) runContractChecks(ctx context.Context, cfg api.AutopilotCon
 	return toDelete, toIgnore, toRefresh, toRenew, nil
 }
 
-func (c *contractor) runContractFormations(ctx context.Context, cfg api.AutopilotConfig, cs api.ConsensusState, gs api.GougingSettings, rs api.RedundancySettings, hosts []hostdb.Host, active []api.Contract, missing uint64, budget *types.Currency, renterAddress types.Address, minScore float64, txnFee types.Currency) ([]types.FileContractID, error) {
+func (c *contractor) runContractFormations(ctx context.Context, hosts []hostdb.Host, active []api.Contract, missing uint64, budget *types.Currency, renterAddress types.Address, minScore float64) ([]types.FileContractID, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "runContractFormations")
 	defer span.End()
 
@@ -430,7 +419,7 @@ func (c *contractor) runContractFormations(ctx context.Context, cfg api.Autopilo
 	c.logger.Debugw(
 		"run contract formations",
 		"active", len(active),
-		"required", cfg.Contracts.Amount,
+		"required", c.ap.state.cfg.Contracts.Amount,
 		"missing", missing,
 		"budget", budget,
 	)
@@ -442,6 +431,9 @@ func (c *contractor) runContractFormations(ctx context.Context, cfg api.Autopilo
 		)
 	}()
 
+	// convenience variables
+	state := c.ap.state
+
 	// create a map of used hosts
 	used := make(map[types.PublicKey]struct{})
 	for _, contract := range active {
@@ -450,13 +442,13 @@ func (c *contractor) runContractFormations(ctx context.Context, cfg api.Autopilo
 
 	// fetch candidate hosts
 	wanted := int(addLeeway(missing, leewayPctCandidateHosts))
-	candidates, err := c.candidateHosts(ctx, cfg, hosts, used, make(map[types.PublicKey]uint64), wanted, minScore)
+	candidates, err := c.candidateHosts(ctx, hosts, used, make(map[types.PublicKey]uint64), wanted, minScore)
 	if err != nil {
 		return nil, err
 	}
 
 	// calculate min/max contract funds
-	minInitialContractFunds, maxInitialContractFunds := initialContractFundingMinMax(cfg)
+	minInitialContractFunds, maxInitialContractFunds := initialContractFundingMinMax(state.cfg)
 
 	for h := 0; missing > 0 && h < len(candidates); h++ {
 		if c.ap.isStopped() {
@@ -478,12 +470,12 @@ func (c *contractor) runContractFormations(ctx context.Context, cfg api.Autopilo
 		}
 
 		// perform gouging checks on the fly to ensure the host is not gouging its prices
-		if gouging, reasons := worker.IsGouging(gs, rs, cs, nil, &pt, txnFee, cfg.Contracts.Period, cfg.Contracts.RenewWindow); gouging {
+		if gouging, reasons := worker.IsGouging(state.gs, state.rs, state.cs, nil, &pt, state.fee, state.cfg.Contracts.Period, state.cfg.Contracts.RenewWindow); gouging {
 			c.logger.Error("candidate host became unusable", "host", host, "reasons", reasons)
 			continue
 		}
 
-		formedContract, proceed, err := c.formContract(ctx, host, txnFee, minInitialContractFunds, maxInitialContractFunds, cs.BlockHeight, budget, renterAddress, cfg)
+		formedContract, proceed, err := c.formContract(ctx, host, minInitialContractFunds, maxInitialContractFunds, budget, renterAddress)
 		if err == nil {
 			// add contract to contract set
 			formed = append(formed, formedContract.ID)
@@ -497,7 +489,7 @@ func (c *contractor) runContractFormations(ctx context.Context, cfg api.Autopilo
 	return formed, nil
 }
 
-func (c *contractor) runContractRenewals(ctx context.Context, cfg api.AutopilotConfig, blockHeight uint64, budget *types.Currency, renterAddress types.Address, toRenew []contractInfo) ([]api.ContractMetadata, error) {
+func (c *contractor) runContractRenewals(ctx context.Context, budget *types.Currency, renterAddress types.Address, toRenew []contractInfo) ([]api.ContractMetadata, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "runContractRenewals")
 	defer span.End()
 
@@ -524,7 +516,7 @@ func (c *contractor) runContractRenewals(ctx context.Context, cfg api.AutopilotC
 			break
 		}
 
-		contract, proceed, err := c.renewContract(ctx, ci, cfg, blockHeight, budget, renterAddress)
+		contract, proceed, err := c.renewContract(ctx, ci, budget, renterAddress)
 		if err == nil {
 			renewed = append(renewed, contract)
 		}
@@ -536,7 +528,7 @@ func (c *contractor) runContractRenewals(ctx context.Context, cfg api.AutopilotC
 	return renewed, nil
 }
 
-func (c *contractor) runContractRefreshes(ctx context.Context, cfg api.AutopilotConfig, blockHeight uint64, budget *types.Currency, renterAddress types.Address, toRefresh []contractInfo) ([]api.ContractMetadata, error) {
+func (c *contractor) runContractRefreshes(ctx context.Context, budget *types.Currency, renterAddress types.Address, toRefresh []contractInfo) ([]api.ContractMetadata, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "runContractRefreshes")
 	defer span.End()
 
@@ -563,7 +555,7 @@ func (c *contractor) runContractRefreshes(ctx context.Context, cfg api.Autopilot
 			break
 		}
 
-		contract, proceed, err := c.refreshContract(ctx, ci, cfg, blockHeight, budget, renterAddress)
+		contract, proceed, err := c.refreshContract(ctx, ci, budget, renterAddress)
 		if err == nil {
 			refreshed = append(refreshed, contract)
 		}
@@ -595,11 +587,7 @@ func (c *contractor) refreshFundingEstimate(ctx context.Context, cfg api.Autopil
 	refreshAmount := ci.contract.TotalCost.Mul64(2)
 
 	// estimate the txn fee
-	txnFee, err := c.ap.bus.RecommendedFee(ctx)
-	if err != nil {
-		return types.ZeroCurrency, err
-	}
-	txnFeeEstimate := txnFee.Mul64(estimatedFileContractTransactionSetSize)
+	txnFeeEstimate := c.ap.state.fee.Mul64(estimatedFileContractTransactionSetSize)
 
 	// check for a sane minimum that is equal to the initial contract funding
 	// but without an upper cap.
@@ -616,7 +604,10 @@ func (c *contractor) refreshFundingEstimate(ctx context.Context, cfg api.Autopil
 	return refreshAmountCapped, nil
 }
 
-func (c *contractor) renewFundingEstimate(ctx context.Context, cfg api.AutopilotConfig, blockHeight uint64, ci contractInfo) (types.Currency, error) {
+func (c *contractor) renewFundingEstimate(ctx context.Context, ci contractInfo) (types.Currency, error) {
+	cfg := c.ap.state.cfg
+	cs := c.ap.state.cs
+
 	// estimate the cost of the current data stored
 	dataStored := ci.contract.FileSize()
 	storageCost := types.NewCurrency64(dataStored).Mul64(cfg.Contracts.Period).Mul(ci.settings.StoragePrice)
@@ -659,14 +650,10 @@ func (c *contractor) renewFundingEstimate(ctx context.Context, cfg api.Autopilot
 	// the file contract (and the transaction fee goes to the miners, not the
 	// file contract).
 	subTotal := storageCost.Add(newUploadsCost).Add(newDownloadsCost).Add(newFundAccountCost).Add(ci.settings.ContractPrice)
-	siaFundFeeEstimate := (consensus.State{Index: types.ChainIndex{Height: blockHeight}}).FileContractTax(types.FileContract{Payout: subTotal})
+	siaFundFeeEstimate := (consensus.State{Index: types.ChainIndex{Height: cs.BlockHeight}}).FileContractTax(types.FileContract{Payout: subTotal})
 
 	// estimate the txn fee
-	txnFee, err := c.ap.bus.RecommendedFee(ctx)
-	if err != nil {
-		return types.ZeroCurrency, err
-	}
-	txnFeeEstimate := txnFee.Mul64(estimatedFileContractTransactionSetSize)
+	txnFeeEstimate := c.ap.state.fee.Mul64(estimatedFileContractTransactionSetSize)
 
 	// add them all up and then return the estimate plus 33% for error margin
 	// and just general volatility of usage pattern.
@@ -694,14 +681,14 @@ func (c *contractor) renewFundingEstimate(ctx context.Context, cfg api.Autopilot
 	return cappedEstimatedCost, nil
 }
 
-func (c *contractor) managedFindMinAllowedHostScores(ctx context.Context, cfg api.AutopilotConfig, hosts []hostdb.Host, storedData map[types.PublicKey]uint64, redundancy float64) (float64, error) {
+func (c *contractor) managedFindMinAllowedHostScores(ctx context.Context, hosts []hostdb.Host, storedData map[types.PublicKey]uint64) (float64, error) {
 	// Pull a new set of hosts from the hostdb that could be used as a new set
 	// to match the allowance. The lowest scoring host of these new hosts will
 	// be used as a baseline for determining whether our existing contracts are
 	// worthwhile.
-	numContracts := cfg.Contracts.Amount
+	numContracts := c.ap.state.cfg.Contracts.Amount
 	buffer := 50
-	hosts, err := c.candidateHosts(ctx, cfg, hosts, make(map[types.PublicKey]struct{}), storedData, int(numContracts)+int(buffer), 1) // 1 to avoid 0 score hosts
+	hosts, err := c.candidateHosts(ctx, hosts, make(map[types.PublicKey]struct{}), storedData, int(numContracts)+int(buffer), 1) // 1 to avoid 0 score hosts
 	if err != nil {
 		return 0, err
 	}
@@ -714,7 +701,7 @@ func (c *contractor) managedFindMinAllowedHostScores(ctx context.Context, cfg ap
 	// good for upload.
 	lowestScore := math.MaxFloat64
 	for i := 0; i < len(hosts); i++ {
-		score := hostScore(cfg, hosts[i], 0, redundancy)
+		score := hostScore(c.ap.state.cfg, hosts[i], 0, c.ap.state.rs.Redundancy())
 		if score < lowestScore {
 			lowestScore = score
 		}
@@ -722,7 +709,7 @@ func (c *contractor) managedFindMinAllowedHostScores(ctx context.Context, cfg ap
 	return lowestScore / minAllowedScoreLeeway, nil
 }
 
-func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig, hosts []hostdb.Host, exclude map[types.PublicKey]struct{}, storedData map[types.PublicKey]uint64, wanted int, minScore float64) ([]hostdb.Host, error) {
+func (c *contractor) candidateHosts(ctx context.Context, hosts []hostdb.Host, exclude map[types.PublicKey]struct{}, storedData map[types.PublicKey]uint64, wanted int, minScore float64) ([]hostdb.Host, error) {
 	c.logger.Debugf("looking for %d candidate hosts", wanted)
 
 	// nothing to do
@@ -730,29 +717,7 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 		return nil, nil
 	}
 
-	// fetch consensus state
-	cs, err := c.ap.bus.ConsensusState(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// fetch recommended fee
-	txnFee, err := c.ap.bus.RecommendedFee(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// fetch gouging settings
-	gs, err := c.ap.bus.GougingSettings(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// fetch redundancy settings
-	rs, err := c.ap.bus.RedundancySettings(ctx)
-	if err != nil {
-		return nil, err
-	}
+	state := c.ap.state
 
 	// create IP filter and add all excluded hosts to it.
 	ipFilter := newIPFilter(c.logger)
@@ -782,11 +747,11 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 		// slows contract maintenance down way too much, we re-evaluate the host
 		// right before forming the contract to ensure we do not form a contract
 		// with a host that's gouging its prices.
-		if usable, _ := isUsableHost(cfg, gs, rs, cs, h.PriceTable, ipFilter, h, minScore, storedData[h.PublicKey], txnFee); !usable {
+		if usable, _ := isUsableHost(state.cfg, state.gs, state.rs, state.cs, h.PriceTable, ipFilter, h, minScore, storedData[h.PublicKey], state.fee); !usable {
 			continue
 		}
 
-		score := hostScore(cfg, h, 0, rs.Redundancy())
+		score := hostScore(state.cfg, h, 0, state.rs.Redundancy())
 		if score == 0 {
 			continue
 		}
@@ -814,7 +779,7 @@ func (c *contractor) candidateHosts(ctx context.Context, cfg api.AutopilotConfig
 	return selected, nil
 }
 
-func (c *contractor) renewContract(ctx context.Context, ci contractInfo, cfg api.AutopilotConfig, blockHeight uint64, budget *types.Currency, renterAddress types.Address) (cm api.ContractMetadata, proceed bool, err error) {
+func (c *contractor) renewContract(ctx context.Context, ci contractInfo, budget *types.Currency, renterAddress types.Address) (cm api.ContractMetadata, proceed bool, err error) {
 	ctx, span := tracing.Tracer.Start(ctx, "renewContract")
 	defer span.End()
 	defer func() {
@@ -827,6 +792,8 @@ func (c *contractor) renewContract(ctx context.Context, ci contractInfo, cfg api
 	span.SetAttributes(attribute.Stringer("contract", ci.contract.ID))
 
 	// convenience variables
+	cfg := c.ap.state.cfg
+	cs := c.ap.state.cs
 	contract := ci.contract
 	settings := ci.settings
 	fcid := contract.ID
@@ -834,7 +801,7 @@ func (c *contractor) renewContract(ctx context.Context, ci contractInfo, cfg api
 	hk := contract.HostKey()
 
 	// calculate the renter funds
-	renterFunds, err := c.renewFundingEstimate(ctx, cfg, blockHeight, ci)
+	renterFunds, err := c.renewFundingEstimate(ctx, ci)
 	if err != nil {
 		c.logger.Errorw(fmt.Sprintf("could not get renew funding estimate, err: %v", err), "hk", hk, "fcid", fcid)
 		return api.ContractMetadata{}, true, err
@@ -848,8 +815,8 @@ func (c *contractor) renewContract(ctx context.Context, ci contractInfo, cfg api
 
 	// calculate the host collateral
 	endHeight := endHeight(cfg, c.currentPeriod())
-	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-blockHeight, settings)
-	newCollateral := rhpv2.ContractRenewalCollateral(rev.FileContract, expectedStorage, settings, blockHeight, endHeight)
+	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-cs.BlockHeight, settings)
+	newCollateral := rhpv2.ContractRenewalCollateral(rev.FileContract, expectedStorage, settings, cs.BlockHeight, endHeight)
 
 	// renew the contract
 	newRevision, _, err := c.ap.worker.RHPRenew(ctx, fcid, endHeight, hk, contract.HostIP, renterAddress, renterFunds, newCollateral)
@@ -865,7 +832,7 @@ func (c *contractor) renewContract(ctx context.Context, ci contractInfo, cfg api
 	*budget = budget.Sub(renterFunds)
 
 	// persist the contract
-	renewedContract, err := c.ap.bus.AddRenewedContract(ctx, newRevision, renterFunds, blockHeight, fcid)
+	renewedContract, err := c.ap.bus.AddRenewedContract(ctx, newRevision, renterFunds, cs.BlockHeight, fcid)
 	if err != nil {
 		c.logger.Errorw(fmt.Sprintf("renewal failed to persist, err: %v", err), "hk", hk, "fcid", fcid)
 		return api.ContractMetadata{}, false, err
@@ -881,7 +848,7 @@ func (c *contractor) renewContract(ctx context.Context, ci contractInfo, cfg api
 	return renewedContract, true, nil
 }
 
-func (c *contractor) refreshContract(ctx context.Context, ci contractInfo, cfg api.AutopilotConfig, blockHeight uint64, budget *types.Currency, renterAddress types.Address) (cm api.ContractMetadata, proceed bool, err error) {
+func (c *contractor) refreshContract(ctx context.Context, ci contractInfo, budget *types.Currency, renterAddress types.Address) (cm api.ContractMetadata, proceed bool, err error) {
 	ctx, span := tracing.Tracer.Start(ctx, "refreshContract")
 	defer span.End()
 	defer func() {
@@ -894,6 +861,8 @@ func (c *contractor) refreshContract(ctx context.Context, ci contractInfo, cfg a
 	span.SetAttributes(attribute.Stringer("contract", ci.contract.ID))
 
 	// convenience variables
+	cfg := c.ap.state.cfg
+	cs := c.ap.state.cs
 	contract := ci.contract
 	settings := ci.settings
 	fcid := contract.ID
@@ -914,8 +883,8 @@ func (c *contractor) refreshContract(ctx context.Context, ci contractInfo, cfg a
 	}
 
 	// calculate the new collateral
-	expectedStorage := renterFundsToExpectedStorage(renterFunds, contract.EndHeight()-blockHeight, settings)
-	newCollateral := rhpv2.ContractRenewalCollateral(rev.FileContract, expectedStorage, settings, blockHeight, contract.EndHeight())
+	expectedStorage := renterFundsToExpectedStorage(renterFunds, contract.EndHeight()-cs.BlockHeight, settings)
+	newCollateral := rhpv2.ContractRenewalCollateral(rev.FileContract, expectedStorage, settings, cs.BlockHeight, contract.EndHeight())
 
 	// do not refresh if the contract's updated collateral will fall below the threshold anyway
 	_, hostMissedPayout, _, _ := rhpv2.CalculateHostPayouts(rev.FileContract, newCollateral, settings, contract.EndHeight())
@@ -939,7 +908,7 @@ func (c *contractor) refreshContract(ctx context.Context, ci contractInfo, cfg a
 	*budget = budget.Sub(renterFunds)
 
 	// persist the contract
-	refreshedContract, err := c.ap.bus.AddRenewedContract(ctx, newRevision, renterFunds, blockHeight, contract.ID)
+	refreshedContract, err := c.ap.bus.AddRenewedContract(ctx, newRevision, renterFunds, cs.BlockHeight, contract.ID)
 	if err != nil {
 		c.logger.Errorw(fmt.Sprintf("refresh failed, err: %v", err), "hk", hk, "fcid", fcid)
 		return api.ContractMetadata{}, false, err
@@ -955,7 +924,7 @@ func (c *contractor) refreshContract(ctx context.Context, ci contractInfo, cfg a
 	return refreshedContract, true, nil
 }
 
-func (c *contractor) formContract(ctx context.Context, host hostdb.Host, fee, minInitialContractFunds, maxInitialContractFunds types.Currency, blockHeight uint64, budget *types.Currency, renterAddress types.Address, cfg api.AutopilotConfig) (cm api.ContractMetadata, proceed bool, err error) {
+func (c *contractor) formContract(ctx context.Context, host hostdb.Host, minInitialContractFunds, maxInitialContractFunds types.Currency, budget *types.Currency, renterAddress types.Address) (cm api.ContractMetadata, proceed bool, err error) {
 	ctx, span := tracing.Tracer.Start(ctx, "formContract")
 	defer span.End()
 	defer func() {
@@ -967,6 +936,9 @@ func (c *contractor) formContract(ctx context.Context, host hostdb.Host, fee, mi
 	hk := host.PublicKey
 	span.SetAttributes(attribute.Stringer("host", hk))
 
+	// convenience variables
+	state := c.ap.state
+
 	// fetch host settings
 	scan, err := c.ap.worker.RHPScan(ctx, hk, host.NetAddress, 0)
 	if err != nil {
@@ -975,7 +947,7 @@ func (c *contractor) formContract(ctx context.Context, host hostdb.Host, fee, mi
 	}
 
 	// check our budget
-	txnFee := fee.Mul64(estimatedFileContractTransactionSetSize)
+	txnFee := state.fee.Mul64(estimatedFileContractTransactionSetSize)
 	renterFunds := initialContractFunding(scan.Settings, txnFee, minInitialContractFunds, maxInitialContractFunds)
 	if budget.Cmp(renterFunds) < 0 {
 		c.logger.Debugw("insufficient budget", "budget", budget, "needed", renterFunds)
@@ -983,9 +955,9 @@ func (c *contractor) formContract(ctx context.Context, host hostdb.Host, fee, mi
 	}
 
 	// calculate the host collateral
-	endHeight := endHeight(cfg, c.currentPeriod())
-	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-blockHeight, scan.Settings)
-	hostCollateral := rhpv2.ContractFormationCollateral(cfg.Contracts.Period, expectedStorage, scan.Settings)
+	endHeight := endHeight(state.cfg, c.currentPeriod())
+	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-state.cs.BlockHeight, scan.Settings)
+	hostCollateral := rhpv2.ContractFormationCollateral(state.cfg.Contracts.Period, expectedStorage, scan.Settings)
 
 	// form contract
 	contract, _, err := c.ap.worker.RHPForm(ctx, endHeight, hk, host.NetAddress, renterAddress, renterFunds, hostCollateral)
@@ -1002,7 +974,7 @@ func (c *contractor) formContract(ctx context.Context, host hostdb.Host, fee, mi
 	*budget = budget.Sub(renterFunds)
 
 	// persist contract in store
-	formedContract, err := c.ap.bus.AddContract(ctx, contract, renterFunds, blockHeight)
+	formedContract, err := c.ap.bus.AddContract(ctx, contract, renterFunds, state.cs.BlockHeight)
 	if err != nil {
 		c.logger.Errorw(fmt.Sprintf("contract formation failed, err: %v", err), "hk", hk)
 		return api.ContractMetadata{}, true, err

--- a/autopilot/contractorspending.go
+++ b/autopilot/contractorspending.go
@@ -13,7 +13,7 @@ func (c *contractor) currentPeriod() uint64 {
 	return c.currPeriod
 }
 
-func (c *contractor) updateCurrentPeriod(cfg api.AutopilotConfig, cs api.ConsensusState) {
+func (c *contractor) updateCurrentPeriod() {
 	c.mu.Lock()
 	defer func(prevPeriod uint64) {
 		if c.currPeriod != prevPeriod {
@@ -21,6 +21,9 @@ func (c *contractor) updateCurrentPeriod(cfg api.AutopilotConfig, cs api.Consens
 		}
 		c.mu.Unlock()
 	}(c.currPeriod)
+
+	cfg := c.ap.state.cfg
+	cs := c.ap.state.cs
 
 	if c.currPeriod == 0 {
 		c.currPeriod = cs.BlockHeight
@@ -73,7 +76,9 @@ func (c *contractor) currentPeriodSpending(contracts []api.Contract) (types.Curr
 	return spent, nil
 }
 
-func (c *contractor) remainingFunds(cfg api.AutopilotConfig, contracts []api.Contract) (types.Currency, error) {
+func (c *contractor) remainingFunds(contracts []api.Contract) (types.Currency, error) {
+	cfg := c.ap.state.cfg
+
 	// find out how much we spent in the current period
 	spent, err := c.currentPeriodSpending(contracts)
 	if err != nil {

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -31,7 +31,7 @@ func newMigrator(ap *Autopilot, healthCutoff float64) *migrator {
 	}
 }
 
-func (m *migrator) tryPerformMigrations(ctx context.Context, cfg api.AutopilotConfig) {
+func (m *migrator) tryPerformMigrations(ctx context.Context) {
 	m.mu.Lock()
 	if m.running || m.ap.isStopped() {
 		m.mu.Unlock()
@@ -41,13 +41,13 @@ func (m *migrator) tryPerformMigrations(ctx context.Context, cfg api.AutopilotCo
 	m.mu.Unlock()
 
 	m.ap.wg.Add(1)
-	go func() {
+	go func(cfg api.AutopilotConfig) {
 		defer m.ap.wg.Done()
 		m.performMigrations(cfg)
 		m.mu.Lock()
 		m.running = false
 		m.mu.Unlock()
-	}()
+	}(m.ap.state.cfg)
 }
 
 func (m *migrator) performMigrations(cfg api.AutopilotConfig) {

--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -152,7 +152,7 @@ func newScanner(ap *Autopilot, scanBatchSize, scanThreads uint64, scanMinInterva
 	}, nil
 }
 
-func (s *scanner) tryPerformHostScan(ctx context.Context, cfg api.AutopilotConfig) {
+func (s *scanner) tryPerformHostScan(ctx context.Context) {
 	s.mu.Lock()
 	if s.scanning || !s.isScanRequired() || s.ap.isStopped() {
 		s.mu.Unlock()
@@ -164,7 +164,7 @@ func (s *scanner) tryPerformHostScan(ctx context.Context, cfg api.AutopilotConfi
 	s.scanning = true
 	s.mu.Unlock()
 
-	go func() {
+	go func(cfg api.AutopilotConfig) {
 		for resp := range s.launchScanWorkers(ctx, s.launchHostScans()) {
 			if s.ap.isStopped() {
 				break
@@ -188,7 +188,7 @@ func (s *scanner) tryPerformHostScan(ctx context.Context, cfg api.AutopilotConfi
 		s.scanning = false
 		s.logger.Debugf("host scan finished after %v", time.Since(s.scanningLastStart))
 		s.mu.Unlock()
-	}()
+	}(s.ap.state.cfg)
 }
 
 func (s *scanner) tryUpdateTimeout() {

--- a/autopilot/scanner_test.go
+++ b/autopilot/scanner_test.go
@@ -86,8 +86,6 @@ func (s *scanner) isScanning() bool {
 }
 
 func TestScanner(t *testing.T) {
-	cfg := api.DefaultAutopilotConfig()
-
 	// prepare 100 hosts
 	hosts := newTestHosts(100)
 
@@ -97,7 +95,7 @@ func TestScanner(t *testing.T) {
 	s := newTestScanner(b, w)
 
 	// assert it started a host scan
-	s.tryPerformHostScan(context.Background(), cfg)
+	s.tryPerformHostScan(context.Background())
 	if !s.isScanning() {
 		t.Fatal("unexpected")
 	}
@@ -125,7 +123,7 @@ func TestScanner(t *testing.T) {
 	}
 
 	// assert we prevent starting a host scan immediately after a scan was done
-	s.tryPerformHostScan(context.Background(), cfg)
+	s.tryPerformHostScan(context.Background())
 	if s.isScanning() {
 		t.Fatal("unexpected")
 	}
@@ -134,14 +132,17 @@ func TestScanner(t *testing.T) {
 	s.scanningLastStart = time.Time{}
 
 	// assert it started a host scan
-	s.tryPerformHostScan(context.Background(), cfg)
+	s.tryPerformHostScan(context.Background())
 	if !s.isScanning() {
 		t.Fatal("unexpected")
 	}
 }
 
 func newTestScanner(b *mockBus, w *mockWorker) *scanner {
-	ap := &Autopilot{stopChan: make(chan struct{})}
+	ap := &Autopilot{
+		state:    loopState{cfg: api.DefaultAutopilotConfig()},
+		stopChan: make(chan struct{}),
+	}
 	return &scanner{
 		ap:     ap,
 		bus:    b,


### PR DESCRIPTION
This PR adds a `loopState` struct that contains some of the stuff we need constantly and are currently passing around all the time. We update it in every iteration of the autopilot loop, ensuring the entire loop uses the same data and we don't needless fetch the same info twice. 