### PR TITLE
Fix worker API

### DIFF
--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -293,6 +293,15 @@ func TestUploadDownload(t *testing.T) {
 		t.Fatal("expected no entries to be returned", len(entries))
 	}
 
+	// fetch entries from the worker for unexisting path
+	entries, err = cluster.Worker.ObjectEntries(context.Background(), "bar/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatal("expected no entries to be returned", len(entries))
+	}
+
 	// prepare two files, a small one and a large one
 	small := make([]byte, rhpv2.SectorSize/12)
 	large := make([]byte, rhpv2.SectorSize*3)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -777,13 +777,14 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 
 	path := strings.TrimPrefix(jc.PathParam("path"), "/")
 	obj, entries, err := w.bus.Object(ctx, path, prefix, off, limit)
-	if errors.Is(err, api.ErrObjectNotFound) {
+	if err != nil && strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	} else if jc.Check("couldn't get object or entries", err) != nil {
 		return
 	}
-	if len(entries) > 0 {
+
+	if strings.HasSuffix(path, "/") {
 		jc.Encode(entries)
 		return
 	}


### PR DESCRIPTION
Make sure the worker is able to return an empty entries list if it is required. We used to encode the entries if and only if we had some, but that is wrong since there are numerous ways you can end up with no entries but still want to serve that empty list.