### PR TITLE
Add endpoint to list all contract sets known to the bus

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -87,6 +87,7 @@ type (
 		AncestorContracts(ctx context.Context, fcid types.FileContractID, minStartHeight uint64) ([]api.ArchivedContract, error)
 		Contract(ctx context.Context, id types.FileContractID) (api.ContractMetadata, error)
 		Contracts(ctx context.Context, set string) ([]api.ContractMetadata, error)
+		ContractSets(ctx context.Context) ([]string, error)
 		RecordContractSpending(ctx context.Context, records []api.ContractSpendingRecord) error
 		RemoveContract(ctx context.Context, id types.FileContractID) error
 		SetContractSet(ctx context.Context, set string, contracts []types.FileContractID) error
@@ -515,6 +516,13 @@ func (b *bus) contractsSetHandlerGET(jc jape.Context) {
 	}
 }
 
+func (b *bus) contractsSetsHandlerGET(jc jape.Context) {
+	sets, err := b.ms.ContractSets(jc.Request.Context())
+	if jc.Check("couldn't fetch contract sets", err) == nil {
+		jc.Encode(sets)
+	}
+}
+
 func (b *bus) contractsSetHandlerPUT(jc jape.Context) {
 	var contractIds []types.FileContractID
 	if set := jc.PathParam("set"); set == "" {
@@ -939,6 +947,7 @@ func (b *bus) Handler() http.Handler {
 		"GET    /hosts/scanning":     b.hostsScanningHandlerGET,
 
 		"GET    /contracts/active":       b.contractsActiveHandlerGET,
+		"GET    /contracts/sets":         b.contractsSetsHandlerGET,
 		"GET    /contracts/set/:set":     b.contractsSetHandlerGET,
 		"PUT    /contracts/set/:set":     b.contractsSetHandlerPUT,
 		"POST   /contracts/spending":     b.contractsSpendingHandlerPOST,

--- a/bus/client.go
+++ b/bus/client.go
@@ -299,6 +299,12 @@ func (c *Client) Contract(ctx context.Context, id types.FileContractID) (contrac
 	return
 }
 
+// ContractSets returns the contract sets of the bus.
+func (c *Client) ContractSets(ctx context.Context) (sets []string, err error) {
+	err = c.c.WithContext(ctx).GET("/contracts/sets", &sets)
+	return
+}
+
 // AddContract adds the provided contract to the metadata store.
 func (c *Client) AddContract(ctx context.Context, contract rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64) (added api.ContractMetadata, err error) {
 	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/contract/%s", contract.ID()), api.ContractsIDAddRequest{

--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -400,6 +400,14 @@ func (s *SQLStore) Contracts(ctx context.Context, set string) ([]api.ContractMet
 	return contracts, nil
 }
 
+func (s *SQLStore) ContractSets(ctx context.Context) ([]string, error) {
+	var sets []string
+	err := s.db.Raw("SELECT name FROM contract_sets WHERE (SELECT DISTINCT(db_contract_set_id) FROM contract_set_contracts)").
+		Scan(&sets).
+		Error
+	return sets, err
+}
+
 func (s *SQLStore) SetContractSet(ctx context.Context, name string, contractIds []types.FileContractID) error {
 	fcids := make([]fileContractID, len(contractIds))
 	for i, fcid := range contractIds {

--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -402,7 +402,7 @@ func (s *SQLStore) Contracts(ctx context.Context, set string) ([]api.ContractMet
 
 func (s *SQLStore) ContractSets(ctx context.Context) ([]string, error) {
 	var sets []string
-	err := s.db.Raw("SELECT name FROM contract_sets WHERE (SELECT DISTINCT(db_contract_set_id) FROM contract_set_contracts)").
+	err := s.db.Raw("SELECT name FROM contract_sets").
 		Scan(&sets).
 		Error
 	return sets, err

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -167,6 +167,23 @@ func TestSQLContractStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Add another contract set.
+	if err := cs.SetContractSet(ctx, "foo2", []types.FileContractID{contracts[0].ID}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fetch contract sets.
+	sets, err := cs.ContractSets(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sets) != 2 {
+		t.Fatal("wrong number of sets")
+	}
+	if sets[0] != "foo" || sets[1] != "foo2" {
+		t.Fatal("wrong sets returned", sets)
+	}
+
 	// Delete the contract.
 	if err := cs.RemoveContract(ctx, c.ID()); err != nil {
 		t.Fatal(err)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -86,6 +86,18 @@ func TestNewTestCluster(t *testing.T) {
 		contract = contracts[0]
 	}
 
+	// Make sure the contract set exists.
+	sets, err := cluster.Bus.ContractSets(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sets) != 1 {
+		t.Fatal("invalid number of setse", len(sets))
+	}
+	if sets[0] != "autopilot" {
+		t.Fatal("set name should be 'autopilot' but was", sets[0])
+	}
+
 	// Verify startHeight and endHeight of the contract.
 	currentPeriod, err := cluster.Autopilot.Status()
 	if err != nil {


### PR DESCRIPTION
Adds the `/contracts/sets` endpoint to list all contract sets currently stored in the bus