### PR TITLE
API client: trim leading / from object path

### DIFF
--- a/bus/client.go
+++ b/bus/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
+	"strings"
 	"time"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
@@ -469,7 +470,7 @@ func (c *Client) Object(ctx context.Context, path, prefix string, offset, limit 
 	values.Set("prefix", prefix)
 	values.Set("offset", fmt.Sprint(offset))
 	values.Set("limit", fmt.Sprint(limit))
-
+	path = strings.TrimLeft(path, "/")
 	var or api.ObjectsResponse
 	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/objects/%s?"+values.Encode(), path), &or)
 	if or.Object != nil {

--- a/worker/client.go
+++ b/worker/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
@@ -152,6 +153,7 @@ func (c *Client) UploadObject(ctx context.Context, r io.Reader, path string) (er
 }
 
 func (c *Client) object(ctx context.Context, path string, w io.Writer, entries *[]string) (err error) {
+	path = strings.TrimLeft(path, "/")
 	c.c.Custom("GET", fmt.Sprintf("/objects/%s", path), nil, (*[]string)(nil))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%v/objects/%v", c.c.BaseURL, path), nil)
@@ -186,12 +188,14 @@ func (c *Client) ObjectEntries(ctx context.Context, path string) (entries []stri
 // DownloadObject downloads the object at the given path, writing its data to
 // w.
 func (c *Client) DownloadObject(ctx context.Context, w io.Writer, path string) (err error) {
+	path = strings.TrimLeft(path, "/")
 	err = c.object(ctx, path, w, nil)
 	return
 }
 
 // DeleteObject deletes the object at the given path.
 func (c *Client) DeleteObject(ctx context.Context, path string) (err error) {
+	path = strings.TrimLeft(path, "/")
 	err = c.c.WithContext(ctx).DELETE(fmt.Sprintf("/objects/%s", path))
 	return
 }


### PR DESCRIPTION
When `Client.Object` returns entries, it includes a leading / in each result. This caused a problem when calling `Client.Object` with the child path.