### PR TITLE
Consensus Network

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -79,6 +79,11 @@ type ConsensusState struct {
 	Synced      bool
 }
 
+// ConsensusNetwork holds the name of the network.
+type ConsensusNetwork struct {
+	Name string
+}
+
 // ContractsIDAddRequest is the request type for the /contract/:id endpoint.
 type ContractsIDAddRequest struct {
 	Contract    rhpv2.ContractRevision `json:"contract"`

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -171,6 +171,12 @@ func (b *bus) consensusStateHandler(jc jape.Context) {
 	})
 }
 
+func (b *bus) consensusNetworkHandler(jc jape.Context) {
+	jc.Encode(api.ConsensusNetwork{
+		Name: b.cm.TipState(jc.Request.Context()).Network.Name,
+	})
+}
+
 func (b *bus) txpoolFeeHandler(jc jape.Context) {
 	fee := b.tp.RecommendedFee()
 	jc.Encode(fee)
@@ -1116,6 +1122,7 @@ func (b *bus) Handler() http.Handler {
 
 		"POST   /consensus/acceptblock":        b.consensusAcceptBlock,
 		"GET    /consensus/state":              b.consensusStateHandler,
+		"GET    /consensus/network":            b.consensusNetworkHandler,
 		"GET    /consensus/siafundfee/:payout": b.contractTaxHandlerGET,
 
 		"GET    /txpool/recommendedfee": b.txpoolFeeHandler,


### PR DESCRIPTION
This PR adds a new route `/bus/consensus/network` that exposes the network name. This is necessary so the UI can differentiate between the `mainnet` and the `zen` testnet. In `DRAFT`, need to merge https://github.com/SiaFoundation/core/pull/111/files first 