### PR TITLE
ObjectList at root

### DIFF
--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -280,8 +280,17 @@ func TestUploadDownloadBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// fetch all entries from the worker
+	entries, err := cluster.Worker.ObjectEntries(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatal("expected one entry to be returned", len(entries))
+	}
+
 	// fetch entries with "file" prefix
-	_, entries, err := cluster.Bus.Object(context.Background(), "foo/", "file", 0, -1)
+	_, entries, err = cluster.Bus.Object(context.Background(), "foo/", "file", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -840,7 +840,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 		return
 	}
 
-	if strings.HasSuffix(path, "/") {
+	if strings.HasSuffix(jc.PathParam("path"), "/") {
 		jc.Encode(entries)
 		return
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -840,7 +840,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 		return
 	}
 
-	if strings.HasSuffix(jc.PathParam("path"), "/") {
+	if path == "" || strings.HasSuffix(path, "/") {
 		jc.Encode(entries)
 		return
 	}


### PR DESCRIPTION
Handling the `path` is pretty annoying. We have to perform the suffix check on the path param and not the sanitised path. I think it's annoying because our clients don't handle paths that well I feel. They expect the user to pass in the path without the slash prefix. 

I played around with stripping the slash in the client but quickly ran into trouble because we have both a worker and bus client and it becomes messy really fast. Since most people are using the API I think it's fine for the time being.