### PR TITLE
Fix object entries

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -10,6 +10,10 @@ import (
 )
 
 var (
+	// ErrOBjectNotFound is returned if get is unable to retrieve an object from
+	// the database.
+	ErrObjectNotFound = errors.New("object not found")
+
 	// ErrSettingNotFound is returned if a requested setting is not present in the
 	// database.
 	ErrSettingNotFound = errors.New("setting not found")

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -684,25 +684,13 @@ func (b *bus) objectEntriesHandlerGET(jc jape.Context, path string) {
 		return
 	}
 
-	// return early if we have found entries or if a prefix was specified
-	if len(entries) > 0 || prefix != "" {
-		jc.Encode(api.ObjectsResponse{Entries: entries})
+	// return a 404 if no entries were found and no prefix was specified
+	if len(entries) == 0 && prefix == "" {
+		jc.Error(fmt.Errorf("no entries found for object at '%v'", path), http.StatusNotFound)
 		return
 	}
 
-	// return a meaningful status code depending on whether the parent exists or not
-	key := strings.TrimPrefix(path, "/")
-	_, err = b.ms.Object(jc.Request.Context(), key)
-	if errors.Is(err, api.ErrObjectNotFound) {
-		jc.Error(err, http.StatusNotFound)
-		return
-	} else if err != nil {
-		jc.Error(err, http.StatusInternalServerError)
-		return
-	} else {
-		jc.Error(fmt.Errorf("object at '%v' is not a directory", key), http.StatusBadRequest)
-		return
-	}
+	jc.Encode(api.ObjectsResponse{Entries: entries})
 }
 
 func (b *bus) objectsHandlerPUT(jc jape.Context) {

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -684,8 +684,8 @@ func (b *bus) objectEntriesHandlerGET(jc jape.Context, path string) {
 		return
 	}
 
-	// return a 404 if no entries were found and no prefix was specified
-	if len(entries) == 0 && prefix == "" {
+	// return a 404 if no entries were found
+	if len(entries) == 0 {
 		jc.Error(fmt.Errorf("no entries found for object at '%v'", path), http.StatusNotFound)
 		return
 	}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -654,7 +654,7 @@ func (b *bus) objectsHandlerGET(jc jape.Context) {
 	}
 
 	o, err := b.ms.Object(jc.Request.Context(), path)
-	if err == api.ErrObjectNotFound {
+	if errors.Is(err, api.ErrObjectNotFound) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	}
@@ -693,7 +693,7 @@ func (b *bus) objectEntriesHandlerGET(jc jape.Context, path string) {
 	// return a meaningful status code depending on whether the parent exists or not
 	key := strings.TrimPrefix(path, "/")
 	_, err = b.ms.Object(jc.Request.Context(), key)
-	if err == api.ErrObjectNotFound {
+	if errors.Is(err, api.ErrObjectNotFound) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	} else if err != nil {

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -93,11 +93,11 @@ type (
 		RemoveContract(ctx context.Context, id types.FileContractID) error
 		SetContractSet(ctx context.Context, set string, contracts []types.FileContractID) error
 
-		Object(ctx context.Context, key string) (object.Object, error)
-		Objects(ctx context.Context, key, prefix string, offset, limit int) ([]string, error)
-		SearchObjects(ctx context.Context, key string, offset, limit int) ([]string, error)
-		UpdateObject(ctx context.Context, key string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
-		RemoveObject(ctx context.Context, key string) error
+		Object(ctx context.Context, path string) (object.Object, error)
+		ObjectEntries(ctx context.Context, path, prefix string, offset, limit int) ([]string, error)
+		SearchObjects(ctx context.Context, substring string, offset, limit int) ([]string, error)
+		UpdateObject(ctx context.Context, path string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
+		RemoveObject(ctx context.Context, path string) error
 
 		UnhealthySlabs(ctx context.Context, healthCutoff float64, set string, limit int) ([]object.Slab, error)
 		UpdateSlab(ctx context.Context, s object.Slab, usedContracts map[types.PublicKey]types.FileContractID) error
@@ -646,36 +646,74 @@ func (b *bus) searchObjectsHandlerGET(jc jape.Context) {
 	jc.Encode(keys)
 }
 
-func (b *bus) objectsKeyHandlerGET(jc jape.Context) {
-	ctx := jc.Request.Context()
-	if strings.HasSuffix(jc.PathParam("key"), "/") {
-		offset := 0
-		limit := -1
-		prefix := ""
-		if jc.DecodeForm("offset", &offset) != nil || jc.DecodeForm("limit", &limit) != nil || jc.DecodeForm("prefix", &prefix) != nil {
-			return
-		}
-		keys, err := b.ms.Objects(ctx, jc.PathParam("key"), prefix, offset, limit)
-		if jc.Check("couldn't list objects", err) == nil {
-			jc.Encode(api.ObjectsResponse{Entries: keys})
-		}
+func (b *bus) objectsHandlerGET(jc jape.Context) {
+	path := jc.PathParam("path")
+	if strings.HasSuffix(path, "/") {
+		b.objectEntriesHandlerGET(jc, path)
 		return
 	}
-	o, err := b.ms.Object(ctx, jc.PathParam("key"))
-	if jc.Check("couldn't load object", err) == nil {
-		jc.Encode(api.ObjectsResponse{Object: &o})
+
+	o, err := b.ms.Object(jc.Request.Context(), path)
+	if err == api.ErrObjectNotFound {
+		jc.Error(err, http.StatusNotFound)
+		return
+	}
+	if jc.Check("couldn't load object", err) != nil {
+		return
+	}
+	jc.Encode(api.ObjectsResponse{Object: &o})
+}
+
+func (b *bus) objectEntriesHandlerGET(jc jape.Context, path string) {
+	var offset int
+	if jc.DecodeForm("offset", &offset) != nil {
+		return
+	}
+	limit := -1
+	if jc.DecodeForm("limit", &limit) != nil {
+		return
+	}
+	var prefix string
+	if jc.DecodeForm("prefix", &prefix) != nil {
+		return
+	}
+
+	// look for object entries
+	entries, err := b.ms.ObjectEntries(jc.Request.Context(), path, prefix, offset, limit)
+	if jc.Check("couldn't list object entries", err) != nil {
+		return
+	}
+
+	// return early if we have found entries or if a prefix was specified
+	if len(entries) > 0 || prefix != "" {
+		jc.Encode(api.ObjectsResponse{Entries: entries})
+		return
+	}
+
+	// return a meaningful status code depending on whether the parent exists or not
+	key := strings.TrimPrefix(path, "/")
+	_, err = b.ms.Object(jc.Request.Context(), key)
+	if err == api.ErrObjectNotFound {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if err != nil {
+		jc.Error(err, http.StatusInternalServerError)
+		return
+	} else {
+		jc.Error(fmt.Errorf("object at '%v' is not a directory", key), http.StatusBadRequest)
+		return
 	}
 }
 
-func (b *bus) objectsKeyHandlerPUT(jc jape.Context) {
+func (b *bus) objectsHandlerPUT(jc jape.Context) {
 	var aor api.AddObjectRequest
 	if jc.Decode(&aor) == nil {
-		jc.Check("couldn't store object", b.ms.UpdateObject(jc.Request.Context(), jc.PathParam("key"), aor.Object, aor.UsedContracts))
+		jc.Check("couldn't store object", b.ms.UpdateObject(jc.Request.Context(), jc.PathParam("path"), aor.Object, aor.UsedContracts))
 	}
 }
 
-func (b *bus) objectsKeyHandlerDELETE(jc jape.Context) {
-	jc.Check("couldn't delete object", b.ms.RemoveObject(jc.Request.Context(), jc.PathParam("key")))
+func (b *bus) objectsHandlerDELETE(jc jape.Context) {
+	jc.Check("couldn't delete object", b.ms.RemoveObject(jc.Request.Context(), jc.PathParam("path")))
 }
 
 func (b *bus) slabHandlerPUT(jc jape.Context) {
@@ -725,24 +763,6 @@ func (b *bus) settingKeyHandlerPUT(jc jape.Context) {
 		jc.Error(errors.New("param 'key' can not be empty"), http.StatusBadRequest)
 	} else if jc.Decode(&value) == nil {
 		jc.Check("could not update setting", b.ss.UpdateSetting(jc.Request.Context(), key, value))
-	}
-}
-
-func (b *bus) setGougingSettings(ctx context.Context, gs api.GougingSettings) error {
-	if js, err := json.Marshal(gs); err != nil {
-		panic(err)
-	} else {
-		return b.ss.UpdateSetting(ctx, SettingGouging, string(js))
-	}
-}
-
-func (b *bus) setRedundancySettings(ctx context.Context, rs api.RedundancySettings) error {
-	if err := rs.Validate(); err != nil {
-		return err
-	} else if js, err := json.Marshal(rs); err != nil {
-		panic(err)
-	} else {
-		return b.ss.UpdateSetting(ctx, SettingRedundancy, string(js))
 	}
 }
 
@@ -996,9 +1016,9 @@ func (b *bus) Handler() http.Handler {
 		"POST /search/hosts":  b.searchHostsHandlerPOST,
 		"GET /search/objects": b.searchObjectsHandlerGET,
 
-		"GET    /objects/*key": b.objectsKeyHandlerGET,
-		"PUT    /objects/*key": b.objectsKeyHandlerPUT,
-		"DELETE /objects/*key": b.objectsKeyHandlerDELETE,
+		"GET    /objects/*path": b.objectsHandlerGET,
+		"PUT    /objects/*path": b.objectsHandlerPUT,
+		"DELETE /objects/*path": b.objectsHandlerDELETE,
 
 		"POST   /slabs/migration": b.slabsMigrationHandlerPOST,
 		"PUT    /slab":            b.slabHandlerPUT,

--- a/bus/client.go
+++ b/bus/client.go
@@ -512,7 +512,7 @@ func (c *Client) AddObject(ctx context.Context, path string, o object.Object, us
 	return
 }
 
-// DeleteObject deletes the object with the given name.
+// DeleteObject deletes the object at the given path.
 func (c *Client) DeleteObject(ctx context.Context, path string) (err error) {
 	err = c.c.WithContext(ctx).DELETE(fmt.Sprintf("/objects/%s", path))
 	return

--- a/bus/client.go
+++ b/bus/client.go
@@ -503,9 +503,9 @@ func (c *Client) Object(ctx context.Context, path string) (o object.Object, entr
 	return
 }
 
-// AddObject stores the provided object under the given name.
-func (c *Client) AddObject(ctx context.Context, name string, o object.Object, usedContract map[types.PublicKey]types.FileContractID) (err error) {
-	err = c.c.WithContext(ctx).PUT(fmt.Sprintf("/objects/%s", name), api.AddObjectRequest{
+// AddObject stores the provided object under the given path.
+func (c *Client) AddObject(ctx context.Context, path string, o object.Object, usedContract map[types.PublicKey]types.FileContractID) (err error) {
+	err = c.c.WithContext(ctx).PUT(fmt.Sprintf("/objects/%s", path), api.AddObjectRequest{
 		Object:        o,
 		UsedContracts: usedContract,
 	})
@@ -513,8 +513,8 @@ func (c *Client) AddObject(ctx context.Context, name string, o object.Object, us
 }
 
 // DeleteObject deletes the object with the given name.
-func (c *Client) DeleteObject(ctx context.Context, name string) (err error) {
-	err = c.c.WithContext(ctx).DELETE(fmt.Sprintf("/objects/%s", name))
+func (c *Client) DeleteObject(ctx context.Context, path string) (err error) {
+	err = c.c.WithContext(ctx).DELETE(fmt.Sprintf("/objects/%s", path))
 	return
 }
 

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -877,8 +877,8 @@ func TestSQLMetadataStore(t *testing.T) {
 	}
 }
 
-// TestObjects is a test for the Objects method.
-func TestObjects(t *testing.T) {
+// TestObjectEntries is a test for the ObjectEntries method.
+func TestObjectEntries(t *testing.T) {
 	os, _, _, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)
@@ -911,7 +911,7 @@ func TestObjects(t *testing.T) {
 		{"/gab/", "/guub", []string{}},
 	}
 	for _, test := range tests {
-		got, err := os.Objects(ctx, test.path, test.prefix, 0, -1)
+		got, err := os.ObjectEntries(ctx, test.path, test.prefix, 0, -1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -919,7 +919,7 @@ func TestObjects(t *testing.T) {
 			t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want)
 		}
 		for offset := 0; offset < len(test.want); offset++ {
-			got, err := os.Objects(ctx, test.path, test.prefix, offset, 1)
+			got, err := os.ObjectEntries(ctx, test.path, test.prefix, offset, 1)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -949,7 +949,7 @@ func TestSearchObjects(t *testing.T) {
 		os.UpdateObject(ctx, path, obj, ucs)
 	}
 	tests := []struct {
-		key  string
+		path string
 		want []string
 	}{
 		{"/", []string{"/foo/bar", "/foo/bat", "/foo/baz/quux", "/foo/baz/quuz", "/gab/guub"}},
@@ -958,20 +958,20 @@ func TestSearchObjects(t *testing.T) {
 		{"uu", []string{"/foo/baz/quux", "/foo/baz/quuz", "/gab/guub"}},
 	}
 	for _, test := range tests {
-		got, err := os.SearchObjects(ctx, test.key, 0, -1)
+		got, err := os.SearchObjects(ctx, test.path, 0, -1)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if !(len(got) == 0 && len(test.want) == 0) && !reflect.DeepEqual(got, test.want) {
-			t.Errorf("\nkey: %v\ngot: %v\nwant: %v", test.key, got, test.want)
+			t.Errorf("\nkey: %v\ngot: %v\nwant: %v", test.path, got, test.want)
 		}
 		for offset := 0; offset < len(test.want); offset++ {
-			got, err := os.SearchObjects(ctx, test.key, offset, 1)
+			got, err := os.SearchObjects(ctx, test.path, offset, 1)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if len(got) != 1 || got[0] != test.want[offset] {
-				t.Errorf("\nkey: %v\ngot: %v\nwant: %v", test.key, got, test.want[offset])
+				t.Errorf("\nkey: %v\ngot: %v\nwant: %v", test.path, got, test.want[offset])
 			}
 		}
 	}

--- a/worker/client.go
+++ b/worker/client.go
@@ -117,11 +117,11 @@ func (c *Client) MigrateSlab(ctx context.Context, slab object.Slab) error {
 	return c.c.WithContext(ctx).POST("/slab/migrate", slab, nil)
 }
 
-// UploadObject uploads the data in r, creating an object with the given name.
-func (c *Client) UploadObject(ctx context.Context, r io.Reader, name string) (err error) {
-	c.c.Custom("PUT", fmt.Sprintf("/objects/%s", name), []byte{}, nil)
+// UploadObject uploads the data in r, creating an object at the given path.
+func (c *Client) UploadObject(ctx context.Context, r io.Reader, path string) (err error) {
+	c.c.Custom("PUT", fmt.Sprintf("/objects/%s", path), []byte{}, nil)
 
-	req, err := http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%v/objects/%v", c.c.BaseURL, name), r)
+	req, err := http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%v/objects/%v", c.c.BaseURL, path), r)
 	if err != nil {
 		panic(err)
 	}
@@ -178,9 +178,9 @@ func (c *Client) DownloadObject(ctx context.Context, w io.Writer, path string) (
 	return
 }
 
-// DeleteObject deletes the object with the given name.
-func (c *Client) DeleteObject(ctx context.Context, name string) (err error) {
-	err = c.c.WithContext(ctx).DELETE(fmt.Sprintf("/objects/%s", name))
+// DeleteObject deletes the object at the given path.
+func (c *Client) DeleteObject(ctx context.Context, path string) (err error) {
+	err = c.c.WithContext(ctx).DELETE(fmt.Sprintf("/objects/%s", path))
 	return
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -764,7 +764,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 
 	path := strings.TrimPrefix(jc.PathParam("path"), "/")
 	obj, entries, err := w.bus.Object(ctx, path)
-	if err == api.ErrObjectNotFound {
+	if errors.Is(err, api.ErrObjectNotFound) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	} else if jc.Check("couldn't get object or entries", err) != nil {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -231,9 +231,9 @@ type Bus interface {
 	GougingParams(ctx context.Context) (api.GougingParams, error)
 	UploadParams(ctx context.Context) (api.UploadParams, error)
 
-	Object(ctx context.Context, key string) (object.Object, []string, error)
-	AddObject(ctx context.Context, key string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
-	DeleteObject(ctx context.Context, key string) error
+	Object(ctx context.Context, path string) (object.Object, []string, error)
+	AddObject(ctx context.Context, path string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
+	DeleteObject(ctx context.Context, path string) error
 
 	Accounts(ctx context.Context, owner string) ([]api.Account, error)
 	UpdateSlab(ctx context.Context, s object.Slab, goodContracts map[types.PublicKey]types.FileContractID) error
@@ -758,20 +758,23 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 	}
 }
 
-func (w *worker) objectsKeyHandlerGET(jc jape.Context) {
+func (w *worker) objectsHandlerGET(jc jape.Context) {
 	ctx := jc.Request.Context()
 	jc.Custom(nil, []string{})
 
-	key := strings.TrimPrefix(jc.PathParam("key"), "/")
-	o, es, err := w.bus.Object(ctx, key)
-	if jc.Check("couldn't get object or entries", err) != nil {
+	path := strings.TrimPrefix(jc.PathParam("path"), "/")
+	obj, entries, err := w.bus.Object(ctx, path)
+	if err == api.ErrObjectNotFound {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if jc.Check("couldn't get object or entries", err) != nil {
 		return
 	}
-	if len(es) > 0 {
-		jc.Encode(es)
+	if len(entries) > 0 {
+		jc.Encode(entries)
 		return
 	}
-	if len(o.Slabs) == 0 {
+	if len(obj.Slabs) == 0 {
 		jc.Error(errors.New("object has no data"), http.StatusInternalServerError)
 		return
 	}
@@ -801,25 +804,25 @@ func (w *worker) objectsKeyHandlerGET(jc jape.Context) {
 	// Read call. We can improve on this to some degree by buffering, but
 	// without knowing the exact ranges being requested, this will always be
 	// suboptimal. Thus, sadly, we have to roll our own range support.
-	offset, length, err := parseRange(jc.Request.Header.Get("Range"), o.Size())
+	offset, length, err := parseRange(jc.Request.Header.Get("Range"), obj.Size())
 	if err != nil {
 		jc.Error(err, http.StatusRequestedRangeNotSatisfiable)
 		return
 	}
-	if length < o.Size() {
+	if length < obj.Size() {
 		jc.ResponseWriter.WriteHeader(http.StatusPartialContent)
-		jc.ResponseWriter.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", offset, offset+length-1, o.Size()))
+		jc.ResponseWriter.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", offset, offset+length-1, obj.Size()))
 	}
 	jc.ResponseWriter.Header().Set("Content-Length", strconv.FormatInt(length, 10))
 
 	// keep track of slow hosts so we can avoid them in consecutive slab uploads
 	slow := make(map[types.PublicKey]int)
 
-	cw := o.Key.Decrypt(jc.ResponseWriter, offset)
-	for i, ss := range slabsForDownload(o.Slabs, offset, length) {
+	cw := obj.Key.Decrypt(jc.ResponseWriter, offset)
+	for i, ss := range slabsForDownload(obj.Slabs, offset, length) {
 		contracts, err := w.bus.ContractsForSlab(ctx, ss.Shards, dp.ContractSet)
 		if err != nil {
-			w.logger.Errorf("couldn't fetch contracts for object %v slab %d, err: %v", key, i, err)
+			w.logger.Errorf("couldn't fetch contracts for object '%v' slab %d, err: %v", path, i, err)
 			if i == 0 {
 				jc.Error(err, http.StatusInternalServerError)
 			}
@@ -828,7 +831,7 @@ func (w *worker) objectsKeyHandlerGET(jc jape.Context) {
 
 		if len(contracts) < int(ss.MinShards) {
 			err = fmt.Errorf("not enough contracts to download the slab, %d<%d", len(contracts), ss.MinShards)
-			w.logger.Errorf("couldn't download object %v slab %d, err: %v", key, i, err)
+			w.logger.Errorf("couldn't download object '%v' slab %d, err: %v", path, i, err)
 			if i == 0 {
 				jc.Error(err, http.StatusInternalServerError)
 			}
@@ -848,7 +851,7 @@ func (w *worker) objectsKeyHandlerGET(jc jape.Context) {
 			slow[contracts[h].HostKey]++
 		}
 		if err != nil {
-			w.logger.Errorf("couldn't download object %v slab %d, err: %v", key, i, err)
+			w.logger.Errorf("couldn't download object '%v' slab %d, err: %v", path, i, err)
 			if i == 0 {
 				jc.Error(err, http.StatusInternalServerError)
 			}
@@ -857,7 +860,7 @@ func (w *worker) objectsKeyHandlerGET(jc jape.Context) {
 	}
 }
 
-func (w *worker) objectsKeyHandlerPUT(jc jape.Context) {
+func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	jc.Custom((*[]byte)(nil), nil)
 	ctx := jc.Request.Context()
 
@@ -951,14 +954,14 @@ func (w *worker) objectsKeyHandlerPUT(jc jape.Context) {
 		}
 	}
 
-	key := strings.TrimPrefix(jc.PathParam("key"), "/")
-	if jc.Check("couldn't add object", w.bus.AddObject(ctx, key, o, usedContracts)) != nil {
+	path := strings.TrimPrefix(jc.PathParam("path"), "/")
+	if jc.Check("couldn't add object", w.bus.AddObject(ctx, path, o, usedContracts)) != nil {
 		return
 	}
 }
 
-func (w *worker) objectsKeyHandlerDELETE(jc jape.Context) {
-	jc.Check("couldn't delete object", w.bus.DeleteObject(jc.Request.Context(), jc.PathParam("key")))
+func (w *worker) objectsHandlerDELETE(jc jape.Context) {
+	jc.Check("couldn't delete object", w.bus.DeleteObject(jc.Request.Context(), jc.PathParam("path")))
 }
 
 func (w *worker) rhpActiveContractsHandlerGET(jc jape.Context) {
@@ -1087,9 +1090,9 @@ func (w *worker) Handler() http.Handler {
 
 		"POST   /slab/migrate": w.slabMigrateHandler,
 
-		"GET    /objects/*key": w.objectsKeyHandlerGET,
-		"PUT    /objects/*key": w.objectsKeyHandlerPUT,
-		"DELETE /objects/*key": w.objectsKeyHandlerDELETE,
+		"GET    /objects/*path": w.objectsHandlerGET,
+		"PUT    /objects/*path": w.objectsHandlerPUT,
+		"DELETE /objects/*path": w.objectsHandlerDELETE,
 	}))
 }
 


### PR DESCRIPTION
I was testing the download endpoints and found that the endpoint is broken because it can not handle the default limit (`-1`) and throws `Error 1690 (22003): signed integer value is out of range in 'mysqld_stmt_execute'`.  More importantly, I found that if you try and fetch the entries at some non-existent path `foo/` you get this weird error that says `object has no data`. I figured that was going to be confusing to a lot of people so I changed the behaviour a little.

For the `limit` I figured it's easiest to set it to `math.MaxInt` where necessary. I considered wrapping it in a convenience function but landed with simply immediately checking the parameter in every method that uses a limit 🤷🏻‍♂️ to avoid rewriting the queries and making them harder to read.

For the non-existing object entries I think returning the following status codes is nice:
- a 500 if we can't query the entries at `/foo/` or fetch the object at `/foo`
- a 404 if there are no entries at `/foo/` and `/foo` does not exist
- a 400 if there are no entries at `/foo/` and `/foo` does exists and is thus considered a file
- a 204 if there are no entries at `/foo/ but a prefix was specified - you then get an empty slice of entries

I updated `key` to `path` to have consistent naming, we were using `key`, `name`, `substring` and `path`.