### PR TITLE
Return 503 Service Unavailable if consensus is not synced

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -1,12 +1,17 @@
 package api
 
 import (
+	"errors"
 	"time"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 )
+
+// ErrConsensusNotSynced is returned by the worker API by endpoints that rely on
+// consensus and the consensus is not synced.
+var ErrConsensusNotSynced = errors.New("consensus is not synced")
 
 type AccountsLockHandlerRequest struct {
 	HostKey   types.PublicKey `json:"hostKey"`

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -795,8 +795,17 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 		return
 	}
 
+	// fetch the upload parameters
 	up, err := w.bus.UploadParams(ctx)
 	if jc.Check("couldn't fetch upload parameters from bus", err) != nil {
+		return
+	}
+
+	// cancel the upload if consensus is not synced
+	if !up.ConsensusState.Synced {
+		err = errors.New("consensus is not synced")
+		w.logger.Errorf("migration cancelled, err: ", err)
+		jc.Error(err, http.StatusServiceUnavailable)
 		return
 	}
 
@@ -993,13 +1002,22 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	// fetch the path
 	path := strings.TrimPrefix(jc.PathParam("path"), "/")
 
+	// fetch the upload parameters
 	up, err := w.bus.UploadParams(ctx)
 	if jc.Check("couldn't fetch upload parameters from bus", err) != nil {
 		return
 	}
-	rs := up.RedundancySettings
+
+	// cancel the upload if consensus is not synced
+	if !up.ConsensusState.Synced {
+		err = errors.New("consensus is not synced")
+		w.logger.Errorf("upload cancelled, err: ", err)
+		jc.Error(err, http.StatusServiceUnavailable)
+		return
+	}
 
 	// allow overriding the redundancy settings
+	rs := up.RedundancySettings
 	if jc.DecodeForm(queryStringParamMinShards, &rs.MinShards) != nil {
 		return
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -803,9 +803,8 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 
 	// cancel the upload if consensus is not synced
 	if !up.ConsensusState.Synced {
-		err = errors.New("consensus is not synced")
-		w.logger.Errorf("migration cancelled, err: ", err)
-		jc.Error(err, http.StatusServiceUnavailable)
+		w.logger.Errorf("migration cancelled, err: ", api.ErrConsensusNotSynced)
+		jc.Error(api.ErrConsensusNotSynced, http.StatusServiceUnavailable)
 		return
 	}
 
@@ -1010,9 +1009,8 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 
 	// cancel the upload if consensus is not synced
 	if !up.ConsensusState.Synced {
-		err = errors.New("consensus is not synced")
-		w.logger.Errorf("upload cancelled, err: ", err)
-		jc.Error(err, http.StatusServiceUnavailable)
+		w.logger.Errorf("upload cancelled, err: ", api.ErrConsensusNotSynced)
+		jc.Error(api.ErrConsensusNotSynced, http.StatusServiceUnavailable)
 		return
 	}
 


### PR DESCRIPTION
When a node is synced it makes no sense trying to upload a file because it is likely to fail down the line because of various block height related errors being thrown, so I added a check for that and return a 503 status code and error message indicating consensus is not synced.

Example upload error:
```
4b6bf45a: Write: host rejected Write request: ReadResponse: communication error: host expected to post at most 676011510135535960064 collateral, but contract has host posting 950240678641284834918: rejected for low paying host missed output
```