### PR TITLE
worker: add logging

### DIFF
--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -152,7 +152,7 @@ func (w *worker) fundAccount(ctx context.Context, hk types.PublicKey, siamuxAddr
 				return errors.New("insufficient funds")
 			}
 			if err := RPCFundAccount(t, &payment, account.id, pt.UID); err != nil {
-				return err
+				return fmt.Errorf("failed to fund account with %v;%w", amount, err)
 			}
 			w.contractSpendingRecorder.Record(revision.ParentID, api.ContractSpending{FundAccount: cost})
 			return nil

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -16,6 +16,7 @@ import (
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/internal/tracing"
 	"go.sia.tech/renterd/object"
+	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
 
@@ -47,7 +48,7 @@ type storeProvider interface {
 	withHostV3(context.Context, types.FileContractID, types.PublicKey, string, func(sectorStore) error) (err error)
 }
 
-func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, contracts []api.ContractMetadata, locker contractLocker, uploadSectorTimeout time.Duration) ([]object.Sector, []int, error) {
+func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, contracts []api.ContractMetadata, locker contractLocker, uploadSectorTimeout time.Duration, logger *zap.SugaredLogger) ([]object.Sector, []int, error) {
 	// ensure the context is cancelled when the slab is uploaded
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -86,17 +87,22 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 			}
 
 			var res resp
-			_ = sp.withHostV2(ctx, r.contract.ID, r.contract.HostKey, r.contract.HostIP, func(ss sectorStore) error {
+			if err := sp.withHostV2(ctx, r.contract.ID, r.contract.HostKey, r.contract.HostIP, func(ss sectorStore) error {
 				root, err := ss.UploadSector(ctx, (*[rhpv2.SectorSize]byte)(shards[r.shardIndex]))
 				if err != nil {
 					span.SetStatus(codes.Error, "uploading the sector failed")
 					span.RecordError(err)
 				}
 				res = resp{r, root, err}
-				return err
-			})
+				return nil // only return the error in the response
+			}); err != nil {
+				logger.Errorf("withHostV2 failed when uploading sector, err: %v, upload failed: ", err, res.err != nil)
+			}
 
-			_ = locker.ReleaseContract(ctx, r.contract.ID, lockID)
+			// NOTE: we release before sending the response to ensure the context isn't cancelled
+			if err := locker.ReleaseContract(ctx, r.contract.ID, lockID); err != nil {
+				logger.Errorf("failed to release lock %v on contract %v, err: %v", lockID, r.contract.ID, err)
+			}
 			respChan <- res
 		}(r)
 
@@ -156,7 +162,9 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 	}
 	if rem > 0 {
 		if errs == nil {
-			return nil, nil, fmt.Errorf("rem > 0 (%v) but errs is nil - this should not happen", rem)
+			err := fmt.Errorf("rem > 0 (%v) but errs is nil - this should not happen", rem)
+			logger.Errorf("upload failed, err: %v", err)
+			return nil, nil, err
 		}
 		return nil, nil, errs
 	}
@@ -180,7 +188,7 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 	return sectors, slowHosts, nil
 }
 
