### PR TITLE
Limit download overdrive

### DIFF
--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -179,6 +179,7 @@ func main() {
 	flag.DurationVar(&workerCfg.SessionTTL, "worker.sessionTTL", 2*time.Minute, "the time a host session is valid for before reconnecting")
 	flag.DurationVar(&workerCfg.DownloadSectorTimeout, "worker.downloadSectorTimeout", 3*time.Second, "timeout applied to sector downloads when downloading a slab")
 	flag.DurationVar(&workerCfg.UploadSectorTimeout, "worker.uploadSectorTimeout", 5*time.Second, "timeout applied to sector uploads when uploading a slab")
+	flag.IntVar(&workerCfg.DownloadMaxOverdrive, "worker.downloadMaxOverdrive", 5, "maximum number of active overdrive workers when downloading a slab")
 	flag.IntVar(&workerCfg.UploadMaxOverdrive, "worker.uploadMaxOverdrive", 5, "maximum number of active overdrive workers when uploading a slab")
 	flag.DurationVar(&autopilotCfg.AccountsRefillInterval, "autopilot.accountRefillInterval", defaultAccountRefillInterval, "interval at which the autopilot checks the workers' accounts balance and refills them if necessary")
 	flag.BoolVar(&autopilotCfg.enabled, "autopilot.enabled", true, "enable/disable the autopilot - can be overwritten using the RENTERD_AUTOPILOT_ENABLED environment variable")

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -38,6 +38,7 @@ type WorkerConfig struct {
 	SessionTTL              time.Duration
 	DownloadSectorTimeout   time.Duration
 	UploadSectorTimeout     time.Duration
+	DownloadMaxOverdrive    int
 	UploadMaxOverdrive      int
 }
 
@@ -282,7 +283,7 @@ func NewBus(cfg BusConfig, dir string, seed types.PrivateKey, l *zap.Logger) (ht
 
 func NewWorker(cfg WorkerConfig, b worker.Bus, seed types.PrivateKey, l *zap.Logger) (http.Handler, ShutdownFn, error) {
 	workerKey := blake2b.Sum256(append([]byte("worker"), seed...))
-	w := worker.New(workerKey, cfg.ID, b, cfg.SessionLockTimeout, cfg.SessionReconnectTimeout, cfg.SessionTTL, cfg.BusFlushInterval, cfg.DownloadSectorTimeout, cfg.UploadSectorTimeout, cfg.UploadMaxOverdrive, l)
+	w := worker.New(workerKey, cfg.ID, b, cfg.SessionLockTimeout, cfg.SessionReconnectTimeout, cfg.SessionTTL, cfg.BusFlushInterval, cfg.DownloadSectorTimeout, cfg.UploadSectorTimeout, cfg.DownloadMaxOverdrive, cfg.UploadMaxOverdrive, l)
 	return w.Handler(), w.Shutdown, nil
 }
 

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -398,7 +398,6 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 					continue // host was already used
 				}
 				shardInfos[shardIndex].usedHosts[contracts[hostIndex].HostKey] = struct{}{}
-				inflight++
 				shardInfos[shardIndex].inflight++
 				return hostIndex, shardIndex
 			}
@@ -426,6 +425,7 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 		if !launchWorker() {
 			panic("should be able to launch minShards workers")
 		}
+		inflight++
 	}
 
 	// collect responses
@@ -473,6 +473,7 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 			if !launchWorker() {
 				break
 			}
