### PR TITLE
Remove ContractsForSlab

### DIFF
--- a/bus/client.go
+++ b/bus/client.go
@@ -383,31 +383,6 @@ func (c *Client) RecommendedFee(ctx context.Context) (fee types.Currency, err er
 	return
 }
 
-// ContractsForSlab returns contracts that can be used to download the provided
-// slab.
-func (c *Client) ContractsForSlab(ctx context.Context, shards []object.Sector, contractSetName string) ([]api.ContractMetadata, error) {
-	// build hosts map
-	hosts := make(map[string]struct{})
-	for _, shard := range shards {
-		hosts[shard.Host.String()] = struct{}{}
-	}
-
-	// fetch all contracts from the set
-	contracts, err := c.Contracts(ctx, contractSetName)
-	if err != nil {
-		return nil, err
-	}
-
-	// filter contracts
-	filtered := contracts[:0]
-	for _, contract := range contracts {
-		if _, ok := hosts[contract.HostKey.String()]; ok {
-			filtered = append(filtered, contract)
-		}
-	}
-	return filtered, nil
-}
-
 // Setting returns the value for the setting with given key.
 func (c *Client) Setting(ctx context.Context, key string) (value string, err error) {
 	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/setting/%s", key), &value)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -221,7 +221,6 @@ type Bus interface {
 
 	ActiveContracts(ctx context.Context) ([]api.ContractMetadata, error)
 	Contracts(ctx context.Context, set string) ([]api.ContractMetadata, error)
-	ContractsForSlab(ctx context.Context, shards []object.Sector, contractSetName string) ([]api.ContractMetadata, error)
 	RecordInteractions(ctx context.Context, interactions []hostdb.Interaction) error
 	RecordContractSpending(ctx context.Context, records []api.ContractSpendingRecord) error
 
@@ -832,17 +831,33 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 	// keep track of slow hosts so we can avoid them in consecutive slab uploads
 	slow := make(map[types.PublicKey]int)
 
+	// fetch contracts
+	set, err := w.bus.Contracts(ctx, dp.ContractSet)
+	if err != nil {
+		jc.Error(err, http.StatusInternalServerError)
+		return
+	}
+
+	// build contract map
+	contracts := make(map[types.PublicKey]api.ContractMetadata)
+	for _, contract := range set {
+		contracts[contract.HostKey] = contract
+	}
+
+	// create a function that returns the contracts for a given slab
+	contractsForSlab := func(s object.Slab) (c []api.ContractMetadata) {
+		for _, shard := range s.Shards {
+			if contract, exists := contracts[shard.Host]; exists {
+				c = append(c, contract)
+			}
+		}
+		return
+	}
+
 	cw := obj.Key.Decrypt(jc.ResponseWriter, offset)
 	for i, ss := range slabsForDownload(obj.Slabs, offset, length) {
-		contracts, err := w.bus.ContractsForSlab(ctx, ss.Shards, dp.ContractSet)
-		if err != nil {
-			w.logger.Errorf("couldn't fetch contracts for object '%v' slab %d, err: %v", path, i, err)
-			if i == 0 {
-				jc.Error(err, http.StatusInternalServerError)
-			}
-			return
-		}
-
+		// fetch contracts for the slab
+		contracts := contractsForSlab(ss.Slab)
 		if len(contracts) < int(ss.MinShards) {
 			err = fmt.Errorf("not enough contracts to download the slab, %d<%d", len(contracts), ss.MinShards)
 			w.logger.Errorf("couldn't download object '%v' slab %d, err: %v", path, i, err)


### PR DESCRIPTION
`ContractsForSlab` doesn't really make sense we keep fetching all contracts in the download set and filtering them down