### PR TITLE
Stable Image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,14 @@ on:
   push:
     branches:
       - master
+      - stable
     tags: 
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   docker:
@@ -28,7 +33,7 @@ jobs:
         name: generate tags
         id: meta
         with:
-          images: ghcr.io/SiaFoundation/renterd
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=sha,prefix=


### PR DESCRIPTION
Add the `stable` branch to the list of branches for which to trigger the publish action.

Verified the publish action: https://github.com/SiaFoundation/renterd/actions/runs/4562155511/jobs/8048993165

```json
  {
    "tags": [
      "ghcr.io/siafoundation/renterd:pj-publish-stable",
      "ghcr.io/siafoundation/renterd:347f0f7"
    ],
    "labels": {
      "org.opencontainers.image.title": "renterd",
      "org.opencontainers.image.description": "A renter for Sia",
      "org.opencontainers.image.url": "https://github.com/SiaFoundation/renterd",
      "org.opencontainers.image.source": "https://github.com/SiaFoundation/renterd",
      "org.opencontainers.image.version": "pj-publish-stable",
      "org.opencontainers.image.created": "2023-03-30T08:18:58.556Z",
      "org.opencontainers.image.revision": "347f0f7f3e1ba6fb3bf219fcd44a5825c5ca0164",
      "org.opencontainers.image.licenses": "MIT"
    }
  }
```

The labels remain the same but the tag includes the branch name so we'll end up with `ghcr.io/siafoundation/renterd:master` and `ghcr.io/siafoundation/renterd:stable` which is probably fine?