### PR TITLE
Fetch revisions over rhpv3

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -74,7 +74,6 @@ type RHPRenewResponse struct {
 type RHPFundRequest struct {
 	ContractID types.FileContractID `json:"contractID"`
 	HostKey    types.PublicKey      `json:"hostKey"`
-	HostIP     string               `json:"hostIP"`
 	SiamuxAddr string               `json:"siamuxAddr"`
 	Balance    types.Currency       `json:"balance"`
 }
@@ -83,7 +82,6 @@ type RHPFundRequest struct {
 type RHPSyncRequest struct {
 	ContractID types.FileContractID `json:"contractID"`
 	HostKey    types.PublicKey      `json:"hostKey"`
-	HostIP     string               `json:"hostIP"`
 	SiamuxAddr string               `json:"siamuxAddr"`
 }
 
@@ -100,7 +98,7 @@ type RHPPreparePaymentRequest struct {
 // endpoint.
 type RHPRegistryReadRequest struct {
 	HostKey     types.PublicKey                    `json:"hostKey"`
-	HostIP      string                             `json:"hostIP"`
+	SiamuxAddr  string                             `json:"siamuxAddr"`
 	RegistryKey rhpv3.RegistryKey                  `json:"registryKey"`
 	Payment     rhpv3.PayByEphemeralAccountRequest `json:"payment"`
 }
@@ -109,7 +107,7 @@ type RHPRegistryReadRequest struct {
 // endpoint.
 type RHPRegistryUpdateRequest struct {
 	HostKey       types.PublicKey     `json:"hostKey"`
-	HostIP        string              `json:"hostIP"`
+	SiamuxAddr    string              `json:"siamuxAddr"`
 	RegistryKey   rhpv3.RegistryKey   `json:"registryKey"`
 	RegistryValue rhpv3.RegistryValue `json:"registryValue"`
 }

--- a/go.mod
+++ b/go.mod
@@ -73,5 +73,3 @@ require (
 	google.golang.org/grpc v1.52.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
-
-replace go.sia.tech/core => ../core

--- a/go.mod
+++ b/go.mod
@@ -73,3 +73,5 @@ require (
 	google.golang.org/grpc v1.52.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
+
+replace go.sia.tech/core => ../core

--- a/worker/client.go
+++ b/worker/client.go
@@ -102,10 +102,10 @@ func (c *Client) RHPPriceTable(ctx context.Context, hostKey types.PublicKey, sia
 }
 
 // RHPReadRegistry reads a registry value.
-func (c *Client) RHPReadRegistry(ctx context.Context, hostKey types.PublicKey, hostIP string, key rhpv3.RegistryKey, payment rhpv3.PayByEphemeralAccountRequest) (resp rhpv3.RegistryValue, err error) {
+func (c *Client) RHPReadRegistry(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, key rhpv3.RegistryKey, payment rhpv3.PayByEphemeralAccountRequest) (resp rhpv3.RegistryValue, err error) {
 	req := api.RHPRegistryReadRequest{
 		HostKey:     hostKey,
-		SiamuxAddr:  hostIP,
+		SiamuxAddr:  siamuxAddr,
 		RegistryKey: key,
 		Payment:     payment,
 	}

--- a/worker/client.go
+++ b/worker/client.go
@@ -73,7 +73,6 @@ func (c *Client) RHPFund(ctx context.Context, contractID types.FileContractID, h
 	req := api.RHPFundRequest{
 		ContractID: contractID,
 		HostKey:    hostKey,
-		HostIP:     hostIP,
 		SiamuxAddr: siamuxAddr,
 		Balance:    balance,
 	}
@@ -86,7 +85,6 @@ func (c *Client) RHPSync(ctx context.Context, contractID types.FileContractID, h
 	req := api.RHPSyncRequest{
 		ContractID: contractID,
 		HostKey:    hostKey,
-		HostIP:     hostIP,
 		SiamuxAddr: siamuxAddr,
 	}
 	err = c.c.WithContext(ctx).POST("/rhp/sync", req, nil)
@@ -107,7 +105,7 @@ func (c *Client) RHPPriceTable(ctx context.Context, hostKey types.PublicKey, sia
 func (c *Client) RHPReadRegistry(ctx context.Context, hostKey types.PublicKey, hostIP string, key rhpv3.RegistryKey, payment rhpv3.PayByEphemeralAccountRequest) (resp rhpv3.RegistryValue, err error) {
 	req := api.RHPRegistryReadRequest{
 		HostKey:     hostKey,
-		HostIP:      hostIP,
+		SiamuxAddr:  hostIP,
 		RegistryKey: key,
 		Payment:     payment,
 	}

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -123,6 +123,7 @@ func (gc gougingChecker) CheckPT(pt *rhpv3.HostPriceTable) (results GougingResul
 func (gr GougingResults) CanDownload() (errs []error) {
 	return filterErrors(
 		gr.downloadErr,
+		gr.gougingErr,
 	)
 }
 

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -11,7 +11,6 @@ import (
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/siad/modules"
 )
 
 const (
@@ -337,7 +336,7 @@ func checkDownloadGougingRHPv3(gs api.GougingSettings, rs api.RedundancySettings
 }
 
 func checkDownloadGouging(gs api.GougingSettings, rs api.RedundancySettings, sectorDownloadPrice types.Currency) error {
-	dpptb, overflow := sectorDownloadPrice.Mul64WithOverflow(1 << 40 / modules.SectorSize) // sectors per TiB
+	dpptb, overflow := sectorDownloadPrice.Mul64WithOverflow(1 << 40 / rhpv2.SectorSize) // sectors per TiB
 	if overflow {
 		return fmt.Errorf("overflow detected when computing download price per TiB")
 	}
@@ -369,7 +368,7 @@ func checkUploadGougingRHPv3(gs api.GougingSettings, rs api.RedundancySettings, 
 }
 
 func checkUploadGouging(gs api.GougingSettings, rs api.RedundancySettings, sectorUploadPricePerMonth types.Currency) error {
-	upptb, overflow := sectorUploadPricePerMonth.Mul64WithOverflow(1 << 40 / modules.SectorSize) // sectors per TiB
+	upptb, overflow := sectorUploadPricePerMonth.Mul64WithOverflow(1 << 40 / rhpv2.SectorSize) // sectors per TiB
 	if overflow {
 		return fmt.Errorf("overflow detected when computing upload price per TiB")
 	}

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -838,14 +838,42 @@ func RPCFundAccount(t *rhpv3.Transport, payment rhpv3.PaymentMethod, account rhp
 	return nil
 }
 
+type RPCLatestRevisionRequest struct {
+	ContractID types.FileContractID
+}
+
+type RPCLatestRevisionResponse struct {
+	Revision types.FileContractRevision
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCLatestRevisionRequest) EncodeTo(e *types.Encoder) {
+	r.ContractID.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCLatestRevisionRequest) DecodeFrom(d *types.Decoder) {
+	r.ContractID.DecodeFrom(d)
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCLatestRevisionResponse) EncodeTo(e *types.Encoder) {
+	r.Revision.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCLatestRevisionResponse) DecodeFrom(d *types.Decoder) {
+	r.Revision.DecodeFrom(d)
+}
+
 func RPCLatestRevision(t *rhpv3.Transport, contractID types.FileContractID, paymentFunc func(rev *types.FileContractRevision) (rhpv3.PaymentMethod, error)) (rev types.FileContractRevision, err error) {
 	defer wrapErr(&err, "LatestRevision")
 	s := t.DialStream()
 	defer s.Close()
-	req := rhpv3.RPCLatestRevisionRequest{
+	req := RPCLatestRevisionRequest{
 		ContractID: contractID,
 	}
-	var resp rhpv3.RPCLatestRevisionResponse
+	var resp RPCLatestRevisionResponse
 	if err := s.WriteRequest(rhpv3.RPCAccountBalanceID, &req); err != nil {
 		return types.FileContractRevision{}, err
 	} else if err := s.ReadResponse(&resp, 4096); err != nil {

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -57,9 +57,9 @@ func (w *worker) FetchRevisionWithAccount(ctx context.Context, pt rhpv3.HostPric
 	err = acc.WithWithdrawal(ctx, func() (types.Currency, error) {
 		cost := pt.LatestRevisionCost
 		return cost, withTransportV3(ctx, siamuxAddr, hostKey, func(t *rhpv3.Transport) (err error) {
-			rev, err = RPCLatestRevision(t, contractID, func(rev *types.FileContractRevision) (rhpv3.PaymentMethod, error) {
+			rev, err = RPCLatestRevision(t, contractID, func(rev *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
 				payment := rhpv3.PayByEphemeralAccount(acc.id, cost, bh+defaultWithdrawalExpiryBlocks, w.accounts.deriveAccountKey(hostKey))
-				return &payment, nil
+				return pt, &payment, nil
 			})
 			if err != nil {
 				return err
@@ -74,24 +74,30 @@ func (w *worker) FetchRevisionWithAccount(ctx context.Context, pt rhpv3.HostPric
 // a contract to pay for it. If no pricetable is provided, a new one is
 // requested.
 func (w *worker) FetchRevisionWithContract(ctx context.Context, pt *rhpv3.HostPriceTable, hostKey types.PublicKey, siamuxAddr string, contractID types.FileContractID) (rev types.FileContractRevision, err error) {
+	acc, err := w.accounts.ForHost(hostKey)
+	if err != nil {
+		return types.FileContractRevision{}, err
+	}
 	err = withTransportV3(ctx, siamuxAddr, hostKey, func(t *rhpv3.Transport) (err error) {
-		rev, err = RPCLatestRevision(t, contractID, func(paymentRev *types.FileContractRevision) (rhpv3.PaymentMethod, error) {
+		rev, err = RPCLatestRevision(t, contractID, func(paymentRev *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
 			// If there is no pricetable, fetch a new one using the revision.
-			newPT, err := w.priceTables.Update(ctx, w.preparePriceTableContractPayment(hostKey, paymentRev), siamuxAddr, hostKey)
-			if err != nil {
-				return nil, err
+			if pt == nil {
+				newPT, err := w.priceTables.Update(ctx, w.preparePriceTableContractPayment(hostKey, paymentRev), siamuxAddr, hostKey)
+				if err != nil {
+					return rhpv3.HostPriceTable{}, nil, err
+				}
+				pt = &newPT
 			}
-			pt = &newPT
 			// Check pt.
 			if errs := PerformGougingChecks(ctx, nil, pt).CanDownload(); len(errs) > 0 {
-				return nil, fmt.Errorf("failed to fetch revision, %w: %v", errGougingHost, errs)
+				return rhpv3.HostPriceTable{}, nil, fmt.Errorf("failed to fetch revision, %w: %v", errGougingHost, errs)
 			}
 			// Pay for the revision.
-			payment, ok := rhpv3.PayByContract(paymentRev, pt.LatestRevisionCost, rhpv3.Account{}, w.deriveRenterKey(hostKey))
+			payment, ok := rhpv3.PayByContract(paymentRev, pt.LatestRevisionCost, acc.id, w.deriveRenterKey(hostKey))
 			if !ok {
-				return nil, errors.New("insufficient funds")
+				return rhpv3.HostPriceTable{}, nil, errors.New("insufficient funds")
 			}
-			return &payment, nil
+			return *pt, &payment, nil
 		})
 		return err
 	})
@@ -243,31 +249,31 @@ func (w *worker) initAccounts(as AccountStore) {
 	}
 }
 
-func (w *worker) fetchPriceTable(ctx context.Context, contractID types.FileContractID, siamuxAddr string, hostKey types.PublicKey) (pt rhpv3.HostPriceTable, err error) {
+func (w *worker) fetchPriceTable(ctx context.Context, contractID types.FileContractID, siamuxAddr string, hostKey types.PublicKey) (rhpv3.HostPriceTable, error) {
 	pt, ptValid := w.priceTables.PriceTable(hostKey)
 	if ptValid {
 		return pt, nil
 	}
 
-	updatePTByContract := func() {
+	updatePTByContract := func() (rhpv3.HostPriceTable, error) {
 		// Fetch a revision to pay for the pricetable. This will implicitly
 		// update the pricetable if no pricetable is provided.
 		_, err := w.FetchRevisionWithContract(ctx, nil, hostKey, siamuxAddr, contractID)
 		if err != nil {
-			return
+			return rhpv3.HostPriceTable{}, err
 		}
 		// Check that we got a valid pricetable now.
 		pt, ptValid = w.priceTables.PriceTable(hostKey)
 		if !ptValid {
-			err = errors.New("pricetable wasn't valid after successfully fetching a revision")
+			return pt, errors.New("pricetable wasn't valid after successfully fetching a revision")
 		}
+		return pt, nil
 	}
 
 	// update price table using contract payment if we don't have a funded account
 	acc, err := w.accounts.ForHost(hostKey)
 	if err != nil || acc.Balance().IsZero() {
-		updatePTByContract()
-		return
+		return updatePTByContract()
 	}
 
 	// fetch block height
@@ -279,9 +285,9 @@ func (w *worker) fetchPriceTable(ctx context.Context, contractID types.FileContr
 	// update price table using account payment if possible, but fall back to ensure we have a valid price table
 	pt, err = w.priceTables.Update(ctx, w.preparePriceTableAccountPayment(hostKey, cs.BlockHeight), siamuxAddr, hostKey)
 	if err != nil {
-		updatePTByContract()
+		return updatePTByContract()
 	}
-	return
+	return pt, nil
 }
 
 func (w *worker) withHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string, fn func(sectorStore) error) (err error) {
@@ -879,7 +885,7 @@ func (r *RPCLatestRevisionResponse) DecodeFrom(d *types.Decoder) {
 	r.Revision.DecodeFrom(d)
 }
 
-func RPCLatestRevision(t *rhpv3.Transport, contractID types.FileContractID, paymentFunc func(rev *types.FileContractRevision) (rhpv3.PaymentMethod, error)) (rev types.FileContractRevision, err error) {
+func RPCLatestRevision(t *rhpv3.Transport, contractID types.FileContractID, paymentFunc func(rev *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error)) (_ types.FileContractRevision, err error) {
 	defer wrapErr(&err, "LatestRevision")
 	s := t.DialStream()
 	defer s.Close()
@@ -887,16 +893,18 @@ func RPCLatestRevision(t *rhpv3.Transport, contractID types.FileContractID, paym
 		ContractID: contractID,
 	}
 	var resp RPCLatestRevisionResponse
-	if err := s.WriteRequest(rhpv3.RPCAccountBalanceID, &req); err != nil {
+	if err := s.WriteRequest(rhpv3.RPCLatestRevisionID, &req); err != nil {
 		return types.FileContractRevision{}, err
 	} else if err := s.ReadResponse(&resp, 4096); err != nil {
 		return types.FileContractRevision{}, err
-	} else if payment, err := paymentFunc(&resp.Revision); err != nil {
+	} else if pt, payment, err := paymentFunc(&resp.Revision); err != nil {
+		return types.FileContractRevision{}, err
+	} else if err := s.WriteResponse(&pt.UID); err != nil {
 		return types.FileContractRevision{}, err
 	} else if err := processPayment(s, payment); err != nil {
 		return types.FileContractRevision{}, err
 	}
-	return
+	return resp.Revision, nil
 }
 
 // RPCReadSector calls the ExecuteProgram RPC with a ReadSector instruction.

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -43,7 +43,7 @@ type sectorStore interface {
 
 type storeProvider interface {
 	withHostV2(context.Context, types.FileContractID, types.PublicKey, string, func(sectorStore) error) (err error)
-	withHostV3(context.Context, types.FileContractID, types.PublicKey, string, string, func(sectorStore) error) (err error)
+	withHostV3(context.Context, types.FileContractID, types.PublicKey, string, func(sectorStore) error) (err error)
 }
 
 func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, contracts []api.ContractMetadata, locker contractLocker, uploadSectorTimeout time.Duration) ([]object.Sector, []int, error) {
@@ -244,7 +244,7 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 			}
 
 			offset, length := ss.SectorRegion()
-			_ = sp.withHostV3(ctx, c.ID, c.HostKey, c.HostIP, c.SiamuxAddr, func(ss sectorStore) error {
+			_ = sp.withHostV3(ctx, c.ID, c.HostKey, c.SiamuxAddr, func(ss sectorStore) error {
 				buf := bytes.NewBuffer(make([]byte, 0, rhpv2.SectorSize))
 				err := ss.DownloadSector(ctx, buf, shard.Root, uint64(offset), uint64(length))
 				if err != nil {

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -108,7 +108,7 @@ func (sp *mockStoreProvider) withHostV2(ctx context.Context, contractID types.Fi
 	return f(h)
 }
 
-func (sp *mockStoreProvider) withHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP, siamuxAddr string, f func(sectorStore) error) (err error) {
+func (sp *mockStoreProvider) withHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string, f func(sectorStore) error) (err error) {
 	h, exists := sp.hosts[hostKey]
 	if !exists {
 		panic("doesn't exist")

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -394,7 +394,7 @@ func (w *worker) withHostV2(ctx context.Context, contractID types.FileContractID
 	})
 }
 
-func (w *worker) withRevision(ctx context.Context, contractID types.FileContractID, hk types.PublicKey, hostIP string, lockPriority int, lockDuration time.Duration, fn func(revision types.FileContractRevision) error) error {
+func (w *worker) withRevisionV2(ctx context.Context, contractID types.FileContractID, hk types.PublicKey, hostIP string, lockPriority int, lockDuration time.Duration, fn func(revision types.FileContractRevision) error) error {
 	// acquire contract lock
 	if lockID, err := w.bus.AcquireContract(ctx, contractID, lockPriority, lockDuration); err != nil {
 		return fmt.Errorf("%v: %w", "failed to acquire contract for funding EA", err)
@@ -420,6 +420,33 @@ func (w *worker) withRevision(ctx context.Context, contractID types.FileContract
 	}
 
 	return fn(revision)
+}
+
+func (w *worker) withRevisionV3(ctx context.Context, contractID types.FileContractID, hk types.PublicKey, siamuxAddr string, lockPriority int, lockDuration time.Duration, fn func(revision types.FileContractRevision) error) error {
+	// acquire contract lock
+	if lockID, err := w.bus.AcquireContract(ctx, contractID, lockPriority, lockDuration); err != nil {
+		return fmt.Errorf("%v: %w", "failed to acquire contract for funding EA", err)
+	} else {
+		defer func() {
+			if err := w.bus.ReleaseContract(ctx, contractID, lockID); err != nil {
+				w.logger.Errorw(fmt.Sprintf("failed to release contract, err: %v", err), "hk", hk, "fcid", contractID)
+			}
+		}()
+	}
+
+	// fetch contract revision
+	pt, valid := w.priceTables.PriceTable(hk)
+	var rev types.FileContractRevision
+	var err error
+	if !valid {
+		rev, err = w.FetchRevisionWithContract(ctx, &pt, hk, siamuxAddr, contractID)
+	} else {
+		rev, err = w.FetchRevisionWithContract(ctx, nil, hk, siamuxAddr, contractID)
+	}
+	if err != nil {
+		return err
+	}
+	return fn(rev)
 }
 
 func (w *worker) unlockHosts(hosts []sectorStore) {
@@ -604,7 +631,7 @@ func (w *worker) rhpRenewHandler(jc jape.Context) {
 	// renew the contract
 	var renewed rhpv2.ContractRevision
 	var txnSet []types.Transaction
-	if jc.Check("couldn't renew contract", w.withRevision(ctx, rrr.ContractID, rrr.HostKey, rrr.HostIP, lockingPriorityRenew, lockingDurationRenew, func(revision types.FileContractRevision) error {
+	if jc.Check("couldn't renew contract", w.withRevisionV2(ctx, rrr.ContractID, rrr.HostKey, rrr.HostIP, lockingPriorityRenew, lockingDurationRenew, func(revision types.FileContractRevision) error {
 		return w.withHostV2(ctx, rrr.ContractID, rrr.HostKey, rrr.HostIP, func(ss sectorStore) error {
 			session := ss.(*sharedSession)
 			renewed, txnSet, err = session.RenewContract(ctx, func(rev types.FileContractRevision, host rhpv2.HostSettings) ([]types.Transaction, types.Currency, func(), error) {
@@ -638,7 +665,7 @@ func (w *worker) rhpFundHandler(jc jape.Context) {
 	}
 
 	// fund the account
-	jc.Check("couldn't fund account", w.withRevision(ctx, rfr.ContractID, rfr.HostKey, rfr.HostIP, lockingPriorityFunding, lockingDurationFunding, func(revision types.FileContractRevision) error {
+	jc.Check("couldn't fund account", w.withRevisionV3(ctx, rfr.ContractID, rfr.HostKey, rfr.SiamuxAddr, lockingPriorityFunding, lockingDurationFunding, func(revision types.FileContractRevision) error {
 		if err := w.fundAccount(ctx, rfr.HostKey, rfr.SiamuxAddr, rfr.Balance, &revision); isMaxBalanceExceeded(err) {
 			// sync and retry funding
 			if err := w.syncAccount(ctx, rfr.HostKey, rfr.SiamuxAddr, &revision); err != nil {
@@ -667,7 +694,7 @@ func (w *worker) rhpRegistryReadHandler(jc jape.Context) {
 		return
 	}
 	var value rhpv3.RegistryValue
-	err := withTransportV3(jc.Request.Context(), rrrr.HostIP, rrrr.HostKey, func(t *rhpv3.Transport) (err error) {
+	err := withTransportV3(jc.Request.Context(), rrrr.SiamuxAddr, rrrr.HostKey, func(t *rhpv3.Transport) (err error) {
 		value, err = RPCReadRegistry(t, &rrrr.Payment, rrrr.RegistryKey)
 		return
 	})
@@ -686,7 +713,7 @@ func (w *worker) rhpRegistryUpdateHandler(jc jape.Context) {
 	rc := pt.UpdateRegistryCost() // TODO: handle refund
 	cost, _ := rc.Total()
 	payment := w.preparePayment(rrur.HostKey, cost, pt.HostBlockHeight)
-	err := withTransportV3(jc.Request.Context(), rrur.HostIP, rrur.HostKey, func(t *rhpv3.Transport) (err error) {
+	err := withTransportV3(jc.Request.Context(), rrur.SiamuxAddr, rrur.HostKey, func(t *rhpv3.Transport) (err error) {
 		return RPCUpdateRegistry(t, &payment, rrur.RegistryKey, rrur.RegistryValue)
 	})
 	if jc.Check("couldn't update registry", err) != nil {
@@ -704,7 +731,7 @@ func (w *worker) rhpSyncHandler(jc jape.Context) {
 	}
 
 	// sync the account
-	jc.Check("couldn't sync account", w.withRevision(ctx, rsr.ContractID, rsr.HostKey, rsr.HostIP, lockingPrioritySyncing, lockingDurationSyncing, func(revision types.FileContractRevision) error {
+	jc.Check("couldn't sync account", w.withRevisionV3(ctx, rsr.ContractID, rsr.HostKey, rsr.SiamuxAddr, lockingPrioritySyncing, lockingDurationSyncing, func(revision types.FileContractRevision) error {
 		return w.syncAccount(ctx, rsr.HostKey, rsr.SiamuxAddr, &revision)
 	}))
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -737,6 +737,15 @@ func (w *worker) rhpSyncHandler(jc jape.Context) {
 		return
 	}
 
+	// fetch gouging params
+	up, err := w.bus.UploadParams(ctx)
+	if jc.Check("couldn't fetch upload parameters from bus", err) != nil {
+		return
+	}
+
+	// attach gouging checker to the context
+	ctx = WithGougingChecker(ctx, up.GougingParams)
+
 	// sync the account
 	jc.Check("couldn't sync account", w.withRevisionV3(ctx, rsr.ContractID, rsr.HostKey, rsr.SiamuxAddr, lockingPrioritySyncing, lockingDurationSyncing, func(revision types.FileContractRevision) error {
 		return w.syncAccount(ctx, rsr.HostKey, rsr.SiamuxAddr, &revision)


### PR DESCRIPTION
Adds support for the LatestRevision RPC which is part of rhpv3. That way we can finally have pure rhpv3 endpoints which don't require both the `hostIP` of v2 and the `siamuxAddr` of v3. 

It also speeds things up a bit since we no longer need to lock a v2 session to get the latest revision. Instead we can just pay via account. This should be especially useful for endpoints fetching revisions frequently or just large numbers of them.