### PR TITLE
Favour Fast Hosts

### DIFF
--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -427,7 +427,7 @@ func (r *hostV3) DownloadSector(ctx context.Context, w io.Writer, root types.Has
 	// return errBalanceInsufficient if balance insufficient
 	defer func() {
 		if isBalanceInsufficient(err) {
-			err = fmt.Errorf("%w %v, err: %v", errNonFundedHost, r.HostKey(), err)
+			err = fmt.Errorf("%w %v, err: %v", errInsufficientBalance, r.HostKey(), err)
 		}
 	}()
 

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -248,7 +248,7 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 				}
 			}
 			if shard == nil {
-				respChan <- resp{r, nil, time.Since(start), fmt.Errorf("host %v, err: %w", c.HostKey, errUnusedHost)}
+				respChan <- resp{r, nil, time.Time{}, fmt.Errorf("host %v, err: %w", c.HostKey, errUnusedHost)}
 				return
 			}
 

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -248,7 +248,7 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 				}
 			}
 			if shard == nil {
-				respChan <- resp{r, nil, time.Time{}, fmt.Errorf("host %v, err: %w", c.HostKey, errUnusedHost)}
+				respChan <- resp{r, nil, 0, fmt.Errorf("host %v, err: %w", c.HostKey, errUnusedHost)}
 				return
 			}
 

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -22,7 +22,7 @@ import (
 const (
 	contractLockingUploadPriority   = 1
 	contractLockingDownloadPriority = 2
-	defaultSectorDownloadTiming     = time.Second
+	defaultSectorDownloadTiming     = 200 * time.Millisecond
 )
 
 var (


### PR DESCRIPTION
So instead of marking hosts as "bad" or "slow" it makes sense to use timings and sort hosts based on their performance so consecutive downloads primarily use fasts hosts. Benchmarks definitely show an improvement but mostly on higher thread counts, which is to be expected.

[benchmark_renterd-benchmark_2023-03-14_14-09-35.txt](https://github.com/SiaFoundation/renterd/files/11029484/benchmark_renterd-benchmark_2023-03-14_14-09-35.txt)
[benchmark_renterd-benchmark_2023-03-14_14-25-53.txt](https://github.com/SiaFoundation/renterd/files/11029485/benchmark_renterd-benchmark_2023-03-14_14-25-53.txt)
