### PR TITLE
Fix Contract Refresh Loop

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -34,6 +34,10 @@ var (
 	// the database.
 	ErrObjectNotFound = errors.New("object not found")
 
+	// ErrContractSetNotFound is returned when a contract can't be retrieved
+	// from the database.
+	ErrContractSetNotFound = errors.New("couldn't find contract set")
+
 	// ErrSettingNotFound is returned if a requested setting is not present in the
 	// database.
 	ErrSettingNotFound = errors.New("setting not found")

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1165,8 +1165,6 @@ func (c *contractor) formContract(ctx context.Context, w Worker, host hostdb.Hos
 	endHeight := endHeight(state.cfg, c.currentPeriod())
 	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-state.cs.BlockHeight, scan.Settings)
 	hostCollateral := rhpv2.ContractFormationCollateral(state.cfg.Contracts.Period, expectedStorage, scan.Settings)
-	fmt.Println("expected storage", expectedStorage, expectedStorage/rhpv2.SectorSize)
-	fmt.Println("host collateral", hostCollateral.String())
 
 	// form contract
 	contract, _, err := w.RHPForm(ctx, endHeight, hk, host.NetAddress, renterAddress, renterFunds, hostCollateral)

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1089,7 +1089,7 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 		newRemainingCollateral = hostMissedPayout.Sub(settings.ContractPrice)
 	}
 	if isBelowCollateralThreshold(newCollateral, newRemainingCollateral) {
-		err := errors.New("refresh failed, new colleteral is below the threshold")
+		err := errors.New("refresh failed, new collateral is below the threshold")
 		c.logger.Errorw(err.Error(), "hk", hk, "fcid", fcid, "expectedCollateral", newCollateral.String(), "actualCollateral", newRemainingCollateral.String(), "maxCollateral", settings.MaxCollateral)
 		return api.ContractMetadata{}, true, err
 	}

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -306,8 +306,8 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 	}
 
 	// build the new contract set (excluding formed contracts)
-	contractset := buildContractSet(active, toArchive, toIgnore, toRefresh, toRenew, append(renewed, refreshed...))
-	numContracts := uint64(len(contractset))
+	contractSet := buildContractSet(active, toArchive, toIgnore, toRefresh, toRenew, append(renewed, refreshed...))
+	numContracts := uint64(len(contractSet))
 
 	// check if we need to form contracts and add them to the contract set
 	var formed []types.FileContractID
@@ -316,27 +316,27 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 			c.logger.Errorf("failed to form contracts, err: %v", err) // continue
 		}
 	}
-	contractset = append(contractset, formed...)
+	contractSet = append(contractSet, formed...)
 
 	// defer logging
 	defer func() {
-		numcontracts := len(currentSet)
+		contractSetContracts := len(currentSet)
 		if err == nil {
-			numcontracts = len(contractset)
+			contractSetContracts = len(contractSet)
 		}
-		if numcontracts < int(state.rs.TotalShards) {
+		if contractSetContracts < int(state.rs.TotalShards) {
 			c.logger.Debugw(
 				"contracts after maintenance are below the minimum required",
 				"formed", len(formed),
 				"renewed", len(renewed),
-				"contractset", numcontracts,
+				"contractset", contractSetContracts,
 			)
 		} else {
 			c.logger.Debugw(
 				"contracts after maintenance",
 				"formed", len(formed),
 				"renewed", len(renewed),
-				"contractset", numcontracts,
+				"contractset", contractSetContracts,
 			)
 		}
 	}()
@@ -346,7 +346,7 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 		err = errors.New("autopilot stopped before maintenance could be completed")
 		return
 	}
-	err = c.ap.bus.SetContractSet(ctx, state.cfg.Contracts.Set, contractset)
+	err = c.ap.bus.SetContractSet(ctx, state.cfg.Contracts.Set, contractSet)
 	return
 }
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -196,7 +196,6 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, renterFunds types.Currency) (usable bool, refresh bool, renew bool, reasons []error) {
 	c, s := ci.contract, ci.settings
 	if isOutOfCollateral(c, s, renterFunds, bh) {
-		panic("Y")
 		reasons = append(reasons, errContractOutOfCollateral)
 		renew = false
 		refresh = true

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -196,6 +196,7 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, renterFunds types.Currency) (usable bool, refresh bool, renew bool, reasons []error) {
 	c, s := ci.contract, ci.settings
 	if isOutOfCollateral(c, s, renterFunds, bh) {
+		panic("Y")
 		reasons = append(reasons, errContractOutOfCollateral)
 		renew = false
 		refresh = true

--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -30,10 +30,6 @@ var (
 	// ErrContractNotFound is returned when a contract can't be retrieved from
 	// the database.
 	ErrContractNotFound = errors.New("couldn't find contract")
-
-	// ErrContractSetNotFound is returned when a contract can't be retrieved
-	// from the database.
-	ErrContractSetNotFound = errors.New("couldn't find contract set")
 )
 
 type (
@@ -966,7 +962,7 @@ func (s *SQLStore) contracts(ctx context.Context, set string) ([]dbContract, err
 		Error
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, ErrContractSetNotFound
+		return nil, fmt.Errorf("%w '%s'", api.ErrContractSetNotFound, set)
 	} else if err != nil {
 		return nil, err
 	}

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -168,7 +168,7 @@ func TestSQLContractStore(t *testing.T) {
 	} else if len(contracts) != 1 {
 		t.Fatalf("should have 1 contracts but got %v", len(contracts))
 	}
-	if _, err := cs.Contracts(ctx, "bar"); err != ErrContractSetNotFound {
+	if _, err := cs.Contracts(ctx, "bar"); !errors.Is(err, api.ErrContractSetNotFound) {
 		t.Fatal(err)
 	}
 

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -18,7 +18,7 @@ func TestHostPruning(t *testing.T) {
 	ctx := context.Background()
 
 	// create a new test cluster
-	cluster, err := newTestCluster(t.TempDir(), newTestLoggerCustom(zapcore.ErrorLevel))
+	cluster, err := newTestCluster(t.TempDir(), newTestLoggerCustom(zapcore.DebugLevel))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR fixes a bug in the contractor where a contract would get refreshed over and over again, each time doubling it renter funds, leading to the user's entire wallet balance being locked up in a single contract. We had foreseen this refresh loop but the check we added to prevent it from happening did not take into account the contract price (which is taken into account when doing the checks that indicate a refresh is needed).