### PR TITLE
Make sure releasing a contract isn't blocked by a cancelled context

### DIFF
--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -244,11 +244,11 @@ func (w *worker) fetchPriceTable(ctx context.Context, contractID types.FileContr
 	}
 
 	updatePTByContract := func() (rhpv3.HostPriceTable, error) {
-		lockID, err := w.bus.AcquireContract(ctx, contractID, lockingPriorityPriceTable, lockingDurationPriceTable)
+		lockID, err := w.AcquireContract(ctx, contractID, lockingPriorityPriceTable, lockingDurationPriceTable)
 		if err != nil {
 			return rhpv3.HostPriceTable{}, err
 		}
-		defer w.bus.ReleaseContract(ctx, contractID, lockID)
+		defer w.ReleaseContract(ctx, contractID, lockID)
 		// Fetch a revision to pay for the pricetable. This will implicitly
 		// update the pricetable if no pricetable is provided.
 		_, err = w.FetchRevisionWithContract(ctx, nil, hostKey, siamuxAddr, contractID)

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -272,8 +272,8 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 				}
 				res = resp{r, buf.Bytes(), time.Since(start), err}
 				return nil // only return the error in the response
-			}); err != nil {
-				logger.Errorf("withHostV3 failed when downloading sector, err: %v, download failed: ", err, res.err != nil)
+			}); err != nil && !errors.Is(err, context.Canceled) {
+				logger.Errorf("withHostV3 failed when downloading sector, err: %v, download failed: %v", err, res.err != nil)
 			}
 			respChan <- res
 		}(r)

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -95,8 +95,8 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 				}
 				res = resp{r, root, err}
 				return nil // only return the error in the response
-			}); err != nil {
-				logger.Errorf("withHostV2 failed when uploading sector, err: %v, upload failed: ", err, res.err != nil)
+			}); err != nil && !errors.Is(err, context.Canceled) {
+				logger.Errorf("withHostV2 failed when uploading sector, err: %v, upload failed: %v", err, res.err != nil)
 			}
 
 			// NOTE: we release before sending the response to ensure the context isn't cancelled

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1031,6 +1031,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 		})
 
 		// upload the slab
+		start := time.Now()
 		s, length, slowHosts, err = uploadSlab(ctx, w, lr, uint8(rs.MinShards), uint8(rs.TotalShards), contracts, &tracedContractLocker{w.bus}, w.uploadSectorTimeout, w.logger)
 		for _, h := range slowHosts {
 			slow[contracts[h].HostKey]++
@@ -1042,7 +1043,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 				"objectSize", objectSize,
 			)
 			break
-		} else if jc.Check("couldn't upload slab", err); err != nil {
+		} else if jc.Check(fmt.Sprintf("uploading slab failed after %v", time.Since(start)), err); err != nil {
 			w.logger.Errorf("couldn't upload object '%v' slab %d, err: %v", path, len(o.Slabs), err)
 			return
 		}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -1,0 +1,42 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.sia.tech/core/types"
+)
+
+type contextCheckingLocker struct {
+}
+
+func (l *contextCheckingLocker) AcquireContract(ctx context.Context, fcid types.FileContractID, priority int, d time.Duration) (lockID uint64, err error) {
+	return 0, nil
+}
+
+func (l *contextCheckingLocker) ReleaseContract(ctx context.Context, fcid types.FileContractID, lockID uint64) (err error) {
+	select {
+	case <-ctx.Done():
+		return context.Canceled
+	default:
+	}
+	return nil
+}
+
+// TestReleaseContract is a test to verify that calling `ReleaseContract` on a
+// tracedContractLocker with an already cancelled context will not fail.
+func TestReleaseContract(t *testing.T) {
+	t.Parallel()
+
+	l := &tracedContractLocker{
+		l: &contextCheckingLocker{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := l.ReleaseContract(ctx, types.FileContractID{}, 0); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR fixes delays on releasing contracts due to passing already cancelled contexts by swapping out the context in `ReleaseContract` with a different one that eventually times out for safety. The span is retrieved from the original context and attached to the new one to maintain traceability. 


Update: I've been running this over night without issues. 