### PR TITLE
Include Blocked Hosts in HostsForScanning 

### DIFF
--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -448,7 +448,6 @@ func (ss *SQLStore) HostsForScanning(ctx context.Context, maxLastScan time.Time,
 	var hostAddresses []hostdb.HostAddress
 
 	err := ss.db.
-		Scopes(ss.excludeBlocked).
 		Model(&dbHost{}).
 		Where("last_scan < ?", maxLastScan.UnixNano()).
 		Offset(offset).


### PR DESCRIPTION
blocked hosts should be included for scanning for two reasons:
- we definitely want to keep tabs on a host's uptime even if it is currently on the blocklist (or not on the allowlist)
- host pruning does not kick in if hosts are not being scanned

essentially this will "hurt" the autopilot for a while (~10days) and after that it should get rid of 95% of the bad hosts and continue with the actual host network