### PR TITLE
Refill after sync

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -74,7 +74,7 @@ type RHPRenewResponse struct {
 type RHPFundRequest struct {
 	ContractID types.FileContractID `json:"contractID"`
 	HostKey    types.PublicKey      `json:"hostKey"`
-	Amount     types.Currency       `json:"amount"`
+	Balance    types.Currency       `json:"balance"`
 }
 
 // RHPPreparePaymentRequest is the request type for the /rhp/prepare/payment

--- a/autopilot/accounts.go
+++ b/autopilot/accounts.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	minBalance  = types.Siacoins(1).Div64(2).Big()
-	maxBalance  = types.Siacoins(1).Big()
+	maxBalance  = types.Siacoins(1)
 	maxNegDrift = new(big.Int).Neg(types.Siacoins(10).Big())
 )
 
@@ -172,29 +172,19 @@ func (a *accounts) refillWorkerAccounts(w Worker) {
 			if account.Balance.Cmp(minBalance) >= 0 {
 				return nil // nothing to do
 			}
-			fundAmt := new(big.Int).Sub(maxBalance, account.Balance)
 
-			fundCurrency, err := types.ParseCurrency(fundAmt.String())
-			if err != nil {
-				a.logger.Errorw(fmt.Sprintf("failed to parse fundAmt as currency: %s", err),
-					"account", account.ID,
-					"host", contract.HostKey,
-					"balance", account.Balance)
-				return err
-			}
-
-			if err := w.RHPFund(ctx, contract.ID, contract.HostKey, fundCurrency); err != nil {
+			if err := w.RHPFund(ctx, contract.ID, contract.HostKey, maxBalance); err != nil {
 				a.logger.Errorw(fmt.Sprintf("failed to fund account: %s", err),
 					"account", account.ID,
 					"host", contract.HostKey,
 					"balance", account.Balance,
-					"fundAmt", fundCurrency.String())
+					"expected", maxBalance)
 				return err
 			}
 			a.logger.Infow("Successfully funded account",
 				"account", account.ID,
 				"host", contract.HostKey,
-				"fundAmt", fundCurrency.String())
+				"balance", maxBalance)
 			return nil
 		}(contract)
 	}

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -81,7 +81,7 @@ type Worker interface {
 	ID(ctx context.Context) (string, error)
 	MigrateSlab(ctx context.Context, s object.Slab) error
 	RHPForm(ctx context.Context, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds types.Currency, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
-	RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, amount types.Currency) (err error)
+	RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, balance types.Currency) (err error)
 	RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string) (rhpv3.HostPriceTable, error)
 	RHPRenew(ctx context.Context, fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds, newCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPScan(ctx context.Context, hostKey types.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)

--- a/worker/client.go
+++ b/worker/client.go
@@ -69,11 +69,11 @@ func (c *Client) RHPRenew(ctx context.Context, fcid types.FileContractID, endHei
 }
 
 // RHPFund funds an ephemeral account using the supplied contract.
-func (c *Client) RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, amount types.Currency) (err error) {
+func (c *Client) RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, balance types.Currency) (err error) {
 	req := api.RHPFundRequest{
 		ContractID: contractID,
 		HostKey:    hostKey,
-		Amount:     amount,
+		Balance:    balance,
 	}
 	err = c.c.WithContext(ctx).POST("/rhp/fund", req, nil)
 	return

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -668,8 +668,9 @@ func (w *worker) rhpFundHandler(jc jape.Context) {
 		balanceAfterSync := account.Balance()
 
 		// Try funding the account again.
-		if balanceAfterSync.Cmp(balanceBeforeSync.Add(rfr.Amount)) < 0 {
-			fundAmount := balanceBeforeSync.Add(rfr.Amount).Sub(balanceAfterSync)
+		expectedBalance := balanceBeforeSync.Add(rfr.Amount)
+		if balanceAfterSync.Cmp(expectedBalance) < 0 {
+			fundAmount := expectedBalance.Sub(balanceAfterSync)
 			if fundAmount.Cmp(rfr.Amount) < 0 {
 				fundAmount = rfr.Amount
 			}


### PR DESCRIPTION
I think we should try and fund after syncing. I can't see of downsides really there's only upsides. One of the reasons driving this change is the logging in the autopilot which says `"Successfully funded account"` after potentially failing to fund but succeeding so sync (which clears the error). With this change, seeing that log line will effectively mean that the account was funded to the expected balance.

edit: updated PR to update the `/fund` endpoint to take the expected balance instead