### PR TITLE
Autopilot Config Validation

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -12,6 +13,12 @@ const (
 	// blocksPerDay defines the amount of blocks that are mined in a day (one
 	// block every 10 minutes roughly)
 	blocksPerDay = 144
+)
+
+var (
+	// ErrMaxDowntimeHoursTooHigh is returned if the autopilot config is updated
+	// with a value that exceeds the maximum of 99 years.
+	ErrMaxDowntimeHoursTooHigh = errors.New("MaxDowntimeHours is too high, exceeds max value of 99 years")
 )
 
 type (
@@ -144,6 +151,13 @@ func (hgb HostGougingBreakdown) Reasons() string {
 
 func (sb HostScoreBreakdown) Score() float64 {
 	return sb.Age * sb.Collateral * sb.Interactions * sb.StorageRemaining * sb.Uptime * sb.Version * sb.Prices
+}
+
+func (c AutopilotConfig) Validate() error {
+	if c.Hosts.MaxDowntimeHours > 99*365*24 {
+		return ErrMaxDowntimeHoursTooHigh
+	}
+	return nil
 }
 
 // DefaultAutopilotConfig returns a configuration with sane default values.

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -166,6 +166,9 @@ func (ap *Autopilot) Config() api.AutopilotConfig {
 
 // SetConfig updates the autopilot's configuration.
 func (ap *Autopilot) SetConfig(c api.AutopilotConfig) error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
 	return ap.store.SetConfig(c)
 }
 

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -37,8 +37,9 @@ const (
 )
 
 var (
-	ErrHostNotFound   = errors.New("host doesn't exist in hostdb")
-	ErrNegativeOffset = errors.New("offset can not be negative")
+	ErrHostNotFound        = errors.New("host doesn't exist in hostdb")
+	ErrNegativeOffset      = errors.New("offset can not be negative")
+	ErrNegativeMaxDowntime = errors.New("max downtime can not be negative")
 )
 
 type (
@@ -526,6 +527,11 @@ func (ss *SQLStore) Hosts(ctx context.Context, offset, limit int) ([]hostdb.Host
 }
 
 func (ss *SQLStore) RemoveOfflineHosts(ctx context.Context, minRecentFailures uint64, maxDowntime time.Duration) (removed uint64, err error) {
+	fmt.Println("DEBUG PJ: removing offline hosts", minRecentFailures, maxDowntime)
+	if maxDowntime < 0 {
+		return 0, ErrNegativeMaxDowntime
+	}
+
 	// fetch all hosts outside of the transaction
 	var hosts []dbHost
 	if err := ss.db.

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -527,7 +527,7 @@ func (ss *SQLStore) Hosts(ctx context.Context, offset, limit int) ([]hostdb.Host
 }
 
 func (ss *SQLStore) RemoveOfflineHosts(ctx context.Context, minRecentFailures uint64, maxDowntime time.Duration) (removed uint64, err error) {
-	fmt.Println("DEBUG PJ: removing offline hosts", minRecentFailures, maxDowntime)
+	// sanity check 'maxDowntime'
 	if maxDowntime < 0 {
 		return 0, ErrNegativeMaxDowntime
 	}

--- a/internal/stores/hostdb.go
+++ b/internal/stores/hostdb.go
@@ -893,6 +893,13 @@ func (ss *SQLStore) ProcessConsensusChange(cc modules.ConsensusChange) {
 		}
 	}
 	ss.persistTimer = time.AfterFunc(10*time.Second, func() {
+		ss.mu.Lock()
+		if ss.closed {
+			ss.mu.Unlock()
+			return
+		}
+		ss.mu.Unlock()
+
 		ss.persistMu.Lock()
 		defer ss.persistMu.Unlock()
 		if err := ss.applyUpdates(true); err != nil {

--- a/internal/stores/sql.go
+++ b/internal/stores/sql.go
@@ -43,6 +43,7 @@ type (
 		mu           sync.Mutex
 		hasAllowlist bool
 		hasBlocklist bool
+		closed       bool
 
 		knownContracts map[types.FileContractID]struct{}
 	}
@@ -267,7 +268,16 @@ func (s *SQLStore) Close() error {
 	if err != nil {
 		return err
 	}
-	return db.Close()
+
+	err = db.Close()
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.closed = true
+	s.mu.Unlock()
+	return nil
 }
 
 func (s *SQLStore) retryTransaction(fc func(tx *gorm.DB) error, opts ...*sql.TxOptions) error {

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -140,9 +140,13 @@ func newTestCluster(dir string, logger *zap.Logger) (*TestCluster, error) {
 // newTestClusterWithFunding creates a new cluster without hosts that is funded
 // by mining multiple blocks if 'funding' is set.
 func newTestClusterWithFunding(dir, dbName string, funding bool, wk types.PrivateKey, logger *zap.Logger) (*TestCluster, error) {
+	return newTestClusterCustom(dir, dbName, funding, wk, testBusCfg(), testWorkerCfg(), testApCfg(), logger)
+}
+
+// newTestClusterCustom creates a customisable cluster.
+func newTestClusterCustom(dir, dbName string, funding bool, wk types.PrivateKey, busCfg node.BusConfig, workerCfg node.WorkerConfig, apCfg node.AutopilotConfig, logger *zap.Logger) (*TestCluster, error) {
 	// Check if we are testing against an external database. If so, we create a
 	// database with a random name first.
-	var dialector gorm.Dialector
 	uri, user, password, _ := stores.DBConfigFromEnv()
 	if uri != "" {
 		tmpDB, err := gorm.Open(stores.NewMySQLConnection(user, password, uri, ""))
@@ -155,7 +159,7 @@ func newTestClusterWithFunding(dir, dbName string, funding bool, wk types.Privat
 		if err := tmpDB.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s;", dbName)).Error; err != nil {
 			return nil, err
 		}
-		dialector = stores.NewMySQLConnection(user, password, uri, dbName)
+		busCfg.DBDialector = stores.NewMySQLConnection(user, password, uri, dbName)
 	}
 
 	// Prepare individual dirs.
@@ -189,18 +193,11 @@ func newTestClusterWithFunding(dir, dbName string, funding bool, wk types.Privat
 	workerClient := worker.NewClient(workerAddr, workerPassword)
 
 	// Create miner.
-	miner := node.NewMiner(busClient)
+	busCfg.Miner = node.NewMiner(busClient)
 
 	// Create bus.
 	var shutdownFns []func(context.Context) error
-	b, bStopFn, err := node.NewBus(node.BusConfig{
-		DBDialector:     dialector,
-		Bootstrap:       false,
-		GatewayAddr:     "127.0.0.1:0",
-		Miner:           miner,
-		Network:         testNetwork(),
-		PersistInterval: testPersistInterval,
-	}, busDir, wk, logger)
+	b, bStopFn, err := node.NewBus(busCfg, busDir, wk, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -212,12 +209,7 @@ func newTestClusterWithFunding(dir, dbName string, funding bool, wk types.Privat
 	shutdownFns = append(shutdownFns, busServer.Shutdown)
 
 	// Create worker.
-	w, wStopFn, err := node.NewWorker(node.WorkerConfig{
-		ID:                      "worker",
-		BusFlushInterval:        testBusFlushInterval,
-		SessionReconnectTimeout: 10 * time.Second,
-		SessionTTL:              2 * time.Minute,
-	}, busClient, wk, logger)
+	w, wStopFn, err := node.NewWorker(workerCfg, busClient, wk, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -241,15 +233,7 @@ func newTestClusterWithFunding(dir, dbName string, funding bool, wk types.Privat
 	}
 
 	// Create autopilot.
-	ap, aStartFn, aStopFn, err := node.NewAutopilot(node.AutopilotConfig{
-		AccountsRefillInterval:   time.Second,
-		Heartbeat:                time.Second,
-		MigrationHealthCutoff:    0.99,
-		ScannerInterval:          time.Second,
-		ScannerBatchSize:         10,
-		ScannerNumThreads:        1,
-		ScannerMinRecentFailures: 5,
-	}, autopilotStore, busClient, []autopilot.Worker{workerClient}, logger)
+	ap, aStartFn, aStopFn, err := node.NewAutopilot(apCfg, autopilotStore, busClient, []autopilot.Worker{workerClient}, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +248,7 @@ func newTestClusterWithFunding(dir, dbName string, funding bool, wk types.Privat
 		dir:    dir,
 		dbName: dbName,
 		logger: logger,
-		miner:  miner,
+		miner:  busCfg.Miner,
 		wk:     wk,
 
 		Autopilot: autopilotClient,
@@ -705,4 +689,34 @@ func testNetwork() *consensus.Network {
 	n.HardforkFoundation.FailsafeAddress = types.GeneratePrivateKey().PublicKey().StandardAddress()
 
 	return n
+}
+
+func testBusCfg() node.BusConfig {
+	return node.BusConfig{
+		Bootstrap:       false,
+		GatewayAddr:     "127.0.0.1:0",
+		Network:         testNetwork(),
+		PersistInterval: testPersistInterval,
+	}
+}
+
+func testWorkerCfg() node.WorkerConfig {
+	return node.WorkerConfig{
+		ID:                      "worker",
+		BusFlushInterval:        testBusFlushInterval,
+		SessionReconnectTimeout: 10 * time.Second,
+		SessionTTL:              2 * time.Minute,
+	}
+}
+
+func testApCfg() node.AutopilotConfig {
+	return node.AutopilotConfig{
+		AccountsRefillInterval:   time.Second,
+		Heartbeat:                time.Second,
+		MigrationHealthCutoff:    0.99,
+		ScannerInterval:          time.Second,
+		ScannerBatchSize:         10,
+		ScannerNumThreads:        1,
+		ScannerMinRecentFailures: 5,
+	}
 }

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -9,7 +9,6 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/hostdb"
-	"go.uber.org/zap/zapcore"
 )
 
 func TestHostPruning(t *testing.T) {
@@ -20,7 +19,7 @@ func TestHostPruning(t *testing.T) {
 	ctx := context.Background()
 
 	// create a new test cluster
-	cluster, err := newTestCluster(t.TempDir(), newTestLoggerCustom(zapcore.DebugLevel))
+	cluster, err := newTestCluster(t.TempDir(), newTestLogger())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -135,11 +135,14 @@ func TestHostPruning(t *testing.T) {
 		t.Fatalf("host was not pruned, %+v", hostss[0].Interactions)
 	}
 
-	// try update the autopilot config with a value that would overflow the
-	// MaxDowntimeHours duration
+	// assert validation on MaxDowntimeHours
 	cfg := testAutopilotConfig
-	cfg.Hosts.MaxDowntimeHours = 9999999999
+	cfg.Hosts.MaxDowntimeHours = 99*365*24 + 1 // exceed by one
 	if err = a.SetConfig(cfg); errors.Is(err, api.ErrMaxDowntimeHoursTooHigh) {
+		t.Fatal(err)
+	}
+	cfg.Hosts.MaxDowntimeHours = 99 * 365 * 24 // allowed max
+	if err = a.SetConfig(cfg); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
I added validation to the autopilot config. For the time being I've only added a check for `MaxDowntimeHours`. I wanted to "quickly disable" host pruning on my node and updated the `MaxDowntimeHours` setting to 9999999999. It turns out this overflows the duration and essentially disables the prune condition on `recent_downtime`