### PR TITLE
worker: add siamux addr to fund/sync request types

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -74,6 +74,8 @@ type RHPRenewResponse struct {
 type RHPFundRequest struct {
 	ContractID types.FileContractID `json:"contractID"`
 	HostKey    types.PublicKey      `json:"hostKey"`
+	HostIP     string               `json:"hostIP"`
+	SiamuxAddr string               `json:"siamuxAddr"`
 	Balance    types.Currency       `json:"balance"`
 }
 
@@ -81,6 +83,8 @@ type RHPFundRequest struct {
 type RHPSyncRequest struct {
 	ContractID types.FileContractID `json:"contractID"`
 	HostKey    types.PublicKey      `json:"hostKey"`
+	HostIP     string               `json:"hostIP"`
+	SiamuxAddr string               `json:"siamuxAddr"`
 }
 
 // RHPPreparePaymentRequest is the request type for the /rhp/prepare/payment

--- a/autopilot/accounts.go
+++ b/autopilot/accounts.go
@@ -170,7 +170,7 @@ func (a *accounts) refillWorkerAccounts(w Worker) {
 
 			// Check if a resync is needed.
 			if account.RequiresSync {
-				err := w.RHPSync(ctx, contract.ID, contract.HostKey)
+				err := w.RHPSync(ctx, contract.ID, contract.HostKey, contract.HostIP, contract.SiamuxAddr)
 				if err != nil {
 					a.logger.Errorw(fmt.Sprintf("failed to sync account's balance: %s", err),
 						"account", account.ID,
@@ -189,7 +189,7 @@ func (a *accounts) refillWorkerAccounts(w Worker) {
 				return nil // nothing to do
 			}
 
-			if err := w.RHPFund(ctx, contract.ID, contract.HostKey, maxBalance); err != nil {
+			if err := w.RHPFund(ctx, contract.ID, contract.HostKey, contract.HostIP, contract.SiamuxAddr, maxBalance); err != nil {
 				a.logger.Errorw(fmt.Sprintf("failed to fund account: %s", err),
 					"account", account.ID,
 					"host", contract.HostKey,

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -81,11 +81,11 @@ type Worker interface {
 	ID(ctx context.Context) (string, error)
 	MigrateSlab(ctx context.Context, s object.Slab) error
 	RHPForm(ctx context.Context, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds types.Currency, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
-	RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, balance types.Currency) (err error)
+	RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP, siamuxAddr string, balance types.Currency) (err error)
 	RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string) (rhpv3.HostPriceTable, error)
 	RHPRenew(ctx context.Context, fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds, newCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPScan(ctx context.Context, hostKey types.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)
-	RHPSync(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey) (err error)
+	RHPSync(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP, siamuxAddr string) (err error)
 }
 
 type Autopilot struct {

--- a/worker/client.go
+++ b/worker/client.go
@@ -69,10 +69,12 @@ func (c *Client) RHPRenew(ctx context.Context, fcid types.FileContractID, endHei
 }
 
 // RHPFund funds an ephemeral account using the supplied contract.
-func (c *Client) RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, balance types.Currency) (err error) {
+func (c *Client) RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP, siamuxAddr string, balance types.Currency) (err error) {
 	req := api.RHPFundRequest{
 		ContractID: contractID,
 		HostKey:    hostKey,
+		HostIP:     hostIP,
+		SiamuxAddr: siamuxAddr,
 		Balance:    balance,
 	}
 	err = c.c.WithContext(ctx).POST("/rhp/fund", req, nil)
@@ -80,10 +82,11 @@ func (c *Client) RHPFund(ctx context.Context, contractID types.FileContractID, h
 }
 
 // RHPSync funds an ephemeral account using the supplied contract.
-func (c *Client) RHPSync(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey) (err error) {
+func (c *Client) RHPSync(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP, siamuxAddr string) (err error) {
 	req := api.RHPSyncRequest{
 		ContractID: contractID,
 		HostKey:    hostKey,
+		SiamuxAddr: siamuxAddr,
 	}
 	err = c.c.WithContext(ctx).POST("/rhp/sync", req, nil)
 	return


### PR DESCRIPTION
There's a couple of redundant `Host` calls to the `bus` to fetch the host IP and mux address. We have that info in the autopilot already so I added it to the requests.