-func uploadSlab(ctx context.Context, sp storeProvider, r io.Reader, m, n uint8, contracts []api.ContractMetadata, locker contractLocker, uploadSectorTimeout time.Duration) (object.Slab, int, []int, error) {
+func uploadSlab(ctx context.Context, sp storeProvider, r io.Reader, m, n uint8, contracts []api.ContractMetadata, locker contractLocker, uploadSectorTimeout time.Duration, logger *zap.SugaredLogger) (object.Slab, int, []int, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "uploadSlab")
 	defer span.End()
 
@@ -197,7 +205,7 @@ func uploadSlab(ctx context.Context, sp storeProvider, r io.Reader, m, n uint8, 
 	s.Encode(buf, shards)
 	s.Encrypt(shards)
 
-	sectors, slowHosts, err := parallelUploadSlab(ctx, sp, shards, contracts, locker, uploadSectorTimeout)
+	sectors, slowHosts, err := parallelUploadSlab(ctx, sp, shards, contracts, locker, uploadSectorTimeout, logger)
 	if err != nil {
 		return object.Slab{}, 0, nil, err
 	}
@@ -206,7 +214,7 @@ func uploadSlab(ctx context.Context, sp storeProvider, r io.Reader, m, n uint8, 
 	return s, length, slowHosts, nil
 }
 
-func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration) ([][]byte, []int64, error) {
+func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, logger *zap.SugaredLogger) ([][]byte, []int64, error) {
 	// prepopulate the timings with a value for all contracts to ensure unused hosts aren't necessarily favoured in consecutive downloads
 	timings := make([]int64, len(contracts))
 	for i := 0; i < len(contracts); i++ {
@@ -255,17 +263,21 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 				return
 			}
 
+			var res resp
 			offset, length := ss.SectorRegion()
-			_ = sp.withHostV3(ctx, c.ID, c.HostKey, c.SiamuxAddr, func(ss sectorStore) error {
+			if err := sp.withHostV3(ctx, c.ID, c.HostKey, c.SiamuxAddr, func(ss sectorStore) error {
 				buf := bytes.NewBuffer(make([]byte, 0, rhpv2.SectorSize))
 				err := ss.DownloadSector(ctx, buf, shard.Root, uint64(offset), uint64(length))
 				if err != nil {
 					span.SetStatus(codes.Error, "downloading the sector failed")
 					span.RecordError(err)
 				}
-				respChan <- resp{r, buf.Bytes(), time.Since(start), err}
-				return err
-			})
+				res = resp{r, buf.Bytes(), time.Since(start), err}
+				return nil // only return the error in the response
+			}); err != nil {
+				logger.Errorf("withHostV3 failed when downloading sector, err: %v, download failed: ", err, res.err != nil)
+			}
+			respChan <- res
 		}(r)
 
 		if downloadSectorTimeout > 0 {
@@ -340,17 +352,22 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 		}
 	}
 	if rem > 0 {
+		if errs == nil {
+			err := fmt.Errorf("rem > 0 (%v) but errs is nil - this should not happen", rem)
+			logger.Errorf("download failed, err: %v", err)
+			return nil, nil, err
+		}
 		return nil, nil, errs
 	}
 
 	return shards, timings, nil
 }
 