+			inflight++
 		}
 	}
 	if rem > 0 {

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -279,7 +279,7 @@ func uploadSlab(ctx context.Context, sp storeProvider, r io.Reader, m, n uint8, 
 	return s, length, slowHosts, nil
 }
 
-func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, logger *zap.SugaredLogger) ([][]byte, []int64, error) {
+func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, maxOverdrive int, logger *zap.SugaredLogger) ([][]byte, []int64, error) {
 	// prepopulate the timings with a value for all hosts to ensure unused hosts aren't necessarily favoured in consecutive downloads
 	timings := make([]int64, len(contracts))
 	for i := 0; i < len(contracts); i++ {
@@ -370,58 +370,69 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 	}
 
 	// track which hosts have tried a shard already.
-	shardsUsedHosts := make([]map[types.PublicKey]struct{}, len(ss.Shards))
+	type shardInfo struct {
+		usedHosts map[types.PublicKey]struct{}
+		inflight  int
+		done      bool
+	}
+	shardInfos := make([]shardInfo, len(ss.Shards))
 	for i := range ss.Shards {
-		shardsUsedHosts[i] = make(map[types.PublicKey]struct{})
+		shardInfos[i].usedHosts = make(map[types.PublicKey]struct{})
 	}
 
 	// helper to find worker for a shard.
 	inflight := 0
-	workerForShard := func(shardIndex int) int {
-		for hostIndex := range contracts {
-			if ss.Shards[shardIndex].Host != contracts[hostIndex].HostKey {
-				continue // host is not useful
+	workerForSlab := func() (int, int) {
+		for shardIndex := range ss.Shards {
+			if shardInfos[shardIndex].done {
+				continue // shard is done already
 			}
-			if _, used := shardsUsedHosts[shardIndex][contracts[hostIndex].HostKey]; used {
-				continue // host was already used
+			if shardInfos[shardIndex].inflight > 0 {
+				continue // only have 1 worker running per shard
 			}
-			shardsUsedHosts[shardIndex][contracts[hostIndex].HostKey] = struct{}{}
-			inflight++
-			return hostIndex
+			for hostIndex := range contracts {
+				if ss.Shards[shardIndex].Host != contracts[hostIndex].HostKey {
+					continue // host is not useful
+				}
+				if _, used := shardInfos[shardIndex].usedHosts[contracts[hostIndex].HostKey]; used {
+					continue // host was already used
+				}
+				shardInfos[shardIndex].usedHosts[contracts[hostIndex].HostKey] = struct{}{}
+				inflight++
+				shardInfos[shardIndex].inflight++
+				return hostIndex, shardIndex
+			}
 		}
-		return -1
+		return -1, -1
 	}
 
 	// helper to launch worker.
 	offset, length := ss.SectorRegion()
-	launchWorker := func(r req) {
-		hostIndex := workerForShard(r.shardIndex)
+	launchWorker := func() bool {
+		hostIndex, shardIndex := workerForSlab()
 		if hostIndex == -1 {
-			return
+			return false
 		}
 		go worker(hostIndex, req{
 			offset:     offset,
 			length:     length,
-			shardIndex: r.shardIndex,
-		})
-	}
-
-	// spawn workers
-	for shardIndex := range ss.Shards {
-		launchWorker(req{
-			offset:     offset,
-			length:     length,
 			shardIndex: shardIndex,
 		})
+		return true
 	}
-	if uint8(inflight) < ss.MinShards {
-		panic("not enough workers launched")
+
+	// spawn workers for the minimum number of shards
+	for i := 0; i < int(ss.MinShards); i++ {
+		if !launchWorker() {
+			panic("should be able to launch minShards workers")
+		}
 	}
 
 	// collect responses
 	var errs HostErrorSet
 	shards := make([][]byte, len(ss.Shards))
 	rem := ss.MinShards
+	var overdrive int
 	for inflight > 0 {
 		resp := <-respChan
 
@@ -442,12 +453,9 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 			// make sure slow hosts are not not used for consecutive downloads
 			if errors.Is(resp.err, errDownloadSectorTimeout) {
 				timings[resp.hostIndex] = int64(resp.dur) * 10
-			}
-
-			// try next host
-			hostIndex := workerForShard(resp.req.shardIndex)
-			if hostIndex != -1 {
-				launchWorker(resp.req)
+				if overdrive < maxOverdrive {
+					overdrive++ // add more overdrive
+				}
 			}
 		} else {
 			timings[resp.hostIndex] = int64(resp.dur)
@@ -457,6 +465,13 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 				if rem == 0 {
 					break
 				}
+			}
+		}
+
+		// launch more hosts if necessary
+		for inflight < int(ss.MinShards)+overdrive {
+			if !launchWorker() {
+				break
 			}
 		}
 	}
@@ -470,11 +485,11 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 	return shards, timings, nil
 }
 
-func downloadSlab(ctx context.Context, sp storeProvider, out io.Writer, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, logger *zap.SugaredLogger) ([]int64, error) {
+func downloadSlab(ctx context.Context, sp storeProvider, out io.Writer, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, maxOverdrive int, logger *zap.SugaredLogger) ([]int64, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "parallelDownloadSlab")
 	defer span.End()
 
-	shards, timings, err := parallelDownloadSlab(ctx, sp, ss, contracts, downloadSectorTimeout, logger)
+	shards, timings, err := parallelDownloadSlab(ctx, sp, ss, contracts, downloadSectorTimeout, maxOverdrive, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -598,7 +613,7 @@ func migrateSlab(ctx context.Context, sp storeProvider, s *object.Slab, contract
 		Offset: 0,
 		Length: uint32(s.MinShards) * rhpv2.SectorSize,
 	}
-	shards, _, err := parallelDownloadSlab(ctx, sp, ss, contracts, downloadSectorTimeout, logger)
+	shards, _, err := parallelDownloadSlab(ctx, sp, ss, contracts, downloadSectorTimeout, 0, logger) // no overdrive for downloads
 	if err != nil {
 		return fmt.Errorf("failed to download slab for migration: %w", err)
 	}

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -181,7 +181,7 @@ func TestMultipleObjects(t *testing.T) {
 		dst := o.Key.Decrypt(&buf, int64(offset))
 		ss := slabsForDownload(o.Slabs, int64(offset), int64(length))
 		for _, s := range ss {
-			if _, err := downloadSlab(context.Background(), sp, dst, s, contracts, 0, zap.NewNop().Sugar()); err != nil {
+			if _, err := downloadSlab(context.Background(), sp, dst, s, contracts, 0, 0, zap.NewNop().Sugar()); err != nil {
 				t.Error(err)
 				return
 			}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -287,6 +287,7 @@ type worker struct {
 
 	downloadSectorTimeout time.Duration
 	uploadSectorTimeout   time.Duration
+	downloadMaxOverdrive  int
 	uploadMaxOverdrive    int
 
 	logger *zap.SugaredLogger
@@ -1032,7 +1033,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 			return performance[contracts[i].HostKey] < performance[contracts[j].HostKey]
 		})
 
-		timings, err := downloadSlab(ctx, w, cw, ss, contracts, w.downloadSectorTimeout, w.logger)
+		timings, err := downloadSlab(ctx, w, cw, ss, contracts, w.downloadSectorTimeout, w.downloadMaxOverdrive, w.logger)
 
 		// update historic host performance
 		//
@@ -1226,7 +1227,7 @@ func (w *worker) accountHandlerGET(jc jape.Context) {
 }
 
 // New returns an HTTP handler that serves the worker API.
-func New(masterKey [32]byte, id string, b Bus, sessionLockTimeout, sessionReconectTimeout, sessionTTL, busFlushInterval, downloadSectorTimeout, uploadSectorTimeout time.Duration, maxUploadOverdrive int, l *zap.Logger) *worker {
+func New(masterKey [32]byte, id string, b Bus, sessionLockTimeout, sessionReconectTimeout, sessionTTL, busFlushInterval, downloadSectorTimeout, uploadSectorTimeout time.Duration, maxDownloadOverdrive, maxUploadOverdrive int, l *zap.Logger) *worker {
 	w := &worker{
 		id:                    id,
 		bus:                   b,
@@ -1235,6 +1236,7 @@ func New(masterKey [32]byte, id string, b Bus, sessionLockTimeout, sessionRecone
 		busFlushInterval:      busFlushInterval,
 		downloadSectorTimeout: downloadSectorTimeout,
 		uploadSectorTimeout:   uploadSectorTimeout,
+		downloadMaxOverdrive:  maxDownloadOverdrive,
 		uploadMaxOverdrive:    maxUploadOverdrive,
 		logger:                l.Sugar().Named("worker").Named(id),
 	}


### PR DESCRIPTION
This refactors the download code to match the upload code in regards to limiting the ongoing overdrive during a download.

The overdrive starts at 0 and as slow responses come in increases to 5. 

NOTE: before this PR the download code would just launch 1 worker per shard right away. 