### PR TITLE
Contractor Logging

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -737,7 +737,7 @@ func (c *contractor) candidateHosts(ctx context.Context, w Worker, hosts []hostd
 	for _, h := range hosts {
 		// filter out used hosts
 		if _, exclude := used[h.PublicKey]; exclude {
-			ipFilter.isRedundantIP(h)
+			_ = ipFilter.isRedundantIP(h) // ensure the host's IP is registered as used
 			excluded++
 			continue
 		}
@@ -749,7 +749,7 @@ func (c *contractor) candidateHosts(ctx context.Context, w Worker, hosts []hostd
 		candidates = append(candidates, h)
 	}
 
-	c.logger.Debugw(fmt.Sprintf("filtered %d candidate hosts out of %d", len(candidates), len(hosts)),
+	c.logger.Debugw(fmt.Sprintf("selected %d candidate hosts out of %d", len(candidates), len(hosts)),
 		"excluded", excluded,
 		"unscanned", unscanned)
 
@@ -797,9 +797,13 @@ func (c *contractor) candidateHosts(ctx context.Context, w Worker, hosts []hostd
 		scores[i], scores = scores[len(scores)-1], scores[:len(scores)-1]
 	}
 
-	if len(selected) < wanted {
-		c.logger.Debugf("found %d candidate hosts out of the %d we wanted", len(selected), wanted)
+	// print warning if no candidate hosts were found
+	if len(selected) == 0 {
+		c.logger.Warnf("no candidate hosts found")
+	} else if len(selected) < wanted {
+		c.logger.Debugf("only found %d candidate host(s) out of the %d we wanted", len(selected), wanted)
 	}
+
 	return selected, nil
 }
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -26,7 +26,7 @@ import (
 const (
 	// contractHostPriceTableTimeout is the amount of time we wait to receive a
 	// price table from the host
-	contractHostPriceTableTimeout = 10 * time.Second
+	contractHostPriceTableTimeout = 30 * time.Second
 
 	// contractHostTimeout is the amount of time we wait to receive the latest
 	// revision from the host
@@ -467,7 +467,7 @@ func (c *contractor) runContractFormations(ctx context.Context, w Worker, hosts 
 
 		// perform gouging checks on the fly to ensure the host is not gouging its prices
 		if gouging, reasons := worker.IsGouging(state.gs, state.rs, state.cs, nil, &pt, state.fee, state.cfg.Contracts.Period, state.cfg.Contracts.RenewWindow, false); gouging {
-			c.logger.Error("candidate host became unusable", "host", host, "reasons", reasons)
+			c.logger.Errorw("candidate host became unusable", "hk", host.PublicKey, "reasons", reasons)
 			continue
 		}
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -44,6 +44,26 @@ var (
 	errContractExpired           = errors.New("contract has expired")
 )
 
+func hostErrCounts(errs []error, counts map[string]int) {
+	list := map[string]error{
+		"blocked":      errHostBlocked,
+		"offline":      errHostOffline,
+		"lowscore":     errLowScore,
+		"redundantip":  errHostRedundantIP,
+		"badsettings":  errHostBadSettings,
+		"gouging":      errHostPriceGouging,
+		"notannounced": errHostNotAnnounced,
+		"nopricetable": errHostNoPriceTable,
+	}
+	for _, err := range errs {
+		for k, v := range list {
+			if errors.Is(err, v) {
+				counts[k]++
+			}
+		}
+	}
+}
+
 // isUsableHost returns whether the given host is usable along with a list of
 // reasons why it was deemed unusable.
 func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.RedundancySettings, cs api.ConsensusState, f *ipFilter, h hostdb.Host, minScore float64, storedData uint64, txnFee types.Currency, ignoreBlockHeight bool) (bool, []error) {


### PR DESCRIPTION
Nate reported a silly mistake in the `contractor` logging:
```
DEBUG    autopilot.contractor    autopilot/contractor.go:721    looking for 53 candidate hosts
DEBUG    autopilot.contractor    autopilot/contractor.go:739    found -25 candidate hosts
DEBUG    autopilot.contractor    autopilot/contractor.go:771    scored -25 candidate hosts, took 1.214668ms
DEBUG    autopilot.contractor    autopilot/contractor.go:785    could not fetch 'wanted' candidate hosts, 
```

Refactored `candidateHosts` to avoid safe sub checks and bumped the lack of candidate hosts to a warning. Also added a breakdown of error counts if we are unable to get the amount of candidate hosts we are looking for. Should give insights into why your hosts are no good to allow you to more easily debug what's off.