### PR TITLE
Archived Contracts Missing Host

### DIFF
--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -1007,6 +1007,7 @@ func contracts(tx *gorm.DB, ids []types.FileContractID) (dbContracts []dbContrac
 	err = tx.
 		Model(&dbContract{}).
 		Where("fcid IN (?)", fcids).
+		Preload("Host").
 		Find(&dbContracts).
 		Error
 	return

--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -1070,6 +1070,11 @@ func addContract(tx *gorm.DB, c rhpv2.ContractRevision, totalCost types.Currency
 // NOTE: this function archives the contracts without setting a renewed ID
 func archiveContracts(tx *gorm.DB, contracts []dbContract, toArchive map[types.FileContractID]string) error {
 	for _, contract := range contracts {
+		// sanity check the host is populated
+		if contract.Host.ID == 0 {
+			return fmt.Errorf("host not populated for contract %v", contract.FCID)
+		}
+
 		// create a copy in the archive
 		if err := tx.Create(&dbArchivedContract{
 			Host:   publicKey(contract.Host.PublicKey),


### PR DESCRIPTION
I noticed some of my archived contracts didn't have their host key field populated. That's not a big deal but it's probably best to make sure it's set correctly, it makes it easier to revert archiving a contract should that ever be necessary and it's just inconsistent so I updated it.