### PR TITLE
ui: v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	go.sia.tech/hostd v0.0.0-20230405162657-88bf725a9836
 	go.sia.tech/jape v0.9.0
 	go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca
-	go.sia.tech/web/renterd v0.10.0
+	go.sia.tech/web/renterd v0.12.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.6.0
 	golang.org/x/sys v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -330,6 +330,8 @@ go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca h1:aZMg2AKevn7jKx+wlusWQf
 go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca/go.mod h1:h/1afFwpxzff6/gG5i1XdAgPK7dEY6FaibhK7N5F86Y=
 go.sia.tech/web/renterd v0.10.0 h1:6YbPT9a3VuAyEhx722o4i0tetTBUK2Ke5xXLZoPY6lo=
 go.sia.tech/web/renterd v0.10.0/go.mod h1:jr4PVQW1KU8JpAzmJRfFecDeJ5SPIRrKM3OKZ+FvGvE=
+go.sia.tech/web/renterd v0.12.0 h1:Ic9MTgBh9rInUEqUPYTYQZa3LcVHgRrEy23pxJmOAyQ=
+go.sia.tech/web/renterd v0.12.0/go.mod h1:jr4PVQW1KU8JpAzmJRfFecDeJ5SPIRrKM3OKZ+FvGvE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=


### PR DESCRIPTION
<img width="663" alt="Screen Shot 2023-04-21 at 7 43 05 PM" src="https://user-images.githubusercontent.com/1412796/233749912-322efb65-8f31-4dff-bd29-9750188a9fbc.png">

- Fixed an issue where the entire UI errors - UI is now compatible with the updated objects endpoint schema.
- The sync screen now shows the correct network block height when using the Zen testnet.
- The unlock form now times out after 5s and shows a new 'Error, daemon did not respond' error - this occurs when the wallet is re-indexing.
- The hosts explorer column state icons are now more clear, some columns now use a gray negative or non-initialized state.
- The network block height is now estimated. renterd no longer uses SiaStats for anything so the 3rd party data privacy toggle has also been removed.