### PR TITLE
Add /objectsinfo endpoint

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -102,6 +102,14 @@ type HostsRemoveRequest struct {
 	MaxDowntimeHours      ParamDurationHour `json:"maxDowntimeHours"`
 }
 
+// ObjectsSize is the response type for the /objectssize endpoint.
+type ObjectsSizeResponse struct {
+	Objects  uint64 `json:"objects"`  // size of all objects
+	Sectors  uint64 `json:"sectors"`  // uploaded size of all objects
+	Uploaded uint64 `json:"uploaded"` // uploaded size of all objects including redundant sectors
+
+}
+
 // WalletFundRequest is the request type for the /wallet/fund endpoint.
 type WalletFundRequest struct {
 	Transaction types.Transaction `json:"transaction"`

--- a/api/bus.go
+++ b/api/bus.go
@@ -102,13 +102,12 @@ type HostsRemoveRequest struct {
 	MaxDowntimeHours      ParamDurationHour `json:"maxDowntimeHours"`
 }
 
-// ObjectsInfo is the response type for the /objectssize endpoint.
-type ObjectsInfo struct {
-	NumObjects   uint64 `json:"numObjects"`   // number of objects
-	ObjectsSize  uint64 `json:"objectsSize"`  // size of all objects
-	SectorsSize  uint64 `json:"sectorsSize"`  // uploaded size of all objects
-	UploadedSize uint64 `json:"uploadedSize"` // uploaded size of all objects including redundant sectors
-
+// ObjectsStats is the response type for the /stats/objects endpoint.
+type ObjectsStats struct {
+	NumObjects        uint64 `json:"numObjects"`        // number of objects
+	TotalObjectsSize  uint64 `json:"totalObjectsSize"`  // size of all objects
+	TotalSectorsSize  uint64 `json:"totalSectorsSize"`  // uploaded size of all objects
+	TotalUploadedSize uint64 `json:"totalUploadedSize"` // uploaded size of all objects including redundant sectors
 }
 
 // WalletFundRequest is the request type for the /wallet/fund endpoint.

--- a/api/bus.go
+++ b/api/bus.go
@@ -102,11 +102,12 @@ type HostsRemoveRequest struct {
 	MaxDowntimeHours      ParamDurationHour `json:"maxDowntimeHours"`
 }
 
-// ObjectsSize is the response type for the /objectssize endpoint.
-type ObjectsSizeResponse struct {
-	Objects  uint64 `json:"objects"`  // size of all objects
-	Sectors  uint64 `json:"sectors"`  // uploaded size of all objects
-	Uploaded uint64 `json:"uploaded"` // uploaded size of all objects including redundant sectors
+// ObjectsInfo is the response type for the /objectssize endpoint.
+type ObjectsInfo struct {
+	NumObjects   uint64 `json:"numObjects"`   // number of objects
+	ObjectsSize  uint64 `json:"objectsSize"`  // size of all objects
+	SectorsSize  uint64 `json:"sectorsSize"`  // uploaded size of all objects
+	UploadedSize uint64 `json:"uploadedSize"` // uploaded size of all objects including redundant sectors
 
 }
 

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -101,7 +101,7 @@ type (
 		UpdateObject(ctx context.Context, path string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
 		RemoveObject(ctx context.Context, path string) error
 
-		ObjectsInfo(ctx context.Context) (api.ObjectsInfo, error)
+		ObjectsStats(ctx context.Context) (api.ObjectsStats, error)
 
 		UnhealthySlabs(ctx context.Context, healthCutoff float64, set string, limit int) ([]object.Slab, error)
 		UpdateSlab(ctx context.Context, s object.Slab, usedContracts map[types.PublicKey]types.FileContractID) error
@@ -714,9 +714,9 @@ func (b *bus) objectsHandlerDELETE(jc jape.Context) {
 	jc.Check("couldn't delete object", b.ms.RemoveObject(jc.Request.Context(), jc.PathParam("path")))
 }
 
-func (b *bus) objectsInfoHandlerGET(jc jape.Context) {
-	info, err := b.ms.ObjectsInfo(jc.Request.Context())
-	if jc.Check("couldn't get objects size", err) != nil {
+func (b *bus) objectsStatshandlerGET(jc jape.Context) {
+	info, err := b.ms.ObjectsStats(jc.Request.Context())
+	if jc.Check("couldn't get objects stats", err) != nil {
 		return
 	}
 	jc.Encode(info)
@@ -1107,7 +1107,8 @@ func (b *bus) Handler() http.Handler {
 		"POST /search/hosts":   b.searchHostsHandlerPOST,
 		"GET  /search/objects": b.searchObjectsHandlerGET,
 
-		"GET    /objectsinfo":   b.objectsInfoHandlerGET,
+		"GET    /stats/objects": b.objectsStatshandlerGET,
+
 		"GET    /objects/*path": b.objectsHandlerGET,
 		"PUT    /objects/*path": b.objectsHandlerPUT,
 		"DELETE /objects/*path": b.objectsHandlerDELETE,

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -101,9 +101,7 @@ type (
 		UpdateObject(ctx context.Context, path string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
 		RemoveObject(ctx context.Context, path string) error
 
-		ObjectsSize(ctx context.Context) (uint64, error)
-		SectorsSize(ctx context.Context) (uint64, error)
-		UploadedSize(ctx context.Context) (uint64, error)
+		ObjectsInfo(ctx context.Context) (api.ObjectsInfo, error)
 
 		UnhealthySlabs(ctx context.Context, healthCutoff float64, set string, limit int) ([]object.Slab, error)
 		UpdateSlab(ctx context.Context, s object.Slab, usedContracts map[types.PublicKey]types.FileContractID) error
@@ -716,24 +714,12 @@ func (b *bus) objectsHandlerDELETE(jc jape.Context) {
 	jc.Check("couldn't delete object", b.ms.RemoveObject(jc.Request.Context(), jc.PathParam("path")))
 }
 
-func (b *bus) ObjectsSizeHandlerGET(jc jape.Context) {
-	objectsSize, err := b.ms.ObjectsSize(jc.Request.Context())
+func (b *bus) objectsInfoHandlerGET(jc jape.Context) {
+	info, err := b.ms.ObjectsInfo(jc.Request.Context())
 	if jc.Check("couldn't get objects size", err) != nil {
 		return
 	}
-	sectorsSize, err := b.ms.SectorsSize(jc.Request.Context())
-	if jc.Check("couldn't get sectors size", err) != nil {
-		return
-	}
-	uploadedSize, err := b.ms.UploadedSize(jc.Request.Context())
-	if jc.Check("couldn't get uploaded size", err) != nil {
-		return
-	}
-	jc.Encode(api.ObjectsSizeResponse{
-		Objects:  objectsSize,
-		Sectors:  sectorsSize,
-		Uploaded: uploadedSize,
-	})
+	jc.Encode(info)
 }
 
 func (b *bus) slabHandlerPUT(jc jape.Context) {
@@ -1121,7 +1107,7 @@ func (b *bus) Handler() http.Handler {
 		"POST /search/hosts":   b.searchHostsHandlerPOST,
 		"GET  /search/objects": b.searchObjectsHandlerGET,
 
-		"GET    /objectssize":   b.objectsSizeHandlerGET,
+		"GET    /objectsinfo":   b.objectsInfoHandlerGET,
 		"GET    /objects/*path": b.objectsHandlerGET,
 		"PUT    /objects/*path": b.objectsHandlerPUT,
 		"DELETE /objects/*path": b.objectsHandlerDELETE,

--- a/bus/client.go
+++ b/bus/client.go
@@ -615,6 +615,12 @@ func (c *Client) FileContractTax(ctx context.Context, payout types.Currency) (ta
 	return
 }
 
+// ObjectsInfo returns information about the number of objects and their size.
+func (c *Client) ObjectsInfo() (osr api.ObjectsInfo, err error) {
+	err = c.c.GET("/objectsinfo", &osr)
+	return
+}
+
 // NewClient returns a client that communicates with a renterd store server
 // listening on the specified address.
 func NewClient(addr, password string) *Client {

--- a/bus/client.go
+++ b/bus/client.go
@@ -615,9 +615,9 @@ func (c *Client) FileContractTax(ctx context.Context, payout types.Currency) (ta
 	return
 }
 
-// ObjectsInfo returns information about the number of objects and their size.
-func (c *Client) ObjectsInfo() (osr api.ObjectsInfo, err error) {
-	err = c.c.GET("/objectsinfo", &osr)
+// ObjectsStats returns information about the number of objects and their size.
+func (c *Client) ObjectsStats() (osr api.ObjectsStats, err error) {
+	err = c.c.GET("/stats/objects", &osr)
 	return
 }
 

--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -263,11 +263,11 @@ func (o dbObject) convert() (object.Object, error) {
 	return obj, nil
 }
 
-// ObjectsInfo returns some info related to the objects stored in the store. To
-// make reduce locking and make sure all results are consistent, everything is
-// done within a single transaction.
-func (s *SQLStore) ObjectsInfo(ctx context.Context) (api.ObjectsInfo, error) {
-	var resp api.ObjectsInfo
+// ObjectsStats returns some info related to the objects stored in the store. To
+// reduce locking and make sure all results are consistent, everything is done
+// within a single transaction.
+func (s *SQLStore) ObjectsStats(ctx context.Context) (api.ObjectsStats, error) {
+	var resp api.ObjectsStats
 	return resp, s.db.Transaction(func(tx *gorm.DB) error {
 		// Number of objects.
 		err := tx.
@@ -282,7 +282,7 @@ func (s *SQLStore) ObjectsInfo(ctx context.Context) (api.ObjectsInfo, error) {
 		err = tx.
 			Model(&dbSlice{}).
 			Select("SUM(length)").
-			Scan(&resp.ObjectsSize).
+			Scan(&resp.TotalObjectsSize).
 			Error
 		if err != nil {
 			return err
@@ -300,8 +300,8 @@ func (s *SQLStore) ObjectsInfo(ctx context.Context) (api.ObjectsInfo, error) {
 		if err != nil {
 			return err
 		}
-		resp.SectorsSize = sectorSizes.SectorsSize
-		resp.UploadedSize = sectorSizes.UploadedSize
+		resp.TotalSectorsSize = sectorSizes.SectorsSize
+		resp.TotalUploadedSize = sectorSizes.UploadedSize
 		return nil
 	})
 }

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -1639,8 +1639,8 @@ func TestRecordContractSpending(t *testing.T) {
 	}
 }
 
-// TestObjectsInfo is a unit test for ObjectsInfo.
-func TestObjectsInfo(t *testing.T) {
+// TestObjectsStats is a unit test for ObjectsStats.
+func TestObjectsStats(t *testing.T) {
 	cs, _, _, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -1699,18 +1699,18 @@ func TestObjectsInfo(t *testing.T) {
 	}
 
 	// Check sizes.
-	info, err := cs.ObjectsInfo(context.Background())
+	info, err := cs.ObjectsStats(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.ObjectsSize != objectsSize {
-		t.Fatal("wrong size", info.ObjectsSize, objectsSize)
+	if info.TotalObjectsSize != objectsSize {
+		t.Fatal("wrong size", info.TotalObjectsSize, objectsSize)
 	}
-	if info.SectorsSize != sectorsSize {
-		t.Fatal("wrong size", info.SectorsSize, sectorsSize)
+	if info.TotalSectorsSize != sectorsSize {
+		t.Fatal("wrong size", info.TotalSectorsSize, sectorsSize)
 	}
-	if info.UploadedSize != sectorsSize*2 {
-		t.Fatal("wrong size", info.UploadedSize, sectorsSize*2)
+	if info.TotalUploadedSize != sectorsSize*2 {
+		t.Fatal("wrong size", info.TotalUploadedSize, sectorsSize*2)
 	}
 	if info.NumObjects != 2 {
 		t.Fatal("wrong number of objects", info.NumObjects, 2)

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -1639,8 +1639,8 @@ func TestRecordContractSpending(t *testing.T) {
 	}
 }
 
-// TestSizes is a unit tset for ObjectsSize, SectorsSize and UploadedSize.
-func TestSizes(t *testing.T) {
+// TestObjectsInfo is a unit test for ObjectsInfo.
+func TestObjectsInfo(t *testing.T) {
 	cs, _, _, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)
@@ -1699,25 +1699,20 @@ func TestSizes(t *testing.T) {
 	}
 
 	// Check sizes.
-	size, err := cs.ObjectsSize(context.Background())
+	info, err := cs.ObjectsInfo(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if size != objectsSize {
-		t.Fatal("wrong size", size, objectsSize)
+	if info.ObjectsSize != objectsSize {
+		t.Fatal("wrong size", info.ObjectsSize, objectsSize)
 	}
-	size, err = cs.SectorsSize(context.Background())
-	if err != nil {
-		t.Fatal(err)
+	if info.SectorsSize != sectorsSize {
+		t.Fatal("wrong size", info.SectorsSize, sectorsSize)
 	}
-	if size != sectorsSize {
-		t.Fatal("wrong size", size, sectorsSize)
+	if info.UploadedSize != sectorsSize*2 {
+		t.Fatal("wrong size", info.UploadedSize, sectorsSize*2)
 	}
-	size, err = cs.UploadedSize(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if size != sectorsSize*2 {
-		t.Fatal("wrong size", size, sectorsSize*2)
+	if info.NumObjects != 2 {
+		t.Fatal("wrong number of objects", info.NumObjects, 2)
 	}
 }

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -331,6 +331,26 @@ func TestUploadDownloadBasic(t *testing.T) {
 		}
 	}
 
+	// check objects info.
+	info, err := cluster.Bus.ObjectsInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	objectsSize := uint64(len(file1) + len(file2) + len(small) + len(large))
+	if info.ObjectsSize != objectsSize {
+		t.Error("wrong size", info.ObjectsSize, len(small)+len(large))
+	}
+	sectorsSize := 15 * rhpv2.SectorSize
+	if info.SectorsSize != uint64(sectorsSize) {
+		t.Error("wrong size", info.SectorsSize, sectorsSize)
+	}
+	if info.UploadedSize != uint64(sectorsSize) {
+		t.Error("wrong size", info.UploadedSize, sectorsSize)
+	}
+	if info.NumObjects != 4 {
+		t.Error("wrong number of objects", info.NumObjects, 4)
+	}
+
 	// download the data
 	for _, data := range [][]byte{small, large} {
 		name := fmt.Sprintf("data_%v", len(data))

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -332,20 +332,20 @@ func TestUploadDownloadBasic(t *testing.T) {
 	}
 
 	// check objects info.
-	info, err := cluster.Bus.ObjectsInfo()
+	info, err := cluster.Bus.ObjectsStats()
 	if err != nil {
 		t.Fatal(err)
 	}
 	objectsSize := uint64(len(file1) + len(file2) + len(small) + len(large))
-	if info.ObjectsSize != objectsSize {
-		t.Error("wrong size", info.ObjectsSize, len(small)+len(large))
+	if info.TotalObjectsSize != objectsSize {
+		t.Error("wrong size", info.TotalObjectsSize, len(small)+len(large))
 	}
 	sectorsSize := 15 * rhpv2.SectorSize
-	if info.SectorsSize != uint64(sectorsSize) {
-		t.Error("wrong size", info.SectorsSize, sectorsSize)
+	if info.TotalSectorsSize != uint64(sectorsSize) {
+		t.Error("wrong size", info.TotalSectorsSize, sectorsSize)
 	}
-	if info.UploadedSize != uint64(sectorsSize) {
-		t.Error("wrong size", info.UploadedSize, sectorsSize)
+	if info.TotalUploadedSize != uint64(sectorsSize) {
+		t.Error("wrong size", info.TotalUploadedSize, sectorsSize)
 	}
 	if info.NumObjects != 4 {
 		t.Error("wrong number of objects", info.NumObjects, 4)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -331,7 +331,7 @@ func TestUploadDownloadBasic(t *testing.T) {
 		}
 	}
 
-	// check objects info.
+	// check objects stats.
 	info, err := cluster.Bus.ObjectsStats()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
New endpoint that provides some info related to objects stored in the bus.

It returns:
- number of objects
- size of all objects before uploading
- size of all distinct sectors that make up the objects
- size of all sectors that make up the objects

The last 2 usually match unless objects are repaired.