### PR TITLE
Host AfterCreate Hook

### DIFF
--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -777,9 +777,7 @@ func (ss *SQLStore) ProcessConsensusChange(cc modules.ConsensusChange) {
 	ss.unappliedCCID = cc.ID
 
 	if err := ss.applyUpdates(); err != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		ss.logger.Error(ctx, fmt.Sprintf("failed to apply updates, err: %v", err))
-		cancel()
+		ss.logger.Error(context.Background(), fmt.Sprintf("failed to apply updates, err: %v", err))
 	}
 }
 

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -915,6 +915,8 @@ func insertAnnouncements(tx *gorm.DB, as []announcement) error {
 			}
 		}
 	}
+
+	// NOTE: this upsert works because of the BeforeCreate hook on dbHost
 	if err := tx.CreateInBatches(&hosts, 100).Error; err != nil {
 		return err
 	}

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -33,6 +33,7 @@ type (
 		lastAnnouncementSave   time.Time
 		persistInterval        time.Duration
 		unappliedAnnouncements []announcement
+		unappliedHostKeys      map[types.PublicKey]struct{}
 		unappliedCCID          modules.ConsensusChangeID
 		unappliedRevisions     map[types.FileContractID]revisionUpdate
 		unappliedProofs        map[types.FileContractID]uint64
@@ -203,6 +204,7 @@ func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duratio
 		persistInterval:      persistInterval,
 		hasAllowlist:         allowlistCnt > 0,
 		hasBlocklist:         blocklistCnt > 0,
+		unappliedHostKeys:    make(map[types.PublicKey]struct{}),
 		unappliedRevisions:   make(map[types.FileContractID]revisionUpdate),
 		unappliedProofs:      make(map[types.FileContractID]uint64),
 	}


### PR DESCRIPTION
If my node needs to sync up I sometimes run into the following warning:

```go
2023-03-21T10:01:37+01:00       WARN    db      stores/hostdb.go:822    transaction attempt 5/5 failed, err: Error 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (`renterd`.`host_allowlist_entry_hosts`, CONSTRAINT `fk_host_allowlist_entry_hosts_db_host` FOREIGN KEY (`db_host_id`) REFERENCES `hosts` (`id`) ON DELETE CASCADE); ...  Error 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (`renterd`.`host_allowlist_entry_hosts`, CONSTRAINT `fk_host_allowlist_entry_hosts_db_host` FOREIGN KEY (`db_host_id`) REFERENCES `hosts` (`id`) ON DELETE CASCADE); Error 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (`renterd`.`host_allowlist_entry_hosts`, CONSTRAINT `fk_host_allowlist_entry_hosts_db_host` FOREIGN KEY (`db_host_id`) REFERENCES `hosts` (`id`) ON DELETE CASCADE)

failed to apply 74 announcements - should never happen
```

(note the "should never happen" log line 😁)

There's also the following error:

```go
2023-03-21T10:01:37+01:00       ERROR   db      callbacks/create.go:160 Error 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (`renterd`.`host_allowlist_entry_hosts`, CONSTRAINT `fk_host_allowlist_entry_hosts_db_host` FOREIGN KEY (`db_host_id`) REFERENCES `hosts` (`id`) ON DELETE CASCADE)        {"elapsed": "0.876ms", "rows": 0, "sql": "INSERT INTO `host_allowlist_entry_hosts` (`db_host_id`,`db_allowlist_entry_id`) VALUES (357988,226) ON DUPLICATE KEY UPDATE `db_host_id`=`db_host_id`"}
```

I have tried to reproduce the error on my node as well as in unit and integration tests but failed. I've been thinking to inline all blocklist related code and get rid of the hooks entirely, but removing the many-to-many and using columns (over) complicates a bunch of things. From what I can see everything is working fine, so I decided to get rid of the `AfterCreate` hook which seems to be causing this issue and inline it. 