-func downloadSlab(ctx context.Context, sp storeProvider, out io.Writer, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration) ([]int64, error) {
+func downloadSlab(ctx context.Context, sp storeProvider, out io.Writer, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, logger *zap.SugaredLogger) ([]int64, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "parallelDownloadSlab")
 	defer span.End()
 
-	shards, timings, err := parallelDownloadSlab(ctx, sp, ss, contracts, downloadSectorTimeout)
+	shards, timings, err := parallelDownloadSlab(ctx, sp, ss, contracts, downloadSectorTimeout, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -425,7 +442,7 @@ func deleteSlabs(ctx context.Context, slabs []object.Slab, hosts []sectorStore) 
 	return nil
 }
 
-func migrateSlab(ctx context.Context, sp storeProvider, s *object.Slab, contracts []api.ContractMetadata, locker contractLocker, downloadSectorTimeout, uploadSectorTimeout time.Duration) error {
+func migrateSlab(ctx context.Context, sp storeProvider, s *object.Slab, contracts []api.ContractMetadata, locker contractLocker, downloadSectorTimeout, uploadSectorTimeout time.Duration, logger *zap.SugaredLogger) error {
 	ctx, span := tracing.Tracer.Start(ctx, "migrateSlab")
 	defer span.End()
 
@@ -474,7 +491,7 @@ func migrateSlab(ctx context.Context, sp storeProvider, s *object.Slab, contract
 		Offset: 0,
 		Length: uint32(s.MinShards) * rhpv2.SectorSize,
 	}
-	shards, _, err := parallelDownloadSlab(ctx, sp, ss, contracts, downloadSectorTimeout)
+	shards, _, err := parallelDownloadSlab(ctx, sp, ss, contracts, downloadSectorTimeout, logger)
 	if err != nil {
 		return fmt.Errorf("failed to download slab for migration: %w", err)
 	}
@@ -502,7 +519,7 @@ func migrateSlab(ctx context.Context, sp storeProvider, s *object.Slab, contract
 	frand.Shuffle(len(filtered), func(i, j int) { filtered[i], filtered[j] = filtered[j], filtered[i] })
 
 	// reupload those shards
-	uploaded, _, err := parallelUploadSlab(ctx, sp, shards, filtered, locker, uploadSectorTimeout)
+	uploaded, _, err := parallelUploadSlab(ctx, sp, shards, filtered, locker, uploadSectorTimeout, logger)
 	if err != nil {
 		return fmt.Errorf("failed to upload slab for migration: %w", err)
 	}

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -162,9 +162,7 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 	}
 	if rem > 0 {
 		if errs == nil {
-			err := fmt.Errorf("rem > 0 (%v) but errs is nil - this should not happen", rem)
-			logger.Errorf("upload failed, err: %v", err)
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("rem > 0 (%v) but errs is nil - this should not happen", rem)
 		}
 		return nil, nil, errs
 	}
@@ -353,9 +351,7 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 	}
 	if rem > 0 {
 		if errs == nil {
-			err := fmt.Errorf("rem > 0 (%v) but errs is nil - this should not happen", rem)
-			logger.Errorf("download failed, err: %v", err)
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("rem > 0 (%v) but errs is nil - this should not happen", rem)
 		}
 		return nil, nil, errs
 	}

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -14,6 +14,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/object"
+	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
 
@@ -150,7 +151,7 @@ func TestMultipleObjects(t *testing.T) {
 	// upload
 	var slabs []object.Slab
 	for {
-		s, _, _, err := uploadSlab(context.Background(), sp, r, 3, 10, contracts, mockLocker, 0)
+		s, _, _, err := uploadSlab(context.Background(), sp, r, 3, 10, contracts, mockLocker, 0, zap.NewNop().Sugar())
 		if err == io.EOF {
 			break
 		} else if err != nil {
@@ -180,7 +181,7 @@ func TestMultipleObjects(t *testing.T) {
 		dst := o.Key.Decrypt(&buf, int64(offset))
 		ss := slabsForDownload(o.Slabs, int64(offset), int64(length))
 		for _, s := range ss {
-			if _, err := downloadSlab(context.Background(), sp, dst, s, contracts, 0); err != nil {
+			if _, err := downloadSlab(context.Background(), sp, dst, s, contracts, 0, zap.NewNop().Sugar()); err != nil {
 				t.Error(err)
 				return
 			}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -691,6 +691,7 @@ func (w *worker) rhpFundHandler(jc jape.Context) {
 			// try funding the account again
 			err = w.fundAccount(ctx, rfr.HostKey, rfr.SiamuxAddr, rfr.Balance, &revision)
 			if errors.Is(err, errBalanceSufficient) {
+				w.logger.Debugf("account balance for host %v restored after sync", rfr.HostKey)
 				return nil
 			}
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -957,6 +957,9 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	jc.Custom((*[]byte)(nil), nil)
 	ctx := jc.Request.Context()
 
+	// fetch the path
+	path := strings.TrimPrefix(jc.PathParam("path"), "/")
+
 	up, err := w.bus.UploadParams(ctx)
 	if jc.Check("couldn't fetch upload parameters from bus", err) != nil {
 		return
@@ -1039,6 +1042,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 			)
 			break
 		} else if jc.Check("couldn't upload slab", err); err != nil {
+			w.logger.Errorf("couldn't upload object '%v' slab %d, err: %v", path, len(o.Slabs), err)
 			return
 		}
 
@@ -1061,7 +1065,6 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 		}
 	}
 
-	path := strings.TrimPrefix(jc.PathParam("path"), "/")
 	if jc.Check("couldn't add object", w.bus.AddObject(ctx, path, o, usedContracts)) != nil {
 		return
 	}


### PR DESCRIPTION
Passed a logger to `upload`, `download` and `migrate`. I considered making them methods on the `worker` but we still have to pass in the `worker` because of the provider interface which is kind of silly. 

I rewrote the `rhpFundHandler` because on my node I'm seeing some of these errors which are terribly non-descriptive and should not even be happening. 

```
2023-03-23T09:28:25+01:00       ERROR   worker.worker   worker/worker.go:692    failed to fund account: FundAccount: ReadResponse: [Funding ephemeral failed; Could not deposit funds; Deposit failed; ephemeral account maximum balance exceeded] {"host": "ed25519:70c74a963eb31ee10decbc3ee508697a6cd549dfd1908b1326f548595952422b", "balance": "1 SC"}
```