### PR TITLE
Fix ObjectEntries Query

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -44,7 +44,7 @@ type Bus interface {
 	// hostdb
 	Host(ctx context.Context, hostKey types.PublicKey) (hostdb.HostInfo, error)
 	Hosts(ctx context.Context, offset, limit int) ([]hostdb.Host, error)
-	SearchHosts(ctx context.Context, offset, limit int, filterMode, addressContains string, keyIn []types.PublicKey) ([]hostdb.Host, error)
+	SearchHosts(ctx context.Context, filterMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]hostdb.Host, error)
 	HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) ([]hostdb.HostAddress, error)
 	RecordInteractions(ctx context.Context, interactions []hostdb.Interaction) error
 	RemoveOfflineHosts(ctx context.Context, minRecentScanFailures uint64, maxDowntime time.Duration) (uint64, error)
@@ -437,7 +437,7 @@ func (ap *Autopilot) hostsHandlerPOST(jc jape.Context) {
 	if jc.Decode(&req) != nil {
 		return
 	}
-	hosts, err := ap.c.HostInfos(jc.Request.Context(), req.Offset, req.Limit, req.FilterMode, req.AddressContains, req.KeyIn)
+	hosts, err := ap.c.HostInfos(jc.Request.Context(), req.FilterMode, req.AddressContains, req.KeyIn, req.Offset, req.Limit)
 	if jc.Check("failed to get host info", err) != nil {
 		return
 	}

--- a/autopilot/client.go
+++ b/autopilot/client.go
@@ -53,7 +53,7 @@ func (c *Client) HostInfo(hostKey types.PublicKey) (resp api.HostHandlerGET, err
 	return
 }
 
-func (c *Client) HostInfos(ctx context.Context, offset, limit int, filterMode string, addressContains string, keyIn []types.PublicKey) (resp []api.HostHandlerGET, err error) {
+func (c *Client) HostInfos(ctx context.Context, filterMode string, addressContains string, keyIn []types.PublicKey, offset, limit int) (resp []api.HostHandlerGET, err error) {
 	err = c.c.POST("/hosts", api.SearchHostsRequest{
 		Offset:          offset,
 		Limit:           limit,

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -124,8 +124,8 @@ func (c *contractor) HostInfo(ctx context.Context, hostKey types.PublicKey) (api
 	}, nil
 }
 
-func (c *contractor) HostInfos(ctx context.Context, offset, limit int, filterMode, addressContains string, keyIn []types.PublicKey) ([]api.HostHandlerGET, error) {
-	hosts, err := c.ap.bus.SearchHosts(ctx, offset, limit, filterMode, addressContains, keyIn)
+func (c *contractor) HostInfos(ctx context.Context, filterMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]api.HostHandlerGET, error) {
+	hosts, err := c.ap.bus.SearchHosts(ctx, filterMode, addressContains, keyIn, offset, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch requested host from bus: %w", err)
 	}

--- a/bus/client.go
+++ b/bus/client.go
@@ -490,11 +490,16 @@ func (c *Client) SearchObjects(ctx context.Context, offset, limit int, key strin
 	return
 }
 
-// Object returns the object at the given path, or, if path ends in '/', the
-// entries under that path.
-func (c *Client) Object(ctx context.Context, path string) (o object.Object, entries []string, err error) {
+// Object returns the object at the given path with the given prefix, or, if
+// path ends in '/', the entries under that path.
+func (c *Client) Object(ctx context.Context, path, prefix string, offset, limit int) (o object.Object, entries []string, err error) {
+	values := url.Values{}
+	values.Set("prefix", prefix)
+	values.Set("offset", fmt.Sprint(offset))
+	values.Set("limit", fmt.Sprint(limit))
+
 	var or api.ObjectsResponse
-	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/objects/%s", path), &or)
+	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/objects/%s?", path)+values.Encode(), &or)
 	if or.Object != nil {
 		o = *or.Object
 	} else {

--- a/bus/client.go
+++ b/bus/client.go
@@ -469,7 +469,7 @@ func (c *Client) UpdateRedundancySettings(ctx context.Context, rs api.Redundancy
 }
 
 // SearchHosts returns all hosts that match certain search criteria.
-func (c *Client) SearchHosts(ctx context.Context, offset, limit int, filterMode string, addressContains string, keyIn []types.PublicKey) (hosts []hostdb.Host, err error) {
+func (c *Client) SearchHosts(ctx context.Context, filterMode string, addressContains string, keyIn []types.PublicKey, offset, limit int) (hosts []hostdb.Host, err error) {
 	err = c.c.WithContext(ctx).POST("/search/hosts", api.SearchHostsRequest{
 		Offset:          offset,
 		Limit:           limit,
@@ -481,7 +481,7 @@ func (c *Client) SearchHosts(ctx context.Context, offset, limit int, filterMode 
 }
 
 // SearchObjects returns all objects that contains a sub-string in their key.
-func (c *Client) SearchObjects(ctx context.Context, offset, limit int, key string) (entries []string, err error) {
+func (c *Client) SearchObjects(ctx context.Context, key string, offset, limit int) (entries []string, err error) {
 	values := url.Values{}
 	values.Set("offset", fmt.Sprint(offset))
 	values.Set("limit", fmt.Sprint(limit))

--- a/bus/client.go
+++ b/bus/client.go
@@ -499,7 +499,7 @@ func (c *Client) Object(ctx context.Context, path, prefix string, offset, limit 
 	values.Set("limit", fmt.Sprint(limit))
 
 	var or api.ObjectsResponse
-	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/objects/%s?", path)+values.Encode(), &or)
+	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/objects/%s?"+values.Encode(), path), &or)
 	if or.Object != nil {
 		o = *or.Object
 	} else {

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -510,7 +510,7 @@ func (ss *SQLStore) HostsForScanning(ctx context.Context, maxLastScan time.Time,
 	return hostAddresses, err
 }
 
-func (ss *SQLStore) SearchHosts(ctx context.Context, offset, limit int, filterMode, addressContains string, keyIn []types.PublicKey) ([]hostdb.Host, error) {
+func (ss *SQLStore) SearchHosts(ctx context.Context, filterMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]hostdb.Host, error) {
 	if offset < 0 {
 		return nil, ErrNegativeOffset
 	}
@@ -567,7 +567,7 @@ func (ss *SQLStore) SearchHosts(ctx context.Context, offset, limit int, filterMo
 
 // Hosts returns non-blocked hosts at given offset and limit.
 func (ss *SQLStore) Hosts(ctx context.Context, offset, limit int) ([]hostdb.Host, error) {
-	return ss.SearchHosts(ctx, offset, limit, api.HostFilterModeAllowed, "", nil)
+	return ss.SearchHosts(ctx, api.HostFilterModeAllowed, "", nil, offset, limit)
 }
 
 func (ss *SQLStore) RemoveOfflineHosts(ctx context.Context, minRecentFailures uint64, maxDowntime time.Duration) (removed uint64, err error) {

--- a/internal/stores/hostdb_test.go
+++ b/internal/stores/hostdb_test.go
@@ -370,19 +370,19 @@ func TestSearchHosts(t *testing.T) {
 	hk1, hk2, hk3 := hks[0], hks[1], hks[2]
 
 	// Search by address.
-	if hosts, err := db.SearchHosts(ctx, 0, -1, api.HostFilterModeAll, "1", nil); err != nil || len(hosts) != 1 {
+	if hosts, err := db.SearchHosts(ctx, api.HostFilterModeAll, "1", nil, 0, -1); err != nil || len(hosts) != 1 {
 		t.Fatal("unexpected", len(hosts), err)
 	}
 	// Filter by key.
-	if hosts, err := db.SearchHosts(ctx, 0, -1, api.HostFilterModeAll, "", []types.PublicKey{hk1, hk2}); err != nil || len(hosts) != 2 {
+	if hosts, err := db.SearchHosts(ctx, api.HostFilterModeAll, "", []types.PublicKey{hk1, hk2}, 0, -1); err != nil || len(hosts) != 2 {
 		t.Fatal("unexpected", len(hosts), err)
 	}
 	// Filter by address and key.
-	if hosts, err := db.SearchHosts(ctx, 0, -1, api.HostFilterModeAll, "1", []types.PublicKey{hk1, hk2}); err != nil || len(hosts) != 1 {
+	if hosts, err := db.SearchHosts(ctx, api.HostFilterModeAll, "1", []types.PublicKey{hk1, hk2}, 0, -1); err != nil || len(hosts) != 1 {
 		t.Fatal("unexpected", len(hosts), err)
 	}
 	// Filter by key and limit results
-	if hosts, err := db.SearchHosts(ctx, 0, 1, api.HostFilterModeAll, "3", []types.PublicKey{hk3}); err != nil || len(hosts) != 1 {
+	if hosts, err := db.SearchHosts(ctx, api.HostFilterModeAll, "3", []types.PublicKey{hk3}, 0, -1); err != nil || len(hosts) != 1 {
 		t.Fatal("unexpected", len(hosts), err)
 	}
 }
@@ -806,21 +806,21 @@ func TestSQLHostAllowlist(t *testing.T) {
 
 	assertSearch := func(total, allowed, blocked int) error {
 		t.Helper()
-		hosts, err := hdb.SearchHosts(context.Background(), 0, -1, api.HostFilterModeAll, "", nil)
+		hosts, err := hdb.SearchHosts(context.Background(), api.HostFilterModeAll, "", nil, 0, -1)
 		if err != nil {
 			return err
 		}
 		if len(hosts) != total {
 			return fmt.Errorf("invalid number of hosts: %v", len(hosts))
 		}
-		hosts, err = hdb.SearchHosts(context.Background(), 0, -1, api.HostFilterModeAllowed, "", nil)
+		hosts, err = hdb.SearchHosts(context.Background(), api.HostFilterModeAllowed, "", nil, 0, -1)
 		if err != nil {
 			return err
 		}
 		if len(hosts) != allowed {
 			return fmt.Errorf("invalid number of hosts: %v", len(hosts))
 		}
-		hosts, err = hdb.SearchHosts(context.Background(), 0, -1, api.HostFilterModeBlocked, "", nil)
+		hosts, err = hdb.SearchHosts(context.Background(), api.HostFilterModeBlocked, "", nil, 0, -1)
 		if err != nil {
 			return err
 		}

--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -490,7 +490,7 @@ func (s *SQLStore) ObjectEntries(ctx context.Context, path, prefix string, offse
 
 	// apply prefix
 	if prefix != "" {
-		query = s.db.Raw(fmt.Sprintf("SELECT * FROM (?) WHERE result LIKE %s", concat("?", "?")), query, path, prefix+"%")
+		query = s.db.Raw(fmt.Sprintf("SELECT * FROM (?) AS i WHERE result LIKE %s", concat("?", "?")), query, path, prefix+"%")
 	}
 
 	var entries []string

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -209,7 +209,7 @@ func TestNewTestCluster(t *testing.T) {
 			t.Fatal("host wasn't set")
 		}
 	}
-	hostInfos, err := cluster.Autopilot.HostInfos(context.Background(), 0, -1, api.HostFilterModeAll, "", nil)
+	hostInfos, err := cluster.Autopilot.HostInfos(context.Background(), api.HostFilterModeAll, "", nil, 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,9 +285,12 @@ func TestUploadDownload(t *testing.T) {
 	}
 
 	// fetch entries with "foo" prefix
-	_, _, err = cluster.Bus.Object(context.Background(), "foo/", "foo", 0, -1)
-	if errors.Is(err, api.ErrObjectNotFound) {
+	_, entries, err = cluster.Bus.Object(context.Background(), "foo/", "foo", 0, -1)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatal("expected no entries to be returned", len(entries))
 	}
 
 	// prepare two files, a small one and a large one
@@ -341,21 +344,21 @@ func TestUploadDownload(t *testing.T) {
 	uploadDownload()
 
 	// Fuzzy search for uploaded data in various ways.
-	objects, err := cluster.Bus.SearchObjects(context.Background(), 0, -1, "")
+	objects, err := cluster.Bus.SearchObjects(context.Background(), "", 0, -1)
 	if err != nil {
 		t.Fatal("should fail")
 	}
 	if len(objects) != 4 {
 		t.Fatalf("should have 4 objects but got %v", len(objects))
 	}
-	objects, err = cluster.Bus.SearchObjects(context.Background(), 0, -1, "ata")
+	objects, err = cluster.Bus.SearchObjects(context.Background(), "ata", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(objects) != 2 {
 		t.Fatalf("should have 2 objects but got %v", len(objects))
 	}
-	objects, err = cluster.Bus.SearchObjects(context.Background(), 0, -1, "12288")
+	objects, err = cluster.Bus.SearchObjects(context.Background(), "12288", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/migrations_test.go
+++ b/internal/testing/migrations_test.go
@@ -48,7 +48,7 @@ func TestMigrations(t *testing.T) {
 
 	usedHosts := func() []types.PublicKey {
 		t.Helper()
-		obj, _, err := b.Object(context.Background(), "foo")
+		obj, _, err := b.Object(context.Background(), "foo", "", 0, -1)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Chris ran into "Every derived table must have its own alias". Turns out there was never an integration test to check whether path prefixes behave as they should so I extended the integration tests to cover that case. I also exposed `offset` and `limit` in the worker API while I was at it... I was on the fence there but I figure it makes sense.