### PR TITLE
Update Gouging Settings

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -28,9 +28,9 @@ var (
 	DefaultGougingSettings = GougingSettings{
 		MinMaxCollateral:      types.Siacoins(10),                   // at least up to 10 SC per contract
 		MaxRPCPrice:           types.Siacoins(1).Div64(1000),        // 1mS per RPC
-		MaxContractPrice:      types.Siacoins(10),                   // 10 SC per contract
-		MaxDownloadPrice:      types.Siacoins(1000),                 // 1000 SC per 1 TiB
-		MaxUploadPrice:        types.Siacoins(1000),                 // 1000 SC per 1 TiB
+		MaxContractPrice:      types.Siacoins(15),                   // 15 SC per contract
+		MaxDownloadPrice:      types.Siacoins(3000),                 // 3000 SC per 1 TiB
+		MaxUploadPrice:        types.Siacoins(3000),                 // 3000 SC per 1 TiB
 		MaxStoragePrice:       types.Siacoins(1000).Div64(144 * 30), // 1000 SC per month
 		HostBlockHeightLeeway: 3,                                    // 3 blocks
 	}


### PR DESCRIPTION
The default gouging settings are quite tight. This loosens them a little since it's meant as a measure to prevent hosts from gouging their prices. The host scoring should make it so the autopilot forms contracts with cheap hosts rather than super expensive hosts.