### PR TITLE
When listing objects, return an array of metadata instead of just the object names

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -125,6 +125,11 @@ type HostsRemoveRequest struct {
 	MinRecentScanFailures uint64            `json:"minRecentScanFailures"`
 }
 
+type ObjectMetadata struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
 // ObjectsStats is the response type for the /stats/objects endpoint.
 type ObjectsStats struct {
 	NumObjects        uint64 `json:"numObjects"`        // number of objects
@@ -196,8 +201,8 @@ type WalletPrepareRenewResponse struct {
 
 // ObjectsResponse is the response type for the /objects endpoint.
 type ObjectsResponse struct {
-	Entries []string       `json:"entries,omitempty"`
-	Object  *object.Object `json:"object,omitempty"`
+	Entries []ObjectMetadata `json:"entries,omitempty"`
+	Object  *object.Object   `json:"object,omitempty"`
 }
 
 // AddObjectRequest is the request type for the /object/*key endpoint.

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -91,8 +91,8 @@ type (
 		SetContractSet(ctx context.Context, set string, contracts []types.FileContractID) error
 
 		Object(ctx context.Context, path string) (object.Object, error)
-		ObjectEntries(ctx context.Context, path, prefix string, offset, limit int) ([]string, error)
-		SearchObjects(ctx context.Context, substring string, offset, limit int) ([]string, error)
+		ObjectEntries(ctx context.Context, path, prefix string, offset, limit int) ([]api.ObjectMetadata, error)
+		SearchObjects(ctx context.Context, substring string, offset, limit int) ([]api.ObjectMetadata, error)
 		UpdateObject(ctx context.Context, path string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
 		RemoveObject(ctx context.Context, path string) error
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -462,7 +462,7 @@ func (c *Client) SearchHosts(ctx context.Context, filterMode string, addressCont
 }
 
 // SearchObjects returns all objects that contains a sub-string in their key.
-func (c *Client) SearchObjects(ctx context.Context, key string, offset, limit int) (entries []string, err error) {
+func (c *Client) SearchObjects(ctx context.Context, key string, offset, limit int) (entries []api.ObjectMetadata, err error) {
 	values := url.Values{}
 	values.Set("offset", fmt.Sprint(offset))
 	values.Set("limit", fmt.Sprint(limit))

--- a/bus/client.go
+++ b/bus/client.go
@@ -473,7 +473,7 @@ func (c *Client) SearchObjects(ctx context.Context, key string, offset, limit in
 
 // Object returns the object at the given path with the given prefix, or, if
 // path ends in '/', the entries under that path.
-func (c *Client) Object(ctx context.Context, path, prefix string, offset, limit int) (o object.Object, entries []string, err error) {
+func (c *Client) Object(ctx context.Context, path, prefix string, offset, limit int) (o object.Object, entries []api.ObjectMetadata, err error) {
 	values := url.Values{}
 	values.Set("prefix", prefix)
 	values.Set("offset", fmt.Sprint(offset))

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -984,8 +984,8 @@ func TestObjectEntries(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(got) != 1 || got[0] != test.want[offset] {
-				t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want[offset])
+			if len(got) != 1 || got[0].Name != test.want[offset] || got[0].Size == 0 {
+				t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v\n size: %v", test.path, test.prefix, got, test.want[offset], got[0].Size)
 			}
 		}
 	}
@@ -1023,7 +1023,11 @@ func TestSearchObjects(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !(len(got) == 0 && len(test.want) == 0) && !reflect.DeepEqual(got, test.want) {
+		objectIDs := make([]string, len(got))
+		for i, g := range got {
+			objectIDs[i] = g.Name
+		}
+		if !(len(got) == 0 && len(test.want) == 0) && !reflect.DeepEqual(objectIDs, test.want) {
 			t.Errorf("\nkey: %v\ngot: %v\nwant: %v", test.path, got, test.want)
 		}
 		for offset := 0; offset < len(test.want); offset++ {
@@ -1031,8 +1035,8 @@ func TestSearchObjects(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(got) != 1 || got[0] != test.want[offset] {
-				t.Errorf("\nkey: %v\ngot: %v\nwant: %v", test.path, got, test.want[offset])
+			if len(got) != 1 || got[0].Name != test.want[offset] || got[0].Size == 0 {
+				t.Errorf("\nkey: %v\ngot: %v\nwant: %v\nsize: %v", test.path, got, test.want[offset], got[0].Size)
 			}
 		}
 	}

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -772,6 +772,7 @@ func TestSQLMetadataStore(t *testing.T) {
 	expectedObj := dbObject{
 		ObjectID: objID,
 		Key:      obj1Key,
+		Size:     obj1.Size(),
 		Slabs: []dbSlice{
 			{
 				DBObjectID: 1,
@@ -956,7 +957,7 @@ func TestObjectEntries(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, o := range objects {
-		obj, ucs := newTestObject(frand.Intn(10))
+		obj, ucs := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
 		os.UpdateObject(ctx, o.path, obj, ucs)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -457,7 +457,7 @@ func TestUploadDownloadSpending(t *testing.T) {
 			}
 			var found bool
 			for _, entry := range entries {
-				if entry == fmt.Sprintf("/%s", name) {
+				if entry.Name == fmt.Sprintf("/%s", name) {
 					found = true
 					break
 				}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -485,7 +485,7 @@ func TestUploadDownloadSpending(t *testing.T) {
 	// Fuzzy search for uploaded data in various ways.
 	objects, err := cluster.Bus.SearchObjects(context.Background(), "", 0, -1)
 	if err != nil {
-		t.Fatal("should fail")
+		t.Fatal(err)
 	}
 	if len(objects) != 2 {
 		t.Fatalf("should have 2 objects but got %v", len(objects))

--- a/worker/client.go
+++ b/worker/client.go
@@ -156,9 +156,9 @@ func (c *Client) UploadObject(ctx context.Context, r io.Reader, path string) (er
 	return
 }
 
-func (c *Client) object(ctx context.Context, path string, w io.Writer, entries *[]string) (err error) {
+func (c *Client) object(ctx context.Context, path string, w io.Writer, entries *[]api.ObjectMetadata) (err error) {
 	path = strings.TrimLeft(path, "/")
-	c.c.Custom("GET", fmt.Sprintf("/objects/%s", path), nil, (*[]string)(nil))
+	c.c.Custom("GET", fmt.Sprintf("/objects/%s", path), nil, (*[]api.ObjectMetadata)(nil))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%v/objects/%v", c.c.BaseURL, path), nil)
 	if err != nil {
@@ -184,7 +184,7 @@ func (c *Client) object(ctx context.Context, path string, w io.Writer, entries *
 }
 
 // ObjectEntries returns the entries at the given path, which must end in /.
-func (c *Client) ObjectEntries(ctx context.Context, path string) (entries []string, err error) {
+func (c *Client) ObjectEntries(ctx context.Context, path string) (entries []api.ObjectMetadata, err error) {
 	err = c.object(ctx, path, nil, &entries)
 	return
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -220,7 +220,7 @@ type Bus interface {
 	GougingParams(ctx context.Context) (api.GougingParams, error)
 	UploadParams(ctx context.Context) (api.UploadParams, error)
 
-	Object(ctx context.Context, path, prefix string, offset, limit int) (object.Object, []string, error)
+	Object(ctx context.Context, path, prefix string, offset, limit int) (object.Object, []api.ObjectMetadata, error)
 	AddObject(ctx context.Context, path string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
 	DeleteObject(ctx context.Context, path string) error
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -860,7 +860,7 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 
 func (w *worker) objectsHandlerGET(jc jape.Context) {
 	ctx := jc.Request.Context()
-	jc.Custom(nil, []string{})
+	jc.Custom(nil, []api.ObjectMetadata{})
 
 	var off int
 	if jc.DecodeForm("offset", &off) != nil {


### PR DESCRIPTION
Closes https://github.com/SiaFoundation/renterd/issues/295

Return a slice of `api.ObjectMetadata` instead of ´[]string`.
The metadata contains the name which is the string we returned before as well as the size of the file/folder.