### PR TITLE
Updates some calls from using siad dependencies to core

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/NebulousLabs/encoding"
 	"go.sia.tech/core/consensus"
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
@@ -219,7 +218,7 @@ func (b *bus) walletFundHandler(jc jape.Context) {
 		return
 	}
 	txn := wfr.Transaction
-	fee := b.tp.RecommendedFee().Mul64(uint64(len(encoding.Marshal(txn))))
+	fee := b.tp.RecommendedFee().Mul64(uint64(types.EncodedLen(txn)))
 	txn.MinerFees = []types.Currency{fee}
 	toSign, err := b.w.FundTransaction(b.cm.TipState(jc.Request.Context()), &txn, wfr.Amount.Add(txn.MinerFees[0]), b.tp.Transactions())
 	if jc.Check("couldn't fund transaction", err) != nil {
@@ -305,7 +304,7 @@ func (b *bus) walletPrepareFormHandler(jc jape.Context) {
 	txn := types.Transaction{
 		FileContracts: []types.FileContract{fc},
 	}
-	txn.MinerFees = []types.Currency{b.tp.RecommendedFee().Mul64(uint64(len(encoding.Marshal(txn))))}
+	txn.MinerFees = []types.Currency{b.tp.RecommendedFee().Mul64(uint64(types.EncodedLen(txn)))}
 	toSign, err := b.w.FundTransaction(cs, &txn, cost.Add(txn.MinerFees[0]), b.tp.Transactions())
 	if jc.Check("couldn't fund transaction", err) != nil {
 		return
@@ -347,7 +346,7 @@ func (b *bus) walletPrepareRenewHandler(jc jape.Context) {
 	txn := types.Transaction{
 		FileContracts: []types.FileContract{fc},
 	}
-	txn.MinerFees = []types.Currency{b.tp.RecommendedFee().Mul64(uint64(len(encoding.Marshal(txn))))}
+	txn.MinerFees = []types.Currency{b.tp.RecommendedFee().Mul64(uint64(types.EncodedLen(txn)))}
 	cost := rhpv2.ContractRenewalCost(cs, fc, wprr.HostSettings.ContractPrice, txn.MinerFees[0], basePrice)
 	toSign, err := b.w.FundTransaction(cs, &txn, cost, b.tp.Transactions())
 	if jc.Check("couldn't fund transaction", err) != nil {

--- a/internal/testing/blocklist_test.go
+++ b/internal/testing/blocklist_test.go
@@ -8,7 +8,6 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/siad/build"
 )
 
 func TestBlocklist(t *testing.T) {
@@ -38,7 +37,7 @@ func TestBlocklist(t *testing.T) {
 
 	// wait until we have 3 contracts in the set
 	var contracts []api.ContractMetadata
-	if err := build.Retry(5, time.Second, func() (err error) {
+	if err := Retry(5, time.Second, func() (err error) {
 		contracts, err = b.Contracts(ctx, "autopilot")
 		if err != nil {
 			t.Fatal(err)
@@ -61,7 +60,7 @@ func TestBlocklist(t *testing.T) {
 	}
 
 	// assert h3 is no longer in the contract set
-	if err := build.Retry(5, time.Second, func() error {
+	if err := Retry(5, time.Second, func() error {
 		contracts, err := b.Contracts(ctx, "autopilot")
 		if err != nil {
 			t.Fatal(err)
@@ -89,7 +88,7 @@ func TestBlocklist(t *testing.T) {
 	}
 
 	// assert h1 is no longer in the contract set
-	if err := build.Retry(5, time.Second, func() error {
+	if err := Retry(5, time.Second, func() error {
 		contracts, err := b.Contracts(ctx, "autopilot")
 		if err != nil {
 			t.Fatal(err)
@@ -115,7 +114,7 @@ func TestBlocklist(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := build.Retry(5, time.Second, func() error {
+	if err := Retry(5, time.Second, func() error {
 		contracts, err := b.Contracts(ctx, "autopilot")
 		if err != nil {
 			t.Fatal(err)

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -21,7 +21,6 @@ import (
 	"go.sia.tech/renterd/bus"
 	"go.sia.tech/renterd/internal/node"
 	"go.sia.tech/renterd/internal/stores"
-	"go.sia.tech/siad/build"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"lukechampine.com/frand"
@@ -560,7 +559,7 @@ func (c *TestCluster) AddHosts(n int) ([]*Host, error) {
 	}
 
 	// Mine a few blocks. The host should show up eventually.
-	err = build.Retry(10, time.Second, func() error {
+	err = Retry(10, time.Second, func() error {
 		if err := c.MineBlocks(1); err != nil {
 			return err
 		}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1,7 +1,6 @@
 package wallet
 
 import (
-	"bytes"
 	"errors"
 	"reflect"
 	"sort"
@@ -223,16 +222,6 @@ func (w *SingleAddressWallet) FundTransaction(cs consensus.State, txn *types.Tra
 func (w *SingleAddressWallet) ReleaseInputs(txn types.Transaction) {
 	for _, in := range txn.SiacoinInputs {
 		delete(w.used, types.Hash256(in.ParentID))
-	}
-}
-
-func convertToSiad(core types.EncoderTo, siad encoding.SiaUnmarshaler) {
-	var buf bytes.Buffer
-	e := types.NewEncoder(&buf)
-	core.EncodeTo(e)
-	e.Flush()
-	if err := siad.UnmarshalSia(&buf); err != nil {
-		panic(err)
 	}
 }
 


### PR DESCRIPTION
Changes some calls to the `encoding` package to `types`, gets rid of an unnecessary `convertToSiad` method and removes the usage of external `build.Retry` and replaces it with the internal one.