### PR TITLE
Gouging Breakdown

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -631,7 +631,7 @@ func (c *contractor) runContractFormations(ctx context.Context, w Worker, hosts 
 		gc := worker.NewGougingChecker(state.gs, state.rs, cs, state.fee, state.cfg.Contracts.Period, state.cfg.Contracts.RenewWindow)
 
 		// perform gouging checks on the fly to ensure the host is not gouging its prices
-		if breakdown := gc.Breakdown(nil, &host.PriceTable.HostPriceTable); breakdown.Gouging() {
+		if breakdown := gc.Check(nil, &host.PriceTable.HostPriceTable); breakdown.Gouging() {
 			c.logger.Errorw("candidate host became unusable", "hk", host.PublicKey, "reasons", breakdown.Reasons())
 			continue
 		}

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -19,11 +19,12 @@ const (
 
 type (
 	GougingChecker interface {
-		CheckHS(*rhpv2.HostSettings) GougingResults
-		CheckPT(*rhpv3.HostPriceTable) GougingResults
+		Breakdown(*rhpv2.HostSettings, *rhpv3.HostPriceTable) api.GougingBreakdown
+		Check(*rhpv2.HostSettings, *rhpv3.HostPriceTable) GougingResults
 	}
 
 	GougingResults struct {
+		contractErr error
 		downloadErr error
 		gougingErr  error
 		uploadErr   error
@@ -34,6 +35,9 @@ type (
 		settings       api.GougingSettings
 		redundancy     api.RedundancySettings
 		txFee          types.Currency
+
+		period      *uint64
+		renewWindow *uint64
 	}
 
 	contextKey string
@@ -41,15 +45,12 @@ type (
 
 var _ GougingChecker = gougingChecker{}
 
-func PerformGougingChecks(ctx context.Context, hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable) (results GougingResults) {
+func GougingCheckerFromContext(ctx context.Context) GougingChecker {
 	gc, ok := ctx.Value(keyGougingChecker).(GougingChecker)
 	if !ok {
 		panic("no gouging checker attached to the context") // developer error
 	}
-
-	results.merge(gc.CheckHS(hs))
-	results.merge(gc.CheckPT(pt))
-	return
+	return gc
 }
 
 func WithGougingChecker(ctx context.Context, gp api.GougingParams) context.Context {
@@ -58,61 +59,76 @@ func WithGougingChecker(ctx context.Context, gp api.GougingParams) context.Conte
 		settings:       gp.GougingSettings,
 		redundancy:     gp.RedundancySettings,
 		txFee:          gp.TransactionFee,
+
+		// NOTE:
+		//
+		// period and renew window are nil here and that's fine, gouging
+		// checkers in the workers don't have easy access to these settings and
+		// thus ignore them when perform gouging checks, the autopilot however
+		// does have those and will pass them when performing gouging checks
 	})
 }
 
-func IsGouging(gs api.GougingSettings, rs api.RedundancySettings, cs api.ConsensusState, hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable, txnFee types.Currency, period, renewWindow uint64, ignoreBlockHeight bool) (gouging bool, reasons string) {
-	if hs == nil && pt == nil {
-		panic("IsGouging needs to be provided with at least host settings or a price table") // developer error
+func NewGougingChecker(gs api.GougingSettings, rs api.RedundancySettings, cs api.ConsensusState, txnFee types.Currency, period, renewWindow uint64) GougingChecker {
+	return gougingChecker{
+		consensusState: cs,
+		settings:       gs,
+		redundancy:     rs,
+		txFee:          txnFee,
+
+		period:      &period,
+		renewWindow: &renewWindow,
 	}
-
-	var errs []error
-	if hs != nil {
-		errs = append(
-			errs,
-
-			// host setting checks
-			checkDownloadGougingRHPv2(gs, rs, *hs),
-			checkPriceGougingHS(gs, hs),
-			checkUploadGougingRHPv2(gs, rs, *hs),
-		)
-	}
-
-	if pt != nil {
-		errs = append(
-			errs,
-
-			// price table checks
-			checkDownloadGougingRHPv3(gs, rs, *pt),
-			checkPriceGougingPT(gs, cs, txnFee, pt, ignoreBlockHeight),
-			checkUploadGougingRHPv3(gs, rs, *pt),
-			checkContractGougingPT(period, renewWindow, pt),
-		)
-	}
-
-	if err := joinErrors(errs...); err != nil {
-		return true, err.Error()
-	}
-
-	return false, ""
 }
 
-func (gc gougingChecker) CheckHS(hs *rhpv2.HostSettings) (results GougingResults) {
+func (gc gougingChecker) Breakdown(hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable) api.GougingBreakdown {
+	if hs == nil && pt == nil {
+		panic("gouging checker needs to be provided with at least host settings or a price table") // developer error
+	}
+
+	rhpv2 := gc.checkHS(hs)
+	rhpv3 := gc.checkPT(pt)
+
+	return api.GougingBreakdown{
+		RHPv2ContractErr: rhpv2.contractErr,
+		RHPv2DownloadErr: rhpv2.downloadErr,
+		RHPv2GougingErr:  rhpv2.gougingErr,
+		RHPv2UploadErr:   rhpv2.uploadErr,
+
+		RHPv3ContractErr: rhpv3.contractErr,
+		RHPv3DownloadErr: rhpv3.downloadErr,
+		RHPv3GougingErr:  rhpv3.gougingErr,
+		RHPv3UploadErr:   rhpv3.uploadErr,
+	}
+}
+
+func (gc gougingChecker) Check(hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable) (results GougingResults) {
+	if hs == nil && pt == nil {
+		panic("gouging checker needs to be provided with at least host settings or a price table") // developer error
+	}
+	results.merge(gc.checkHS(hs))
+	results.merge(gc.checkPT(pt))
+	return
+}
+
+func (gc gougingChecker) checkHS(hs *rhpv2.HostSettings) (results GougingResults) {
 	if hs != nil {
 		results = GougingResults{
+			contractErr: checkContractGougingRHPv2(gc.period, gc.renewWindow, *hs),
 			downloadErr: checkDownloadGougingRHPv2(gc.settings, gc.redundancy, *hs),
-			gougingErr:  checkPriceGougingHS(gc.settings, hs),
+			gougingErr:  checkPriceGougingHS(gc.settings, *hs),
 			uploadErr:   checkUploadGougingRHPv2(gc.settings, gc.redundancy, *hs),
 		}
 	}
 	return
 }
 
-func (gc gougingChecker) CheckPT(pt *rhpv3.HostPriceTable) (results GougingResults) {
+func (gc gougingChecker) checkPT(pt *rhpv3.HostPriceTable) (results GougingResults) {
 	if pt != nil {
 		results = GougingResults{
+			contractErr: checkContractGougingRHPv3(gc.period, gc.renewWindow, *pt),
 			downloadErr: checkDownloadGougingRHPv3(gc.settings, gc.redundancy, *pt),
-			gougingErr:  checkPriceGougingPT(gc.settings, gc.consensusState, gc.txFee, pt, false),
+			gougingErr:  checkPriceGougingPT(gc.settings, gc.consensusState, gc.txFee, *pt),
 			uploadErr:   checkUploadGougingRHPv3(gc.settings, gc.redundancy, *pt),
 		}
 	}
@@ -127,7 +143,12 @@ func (gr GougingResults) CanDownload() (errs []error) {
 }
 
 func (gr GougingResults) CanForm() []error {
-	return gr.CanUpload() // same conditions apply
+	return filterErrors(
+		gr.contractErr,
+		gr.downloadErr,
+		gr.gougingErr,
+		gr.uploadErr,
+	)
 }
 
 func (gr GougingResults) CanUpload() []error {
@@ -140,11 +161,12 @@ func (gr GougingResults) CanUpload() []error {
 
 func (gr *GougingResults) merge(other GougingResults) {
 	gr.downloadErr = joinErrors(gr.downloadErr, other.downloadErr)
+	gr.contractErr = joinErrors(gr.contractErr, other.contractErr)
 	gr.gougingErr = joinErrors(gr.gougingErr, other.gougingErr)
 	gr.uploadErr = joinErrors(gr.uploadErr, other.uploadErr)
 }
 
-func checkPriceGougingHS(gs api.GougingSettings, hs *rhpv2.HostSettings) error {
+func checkPriceGougingHS(gs api.GougingSettings, hs rhpv2.HostSettings) error {
 	// check base rpc price
 	if !gs.MaxRPCPrice.IsZero() && hs.BaseRPCPrice.Cmp(gs.MaxRPCPrice) > 0 {
 		return fmt.Errorf("rpc price exceeds max: %v>%v", hs.BaseRPCPrice, gs.MaxRPCPrice)
@@ -171,24 +193,10 @@ func checkPriceGougingHS(gs api.GougingSettings, hs *rhpv2.HostSettings) error {
 	return nil
 }
 
-func checkContractGougingPT(period, renewWindow uint64, pt *rhpv3.HostPriceTable) error {
-	// check MaxDuration
-	if period != 0 && period > pt.MaxDuration {
-		return fmt.Errorf("MaxDuration %v is lower than the period %v", pt.MaxDuration, period)
-	}
-
-	// check WindowSize
-	if renewWindow != 0 && renewWindow < pt.WindowSize {
-		return fmt.Errorf("minimum WindowSize %v is greater than the renew window %v", pt.WindowSize, renewWindow)
-	}
-
-	return nil
-}
-
 // TODO: if we ever stop assuming that certain prices in the pricetable are
 // always set to 1H we should account for those fields in
 // `hostPeriodCostForScore` as well.
-func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, txnFee types.Currency, pt *rhpv3.HostPriceTable, ignoreBlockHeight bool) error {
+func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, txnFee types.Currency, pt rhpv3.HostPriceTable) error {
 	// check base rpc price
 	if !gs.MaxRPCPrice.IsZero() && gs.MaxRPCPrice.Cmp(pt.InitBaseCost) < 0 {
 		return fmt.Errorf("init base cost exceeds max: %v>%v", pt.InitBaseCost, gs.MaxRPCPrice)
@@ -289,20 +297,18 @@ func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, txnFee t
 	}
 
 	// check block height
-	if !ignoreBlockHeight {
-		if !cs.Synced {
-			if pt.HostBlockHeight < cs.BlockHeight {
-				return fmt.Errorf("consensus not synced and host block height is lower, %v < %v", pt.HostBlockHeight, cs.BlockHeight)
-			}
-		} else {
-			var min uint64
-			if cs.BlockHeight >= uint64(gs.HostBlockHeightLeeway) {
-				min = cs.BlockHeight - uint64(gs.HostBlockHeightLeeway)
-			}
-			max := cs.BlockHeight + uint64(gs.HostBlockHeightLeeway)
-			if !(min <= pt.HostBlockHeight && pt.HostBlockHeight <= max) {
-				return fmt.Errorf("consensus is synced and host block height is not within range, %v-%v %v", min, max, pt.HostBlockHeight)
-			}
+	if !cs.Synced {
+		if pt.HostBlockHeight < cs.BlockHeight {
+			return fmt.Errorf("consensus not synced and host block height is lower, %v < %v", pt.HostBlockHeight, cs.BlockHeight)
+		}
+	} else {
+		var min uint64
+		if cs.BlockHeight >= uint64(gs.HostBlockHeightLeeway) {
+			min = cs.BlockHeight - uint64(gs.HostBlockHeightLeeway)
+		}
+		max := cs.BlockHeight + uint64(gs.HostBlockHeightLeeway)
+		if !(min <= pt.HostBlockHeight && pt.HostBlockHeight <= max) {
+			return fmt.Errorf("consensus is synced and host block height is not within range, %v-%v %v", min, max, pt.HostBlockHeight)
 		}
 	}
 
@@ -314,6 +320,40 @@ func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, txnFee t
 	// check TxnFeeMinRecommended - expect it to be lower or equal than the max
 	if pt.TxnFeeMinRecommended.Cmp(pt.TxnFeeMaxRecommended) > 0 {
 		return fmt.Errorf("TxnFeeMinRecommended is greater than TxnFeeMaxRecommended, %v>%v", pt.TxnFeeMinRecommended, pt.TxnFeeMaxRecommended)
+	}
+
+	return nil
+}
+
+func checkContractGougingRHPv2(period, renewWindow *uint64, hs rhpv2.HostSettings) error {
+	// period and renew window might be nil since we don't always have access to
+	// these settings when performing gouging checks
+	if period == nil || renewWindow == nil {
+		return nil
+	}
+
+	return checkContractGouging(*period, *renewWindow, hs.MaxDuration, hs.WindowSize)
+}
+
+func checkContractGougingRHPv3(period, renewWindow *uint64, pt rhpv3.HostPriceTable) error {
+	// period and renew window might be nil since we don't always have access to
+	// these settings when performing gouging checks
+	if period == nil || renewWindow == nil {
+		return nil
+	}
+
+	return checkContractGouging(*period, *renewWindow, pt.MaxDuration, pt.WindowSize)
+}
+
+func checkContractGouging(period, renewWindow, maxDuration, windowSize uint64) error {
+	// check MaxDuration
+	if period != 0 && period > maxDuration {
+		return fmt.Errorf("MaxDuration %v is lower than the period %v", maxDuration, period)
+	}
+
+	// check WindowSize
+	if renewWindow != 0 && renewWindow < windowSize {
+		return fmt.Errorf("minimum WindowSize %v is greater than the renew window %v", windowSize, renewWindow)
 	}
 
 	return nil

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -53,7 +53,7 @@ var (
 )
 
 func (w *worker) FetchRevisionWithAccount(ctx context.Context, pt rhpv3.HostPriceTable, hostKey types.PublicKey, siamuxAddr string, bh uint64, contractID types.FileContractID) (rev types.FileContractRevision, err error) {
-	if errs := PerformGougingChecks(ctx, nil, &pt).CanDownload(); len(errs) > 0 {
+	if errs := GougingCheckerFromContext(ctx).Check(nil, &pt).CanDownload(); len(errs) > 0 {
 		return types.FileContractRevision{}, fmt.Errorf("failed to fetch revision, %w: %v", errGougingHost, errs)
 	}
 	acc, err := w.accounts.ForHost(hostKey)
@@ -92,7 +92,7 @@ func (w *worker) FetchRevisionWithContract(ctx context.Context, hostKey types.Pu
 				return rhpv3.HostPriceTable{}, nil, fmt.Errorf("failed to fetch pricetable, err: %v", err)
 			}
 			// Check pt.
-			if errs := PerformGougingChecks(ctx, nil, &pt.HostPriceTable).CanDownload(); len(errs) > 0 {
+			if errs := GougingCheckerFromContext(ctx).Check(nil, &pt.HostPriceTable).CanDownload(); len(errs) > 0 {
 				return rhpv3.HostPriceTable{}, nil, fmt.Errorf("failed to fetch revision, %w: %v", errGougingHost, errs)
 			}
 			// Pay for the revision.
@@ -376,7 +376,7 @@ func (*hostV3) DeleteSectors(ctx context.Context, roots []types.Hash256) error {
 
 func (r *hostV3) DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint64) (err error) {
 	// return errGougingHost if gouging checks fail
-	if errs := PerformGougingChecks(ctx, nil, &r.pt).CanDownload(); len(errs) > 0 {
+	if errs := GougingCheckerFromContext(ctx).Check(nil, &r.pt).CanDownload(); len(errs) > 0 {
 		return fmt.Errorf("failed to download sector, %w: %v", errGougingHost, errs)
 	}
 	// return errBalanceInsufficient if balance insufficient

--- a/worker/sessionpool.go
+++ b/worker/sessionpool.go
@@ -103,7 +103,7 @@ func (ss *sharedSession) RenewContract(ctx context.Context, prepareFn func(rev t
 	}
 	defer ss.pool.release(s)
 
-	if errs := PerformGougingChecks(ctx, &s.settings, nil).CanUpload(); len(errs) > 0 {
+	if errs := GougingCheckerFromContext(ctx).Check(&s.settings, nil).CanUpload(); len(errs) > 0 {
 		return rhpv2.ContractRevision{}, nil, fmt.Errorf("failed reneww contract, gouging check failed: %v", errs)
 	}
 
@@ -129,7 +129,7 @@ func (ss *sharedSession) UploadSector(ctx context.Context, sector *[rhpv2.Sector
 		return types.Hash256{}, err
 	}
 	defer ss.pool.release(s)
-	if errs := PerformGougingChecks(ctx, &s.settings, nil).CanUpload(); len(errs) > 0 {
+	if errs := GougingCheckerFromContext(ctx).Check(&s.settings, nil).CanUpload(); len(errs) > 0 {
 		return types.Hash256{}, fmt.Errorf("failed to upload sector, gouging check failed: %v", errs)
 	}
 	return s.appendSector(ctx, sector, currentHeight)
@@ -141,7 +141,7 @@ func (ss *sharedSession) DownloadSector(ctx context.Context, w io.Writer, root t
 		return err
 	}
 	defer ss.pool.release(s)
-	if errs := PerformGougingChecks(ctx, &s.settings, nil).CanDownload(); len(errs) > 0 {
+	if errs := GougingCheckerFromContext(ctx).Check(&s.settings, nil).CanDownload(); len(errs) > 0 {
 		return fmt.Errorf("failed to download sector, gouging check failed: %v", errs)
 	}
 	return s.readSector(ctx, w, root, offset, length)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -638,7 +638,7 @@ func (w *worker) rhpFormHandler(jc jape.Context) {
 			return err
 		}
 
-		if errs := PerformGougingChecks(ctx, &hostSettings, nil).CanForm(); len(errs) > 0 {
+		if errs := GougingCheckerFromContext(ctx).Check(&hostSettings, nil).CanForm(); len(errs) > 0 {
 			return fmt.Errorf("failed to form contract, gouging check failed: %v", errs)
 		}
 


### PR DESCRIPTION
This PR proposes a new `GougingBreakdown` api type that returns a breakdown of the various gouging checks we perform. While I was at it I decided to refactor the gouging code a bit. We were basically defining what gouging checks need to be performed in two locations (`PerformGougingChecks` and `IsGouging`), which is not ideal of course. I updated the interface a bit and I think it's improved a bit. I never really liked that we were passing around `ignoreBlockheight` bools so I want to propose manipulating the price table instead, I personally think that's a cleaner solution.

The breakdown is just a list of errors, exactly as they're returned from the gouging checker. They should be human readable and can definitely be user facing, although the fields in the breakdown are not self-explanatory... I was on the fence here but figured it's best to have the info as granular as possible and not try and get fancy and come up with a nice string representation or something... 
