### PR TITLE
Autopilot Minor Fixes

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -642,7 +642,7 @@ func (c *contractor) runContractFormations(ctx context.Context, w Worker, hosts 
 		// fetch price table on the fly
 		host.PriceTable, err = c.priceTable(ctx, w, host)
 		if err != nil {
-			c.logger.Errorf("failed to fetch price table for candidate host %v: %v", host, err)
+			c.logger.Errorf("failed to fetch price table for candidate host %v: %v", host.PublicKey, err)
 			continue
 		}
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -202,12 +202,12 @@ func isUsableHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.
 		gougingBreakdown = gc.Check(&h.Settings, &h.PriceTable.HostPriceTable)
 		if gougingBreakdown.Gouging() {
 			errs = append(errs, fmt.Errorf("%w: %v", errHostPriceGouging, gougingBreakdown.Reasons()))
-		}
-
-		// perform scoring checks
-		scoreBreakdown = hostScore(cfg, h, storedData, rs.Redundancy(), gougingBreakdown.Gouging())
-		if scoreBreakdown.Score() < minScore {
-			errs = append(errs, fmt.Errorf("%w: %v < %v", errLowScore, scoreBreakdown.Score(), minScore))
+		} else {
+			// perform scoring checks
+			scoreBreakdown = hostScore(cfg, h, storedData, rs.Redundancy(), gougingBreakdown.Gouging())
+			if scoreBreakdown.Score() < minScore {
+				errs = append(errs, fmt.Errorf("%w: %v < %v", errLowScore, scoreBreakdown.Score(), minScore))
+			}
 		}
 	}
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -204,7 +204,12 @@ func isUsableHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.
 			errs = append(errs, fmt.Errorf("%w: %v", errHostPriceGouging, gougingBreakdown.Reasons()))
 		} else {
 			// perform scoring checks
-			scoreBreakdown = hostScore(cfg, h, storedData, rs.Redundancy(), gougingBreakdown.Gouging())
+			//
+			// NOTE: only perform these scoring checks if we know the host is
+			// not gouging, this because the core package does not have overflow
+			// checks in its cost calculations needed to calculate the period
+			// cost
+			scoreBreakdown = hostScore(cfg, h, storedData, rs.Redundancy())
 			if scoreBreakdown.Score() < minScore {
 				errs = append(errs, fmt.Errorf("%w: %v < %v", errLowScore, scoreBreakdown.Score(), minScore))
 			}

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -13,25 +13,17 @@ import (
 	"lukechampine.com/frand"
 )
 
-func hostScore(cfg api.AutopilotConfig, h hostdb.Host, storedData uint64, expectedRedundancy float64, gouging bool) api.HostScoreBreakdown {
-	breakdown := api.HostScoreBreakdown{
+func hostScore(cfg api.AutopilotConfig, h hostdb.Host, storedData uint64, expectedRedundancy float64) api.HostScoreBreakdown {
+	hostPeriodCost := hostPeriodCostForScore(h, cfg, expectedRedundancy)
+	return api.HostScoreBreakdown{
 		Age:              ageScore(h),
+		Collateral:       collateralScore(cfg, hostPeriodCost, h.Settings, expectedRedundancy),
 		Interactions:     interactionScore(h),
+		Prices:           priceAdjustmentScore(hostPeriodCost, cfg),
 		StorageRemaining: storageRemainingScore(cfg, h.Settings, storedData, expectedRedundancy),
 		Uptime:           uptimeScore(h),
 		Version:          versionScore(h.Settings),
 	}
-
-	// NOTE: if we know the host is gouging, we have to avoid calculating the
-	// period cost to calculate the collateral and price score as the core
-	// package does not have overflow checks in its cost calculations
-	if !gouging {
-		hostPeriodCost := hostPeriodCostForScore(h, cfg, expectedRedundancy)
-		breakdown.Collateral = collateralScore(cfg, hostPeriodCost, h.Settings, expectedRedundancy)
-		breakdown.Prices = priceAdjustmentScore(hostPeriodCost, cfg)
-	}
-
-	return breakdown
 }
 
 // priceAdjustmentScore computes a score between 0 and 1 for a host giving its

--- a/autopilot/hostscore_test.go
+++ b/autopilot/hostscore_test.go
@@ -24,13 +24,13 @@ func TestHostScore(t *testing.T) {
 
 	// assert both hosts score equal
 	redundancy := 3.0
-	if hostScore(cfg, h1, 0, redundancy, false) != hostScore(cfg, h2, 0, redundancy, false) {
+	if hostScore(cfg, h1, 0, redundancy) != hostScore(cfg, h2, 0, redundancy) {
 		t.Fatal("unexpected")
 	}
 
 	// assert age affects the score
 	h1.KnownSince = time.Now().Add(-1 * day)
-	if hostScore(cfg, h1, 0, redundancy, false).Score() <= hostScore(cfg, h2, 0, redundancy, false).Score() {
+	if hostScore(cfg, h1, 0, redundancy).Score() <= hostScore(cfg, h2, 0, redundancy).Score() {
 		t.Fatal("unexpected")
 	}
 
@@ -39,21 +39,21 @@ func TestHostScore(t *testing.T) {
 	settings.Collateral = settings.Collateral.Div64(2)
 	settings.MaxCollateral = settings.MaxCollateral.Div64(2)
 	h1 = newHost(settings) // reset
-	if hostScore(cfg, h1, 0, redundancy, false).Score() <= hostScore(cfg, h2, 0, redundancy, false).Score() {
+	if hostScore(cfg, h1, 0, redundancy).Score() <= hostScore(cfg, h2, 0, redundancy).Score() {
 		t.Fatal("unexpected")
 	}
 
 	// assert interactions affect the score
 	h1 = newHost(newTestHostSettings()) // reset
 	h1.Interactions.SuccessfulInteractions++
-	if hostScore(cfg, h1, 0, redundancy, false).Score() <= hostScore(cfg, h2, 0, redundancy, false).Score() {
+	if hostScore(cfg, h1, 0, redundancy).Score() <= hostScore(cfg, h2, 0, redundancy).Score() {
 		t.Fatal("unexpected")
 	}
 
 	// assert uptime affects the score
 	h2 = newHost(newTestHostSettings()) // reset
 	h2.Interactions.SecondToLastScanSuccess = false
-	if hostScore(cfg, h1, 0, redundancy, false).Score() <= hostScore(cfg, h2, 0, redundancy, false).Score() || ageScore(h1) != ageScore(h2) {
+	if hostScore(cfg, h1, 0, redundancy).Score() <= hostScore(cfg, h2, 0, redundancy).Score() || ageScore(h1) != ageScore(h2) {
 		t.Fatal("unexpected")
 	}
 
@@ -61,36 +61,28 @@ func TestHostScore(t *testing.T) {
 	h2Settings := newTestHostSettings()
 	h2Settings.Version = "1.5.6" // lower
 	h2 = newHost(h2Settings)     // reset
-	if hostScore(cfg, h1, 0, redundancy, false).Score() <= hostScore(cfg, h2, 0, redundancy, false).Score() {
+	if hostScore(cfg, h1, 0, redundancy).Score() <= hostScore(cfg, h2, 0, redundancy).Score() {
 		t.Fatal("unexpected")
 	}
 
 	// asseret remaining storage affects the score.
 	h1 = newHost(newTestHostSettings()) // reset
 	h2.Settings.RemainingStorage = 100
-	if hostScore(cfg, h1, 0, redundancy, false).Score() <= hostScore(cfg, h2, 0, redundancy, false).Score() {
+	if hostScore(cfg, h1, 0, redundancy).Score() <= hostScore(cfg, h2, 0, redundancy).Score() {
 		t.Fatal("unexpected")
 	}
 
 	// assert MaxCollateral affects the score.
 	h2 = newHost(newTestHostSettings()) // reset
 	h2.Settings.MaxCollateral = types.ZeroCurrency
-	if hostScore(cfg, h1, 0, redundancy, false).Score() <= hostScore(cfg, h2, 0, redundancy, false).Score() {
+	if hostScore(cfg, h1, 0, redundancy).Score() <= hostScore(cfg, h2, 0, redundancy).Score() {
 		t.Fatal("unexpected")
 	}
 
 	// assert price affects the score.
 	h2 = newHost(newTestHostSettings()) // reset
 	h2.PriceTable.WriteBaseCost = types.Siacoins(1)
-	if hostScore(cfg, h1, 0, redundancy, false).Score() <= hostScore(cfg, h2, 0, redundancy, false).Score() {
-		t.Fatal("unexpected")
-	}
-
-	// assert gouging prevents checking collateral and price scores
-	if hostScore(cfg, h1, 0, redundancy, false).Collateral == 0 || hostScore(cfg, h1, 0, redundancy, true).Collateral != 0 {
-		t.Fatal("unexpected")
-	}
-	if hostScore(cfg, h1, 0, redundancy, false).Prices == 0 || hostScore(cfg, h1, 0, redundancy, true).Prices != 0 {
+	if hostScore(cfg, h1, 0, redundancy).Score() <= hostScore(cfg, h2, 0, redundancy).Score() {
 		t.Fatal("unexpected")
 	}
 }


### PR DESCRIPTION
This PR fixes a log line and prevents the host from being scored if we find it is gouging. There's really no need to score a host if we know it is gouging because we a) can't even perform all checks and b) its score will always be 0 anyway. 