### PR TITLE
Use shared accounts between workers

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -22,10 +22,6 @@ type (
 		// an account and the balance reported by a host.
 		Drift *big.Int `json:"drift"`
 
-		// Owner marks the owner of an account. This is usually a unique
-		// identifier for a worker.
-		Owner string `json:"owner"`
-
 		// RequiresSync indicates whether an account needs to be synced with the
 		// host before it can be used again.
 		RequiresSync bool `json:"requiresSync"`

--- a/api/bus.go
+++ b/api/bus.go
@@ -193,16 +193,13 @@ type UpdateBlocklistRequest struct {
 // endpoint.
 type AccountsUpdateBalanceRequest struct {
 	Host   types.PublicKey `json:"host"`
-	Owner  ParamString     `json:"owner"`
 	Amount *big.Int        `json:"amount"`
-	Drift  *big.Int        `json:"drift"`
 }
 
 // AccountsRequiresSyncRequest is the request type for
 // /accounts/:id/requiressync endpoint.
 type AccountsRequiresSyncRequest struct {
 	Host         types.PublicKey `json:"host"`
-	Owner        ParamString     `json:"owner"`
 	RequiresSync bool            `json:"requiresSync"`
 }
 
@@ -210,7 +207,6 @@ type AccountsRequiresSyncRequest struct {
 // endpoint.
 type AccountsAddBalanceRequest struct {
 	Host   types.PublicKey `json:"host"`
-	Owner  ParamString     `json:"owner"`
 	Amount *big.Int        `json:"amount"`
 }
 

--- a/api/bus.go
+++ b/api/bus.go
@@ -16,6 +16,10 @@ const (
 )
 
 var (
+	// ErrRequiresSyncSetRecently indicates that an account can't be set to sync
+	// yet because it has been set too recently.
+	ErrRequiresSyncSetRecently = errors.New("account had 'requiresSync' flag set recently")
+
 	// ErrOBjectNotFound is returned if get is unable to retrieve an object from
 	// the database.
 	ErrObjectNotFound = errors.New("object not found")
@@ -204,8 +208,7 @@ type AccountsUpdateBalanceRequest struct {
 // AccountsRequiresSyncRequest is the request type for
 // /accounts/:id/requiressync endpoint.
 type AccountsRequiresSyncRequest struct {
-	Host         types.PublicKey `json:"host"`
-	RequiresSync bool            `json:"requiresSync"`
+	Host types.PublicKey `json:"host"`
 }
 
 // AccountsAddBalanceRequest is the request type for /accounts/:id/add

--- a/api/bus.go
+++ b/api/bus.go
@@ -46,6 +46,11 @@ var (
 	}
 )
 
+// AccountHandlerPOST is the request type for the /account/:id endpoint.
+type AccountHandlerPOST struct {
+	HostKey types.PublicKey `json:"hostKey"`
+}
+
 // ConsensusState holds the current blockheight and whether we are synced or not.
 type ConsensusState struct {
 	BlockHeight uint64

--- a/api/worker.go
+++ b/api/worker.go
@@ -8,6 +8,21 @@ import (
 	"go.sia.tech/core/types"
 )
 
+type AccountsLockHandlerRequest struct {
+	HostKey   types.PublicKey `json:"hostKey"`
+	Exclusive bool            `json:"exclusive"`
+	Duration  ParamDuration   `json:"duration"`
+}
+
+type AccountsLockHandlerResponse struct {
+	Account Account `json:"account"`
+	LockID  uint64  `json:"lockID"`
+}
+
+type AccountsUnlockHandlerRequest struct {
+	LockID uint64 `json:"lockID"`
+}
+
 // ContractsResponse is the response type for the /rhp/contracts/active endpoint.
 type ContractsResponse struct {
 	Contracts []Contract `json:"contracts"`

--- a/autopilot/accounts.go
+++ b/autopilot/accounts.go
@@ -145,8 +145,14 @@ func (a *accounts) refillWorkerAccounts(w Worker) {
 				}
 			}()
 
+			// Fetch the account id.
+			accountID, err := w.Account(ctx, contract.HostKey)
+			if err != nil {
+				return err
+			}
+
 			// Fetch the account.
-			account, err := w.Account(ctx, contract.HostKey)
+			account, err := a.b.Account(ctx, accountID, contract.HostKey)
 			if err != nil {
 				return err
 			}
@@ -178,7 +184,7 @@ func (a *accounts) refillWorkerAccounts(w Worker) {
 					return err
 				}
 				// Re-fetch account after sync.
-				account, err = w.Account(ctx, contract.HostKey)
+				account, err = a.b.Account(ctx, accountID, contract.HostKey)
 				if err != nil {
 					return err
 				}

--- a/autopilot/accounts.go
+++ b/autopilot/accounts.go
@@ -87,10 +87,8 @@ func (a *accounts) refillWorkersAccountsLoop(stopChan <-chan struct{}) {
 		case <-ticker.C:
 		}
 
-		a.workers.withWorkers(func(workers []Worker) {
-			for _, w := range workers {
-				a.refillWorkerAccounts(w)
-			}
+		a.workers.withWorker(func(w Worker) {
+			a.refillWorkerAccounts(w)
 		})
 	}
 }

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -29,6 +29,10 @@ type Store interface {
 }
 
 type Bus interface {
+	// Accounts
+	Account(ctx context.Context, id rhpv3.Account, host types.PublicKey) (account api.Account, err error)
+	Accounts(ctx context.Context) (accounts []api.Account, err error)
+
 	// wallet
 	WalletAddress(ctx context.Context) (types.Address, error)
 	WalletBalance(ctx context.Context) (types.Currency, error)
@@ -75,8 +79,7 @@ type Bus interface {
 }
 
 type Worker interface {
-	Account(ctx context.Context, host types.PublicKey) (account api.Account, err error)
-	Accounts(ctx context.Context) (accounts []api.Account, err error)
+	Account(ctx context.Context, hostKey types.PublicKey) (rhpv3.Account, error)
 	ActiveContracts(ctx context.Context, hostTimeout time.Duration) (api.ContractsResponse, error)
 	ID(ctx context.Context) (string, error)
 	MigrateSlab(ctx context.Context, s object.Slab) error

--- a/bus/accounts.go
+++ b/bus/accounts.go
@@ -95,7 +95,7 @@ func (a *accounts) UnlockAccount(id rhpv3.Account, lockID uint64) error {
 	acc, exists := a.byID[id]
 	if !exists {
 		a.mu.Unlock()
-		return fmt.Errorf("account with id %v not found for unlocking", lockID)
+		return errAccountsNotFound
 	}
 	a.mu.Unlock()
 
@@ -182,6 +182,14 @@ func (a *account) convert() api.Account {
 		Host:         a.Host,
 		RequiresSync: a.RequiresSync,
 	}
+}
+
+// Account returns the account with the given id.
+func (a *accounts) Account(id rhpv3.Account, hostKey types.PublicKey) (api.Account, error) {
+	acc := a.account(id, hostKey)
+	acc.mu.Lock()
+	defer acc.mu.Unlock()
+	return acc.convert(), nil
 }
 
 // Accounts returns all accounts for a given owner. Usually called when workers

--- a/bus/accounts.go
+++ b/bus/accounts.go
@@ -1,74 +1,167 @@
 package bus
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"math"
 	"math/big"
 	"sync"
+	"time"
 
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
+	"lukechampine.com/frand"
 )
 
 var errAccountsNotFound = errors.New("account doesn't exist")
 
 type accounts struct {
-	mu      sync.Mutex
-	byID    map[rhpv3.Account]*account
-	byOwner map[string][]*account
+	mu   sync.Mutex
+	byID map[rhpv3.Account]*account
 }
 
 type account struct {
-	mu sync.Mutex
+	mu               sync.Mutex
+	locks            map[uint64]*accountLock
+	requiresSyncTime time.Time
 	api.Account
+
+	rwmu sync.RWMutex
+}
+
+type accountLock struct {
+	heldByID uint64
+	unlock   func()
+	timer    *time.Timer
 }
 
 func newAccounts(accs []api.Account) *accounts {
 	a := &accounts{
-		byID:    make(map[rhpv3.Account]*account),
-		byOwner: make(map[string][]*account),
+		byID: make(map[rhpv3.Account]*account),
 	}
 	for _, acc := range accs {
 		account := &account{
 			Account: acc,
+			locks:   map[uint64]*accountLock{},
 		}
 		a.byID[account.ID] = account
-		a.byOwner[acc.Owner] = append(a.byOwner[acc.Owner], account)
 	}
 	return a
+}
+
+func (a *accounts) LockAccount(ctx context.Context, id rhpv3.Account, hostKey types.PublicKey, exclusive bool, duration time.Duration) (api.Account, uint64) {
+	acc := a.account(id, hostKey)
+
+	// Try to lock the account.
+	if exclusive {
+		acc.rwmu.Lock()
+	} else {
+		acc.rwmu.RLock()
+	}
+
+	// Create a new lock with an unlock function that can only be called once.
+	var once sync.Once
+	heldByID := frand.Uint64n(math.MaxUint64) + 1
+	lock := &accountLock{
+		heldByID: heldByID,
+		unlock: func() {
+			once.Do(func() {
+				if exclusive {
+					acc.rwmu.Unlock()
+				} else {
+					acc.rwmu.RUnlock()
+				}
+				acc.mu.Lock()
+				delete(acc.locks, heldByID)
+				acc.mu.Unlock()
+			})
+		},
+	}
+
+	// Spawn a timer that will eventually unlock the lock.
+	lock.timer = time.AfterFunc(duration, lock.unlock)
+
+	acc.mu.Lock()
+	acc.locks[lock.heldByID] = lock
+	account := acc.convert()
+	acc.mu.Unlock()
+	return account, lock.heldByID
+}
+
+func (a *accounts) UnlockAccount(id rhpv3.Account, lockID uint64) error {
+	a.mu.Lock()
+	acc, exists := a.byID[id]
+	if !exists {
+		a.mu.Unlock()
+		return fmt.Errorf("account with id %v not found for unlocking", lockID)
+	}
+	a.mu.Unlock()
+
+	// Get lock.
+	acc.mu.Lock()
+	lock, exists := acc.locks[lockID]
+	acc.mu.Unlock()
+	if !exists {
+		return fmt.Errorf("account lock with id %v not found", lockID)
+	}
+
+	// Stop timer.
+	lock.timer.Stop()
+	select {
+	case <-lock.timer.C:
+	default:
+	}
+
+	// Unlock
+	lock.unlock()
+	return nil
 }
 
 // AddAmount applies the provided amount to an account through addition. So the
 // input can be both a positive or negative number depending on whether a
 // withdrawal or deposit is recorded. If the account doesn't exist, it is
 // created.
-func (a *accounts) AddAmount(id rhpv3.Account, owner string, hk types.PublicKey, amt *big.Int) {
-	acc := a.account(id, owner, hk)
+func (a *accounts) AddAmount(id rhpv3.Account, hk types.PublicKey, amt *big.Int) {
+	acc := a.account(id, hk)
 
 	// Update balance.
 	acc.mu.Lock()
 	acc.Balance.Add(acc.Balance, amt)
+	if amt.Cmp(new(big.Int)) < 0 {
+		acc.RequiresSync = false // a successful withdrawal resets the sync flag
+	}
 	acc.mu.Unlock()
 }
 
 // SetBalance sets the balance of a given account to the provided amount. If
 // the account doesn't exist, it is created.
-func (a *accounts) SetBalance(id rhpv3.Account, owner string, hk types.PublicKey, balance, drift *big.Int) {
-	acc := a.account(id, owner, hk)
+func (a *accounts) SetBalance(id rhpv3.Account, hk types.PublicKey, balance *big.Int) {
+	acc := a.account(id, hk)
 
 	// Update balance and drift.
 	acc.mu.Lock()
+	delta := new(big.Int).Sub(balance, acc.Balance)
+	acc.Drift = acc.Drift.Add(acc.Drift, delta)
 	acc.Balance.Set(balance)
-	acc.Drift.Set(drift)
-	acc.RequiresSync = false
+	acc.RequiresSync = false // resetting the balance resets the sync field
 	acc.mu.Unlock()
 }
 
 // SetRequiresSync sets the requiresSync flag of an account.
-func (a *accounts) SetRequiresSync(id rhpv3.Account, owner string, hk types.PublicKey, requiresSync bool) error {
-	acc := a.account(id, owner, hk)
+func (a *accounts) SetRequiresSync(id rhpv3.Account, hk types.PublicKey, requiresSync bool) error {
+	acc := a.account(id, hk)
 	acc.mu.Lock()
+	// Only update the sync flag to 'true' if some time has passed since the
+	// last time it was set. That way we avoid multiple workers setting it after
+	// failing at the same time, causing multiple syncs in the process.
+	if requiresSync && time.Since(acc.requiresSyncTime) < 30*time.Second {
+		acc.mu.Unlock()
+		return nil
+	}
 	acc.RequiresSync = requiresSync
+	acc.requiresSyncTime = time.Now()
 	acc.mu.Unlock()
 
 	a.mu.Lock()
@@ -81,22 +174,25 @@ func (a *accounts) SetRequiresSync(id rhpv3.Account, owner string, hk types.Publ
 	return nil
 }
 
+func (a *account) convert() api.Account {
+	return api.Account{
+		ID:           a.ID,
+		Balance:      new(big.Int).Set(a.Balance),
+		Drift:        new(big.Int).Set(a.Drift),
+		Host:         a.Host,
+		RequiresSync: a.RequiresSync,
+	}
+}
+
 // Accounts returns all accounts for a given owner. Usually called when workers
 // request their accounts on startup.
-func (a *accounts) Accounts(owner string) []api.Account {
+func (a *accounts) Accounts() []api.Account {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	accounts := make([]api.Account, len(a.byOwner[owner]))
-	for i, acc := range a.byOwner[owner] {
+	accounts := make([]api.Account, 0, len(a.byID))
+	for _, acc := range a.byID {
 		acc.mu.Lock()
-		accounts[i] = api.Account{
-			ID:           acc.ID,
-			Balance:      new(big.Int).Set(acc.Balance),
-			Drift:        new(big.Int).Set(acc.Drift),
-			Host:         acc.Host,
-			Owner:        acc.Owner,
-			RequiresSync: acc.RequiresSync,
-		}
+		accounts = append(accounts, acc.convert())
 		acc.mu.Unlock()
 	}
 	return accounts
@@ -128,7 +224,6 @@ func (a *accounts) ToPersist() []api.Account {
 			Balance:      new(big.Int).Set(acc.Balance),
 			Drift:        new(big.Int).Set(acc.Drift),
 			Host:         acc.Host,
-			Owner:        acc.Owner,
 			RequiresSync: acc.RequiresSync,
 		})
 		acc.mu.Unlock()
@@ -136,7 +231,7 @@ func (a *accounts) ToPersist() []api.Account {
 	return accounts
 }
 
-func (a *accounts) account(id rhpv3.Account, owner string, hk types.PublicKey) *account {
+func (a *accounts) account(id rhpv3.Account, hk types.PublicKey) *account {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -149,12 +244,11 @@ func (a *accounts) account(id rhpv3.Account, owner string, hk types.PublicKey) *
 				Host:         hk,
 				Balance:      big.NewInt(0),
 				Drift:        big.NewInt(0),
-				Owner:        owner,
 				RequiresSync: false,
 			},
+			locks: map[uint64]*accountLock{},
 		}
 		a.byID[id] = acc
-		a.byOwner[owner] = append(a.byOwner[owner], acc)
 	}
 	return acc
 }

--- a/bus/accounts_test.go
+++ b/bus/accounts_test.go
@@ -1,0 +1,86 @@
+package bus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	rhpv3 "go.sia.tech/core/rhp/v3"
+	"go.sia.tech/core/types"
+	"lukechampine.com/frand"
+)
+
+func TestAccountLocking(t *testing.T) {
+	accounts := newAccounts(nil)
+
+	var accountID rhpv3.Account
+	frand.Read(accountID[:])
+	var hk types.PublicKey
+	frand.Read(hk[:])
+
+	// Lock account non-exclusively a few times.
+	var lockIDs []uint64
+	for i := 0; i < 10; i++ {
+		acc, lockID := accounts.LockAccount(context.Background(), accountID, hk, false, 30*time.Second)
+		if lockID == 0 {
+			t.Fatal("invalid lock id")
+		}
+		if acc.ID != accountID {
+			t.Fatal("wrong id")
+		}
+		lockIDs = append(lockIDs, lockID)
+	}
+
+	// Unlock them again.
+	for _, lockID := range lockIDs {
+		err := accounts.UnlockAccount(accountID, lockID)
+		if err != nil {
+			t.Fatal("failed to unlock", err)
+		}
+	}
+
+	// Acquire exclusive lock.
+	_, exclusiveLockID := accounts.LockAccount(context.Background(), accountID, hk, true, 30*time.Second)
+
+	// Try acquiring a non-exclusive one.
+	var sharedLockID uint64
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, sharedLockID = accounts.LockAccount(context.Background(), accountID, hk, true, 30*time.Second)
+	}()
+
+	// Wait some time to confirm it's not possible.
+	select {
+	case <-done:
+		t.Fatal("lock was acquired even though exclusive one was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Unlock exclusive one.
+	if err := accounts.UnlockAccount(accountID, exclusiveLockID); err != nil {
+		t.Fatal(err)
+	}
+	// Doing so again should fail.
+	if err := accounts.UnlockAccount(accountID, exclusiveLockID); err == nil {
+		t.Fatal("should fail")
+	}
+
+	// Other lock should be acquired now.
+	select {
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("other lock wasn't acquired")
+	case <-done:
+	}
+
+	// Unlock the other lock too.
+	if err := accounts.UnlockAccount(accountID, sharedLockID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Locks should be empty since they clean up after themselves.
+	acc := accounts.account(accountID, hk)
+	if len(acc.locks) != 0 {
+		t.Fatal("should not have any locks", len(acc.locks))
+	}
+}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -929,6 +929,7 @@ func (b *bus) accountsRequiresSyncHandlerPOST(jc jape.Context) {
 	err := b.accounts.SetRequiresSync(id, req.Host, req.RequiresSync)
 	if errors.Is(err, errAccountsNotFound) {
 		jc.Error(err, http.StatusNotFound)
+		return
 	}
 	if jc.Check("failed tot set requiresSync flag on account", err) != nil {
 		return

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -926,12 +926,12 @@ func (b *bus) accountsRequiresSyncHandlerPOST(jc jape.Context) {
 		jc.Error(errors.New("host needs to be set"), http.StatusBadRequest)
 		return
 	}
-	err := b.accounts.SetRequiresSync(id, req.Host, req.RequiresSync)
+	err := b.accounts.ScheduleSync(id, req.Host)
 	if errors.Is(err, errAccountsNotFound) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	}
-	if jc.Check("failed tot set requiresSync flag on account", err) != nil {
+	if jc.Check("failed to set requiresSync flag on account", err) != nil {
 		return
 	}
 }

--- a/bus/client.go
+++ b/bus/client.go
@@ -533,7 +533,7 @@ func (c *Client) GougingParams(ctx context.Context) (gp api.GougingParams, err e
 	return
 }
 
-// Account requests the worker's /accounts/:host endpoint.
+// Account requests the bus's /accounts/:host endpoint.
 func (c *Client) Account(ctx context.Context, id rhpv3.Account, host types.PublicKey) (account api.Account, err error) {
 	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/accounts/%s", id), api.AccountHandlerPOST{
 		HostKey: host,
@@ -541,7 +541,7 @@ func (c *Client) Account(ctx context.Context, id rhpv3.Account, host types.Publi
 	return
 }
 
-// Accounts returns the ephemeral accounts for a given owner.
+// Accounts returns the ephemeral accounts known to the bus.
 func (c *Client) Accounts(ctx context.Context) (accounts []api.Account, err error) {
 	err = c.c.WithContext(ctx).GET("/accounts", &accounts)
 	return
@@ -582,11 +582,10 @@ func (c *Client) SetBalance(ctx context.Context, id rhpv3.Account, hk types.Publ
 	return
 }
 
-// SetRequiresSync sets the requiresSync flag of an account.
-func (c *Client) SetRequiresSync(ctx context.Context, id rhpv3.Account, hk types.PublicKey, requiresSync bool) (err error) {
+// ScheduleSync sets the requiresSync flag of an account.
+func (c *Client) ScheduleSync(ctx context.Context, id rhpv3.Account, hk types.PublicKey) (err error) {
 	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/accounts/%s/requiressync", id), api.AccountsRequiresSyncRequest{
-		Host:         hk,
-		RequiresSync: requiresSync,
+		Host: hk,
 	}, nil)
 	return
 }

--- a/bus/client.go
+++ b/bus/client.go
@@ -533,6 +533,14 @@ func (c *Client) GougingParams(ctx context.Context) (gp api.GougingParams, err e
 	return
 }
 
+// Account requests the worker's /accounts/:host endpoint.
+func (c *Client) Account(ctx context.Context, id rhpv3.Account, host types.PublicKey) (account api.Account, err error) {
+	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/accounts/%s", id), api.AccountHandlerPOST{
+		HostKey: host,
+	}, &account)
+	return
+}
+
 // Accounts returns the ephemeral accounts for a given owner.
 func (c *Client) Accounts(ctx context.Context) (accounts []api.Account, err error) {
 	err = c.c.WithContext(ctx).GET("/accounts", &accounts)

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	// accountRefillInterval is the amount of time between refills of ephemeral
-	// accounts. If we conservatively assume that a good hosts charges 500 SC /
+	// accounts. If we conservatively assume that a good host charges 500 SC /
 	// TiB, we can pay for about 2.2 GiB with 1 SC. Since we want to refill
 	// ahead of time at 0.5 SC, that makes 1.1 GiB. Considering a 1 Gbps uplink
 	// that is shared across 30 uploads, we upload at around 33 Mbps to each

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -34,9 +34,9 @@ const (
 	// ahead of time at 0.5 SC, that makes 1.1 GiB. Considering a 1 Gbps uplink
 	// that is shared across 30 uploads, we upload at around 33 Mbps to each
 	// host. That means uploading 1.1 GiB to drain 0.5 SC takes around 5
-	// minutes.  That's why we assume 30 seconds to be more than frequent enough
+	// minutes. That's why we assume 10 seconds to be more than frequent enough
 	// to refill an account when it's due for another refill.
-	defaultAccountRefillInterval = 30 * time.Second
+	defaultAccountRefillInterval = 10 * time.Second
 )
 
 var (

--- a/internal/stores/accounts.go
+++ b/internal/stores/accounts.go
@@ -14,8 +14,6 @@ type (
 	dbAccount struct {
 		Model
 
-		Owner string `gorm:"NOT NULL"`
-
 		// AccountID identifies an account.
 		AccountID publicKey `gorm:"unique;NOT NULL;size:32"`
 
@@ -45,7 +43,6 @@ func (a dbAccount) convert() api.Account {
 		Host:         types.PublicKey(a.Host),
 		Balance:      (*big.Int)(a.Balance),
 		Drift:        (*big.Int)(a.Drift),
-		Owner:        a.Owner,
 		RequiresSync: a.RequiresSync,
 	}
 }
@@ -72,7 +69,6 @@ func (s *SQLStore) SaveAccounts(ctx context.Context, accounts []api.Account) err
 	dbAccounts := make([]dbAccount, len(accounts))
 	for i, acc := range accounts {
 		dbAccounts[i] = dbAccount{
-			Owner:        acc.Owner,
 			AccountID:    publicKey(acc.ID),
 			Host:         publicKey(acc.Host),
 			Balance:      (*balance)(acc.Balance),

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -447,7 +447,7 @@ func (c *TestCluster) WaitForAccounts() ([]api.Account, error) {
 	}
 
 	// fetch all accounts
-	return c.Worker.Accounts(context.Background())
+	return c.Bus.Accounts(context.Background())
 }
 
 func (c *TestCluster) WaitForContracts() ([]api.Contract, error) {
@@ -618,7 +618,7 @@ func (c *TestCluster) Sync() error {
 // they have money in them
 func (c *TestCluster) waitForHostAccounts(hosts map[types.PublicKey]struct{}) error {
 	return Retry(30, time.Second, func() error {
-		accounts, err := c.Worker.Accounts(context.Background())
+		accounts, err := c.Bus.Accounts(context.Background())
 		if err != nil {
 			return err
 		}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -578,12 +578,9 @@ func TestEphemeralAccounts(t *testing.T) {
 	if acc.Host != types.PublicKey(hg.PublicKey.ToPublicKey()) {
 		t.Fatal("wrong host")
 	}
-	if acc.Owner == "" {
-		t.Fatal("owner not set")
-	}
 
 	// Fetch account from bus directly.
-	busAccounts, err := cluster.Bus.Accounts(context.Background(), "worker")
+	busAccounts, err := cluster.Bus.Accounts(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -611,10 +608,10 @@ func TestEphemeralAccounts(t *testing.T) {
 	// Update the balance to create some drift.
 	newBalance := fundAmt.Div64(2)
 	newDrift := new(big.Int).Sub(newBalance.Big(), fundAmt.Big())
-	if err := cluster.Bus.SetBalance(context.Background(), busAcc.ID, "worker", acc.Host, newBalance.Big(), newDrift); err != nil {
+	if err := cluster.Bus.SetBalance(context.Background(), busAcc.ID, acc.Host, newBalance.Big()); err != nil {
 		t.Fatal(err)
 	}
-	busAccounts, err = cluster.Bus.Accounts(context.Background(), "worker")
+	busAccounts, err = cluster.Bus.Accounts(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -658,7 +655,7 @@ func TestEphemeralAccounts(t *testing.T) {
 	if accounts2[0].Drift.Cmp(new(big.Int)) != 0 {
 		t.Fatal("drift wasn't reset", accounts2[0].Drift.String())
 	}
-	accounts2, err = cluster2.Bus.Accounts(context.Background(), "worker")
+	accounts2, err = cluster2.Bus.Accounts(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -769,13 +766,13 @@ func TestEphemeralAccountSync(t *testing.T) {
 	balanceBefore := acc.Balance
 
 	// Set requiresSync flag on bus and balance to 0.
-	if err := cluster.Bus.SetBalance(context.Background(), acc.ID, acc.Owner, acc.Host, new(big.Int), new(big.Int)); err != nil {
+	if err := cluster.Bus.SetBalance(context.Background(), acc.ID, acc.Host, new(big.Int)); err != nil {
 		t.Fatal(err)
 	}
-	if err := cluster.Bus.SetRequiresSync(context.Background(), acc.ID, acc.Owner, acc.Host, true); err != nil {
+	if err := cluster.Bus.SetRequiresSync(context.Background(), acc.ID, acc.Host, true); err != nil {
 		t.Fatal(err)
 	}
-	accounts, err = cluster.Bus.Accounts(context.Background(), acc.Owner)
+	accounts, err = cluster.Bus.Accounts(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -823,7 +820,7 @@ func TestEphemeralAccountSync(t *testing.T) {
 	}
 
 	// Flag should also be reset on bus now.
-	accounts, err = cluster2.Bus.Accounts(context.Background(), acc.Owner)
+	accounts, err = cluster2.Bus.Accounts(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -766,6 +766,12 @@ func TestParallelDownload(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Wait for accounts to be funded.
+	_, err = cluster.WaitForAccounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	download := func() error {
 		t.Helper()
 		buf := bytes.NewBuffer(nil)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -834,7 +834,7 @@ func TestEphemeralAccountSync(t *testing.T) {
 	if err := cluster.Bus.SetBalance(context.Background(), acc.ID, acc.Host, new(big.Int)); err != nil {
 		t.Fatal(err)
 	}
-	if err := cluster.Bus.SetRequiresSync(context.Background(), acc.ID, acc.Host, true); err != nil {
+	if err := cluster.Bus.ScheduleSync(context.Background(), acc.ID, acc.Host); err != nil {
 		t.Fatal(err)
 	}
 	accounts, err = cluster.Bus.Accounts(context.Background())

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -636,7 +636,7 @@ func TestEphemeralAccounts(t *testing.T) {
 	// manually fix the balance and drift before comparing.
 	accounts[0].Balance = newBalance.Big()
 	accounts[0].Drift = newDrift
-	accounts2, err := cluster2.Worker.Accounts(context.Background())
+	accounts2, err := cluster2.Bus.Accounts(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -645,10 +645,10 @@ func TestEphemeralAccounts(t *testing.T) {
 	}
 
 	// Reset drift again.
-	if err := cluster2.Worker.ResetDrift(context.Background(), acc.ID); err != nil {
+	if err := cluster2.Bus.ResetDrift(context.Background(), acc.ID); err != nil {
 		t.Fatal(err)
 	}
-	accounts2, err = cluster2.Worker.Accounts(context.Background())
+	accounts2, err = cluster2.Bus.Accounts(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -792,7 +792,7 @@ func TestEphemeralAccountSync(t *testing.T) {
 	}()
 
 	// Account should need a sync.
-	account, err := cluster2.Worker.Account(context.Background(), acc.Host)
+	account, err := cluster2.Bus.Account(context.Background(), acc.ID, acc.Host)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -802,7 +802,7 @@ func TestEphemeralAccountSync(t *testing.T) {
 
 	// Wait for autopilot to sync and reset flag.
 	err = Retry(100, 100*time.Millisecond, func() error {
-		account, err := cluster2.Worker.Account(context.Background(), acc.Host)
+		account, err := cluster2.Bus.Account(context.Background(), acc.ID, acc.Host)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/worker/client.go
+++ b/worker/client.go
@@ -201,21 +201,9 @@ func (c *Client) ActiveContracts(ctx context.Context, hostTimeout time.Duration)
 	return
 }
 
-// Account requests the worker's /accounts/:host endpoint.
-func (c *Client) Account(ctx context.Context, host types.PublicKey) (account api.Account, err error) {
-	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/accounts/host/%s", host), &account)
-	return
-}
-
-// Accounts requests the worker's /accounts endpoint.
-func (c *Client) Accounts(ctx context.Context) (accounts []api.Account, err error) {
-	err = c.c.WithContext(ctx).GET("/accounts", &accounts)
-	return
-}
-
-// ResetDrift resets the drift of an account to zero.
-func (c *Client) ResetDrift(ctx context.Context, id rhpv3.Account) (err error) {
-	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/accounts/%s/resetdrift", id), nil, nil)
+// Account returns the account id for a given host.
+func (c *Client) Account(ctx context.Context, hostKey types.PublicKey) (account rhpv3.Account, err error) {
+	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/account/%s", hostKey), &account)
 	return
 }
 

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -141,6 +141,11 @@ func (w *worker) fetchPriceTable(ctx context.Context, contractID types.FileContr
 
 	updatePTByContract := func() (rhpv3.HostPriceTable, error) {
 		var rev rhpv2.ContractRevision
+		lockID, err := w.bus.AcquireContract(ctx, contractID, lockingPriorityPriceTable, lockingDurationPriceTable)
+		if err != nil {
+			return rhpv3.HostPriceTable{}, err
+		}
+		defer w.bus.ReleaseContract(ctx, contractID, lockID)
 		if err = w.withHostV2(ctx, contractID, hostKey, hostIP, func(ss sectorStore) (err error) {
 			rev, err = ss.(*sharedSession).Revision(ctx)
 			return err

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -32,11 +32,13 @@ import (
 )
 
 const (
-	lockingPriorityRenew   = 100 // highest
-	lockingPriorityFunding = 90
+	lockingPriorityRenew      = 100 // highest
+	lockingPriorityPriceTable = 95
+	lockingPriorityFunding    = 90
 
-	lockingDurationRenew   = time.Minute
-	lockingDurationFunding = 30 * time.Second
+	lockingDurationRenew      = time.Minute
+	lockingDurationPriceTable = 30 * time.Second
+	lockingDurationFunding    = 30 * time.Second
 
 	queryStringParamContractSet = "contractset"
 	queryStringParamMinShards   = "minshards"

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -213,7 +213,7 @@ type AccountStore interface {
 
 	ResetDrift(ctx context.Context, id rhpv3.Account) error
 	SetBalance(ctx context.Context, id rhpv3.Account, hk types.PublicKey, amt *big.Int) error
-	SetRequiresSync(ctx context.Context, id rhpv3.Account, hk types.PublicKey, requiresSync bool) error
+	ScheduleSync(ctx context.Context, id rhpv3.Account, hk types.PublicKey) error
 }
 
 type contractLocker interface {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1140,6 +1140,15 @@ func (w *worker) idHandlerGET(jc jape.Context) {
 	jc.Encode(w.id)
 }
 
+func (w *worker) accountHandlerGET(jc jape.Context) {
+	var hostKey types.PublicKey
+	if jc.DecodeParam("hostkey", &hostKey) != nil {
+		return
+	}
+	account := rhpv3.Account(w.accounts.deriveAccountKey(hostKey).PublicKey())
+	jc.Encode(account)
+}
+
 // New returns an HTTP handler that serves the worker API.
 func New(masterKey [32]byte, id string, b Bus, sessionReconectTimeout, sessionTTL, busFlushInterval, downloadSectorTimeout, uploadSectorTimeout time.Duration, l *zap.Logger) *worker {
 	w := &worker{
@@ -1161,7 +1170,8 @@ func New(masterKey [32]byte, id string, b Bus, sessionReconectTimeout, sessionTT
 // Handler returns an HTTP handler that serves the worker API.
 func (w *worker) Handler() http.Handler {
 	return jape.Mux(tracing.TracedRoutes("worker", map[string]jape.Handler{
-		"GET    /id": w.idHandlerGET,
+		"GET    /account/:hostkey": w.accountHandlerGET,
+		"GET    /id":               w.idHandlerGET,
 
 		"GET    /rhp/contracts/active": w.rhpActiveContractsHandlerGET,
 		"POST   /rhp/scan":             w.rhpScanHandler,

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -673,6 +673,16 @@ func (w *worker) rhpFundHandler(jc jape.Context) {
 	}
 	fundAmount := rfr.Balance.Sub(balance)
 
+	// Handle contracts that are either out of money or don't have enough funds
+	// left for a full fund.
+	renterFunds := revision.ValidRenterPayout()
+	if renterFunds.IsZero() {
+		jc.Error(errors.New("contract is out of funds"), http.StatusBadRequest)
+		return
+	} else if maxFundingAmount := renterFunds.Sub(pt.FundAccountCost); maxFundingAmount.Cmp(fundAmount) < 0 {
+		fundAmount = maxFundingAmount
+	}
+
 	// Fund account.
 	err = w.fundAccount(ctx, account, pt, siamuxAddr, rfr.HostKey, fundAmount, &revision)
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -786,10 +786,7 @@ func (w *worker) rhpSyncHandler(jc jape.Context) {
 
 	// Sync account.
 	err = w.syncAccount(ctx, pt, siamuxAddr, rsr.HostKey)
-	if err != nil {
-		w.logger.Errorw(fmt.Sprintf("failed to sync account: %v", err), "host", rsr.HostKey)
-	}
-	if jc.Check("couldn't fund account", err) != nil {
+	if jc.Check("couldn't sync account", err) != nil {
 		return
 	}
 }


### PR DESCRIPTION
This PR makes renterd use shared accounts which are tracked and locked through the bus. There is a trade-off here considering that we are doing network I/O now to lock accounts. Ideally this is <1ms since the cluster is running on the same local network over a wired connection but if that ever becomes a problem we can explore a more fuzzy, lock-free approach. Since we do have tracing in place we should be able to easily keep an eye on this though.