### PR TITLE
Record ContractSpending inside a transaction

### DIFF
--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -479,13 +479,13 @@ func (s *SQLStore) Object(ctx context.Context, key string) (object.Object, error
 	return obj.convert()
 }
 
-func (db *SQLStore) RecordContractSpending(ctx context.Context, records []api.ContractSpendingRecord) error {
+func (s *SQLStore) RecordContractSpending(ctx context.Context, records []api.ContractSpendingRecord) error {
 	squashedRecords := make(map[types.FileContractID]api.ContractSpending)
 	for _, r := range records {
 		squashedRecords[r.ContractID] = squashedRecords[r.ContractID].Add(r.ContractSpending)
 	}
 	for fcid, newSpending := range squashedRecords {
-		err := db.db.Transaction(func(tx *gorm.DB) error {
+		err := s.retryTransaction(func(tx *gorm.DB) error {
 			var contract dbContract
 			err := tx.Model(&dbContract{}).
 				Where("fcid = ?", fileContractID(fcid)).


### PR DESCRIPTION
I ran into the following error on my node:

```bash
2023-03-08T11:03:30+01:00      ERROR    db   gorm@v1.24.3/finisher_api.go:647  database is locked      {"elapsed": "0.090ms", "rows": 0, "sql": "UPDATE `contracts` SET `upload_spending`=\"20573601380386548285440\" WHERE `id` = 994"}
2023-03-08T11:03:30+01:00      ERROR    worker.worker   worker/spending.go:91  failed to record contract spending: failed to record spending metrics for contract: database is locked
```

We missed wrapping a transaction in a retry. I've added a logger to the sql store as well so we can log the retry attempts and make sure it does not go by completely unnoticed.