### PR TITLE
Autopilot Shutdown

### DIFF
--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -247,7 +247,6 @@ func (s *scanner) launchHostScans() chan scanReq {
 				}:
 				}
 			}
-
 		}
 	}()
 


### PR DESCRIPTION
good to catch it now I guess, I would personally _not_ ignore the context in `Shutdown` but perhaps this would've gone unnoticed so...

```
goroutine 1 [semacquire, 18 minutes]:
runtime.gopark(0xc0004abb80?, 0x49d5bd?, 0x60?, 0xe0?, 0xc004cecf80?)
        /usr/local/go/src/runtime/proc.go:363 +0xd6 fp=0xc0004aba98 sp=0xc0004aba78 pc=0x443056
runtime.goparkunlock(...)
        /usr/local/go/src/runtime/proc.go:369
runtime.semacquire1(0xc0005819c8, 0x48?, 0x1, 0x0)
        /usr/local/go/src/runtime/sema.go:150 +0x1fe fp=0xc0004abb00 sp=0xc0004aba98 pc=0x453fbe
sync.runtime_Semacquire(0xc0004abb48?)
        /usr/local/go/src/runtime/sema.go:62 +0x25 fp=0xc0004abb30 sp=0xc0004abb00 pc=0x470045
sync.(*WaitGroup).Wait(0xc000388ba0?)
        /usr/local/go/src/sync/waitgroup.go:139 +0x52 fp=0xc0004abb58 sp=0xc0004abb30 pc=0x47fcd2
go.sia.tech/renterd/autopilot.(*Autopilot).Shutdown(0xc000581860, {0x19b4740?, 0x45d964b800?})
        /root/code/renterd/autopilot/autopilot.go:294 +0xdf fp=0xc0004abba8 sp=0xc0004abb58 pc=0xc2b09f
go.sia.tech/renterd/autopilot.(*Autopilot).Shutdown-fm({0x1285788?, 0xc0039fa960?})
        <autogenerated>:1 +0x39 fp=0xc0004abbd0 sp=0xc0004abba8 pc=0xdde159
main.main()

...

goroutine 71 [chan send, 18 minutes]:
runtime.gopark(0xc005daad20?, 0xc000035640?, 0x98?, 0xbf?, 0x28?)
        /usr/local/go/src/runtime/proc.go:363 +0xd6 fp=0xc0019dbda8 sp=0xc0019dbd88 pc=0x443056
runtime.chansend(0xc000198420, 0xc0019dbf98, 0x1, 0xc0093ad040?)
        /usr/local/go/src/runtime/chan.go:259 +0x42c fp=0xc0019dbe30 sp=0xc0019dbda8 pc=0x40e7ac
runtime.chansend1(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:145 +0x1d fp=0xc0019dbe60 sp=0xc0019dbe30 pc=0x40e35d
go.sia.tech/renterd/autopilot.(*scanner).launchHostScans.func1()
        /root/code/renterd/autopilot/scanner.go:238 +0x3d6 fp=0xc0019dbfe0 sp=0xc0019dbe60 pc=0xc47876
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1594 +0x1 fp=0xc0019dbfe8 sp=0xc0019dbfe0 pc=0x4743c1
created by go.sia.tech/renterd/autopilot.(*scanner).launchHostScans
        /root/code/renterd/autopilot/scanner.go:215 +0xaa
```