### PR TITLE
Make Gouging Checks less granular

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -93,51 +93,6 @@ type (
 	}
 )
 
-func (hgb HostGougingBreakdown) CanDownload() (errs []error) {
-	for _, err := range []error{
-		hgb.V3.DownloadErr,
-		hgb.V2.GougingErr,
-		hgb.V3.GougingErr,
-	} {
-		if err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return
-}
-
-func (hgb HostGougingBreakdown) CanForm() (errs []error) {
-	for _, err := range []error{
-		hgb.V2.ContractErr,
-		hgb.V3.ContractErr,
-		hgb.V3.DownloadErr,
-		hgb.V2.GougingErr,
-		hgb.V3.GougingErr,
-		hgb.V2.UploadErr,
-	} {
-		if err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return
-}
-
-func (hgb HostGougingBreakdown) CanUpload() (errs []error) {
-	for _, err := range []error{
-		hgb.V2.ContractErr,
-		hgb.V3.ContractErr,
-		hgb.V3.DownloadErr,
-		hgb.V2.GougingErr,
-		hgb.V3.GougingErr,
-		hgb.V2.UploadErr,
-	} {
-		if err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return
-}
-
 func (hgb HostGougingBreakdown) Gouging() bool {
 	return hgb.V2.Gouging() || hgb.V3.Gouging()
 }

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -53,8 +53,8 @@ var (
 )
 
 func (w *worker) FetchRevisionWithAccount(ctx context.Context, pt rhpv3.HostPriceTable, hostKey types.PublicKey, siamuxAddr string, bh uint64, contractID types.FileContractID) (rev types.FileContractRevision, err error) {
-	if errs := GougingCheckerFromContext(ctx).Check(nil, &pt).CanDownload(); len(errs) > 0 {
-		return types.FileContractRevision{}, fmt.Errorf("failed to fetch revision, %w: %v", errGougingHost, errs)
+	if breakdown := GougingCheckerFromContext(ctx).Check(nil, &pt); breakdown.Gouging() {
+		return types.FileContractRevision{}, fmt.Errorf("failed to fetch revision, %w: %v", errGougingHost, breakdown.Reasons())
 	}
 	acc, err := w.accounts.ForHost(hostKey)
 	if err != nil {
@@ -92,8 +92,8 @@ func (w *worker) FetchRevisionWithContract(ctx context.Context, hostKey types.Pu
 				return rhpv3.HostPriceTable{}, nil, fmt.Errorf("failed to fetch pricetable, err: %v", err)
 			}
 			// Check pt.
-			if errs := GougingCheckerFromContext(ctx).Check(nil, &pt.HostPriceTable).CanDownload(); len(errs) > 0 {
-				return rhpv3.HostPriceTable{}, nil, fmt.Errorf("failed to fetch revision, %w: %v", errGougingHost, errs)
+			if breakdown := GougingCheckerFromContext(ctx).Check(nil, &pt.HostPriceTable); breakdown.Gouging() {
+				return rhpv3.HostPriceTable{}, nil, fmt.Errorf("failed to fetch revision, %w: %v", errGougingHost, breakdown.Reasons())
 			}
 			// Pay for the revision.
 			payment, ok := rhpv3.PayByContract(revision, pt.LatestRevisionCost, acc.id, w.deriveRenterKey(hostKey))
@@ -376,8 +376,8 @@ func (*hostV3) DeleteSectors(ctx context.Context, roots []types.Hash256) error {
 
 func (r *hostV3) DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint64) (err error) {
 	// return errGougingHost if gouging checks fail
-	if errs := GougingCheckerFromContext(ctx).Check(nil, &r.pt).CanDownload(); len(errs) > 0 {
-		return fmt.Errorf("failed to download sector, %w: %v", errGougingHost, errs)
+	if breakdown := GougingCheckerFromContext(ctx).Check(nil, &r.pt); breakdown.Gouging() {
+		return fmt.Errorf("failed to download sector, %w: %v", errGougingHost, breakdown.Reasons())
 	}
 	// return errBalanceInsufficient if balance insufficient
 	defer func() {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -638,8 +638,8 @@ func (w *worker) rhpFormHandler(jc jape.Context) {
 			return err
 		}
 
-		if errs := GougingCheckerFromContext(ctx).Check(&hostSettings, nil).CanForm(); len(errs) > 0 {
-			return fmt.Errorf("failed to form contract, gouging check failed: %v", errs)
+		if breakdown := GougingCheckerFromContext(ctx).Check(&hostSettings, nil); breakdown.Gouging() {
+			return fmt.Errorf("failed to form contract, gouging check failed: %v", breakdown.Reasons())
 		}
 
 		renterTxnSet, err := w.bus.WalletPrepareForm(ctx, renterAddress, renterKey, renterFunds, hostCollateral, hostKey, hostSettings, endHeight)


### PR DESCRIPTION
This PR removes `CanDownload`, `CanUpload` and `CanForm`. From now on, a host that is considered to be gouging on any of its price settings is simply considered gouging and won't be used for anything any longer.