### PR TITLE
Fix HostScore overflow panic

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -967,7 +967,6 @@ func (c *contractor) candidateHosts(ctx context.Context, w Worker, hosts []hostd
 				zeros++
 			}
 			unusable++
-			continue
 		}
 	}
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -199,12 +199,14 @@ func isUsableHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.
 		}
 
 		// perform gouging checks
-		if gougingBreakdown := gc.Check(&h.Settings, &h.PriceTable.HostPriceTable); gougingBreakdown.Gouging() {
+		gougingBreakdown = gc.Check(&h.Settings, &h.PriceTable.HostPriceTable)
+		if gougingBreakdown.Gouging() {
 			errs = append(errs, fmt.Errorf("%w: %v", errHostPriceGouging, gougingBreakdown.Reasons()))
 		}
 
 		// perform scoring checks
-		if scoreBreakdown = hostScore(cfg, h, storedData, rs.Redundancy()); scoreBreakdown.Score() < minScore {
+		scoreBreakdown = hostScore(cfg, h, storedData, rs.Redundancy(), gougingBreakdown.Gouging())
+		if scoreBreakdown.Score() < minScore {
 			errs = append(errs, fmt.Errorf("%w: %v < %v", errLowScore, scoreBreakdown.Score(), minScore))
 		}
 	}

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -22,6 +22,9 @@ func hostScore(cfg api.AutopilotConfig, h hostdb.Host, storedData uint64, expect
 		Version:          versionScore(h.Settings),
 	}
 
+	// NOTE: if we know the host is gouging, we have to avoid calculating the
+	// period cost to calculate the collateral and price score as the core
+	// package does not have overflow checks in its cost calculations
 	if !gouging {
 		hostPeriodCost := hostPeriodCostForScore(h, cfg, expectedRedundancy)
 		breakdown.Collateral = collateralScore(cfg, hostPeriodCost, h.Settings, expectedRedundancy)

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -13,17 +13,22 @@ import (
 	"lukechampine.com/frand"
 )
 
-func hostScore(cfg api.AutopilotConfig, h hostdb.Host, storedData uint64, expectedRedundancy float64) api.HostScoreBreakdown {
-	hostPeriodCost := hostPeriodCostForScore(h, cfg, expectedRedundancy)
-	return api.HostScoreBreakdown{
+func hostScore(cfg api.AutopilotConfig, h hostdb.Host, storedData uint64, expectedRedundancy float64, gouging bool) api.HostScoreBreakdown {
+	breakdown := api.HostScoreBreakdown{
 		Age:              ageScore(h),
-		Collateral:       collateralScore(cfg, hostPeriodCost, h.Settings, expectedRedundancy),
 		Interactions:     interactionScore(h),
 		StorageRemaining: storageRemainingScore(cfg, h.Settings, storedData, expectedRedundancy),
 		Uptime:           uptimeScore(h),
 		Version:          versionScore(h.Settings),
-		Prices:           priceAdjustmentScore(hostPeriodCost, cfg),
 	}
+
+	if !gouging {
+		hostPeriodCost := hostPeriodCostForScore(h, cfg, expectedRedundancy)
+		breakdown.Collateral = collateralScore(cfg, hostPeriodCost, h.Settings, expectedRedundancy)
+		breakdown.Prices = priceAdjustmentScore(hostPeriodCost, cfg)
+	}
+
+	return breakdown
 }
 
 // priceAdjustmentScore computes a score between 0 and 1 for a host giving its


### PR DESCRIPTION
This PR ensures the host scoring does not use host settings for hosts that are considered gouging. This prevents a panic when calculating the `hostPeriodCostForScore` which uses the `core` package to calculate all kind of different costs like the `RPCAppendCost` for instance. Instead of extending the `core` package with overflow math, I think we should instead perform the gouging checks and avoid the scoring checks if we know the host is gouging.

Fixes #283 