### PR TITLE
Fix HostInfo

### DIFF
--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -199,7 +199,7 @@ func isUsableHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.
 		}
 
 		// perform gouging checks
-		if gougingBreakdown := gc.Check(&h.Settings, &h.PriceTable.HostPriceTable); gougingBreakdown.Gouging() {
+		if gougingBreakdown = gc.Check(&h.Settings, &h.PriceTable.HostPriceTable); gougingBreakdown.Gouging() {
 			errs = append(errs, fmt.Errorf("%w: %v", errHostPriceGouging, gougingBreakdown.Reasons()))
 		}
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -199,12 +199,14 @@ func isUsableHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.
 		}
 
 		// perform gouging checks
-		if gougingBreakdown = gc.Check(&h.Settings, &h.PriceTable.HostPriceTable); gougingBreakdown.Gouging() {
+		gougingBreakdown = gc.Check(&h.Settings, &h.PriceTable.HostPriceTable)
+		if gougingBreakdown.Gouging() {
 			errs = append(errs, fmt.Errorf("%w: %v", errHostPriceGouging, gougingBreakdown.Reasons()))
 		}
 
 		// perform scoring checks
-		if scoreBreakdown = hostScore(cfg, h, storedData, rs.Redundancy()); scoreBreakdown.Score() < minScore {
+		scoreBreakdown = hostScore(cfg, h, storedData, rs.Redundancy())
+		if scoreBreakdown.Score() < minScore {
 			errs = append(errs, fmt.Errorf("%w: %v < %v", errLowScore, scoreBreakdown.Score(), minScore))
 		}
 	}


### PR DESCRIPTION
The gouging breakdown was not initialised causing the `Gouging` checkmark in the UI to be green all the time. Reported by some beta testers in the community:

![](https://cdn.discordapp.com/attachments/946328563320238190/1097643194977624114/gouging.jpg)
