### PR TITLE
worker: fix nil check in pricetable updates

### DIFF
--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -311,10 +311,10 @@ type priceTable struct {
 	hk     types.PublicKey
 	expiry time.Time
 
-	mu            sync.Mutex
-	updateOngoing bool
-	updateChan    chan struct{}
-	updateErr     error
+	mu              sync.Mutex
+	updateAvailable chan struct{}
+	updateErr       error
+	updateOngoing   bool
 }
 
 func newPriceTables() *priceTables {
@@ -345,7 +345,7 @@ func (pts *priceTables) Update(ctx context.Context, payFn PriceTablePaymentFunc,
 	if !pt.updateOngoing {
 		performUpdate = true
 		pt.updateOngoing = true
-		pt.updateChan = make(chan struct{})
+		pt.updateAvailable = make(chan struct{})
 		pt.updateErr = nil
 	}
 	pt.mu.Unlock()
@@ -356,7 +356,7 @@ func (pts *priceTables) Update(ctx context.Context, payFn PriceTablePaymentFunc,
 		select {
 		case <-ctx.Done():
 			return rhpv3.HostPriceTable{}, errors.New("timeout while blocking for pricetable update")
-		case <-pt.updateChan:
+		case <-pt.updateAvailable:
 		}
 		if pt.updateErr != nil {
 			return rhpv3.HostPriceTable{}, pt.updateErr
@@ -384,7 +384,7 @@ func (pts *priceTables) Update(ctx context.Context, payFn PriceTablePaymentFunc,
 	// Signal that the update is over.
 	pt.updateErr = err
 	pt.updateOngoing = false
-	close(pt.updateChan)
+	close(pt.updateAvailable)
 	return hpt, err
 }
 

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -312,13 +312,9 @@ type priceTable struct {
 	expiry time.Time
 
 	mu            sync.Mutex
-	ongoingUpdate *priceTableUpdate
-}
-
-type priceTableUpdate struct {
-	err  error
-	done chan struct{}
-	pt   *rhpv3.HostPriceTable
+	updateOngoing bool
+	updateChan    chan struct{}
+	updateErr     error
 }
 
 func newPriceTables() *priceTables {
@@ -345,14 +341,12 @@ func (pts *priceTables) Update(ctx context.Context, payFn PriceTablePaymentFunc,
 
 	// Check if there is some update going on already. If not, create one.
 	pt.mu.Lock()
-	ongoing := pt.ongoingUpdate
 	var performUpdate bool
-	if ongoing == nil {
-		ongoing = &priceTableUpdate{
-			done: make(chan struct{}),
-		}
-		pt.ongoingUpdate = ongoing
+	if !pt.updateOngoing {
 		performUpdate = true
+		pt.updateOngoing = true
+		pt.updateChan = make(chan struct{})
+		pt.updateErr = nil
 	}
 	pt.mu.Unlock()
 
@@ -362,12 +356,12 @@ func (pts *priceTables) Update(ctx context.Context, payFn PriceTablePaymentFunc,
 		select {
 		case <-ctx.Done():
 			return rhpv3.HostPriceTable{}, errors.New("timeout while blocking for pricetable update")
-		case <-ongoing.done:
+		case <-pt.updateChan:
 		}
-		if ongoing.err != nil {
-			return rhpv3.HostPriceTable{}, ongoing.err
+		if pt.updateErr != nil {
+			return rhpv3.HostPriceTable{}, pt.updateErr
 		} else {
-			return *ongoing.pt, nil
+			return *pt.pt, nil
 		}
 	}
 
@@ -386,10 +380,11 @@ func (pts *priceTables) Update(ctx context.Context, payFn PriceTablePaymentFunc,
 		pt.pt = &hpt
 		pt.expiry = time.Now().Add(hpt.Validity)
 	}
+
 	// Signal that the update is over.
-	ongoing.err = err
-	close(ongoing.done)
-	pt.ongoingUpdate = nil
+	pt.updateErr = err
+	pt.updateOngoing = false
+	close(pt.updateChan)
 	return hpt, err
 }
 
@@ -398,14 +393,11 @@ func (pts *priceTables) Update(ctx context.Context, payFn PriceTablePaymentFunc,
 func (pts *priceTables) priceTable(hk types.PublicKey) *priceTable {
 	pts.mu.Lock()
 	defer pts.mu.Unlock()
-	pt, exists := pts.priceTables[hk]
-	if !exists {
-		pt = &priceTable{
-			hk: hk,
-		}
-		pts.priceTables[hk] = pt
+
+	if _, exists := pts.priceTables[hk]; !exists {
+		pts.priceTables[hk] = &priceTable{hk: hk}
 	}
-	return pt
+	return pts.priceTables[hk]
 }
 
 // preparePriceTableContractPayment prepare a payment function to pay for a


### PR DESCRIPTION
Price tables are not thread safe. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x474ddc]

goroutine 148 [running]:
go.sia.tech/renterd/worker.(*priceTables).Update(_, {_, _}, _, {_, _}, {0xf0, 0x5e, 0x6e, 0xa6, ...})
        /root/code/renterd/worker/rhpv3.go:558 +0x2f5
go.sia.tech/renterd/worker.(*worker).fetchPriceTable.func1()
        /root/code/renterd/worker/rhpv3.go:161 +0x20c
go.sia.tech/renterd/worker.(*worker).fetchPriceTable(_, {_, _}, {0xcb, 0x3c, 0xfa, 0xe8, 0x6a, 0xe8, 0x5d, ...}, ...)
        /root/code/renterd/worker/rhpv3.go:180 +0x3e3
go.sia.tech/renterd/worker.(*worker).withHostV3(0xc0000dde40, {0x1272520, 0xc00043fef0}, {0xcb, 0x3c, 0xfa, 0xe8, 0x6a, 0xe8, 0x5d, ...}, ...)
        /root/code/renterd/worker/rhpv3.go:191 +0x125
go.sia.tech/renterd/worker.parallelDownloadSlab.func1.1({0xc000166720?})
        /root/code/renterd/worker/transfer.go:236 +0x44c
created by go.sia.tech/renterd/worker.parallelDownloadSlab.func1
        /root/code/renterd/worker/transfer.go:220 +0x4eb
```

The `ongoingUpdate` gets nulled and there's a bunch of threads that are blocking on the channel and then try to access the new pricetable and fail. I rewrote it in the most straightforward way possible to avoid issues. I considered a broadcast + sync.Cond but decided against it 😛 