### PR TITLE
autopilot: hardening/fixes

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -200,13 +200,13 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) e
 		return nil
 	}
 
-	// no maintenace if no allowance was set
+	// no maintenance if no allowance was set
 	if state.cfg.Contracts.Allowance.IsZero() {
 		c.logger.Warn("allowance is set to zero, skipping contract maintenance")
 		return nil
 	}
 
-	// no maintenace if no period was set
+	// no maintenance if no period was set
 	if state.cfg.Contracts.Period == 0 {
 		c.logger.Warn("period is set to zero, skipping contract maintenance")
 		return nil

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -196,13 +196,19 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) e
 
 	// no maintenance if no hosts are requested
 	if state.cfg.Contracts.Amount == 0 {
-		c.logger.Debug("no hosts requested, skipping contract maintenance")
+		c.logger.Warn("contracts is set to zero, skipping contract maintenance")
 		return nil
 	}
 
 	// no maintenace if no allowance was set
 	if state.cfg.Contracts.Allowance.IsZero() {
-		c.logger.Debug("allowance is set to zero, skipping contract maintenance")
+		c.logger.Warn("allowance is set to zero, skipping contract maintenance")
+		return nil
+	}
+
+	// no maintenace if no period was set
+	if state.cfg.Contracts.Period == 0 {
+		c.logger.Warn("period is set to zero, skipping contract maintenance")
 		return nil
 	}
 


### PR DESCRIPTION
This PR adds some zero checks:
- check for zero allowance/hosts/period in `/hosts/:hostkey` endpoint
- skip maintenance and warn if cfg is not sane
- add score breakdown to the result to avoid scoring twice**

** fetching the breakdown separately leads to errors, we weren't passing storage and redundancy and we also don't calculate the score if the host has no price table for instance, overloading the result is not ideal but I don't think we should care too much about that in this case