### PR TITLE
Fix Usable Contract Panic

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -494,7 +494,9 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 				"renew", renew,
 			)
 		}
-		if renew {
+		if archive {
+			toArchive[fcid] = errStr(joinErrors(reasons))
+		} else if renew {
 			renewIndices[fcid] = len(toRenew)
 			toRenew = append(toRenew, contractInfo{
 				contract: contract,
@@ -505,8 +507,6 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 				contract: contract,
 				settings: settings,
 			})
-		} else if archive {
-			toArchive[fcid] = errStr(joinErrors(reasons))
 		}
 
 		// keep track of file size

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -195,35 +195,41 @@ func isUsableHost(cfg api.AutopilotConfig, gs api.GougingSettings, rs api.Redund
 // can be renewed, along with a list of reasons why it was deemed unusable.
 func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, renterFunds types.Currency) (usable, refresh, renew, archive bool, reasons []error) {
 	c, s := ci.contract, ci.settings
-	if isOutOfCollateral(c, s, renterFunds, bh) {
-		reasons = append(reasons, errContractOutOfCollateral)
-		renew = false
-		refresh = true
-	}
-	if isOutOfFunds(cfg, s, c) {
-		reasons = append(reasons, errContractOutOfFunds)
-		renew = false
-		refresh = true
-	}
-	if shouldRenew, secondHalf := isUpForRenewal(cfg, c.Revision, bh); shouldRenew {
-		if secondHalf {
-			reasons = append(reasons, errContractUpForRenewal) // only unusable if in second half of renew window
-		}
-		renew = true
-		refresh = false
-	}
-	if c.Revision.RevisionNumber == math.MaxUint64 {
-		reasons = append(reasons, errContractMaxRevisionNumber)
-		archive = true // can't be revised anymore
-		renew = false
-		refresh = false
-	}
+
 	if bh > c.EndHeight() {
 		reasons = append(reasons, errContractExpired)
 		archive = true // expired
 		renew = false
 		refresh = false
 	}
+
+	if c.Revision.RevisionNumber == math.MaxUint64 {
+		reasons = append(reasons, errContractMaxRevisionNumber)
+		archive = true // can't be revised anymore
+		renew = false
+		refresh = false
+	}
+
+	if !archive {
+		if isOutOfCollateral(c, s, renterFunds, bh) {
+			reasons = append(reasons, errContractOutOfCollateral)
+			renew = false
+			refresh = true
+		}
+		if isOutOfFunds(cfg, s, c) {
+			reasons = append(reasons, errContractOutOfFunds)
+			renew = false
+			refresh = true
+		}
+		if shouldRenew, secondHalf := isUpForRenewal(cfg, c.Revision, bh); shouldRenew {
+			if secondHalf {
+				reasons = append(reasons, errContractUpForRenewal) // only unusable if in second half of renew window
+			}
+			renew = true
+			refresh = false
+		}
+	}
+
 	usable = len(reasons) == 0
 	return
 }


### PR DESCRIPTION
If a contract needs to be archived, we do not have to perform any checks that might result in a contract refresh or renewal. This avoids a panic where the block height exceeds the contract's end height used when computing the new contract's collateral.

Fixes #262 