### PR TITLE
Extend objects search

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -92,7 +92,8 @@ type (
 		SetContractSet(ctx context.Context, set string, contracts []types.FileContractID) error
 
 		Object(ctx context.Context, key string) (object.Object, error)
-		Objects(ctx context.Context, key string) ([]string, error)
+		Objects(ctx context.Context, offset, limit int, key, prefix string) ([]string, error)
+		ObjectsFuzzy(ctx context.Context, offset, limit int, key string) ([]string, error)
 		UpdateObject(ctx context.Context, key string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
 		RemoveObject(ctx context.Context, key string) error
 
@@ -610,10 +611,30 @@ func (b *bus) contractIDHandlerDELETE(jc jape.Context) {
 	jc.Check("couldn't remove contract", b.ms.RemoveContract(jc.Request.Context(), id))
 }
 
+func (b *bus) fuzzyObjectsHandlerGET(jc jape.Context) {
+	offset := 0
+	limit := -1
+	var key string
+	if jc.DecodeForm("offset", &offset) != nil || jc.DecodeForm("limit", &limit) != nil || jc.DecodeForm("key", &key) != nil {
+		return
+	}
+	keys, err := b.ms.ObjectsFuzzy(jc.Request.Context(), offset, limit, key)
+	if jc.Check("couldn't list objects", err) != nil {
+		return
+	}
+	jc.Encode(keys)
+}
+
 func (b *bus) objectsKeyHandlerGET(jc jape.Context) {
 	ctx := jc.Request.Context()
 	if strings.HasSuffix(jc.PathParam("key"), "/") {
-		keys, err := b.ms.Objects(ctx, jc.PathParam("key"))
+		offset := 0
+		limit := -1
+		prefix := ""
+		if jc.DecodeForm("offset", &offset) != nil || jc.DecodeForm("limit", &limit) != nil || jc.DecodeForm("prefix", &prefix) != nil {
+			return
+		}
+		keys, err := b.ms.Objects(ctx, offset, limit, jc.PathParam("key"), prefix)
 		if jc.Check("couldn't list objects", err) == nil {
 			jc.Encode(api.ObjectsResponse{Entries: keys})
 		}
@@ -949,6 +970,8 @@ func (b *bus) Handler() http.Handler {
 		"DELETE /contract/:id":           b.contractIDHandlerDELETE,
 		"POST   /contract/:id/acquire":   b.contractAcquireHandlerPOST,
 		"POST   /contract/:id/release":   b.contractReleaseHandlerPOST,
+
+		"GET /fuzzy/objects": b.fuzzyObjectsHandlerGET,
 
 		"GET    /objects/*key": b.objectsKeyHandlerGET,
 		"PUT    /objects/*key": b.objectsKeyHandlerPUT,

--- a/bus/client.go
+++ b/bus/client.go
@@ -464,6 +464,17 @@ func (c *Client) UpdateRedundancySettings(ctx context.Context, rs api.Redundancy
 
 // Object returns the object at the given path, or, if path ends in '/', the
 // entries under that path.
+func (c *Client) ObjectsFuzzy(ctx context.Context, offset, limit int, key string) (entries []string, err error) {
+	values := url.Values{}
+	values.Set("offset", fmt.Sprint(offset))
+	values.Set("limit", fmt.Sprint(limit))
+	values.Set("key", key)
+	err = c.c.WithContext(ctx).GET("/fuzzy/objects", &entries)
+	return
+}
+
+// Object returns the object at the given path, or, if path ends in '/', the
+// entries under that path.
 func (c *Client) Object(ctx context.Context, path string) (o object.Object, entries []string, err error) {
 	var or api.ObjectsResponse
 	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/objects/%s", path), &or)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -251,6 +251,15 @@ func TestUploadDownload(t *testing.T) {
 	// Run uploads once.
 	uploadDownload()
 
+	// Fuzzy search for the objects.
+	objects, err := cluster.Bus.ObjectsFuzzy(context.Background(), 0, -1, "ata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 2 {
+		t.Fatalf("should have 2 objects but got %v", len(objects))
+	}
+
 	// Renew contracts.
 	if err := cluster.MineToRenewWindow(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR adds the `offset`, `limit` and `prefix` query arguments to the `/objects` endpoint. `prefix` will filter out any objects that don't start with a given prefix.

It also adds a `/fuzzy/objects?key=foo` endpoint which allows for fuzzy searching all objects that contain a given `key` in their name.