### PR TITLE
Retry AddContract and harden AddRenewedContract

### DIFF
--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -43,7 +43,6 @@ type (
 		ContractCommon
 		RenewedTo fileContractID `gorm:"index;size:32"`
 
-		HostID uint      `gorm:"index"`
 		Host   publicKey `gorm:"index;NOT NULL;size:32"`
 		Reason string
 	}
@@ -352,7 +351,6 @@ func (s *SQLStore) AddRenewedContract(ctx context.Context, c rhpv2.ContractRevis
 		// Create copy in archive.
 		err = tx.Create(&dbArchivedContract{
 			Host:      publicKey(oldContract.Host.PublicKey),
-			HostID:    oldContract.HostID,
 			Reason:    api.ContractArchivalReasonRenewed,
 			RenewedTo: fileContractID(c.ID()),
 
@@ -1078,7 +1076,6 @@ func archiveContracts(tx *gorm.DB, contracts []dbContract, toArchive map[types.F
 		// create a copy in the archive
 		if err := tx.Create(&dbArchivedContract{
 			Host:   publicKey(contract.Host.PublicKey),
-			HostID: contract.HostID,
 			Reason: toArchive[types.FileContractID(contract.FCID)],
 
 			ContractCommon: ContractCommon{

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -424,7 +424,6 @@ func TestRenewedContract(t *testing.T) {
 	ac.Model = Model{}
 	expectedContract := dbArchivedContract{
 		Host:      publicKey(c.HostKey()),
-		HostID:    1,
 		RenewedTo: fileContractID(fcid1Renewed),
 		Reason:    api.ContractArchivalReasonRenewed,
 

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/siad/build"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestHostPruning(t *testing.T) {
@@ -18,7 +19,7 @@ func TestHostPruning(t *testing.T) {
 	ctx := context.Background()
 
 	// create a new test cluster
-	cluster, err := newTestCluster(t.TempDir(), newTestLogger())
+	cluster, err := newTestCluster(t.TempDir(), newTestLoggerCustom(zapcore.DebugLevel))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -58,27 +58,31 @@ func TestHostPruning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// wait until we have 2 hosts in the set - we expect one host to be removed
-	// by the host pruning - this takes ~10 failed scans so we retry for 30s
+	// record a number of failed interaction for h1 that push his downtime well
+	// over the default 'MaxDowntimeHours' setting of 10 hours and ensures we
+	// push it over the 'MinRecentScanFailures' limit
+	//
+	// NOTE: we do this manually to avoid bypassing the condition by adding
+	// flags or extending the config with properties only used in testing
 	now := time.Now()
-	if err := Retry(30, time.Second, func() error {
-		// record a  failed interaction for h1 that push his downtime well over
-		// the default 'MaxDowntimeHours' setting of 10 hours and ensures we
-		// push it over the 'MinRecentScanFailures' limit
-		//
-		// NOTE: we do this manually to avoid bypassing the condition by adding
-		// flags or extending the config with properties only used in testing
-		now = now.Add(time.Hour * 10)
-		if err = b.RecordInteractions(context.Background(), []hostdb.Interaction{{
+	his := make([]hostdb.Interaction, 20)
+	for i := 0; i < 20; i++ {
+		now = now.Add(time.Hour * 20)
+		his[i] = hostdb.Interaction{
 			Host:      hk1,
 			Timestamp: now,
 			Success:   false,
 			Type:      hostdb.InteractionTypeScan,
-		}}); err != nil {
-			t.Fatal(err)
 		}
+	}
+	if err = b.RecordInteractions(context.Background(), his); err != nil {
+		t.Fatal(err)
+	}
 
-		// check if the host got prouned
+	// wait until we have 2 hosts in the set - we expect one host to be removed
+	// by the host pruning
+	if err := Retry(30, 100*time.Millisecond, func() error {
+		// check if the host got pruned
 		hosts, err := b.Hosts(context.Background(), 0, -1)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
I found out we are not retrying adding a contract, that's definitely not ideal so I added that. Alex told me some hosts have more than one active contract, and he's right. There are some active (renewed) contracts that weren't properly removed. That's a bit odd because we do that in a transaction that includes the deletion so I think it may be a legacy issue. I'm not sure so I figured I would add an assertion on `RowsAffected` after the deletion.

I added `TestArchiveContracts` since I was there anyway and it's a test I wanted to add to the HostDB pruning PR that got merged already. It's just a basic test that asserts contract archival works and the reason gets set.