### PR TITLE
Add extra endpoints

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -91,7 +91,9 @@ type (
 		ContractSets(ctx context.Context) ([]string, error)
 		RecordContractSpending(ctx context.Context, records []api.ContractSpendingRecord) error
 		RemoveContract(ctx context.Context, id types.FileContractID) error
+		RemoveContracts(ctx context.Context) error
 		SetContractSet(ctx context.Context, set string, contracts []types.FileContractID) error
+		DeleteContractSet(ctx context.Context, name string) error
 
 		Object(ctx context.Context, path string) (object.Object, error)
 		ObjectEntries(ctx context.Context, path, prefix string, offset, limit int) ([]string, error)
@@ -546,6 +548,12 @@ func (b *bus) contractsSetHandlerPUT(jc jape.Context) {
 	}
 }
 
+func (b *bus) contractsSetHandlerDELETE(jc jape.Context) {
+	if set := jc.PathParam("set"); set != "" {
+		jc.Check("could not remove contract set", b.ms.DeleteContractSet(jc.Request.Context(), set))
+	}
+}
+
 func (b *bus) contractAcquireHandlerPOST(jc jape.Context) {
 	var id types.FileContractID
 	if jc.DecodeParam("id", &id) != nil {
@@ -630,6 +638,10 @@ func (b *bus) contractIDHandlerDELETE(jc jape.Context) {
 		return
 	}
 	jc.Check("couldn't remove contract", b.ms.RemoveContract(jc.Request.Context(), id))
+}
+
+func (b *bus) contractsAllHandlerDELETE(jc jape.Context) {
+	jc.Check("couldn't remove contracts", b.ms.RemoveContracts(jc.Request.Context()))
 }
 
 func (b *bus) searchObjectsHandlerGET(jc jape.Context) {
@@ -1021,6 +1033,7 @@ func (b *bus) Handler() http.Handler {
 		"GET    /contracts/sets":         b.contractsSetsHandlerGET,
 		"GET    /contracts/set/:set":     b.contractsSetHandlerGET,
 		"PUT    /contracts/set/:set":     b.contractsSetHandlerPUT,
+		"DELETE /contracts/set/:set":     b.contractsSetHandlerDELETE,
 		"POST   /contracts/spending":     b.contractsSpendingHandlerPOST,
 		"GET    /contract/:id":           b.contractIDHandlerGET,
 		"POST   /contract/:id":           b.contractIDHandlerPOST,
@@ -1029,6 +1042,7 @@ func (b *bus) Handler() http.Handler {
 		"DELETE /contract/:id":           b.contractIDHandlerDELETE,
 		"POST   /contract/:id/acquire":   b.contractAcquireHandlerPOST,
 		"POST   /contract/:id/release":   b.contractReleaseHandlerPOST,
+		"DELETE /contracts/all":          b.contractsAllHandlerDELETE,
 
 		"POST /search/hosts":  b.searchHostsHandlerPOST,
 		"GET /search/objects": b.searchObjectsHandlerGET,

--- a/bus/client.go
+++ b/bus/client.go
@@ -305,6 +305,12 @@ func (c *Client) ContractSets(ctx context.Context) (sets []string, err error) {
 	return
 }
 
+// DeleteContractSet removes the contract set from the bus.
+func (c *Client) DeleteContractSet(ctx context.Context, set string) (err error) {
+	err = c.c.WithContext(ctx).DELETE(fmt.Sprintf("/contracts/set/%s", set))
+	return
+}
+
 // AddContract adds the provided contract to the metadata store.
 func (c *Client) AddContract(ctx context.Context, contract rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64) (added api.ContractMetadata, err error) {
 	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/contract/%s", contract.ID()), api.ContractsIDAddRequest{
@@ -354,6 +360,12 @@ func (c *Client) DeleteContracts(ctx context.Context, ids []types.FileContractID
 // DeleteContract deletes the contract with the given ID.
 func (c *Client) DeleteContract(ctx context.Context, id types.FileContractID) (err error) {
 	err = c.c.WithContext(ctx).DELETE(fmt.Sprintf("/contract/%s", id))
+	return
+}
+
+// DeleteAllContracts deletes all contracts from the bus.
+func (c *Client) DeleteAllContracts(ctx context.Context) (err error) {
+	err = c.c.WithContext(ctx).DELETE("/contracts/all")
 	return
 }
 

--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -438,12 +438,27 @@ func (s *SQLStore) SetContractSet(ctx context.Context, name string, contractIds 
 	return s.db.Model(&contractset).Association("Contracts").Replace(&dbContracts)
 }
 
+func (s *SQLStore) DeleteContractSet(ctx context.Context, name string) error {
+	return s.db.
+		Where(dbContractSet{Name: name}).
+		Delete(&dbContractSet{}).
+		Error
+}
+
 func (s *SQLStore) RemoveContract(ctx context.Context, id types.FileContractID) error {
 	err := removeContract(s.db, fileContractID(id))
 	if err != nil {
 		return err
 	}
 	delete(s.knownContracts, id)
+	return nil
+}
+
+func (s *SQLStore) RemoveContracts(ctx context.Context) error {
+	if err := s.db.Where("TRUE").Delete(&dbContract{}).Error; err != nil {
+		return err
+	}
+	s.knownContracts = nil
 	return nil
 }
 


### PR DESCRIPTION
1. Create a `DELETE /bus/contracts/set:set` endpoint that allows deleting a contract set, which isn't needed anymore.
2. Create a `DELETE /bus/contracts/all` endpoint to batch delete all contracts from the bus.