### PR TITLE
Settings

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -175,7 +175,7 @@ type AddObjectRequest struct {
 
 // MigrationSlabsRequest is the request type for the /slabs/migration endpoint.
 type MigrationSlabsRequest struct {
-	ContractSet  string  `json:"contractset"`
+	ContractSet  string  `json:"contractSet"`
 	HealthCutoff float64 `json:"healthCutoff"`
 	Limit        int     `json:"limit"`
 }
@@ -238,6 +238,12 @@ type GougingParams struct {
 	GougingSettings    GougingSettings
 	RedundancySettings RedundancySettings
 	TransactionFee     types.Currency
+}
+
+// ContractSetSettings contains settings needed by the worker to figure out what
+// contract set to use.
+type ContractSetSettings struct {
+	Set string `json:"set"`
 }
 
 // GougingSettings contain some price settings used in price gouging.

--- a/api/bus.go
+++ b/api/bus.go
@@ -15,6 +15,12 @@ const (
 	HostFilterModeBlocked = "blocked"
 )
 
+const (
+	SettingContractSet = "contractset"
+	SettingGouging     = "gouging"
+	SettingRedundancy  = "redundancy"
+)
+
 var (
 	// ErrRequiresSyncSetRecently indicates that an account can't be set to sync
 	// yet because it has been set too recently.

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -73,7 +73,7 @@ type Bus interface {
 	SlabsForMigration(ctx context.Context, healthCutoff float64, set string, limit int) ([]object.Slab, error)
 
 	// settings
-	UpdateContractSetSettings(ctx context.Context, css api.ContractSetSettings) error
+	UpdateSetting(ctx context.Context, key string, value interface{}) error
 	GougingSettings(ctx context.Context) (gs api.GougingSettings, err error)
 	RedundancySettings(ctx context.Context) (rs api.RedundancySettings, err error)
 }
@@ -189,7 +189,7 @@ func (ap *Autopilot) Run() error {
 
 	// update the contract set setting
 	setting := api.ContractSetSettings{Set: ap.store.Config().Contracts.Set}
-	err := ap.bus.UpdateContractSetSettings(context.Background(), setting)
+	err := ap.bus.UpdateSetting(context.Background(), api.SettingContractSet, setting)
 	if err != nil {
 		ap.logger.Errorf("failed to update contract set setting, err: %v", err)
 	}
@@ -234,7 +234,7 @@ func (ap *Autopilot) Run() error {
 
 			// update the contract set setting
 			setting = api.ContractSetSettings{Set: ap.store.Config().Contracts.Set}
-			err = ap.bus.UpdateContractSetSettings(context.Background(), setting)
+			err = ap.bus.UpdateSetting(context.Background(), api.SettingContractSet, setting)
 			if err != nil {
 				ap.logger.Errorf("failed to update contract set setting, err: %v", err)
 			}

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -14,7 +14,6 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/jape"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/bus"
 	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/tracing"
 	"go.sia.tech/renterd/object"
@@ -74,7 +73,7 @@ type Bus interface {
 	SlabsForMigration(ctx context.Context, healthCutoff float64, set string, limit int) ([]object.Slab, error)
 
 	// settings
-	UpdateSetting(ctx context.Context, key string, value string) error
+	UpdateContractSetSettings(ctx context.Context, css api.ContractSetSettings) error
 	GougingSettings(ctx context.Context) (gs api.GougingSettings, err error)
 	RedundancySettings(ctx context.Context) (rs api.RedundancySettings, err error)
 }
@@ -189,7 +188,8 @@ func (ap *Autopilot) Run() error {
 	ap.startStopMu.Unlock()
 
 	// update the contract set setting
-	err := ap.bus.UpdateSetting(context.Background(), bus.SettingContractSet, ap.store.Config().Contracts.Set)
+	setting := api.ContractSetSettings{Set: ap.store.Config().Contracts.Set}
+	err := ap.bus.UpdateContractSetSettings(context.Background(), setting)
 	if err != nil {
 		ap.logger.Errorf("failed to update contract set setting, err: %v", err)
 	}
@@ -233,7 +233,8 @@ func (ap *Autopilot) Run() error {
 			}
 
 			// update the contract set setting
-			err = ap.bus.UpdateSetting(ctx, bus.SettingContractSet, ap.state.cfg.Contracts.Set)
+			setting = api.ContractSetSettings{Set: ap.store.Config().Contracts.Set}
+			err = ap.bus.UpdateContractSetSettings(context.Background(), setting)
 			if err != nil {
 				ap.logger.Errorf("failed to update contract set setting, err: %v", err)
 			}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -806,13 +806,16 @@ func (b *bus) paramsHandlerDownloadGET(jc jape.Context) {
 		return
 	}
 
-	cs, err := b.ss.Setting(jc.Request.Context(), api.SettingContractSet)
-	if jc.Check("could not get contract set setting", err) != nil {
+	var css api.ContractSetSettings
+	if csss, err := b.ss.Setting(jc.Request.Context(), api.SettingContractSet); err != nil {
+		jc.Error(fmt.Errorf("could not fetch contract set setting, err: %v", err), http.StatusInternalServerError)
 		return
+	} else if err := json.Unmarshal([]byte(csss), &css); err != nil {
+		b.logger.Panicf("failed to unmarshal gouging settings '%s': %v", csss, err)
 	}
 
 	jc.Encode(api.DownloadParams{
-		ContractSet:   cs,
+		ContractSet:   css.Set,
 		GougingParams: gp,
 	})
 }
@@ -823,13 +826,16 @@ func (b *bus) paramsHandlerUploadGET(jc jape.Context) {
 		return
 	}
 
-	cs, err := b.ss.Setting(jc.Request.Context(), api.SettingContractSet)
-	if jc.Check("could not get contract set setting", err) != nil {
+	var css api.ContractSetSettings
+	if csss, err := b.ss.Setting(jc.Request.Context(), api.SettingContractSet); err != nil {
+		jc.Error(fmt.Errorf("could not fetch contract set setting, err: %v", err), http.StatusInternalServerError)
 		return
+	} else if err := json.Unmarshal([]byte(csss), &css); err != nil {
+		b.logger.Panicf("failed to unmarshal gouging settings '%s': %v", csss, err)
 	}
 
 	jc.Encode(api.UploadParams{
-		ContractSet:   cs,
+		ContractSet:   css.Set,
 		CurrentHeight: b.cm.TipState(jc.Request.Context()).Index.Height,
 		GougingParams: gp,
 	})

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -23,12 +23,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	SettingContractSet = "contractset"
-	SettingGouging     = "gouging"
-	SettingRedundancy  = "redundancy"
-)
-
 type (
 	// A ChainManager manages blockchain state.
 	ChainManager interface {
@@ -812,7 +806,7 @@ func (b *bus) paramsHandlerDownloadGET(jc jape.Context) {
 		return
 	}
 
-	cs, err := b.ss.Setting(jc.Request.Context(), SettingContractSet)
+	cs, err := b.ss.Setting(jc.Request.Context(), api.SettingContractSet)
 	if jc.Check("could not get contract set setting", err) != nil {
 		return
 	}
@@ -829,7 +823,7 @@ func (b *bus) paramsHandlerUploadGET(jc jape.Context) {
 		return
 	}
 
-	cs, err := b.ss.Setting(jc.Request.Context(), SettingContractSet)
+	cs, err := b.ss.Setting(jc.Request.Context(), api.SettingContractSet)
 	if jc.Check("could not get contract set setting", err) != nil {
 		return
 	}
@@ -851,14 +845,14 @@ func (b *bus) paramsHandlerGougingGET(jc jape.Context) {
 
 func (b *bus) gougingParams(ctx context.Context) (api.GougingParams, error) {
 	var gs api.GougingSettings
-	if gss, err := b.ss.Setting(ctx, SettingGouging); err != nil {
+	if gss, err := b.ss.Setting(ctx, api.SettingGouging); err != nil {
 		return api.GougingParams{}, err
 	} else if err := json.Unmarshal([]byte(gss), &gs); err != nil {
 		b.logger.Panicf("failed to unmarshal gouging settings '%s': %v", gss, err)
 	}
 
 	var rs api.RedundancySettings
-	if rss, err := b.ss.Setting(ctx, SettingRedundancy); err != nil {
+	if rss, err := b.ss.Setting(ctx, api.SettingRedundancy); err != nil {
 		return api.GougingParams{}, err
 	} else if err := json.Unmarshal([]byte(rss), &rs); err != nil {
 		b.logger.Panicf("failed to unmarshal redundancy settings '%s': %v", rss, err)
@@ -1040,8 +1034,8 @@ func New(s Syncer, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, ms
 
 	// Load default settings if the setting is not already set.
 	for key, value := range map[string]interface{}{
-		SettingGouging:    api.DefaultGougingSettings,
-		SettingRedundancy: api.DefaultRedundancySettings,
+		api.SettingGouging:    api.DefaultGougingSettings,
+		api.SettingRedundancy: api.DefaultRedundancySettings,
 	} {
 		if _, err := b.ss.Setting(ctx, key); errors.Is(err, api.ErrSettingNotFound) {
 			if bytes, err := json.Marshal(value); err != nil {

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -742,6 +742,7 @@ func (b *bus) settingKeyHandlerGET(jc jape.Context) {
 	}
 	if err != nil {
 		jc.Error(err, http.StatusInternalServerError)
+		return
 	}
 
 	var resp interface{}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -107,6 +107,7 @@ type (
 
 	// A SettingStore stores settings.
 	SettingStore interface {
+		DeleteSetting(ctx context.Context, key string) error
 		Setting(ctx context.Context, key string) (string, error)
 		Settings(ctx context.Context) ([]string, error)
 		UpdateSetting(ctx context.Context, key, value string) error
@@ -780,6 +781,15 @@ func (b *bus) settingKeyHandlerPUT(jc jape.Context) {
 	jc.Check("could not update setting", b.ss.UpdateSetting(jc.Request.Context(), key, string(js)))
 }
 
+func (b *bus) settingKeyHandlerDELETE(jc jape.Context) {
+	key := jc.PathParam("key")
+	if key == "" {
+		jc.Error(errors.New("param 'key' can not be empty"), http.StatusBadRequest)
+		return
+	}
+	jc.Check("could not delete setting", b.ss.DeleteSetting(jc.Request.Context(), key))
+}
+
 func (b *bus) contractIDAncestorsHandler(jc jape.Context) {
 	var fcid types.FileContractID
 	if jc.DecodeParam("id", &fcid) != nil {
@@ -1125,6 +1135,7 @@ func (b *bus) Handler() http.Handler {
 		"GET    /settings":     b.settingsHandlerGET,
 		"GET    /setting/:key": b.settingKeyHandlerGET,
 		"PUT    /setting/:key": b.settingKeyHandlerPUT,
+		"DELETE /setting/:key": b.settingKeyHandlerDELETE,
 
 		"GET    /params/download": b.paramsHandlerDownloadGET,
 		"GET    /params/upload":   b.paramsHandlerUploadGET,

--- a/bus/client.go
+++ b/bus/client.go
@@ -411,7 +411,7 @@ func (c *Client) UpdateSetting(ctx context.Context, key string, value interface{
 	return c.c.WithContext(ctx).PUT(fmt.Sprintf("/setting/%s", key), value)
 }
 
-// ContractSetSettings returns the contractset settings.
+// ContractSetSettings returns the contract set settings.
 func (c *Client) ContractSetSettings(ctx context.Context) (css api.ContractSetSettings, err error) {
 	setting, err := c.Setting(ctx, SettingContractSet)
 	if err != nil {

--- a/bus/client.go
+++ b/bus/client.go
@@ -395,7 +395,7 @@ func (c *Client) RecommendedFee(ctx context.Context) (fee types.Currency, err er
 }
 
 // Setting returns the value for the setting with given key.
-func (c *Client) Setting(ctx context.Context, key string) (value interface{}, err error) {
+func (c *Client) Setting(ctx context.Context, key string, value interface{}) (err error) {
 	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/setting/%s", key), &value)
 	return
 }
@@ -413,47 +413,20 @@ func (c *Client) UpdateSetting(ctx context.Context, key string, value interface{
 
 // ContractSetSettings returns the contract set settings.
 func (c *Client) ContractSetSettings(ctx context.Context) (css api.ContractSetSettings, err error) {
-	setting, err := c.Setting(ctx, api.SettingContractSet)
-	if err != nil {
-		return api.ContractSetSettings{}, err
-	}
-
-	css, ok := setting.(api.ContractSetSettings)
-	if !ok {
-		return api.ContractSetSettings{}, fmt.Errorf("invalid contractset settings: %v", setting)
-	}
-
-	return css, nil
+	err = c.Setting(ctx, api.SettingContractSet, &css)
+	return
 }
 
 // GougingSettings returns the gouging settings.
 func (c *Client) GougingSettings(ctx context.Context) (gs api.GougingSettings, err error) {
-	setting, err := c.Setting(ctx, api.SettingGouging)
-	if err != nil {
-		return api.GougingSettings{}, err
-	}
-
-	gs, ok := setting.(api.GougingSettings)
-	if !ok {
-		return api.GougingSettings{}, fmt.Errorf("invalid gouging settings: %v", setting)
-	}
-
-	return gs, nil
+	err = c.Setting(ctx, api.SettingGouging, &gs)
+	return
 }
 
 // RedundancySettings returns the redundancy settings.
 func (c *Client) RedundancySettings(ctx context.Context) (rs api.RedundancySettings, err error) {
-	setting, err := c.Setting(ctx, api.SettingRedundancy)
-	if err != nil {
-		return api.RedundancySettings{}, err
-	}
-
-	rs, ok := setting.(api.RedundancySettings)
-	if !ok {
-		return api.RedundancySettings{}, fmt.Errorf("invalid redundancy settings: %v", setting)
-	}
-
-	return rs, nil
+	err = c.Setting(ctx, api.SettingRedundancy, &rs)
+	return
 }
 
 // SearchHosts returns all hosts that match certain search criteria.

--- a/bus/client.go
+++ b/bus/client.go
@@ -413,7 +413,7 @@ func (c *Client) UpdateSetting(ctx context.Context, key string, value interface{
 
 // ContractSetSettings returns the contract set settings.
 func (c *Client) ContractSetSettings(ctx context.Context) (css api.ContractSetSettings, err error) {
-	setting, err := c.Setting(ctx, SettingContractSet)
+	setting, err := c.Setting(ctx, api.SettingContractSet)
 	if err != nil {
 		return api.ContractSetSettings{}, err
 	}
@@ -426,14 +426,9 @@ func (c *Client) ContractSetSettings(ctx context.Context) (css api.ContractSetSe
 	return css, nil
 }
 
-// UpdateContractSetSettings allows configuring the contractset settings.
-func (c *Client) UpdateContractSetSettings(ctx context.Context, css api.ContractSetSettings) error {
-	return c.UpdateSetting(ctx, SettingContractSet, css)
-}
-
 // GougingSettings returns the gouging settings.
 func (c *Client) GougingSettings(ctx context.Context) (gs api.GougingSettings, err error) {
-	setting, err := c.Setting(ctx, SettingGouging)
+	setting, err := c.Setting(ctx, api.SettingGouging)
 	if err != nil {
 		return api.GougingSettings{}, err
 	}
@@ -446,14 +441,9 @@ func (c *Client) GougingSettings(ctx context.Context) (gs api.GougingSettings, e
 	return gs, nil
 }
 
-// UpdateGougingSettings allows configuring the gouging settings.
-func (c *Client) UpdateGougingSettings(ctx context.Context, gs api.GougingSettings) error {
-	return c.UpdateSetting(ctx, SettingGouging, gs)
-}
-
 // RedundancySettings returns the redundancy settings.
 func (c *Client) RedundancySettings(ctx context.Context) (rs api.RedundancySettings, err error) {
-	setting, err := c.Setting(ctx, SettingRedundancy)
+	setting, err := c.Setting(ctx, api.SettingRedundancy)
 	if err != nil {
 		return api.RedundancySettings{}, err
 	}
@@ -464,11 +454,6 @@ func (c *Client) RedundancySettings(ctx context.Context) (rs api.RedundancySetti
 	}
 
 	return rs, nil
-}
-
-// UpdateRedundancySettings allows configuring the redundancy.
-func (c *Client) UpdateRedundancySettings(ctx context.Context, rs api.RedundancySettings) error {
-	return c.UpdateSetting(ctx, SettingRedundancy, rs)
 }
 
 // SearchHosts returns all hosts that match certain search criteria.

--- a/bus/client.go
+++ b/bus/client.go
@@ -411,6 +411,11 @@ func (c *Client) UpdateSetting(ctx context.Context, key string, value interface{
 	return c.c.WithContext(ctx).PUT(fmt.Sprintf("/setting/%s", key), value)
 }
 
+// DeleteSetting will delete the setting with given key.
+func (c *Client) DeleteSetting(ctx context.Context, key string) error {
+	return c.c.WithContext(ctx).DELETE(fmt.Sprintf("/setting/%s", key))
+}
+
 // ContractSetSettings returns the contract set settings.
 func (c *Client) ContractSetSettings(ctx context.Context) (css api.ContractSetSettings, err error) {
 	err = c.Setting(ctx, api.SettingContractSet, &css)

--- a/bus/client_test.go
+++ b/bus/client_test.go
@@ -34,7 +34,7 @@ func TestClient(t *testing.T) {
 	go serveFn()
 
 	// assert setting 'foo' is not found
-	if _, err := c.Setting(ctx, "foo"); err == nil || !strings.Contains(err.Error(), api.ErrSettingNotFound.Error()) {
+	if err := c.Setting(ctx, "foo", nil); err == nil || !strings.Contains(err.Error(), api.ErrSettingNotFound.Error()) {
 		t.Fatal("unexpected err", err)
 	}
 
@@ -44,7 +44,8 @@ func TestClient(t *testing.T) {
 	}
 
 	// fetch setting 'foo' and assert it matches
-	if value, err := c.Setting(ctx, "foo"); err != nil {
+	var value string
+	if err := c.Setting(ctx, "foo", &value); err != nil {
 		t.Fatal("unexpected err", err)
 	} else if value != "bar" {
 		t.Fatal("unexpected result", value)

--- a/internal/stores/settingsdb.go
+++ b/internal/stores/settingsdb.go
@@ -22,6 +22,11 @@ type (
 // TableName implements the gorm.Tabler interface.
 func (dbSetting) TableName() string { return "settings" }
 
+// DeleteSetting implements the bus.SettingStore interface.
+func (s *SQLStore) DeleteSetting(ctx context.Context, key string) error {
+	return s.db.Where(&dbSetting{Key: key}).Delete(&dbSetting{}).Error
+}
+
 // Setting implements the bus.SettingStore interface.
 func (s *SQLStore) Setting(ctx context.Context, key string) (string, error) {
 	var entry dbSetting

--- a/internal/stores/settingsdb.go
+++ b/internal/stores/settingsdb.go
@@ -53,19 +53,3 @@ func (s *SQLStore) UpdateSetting(ctx context.Context, key, value string) error {
 		Value: value,
 	}).Error
 }
-
-// UpdateSettings implements the bus.SettingStore interface.
-func (s *SQLStore) UpdateSettings(ctx context.Context, settings map[string]string) error {
-	var dbSettings []dbSetting
-	for key, value := range settings {
-		dbSettings = append(dbSettings, dbSetting{
-			Key:   key,
-			Value: value,
-		})
-	}
-
-	return s.db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "key"}},
-		DoUpdates: clause.AssignmentColumns([]string{"value"}),
-	}).Create(&dbSettings).Error
-}

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -316,11 +316,11 @@ func newTestClusterWithFunding(dir, dbName string, funding bool, wk types.Privat
 	}
 
 	// Update the bus settings.
-	err = busClient.UpdateGougingSettings(context.Background(), testGougingSettings)
+	err = busClient.UpdateSetting(context.Background(), api.SettingGouging, testGougingSettings)
 	if err != nil {
 		return nil, err
 	}
-	err = busClient.UpdateRedundancySettings(context.Background(), testRedundancySettings)
+	err = busClient.UpdateSetting(context.Background(), api.SettingRedundancy, testRedundancySettings)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -670,11 +670,6 @@ func TestEphemeralAccounts(t *testing.T) {
 
 // newTestLogger creates a console logger used for testing.
 func newTestLogger() *zap.Logger {
-	return newTestLoggerCustom(zapcore.ErrorLevel)
-}
-
-// newTestLoggerCustom creates a console logger used for testing and allows passing in the desired log level.
-func newTestLoggerCustom(level zapcore.Level) *zap.Logger {
 	config := zap.NewProductionEncoderConfig()
 	config.EncodeTime = zapcore.RFC3339TimeEncoder
 	config.EncodeLevel = zapcore.CapitalColorLevelEncoder
@@ -682,9 +677,9 @@ func newTestLoggerCustom(level zapcore.Level) *zap.Logger {
 	consoleEncoder := zapcore.NewConsoleEncoder(config)
 
 	return zap.New(
-		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), level),
+		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), zapcore.ErrorLevel),
 		zap.AddCaller(),
-		zap.AddStacktrace(level),
+		zap.AddStacktrace(zapcore.ErrorLevel),
 	)
 }
 

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -670,6 +670,11 @@ func TestEphemeralAccounts(t *testing.T) {
 
 // newTestLogger creates a console logger used for testing.
 func newTestLogger() *zap.Logger {
+	return newTestLoggerCustom(zapcore.ErrorLevel)
+}
+
+// newTestLoggerCustom creates a console logger used for testing and allows passing in the desired log level.
+func newTestLoggerCustom(level zapcore.Level) *zap.Logger {
 	config := zap.NewProductionEncoderConfig()
 	config.EncodeTime = zapcore.RFC3339TimeEncoder
 	config.EncodeLevel = zapcore.CapitalColorLevelEncoder
@@ -677,9 +682,9 @@ func newTestLogger() *zap.Logger {
 	consoleEncoder := zapcore.NewConsoleEncoder(config)
 
 	return zap.New(
-		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), zapcore.ErrorLevel),
+		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), level),
 		zap.AddCaller(),
-		zap.AddStacktrace(zapcore.ErrorLevel),
+		zap.AddStacktrace(level),
 	)
 }
 


### PR DESCRIPTION
A couple of ppl in the community were running into issues with the formatting in the settings API. This PR changes that and makes curl'ing our API more pleasant. The database still stores strings, I considered using the JSON datatype `gorm` provides but that requires a sqlite plugin so I figured strings would do just fine.

Updating a setting works as you would expect it to now:
```bash
➜  ~ curl -X PUT -v -u "":test http://localhost:9980/api/bus/setting/gouging -d '{
        "hostBlockHeightLeeway": 7,
        "maxContractPrice": "10000000000000000000000000",
        "maxDownloadPrice": "3000000000000000000000000000",
        "maxRPCPrice": "1000000000000000000000",
        "maxStoragePrice": "231481481481481481481481",
        "maxUploadPrice": "3000000000000000000000000000",
        "minMaxCollateral": "10000000000000000000000000"
}'
```

and fetching settings returns JSON:
```bash
➜  ~ curl -u "":test http://localhost:9980/api/bus/setting/gouging
{
	"hostBlockHeightLeeway": 5,
	"maxContractPrice": "10000000000000000000000000",
	"maxDownloadPrice": "3000000000000000000000000000",
	"maxRPCPrice": "1000000000000000000000",
	"maxStoragePrice": "231481481481481481481481",
	"maxUploadPrice": "3000000000000000000000000000",
	"minMaxCollateral": "10000000000000000000000000"
}
```