### PR TITLE
Add support for UTF-8 object paths

### DIFF
--- a/internal/stores/metadata.go
+++ b/internal/stores/metadata.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"unicode/utf8"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
@@ -579,7 +580,7 @@ func (s *SQLStore) ObjectEntries(ctx context.Context, path, prefix string, offse
 		) AS i
 	) AS m
 	GROUP BY name
-	LIMIT ? OFFSET ?`, concat("?", "trimmed"), concat("?", "substr(trimmed, 1, slashindex)")), path, path, "/", len(path)+1, path+"%", limit, offset)
+	LIMIT ? OFFSET ?`, concat("?", "trimmed"), concat("?", "substr(trimmed, 1, slashindex)")), path, path, "/", utf8.RuneCountInString(path)+1, path+"%", limit, offset)
 
 	// apply prefix
 	if prefix != "" {

--- a/internal/stores/metadata_test.go
+++ b/internal/stores/metadata_test.go
@@ -996,6 +996,7 @@ func TestObjectEntries(t *testing.T) {
 		{"/foo/baz/quux", 3},
 		{"/foo/baz/quuz", 4},
 		{"/gab/guub", 5},
+		{"/fileś/śpecial", 6}, // utf8
 	}
 	ctx := context.Background()
 	for _, o := range objects {
@@ -1009,12 +1010,13 @@ func TestObjectEntries(t *testing.T) {
 		prefix string
 		want   []api.ObjectMetadata
 	}{
-		{"/", "", []api.ObjectMetadata{{Name: "/foo/", Size: 10}, {Name: "/gab/", Size: 5}}},
+		{"/", "", []api.ObjectMetadata{{Name: "/fileś/", Size: 6}, {Name: "/foo/", Size: 10}, {Name: "/gab/", Size: 5}}},
 		{"/foo/", "", []api.ObjectMetadata{{Name: "/foo/bar", Size: 1}, {Name: "/foo/bat", Size: 2}, {Name: "/foo/baz/", Size: 7}}},
 		{"/foo/baz/", "", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3}, {Name: "/foo/baz/quuz", Size: 4}}},
 		{"/gab/", "", []api.ObjectMetadata{{Name: "/gab/guub", Size: 5}}},
+		{"/fileś/", "", []api.ObjectMetadata{{Name: "/fileś/śpecial", Size: 6}}},
 
-		{"/", "f", []api.ObjectMetadata{{Name: "/foo/", Size: 10}}},
+		{"/", "f", []api.ObjectMetadata{{Name: "/fileś/", Size: 6}, {Name: "/foo/", Size: 10}}},
 		{"/foo/", "fo", []api.ObjectMetadata{}},
 		{"/foo/baz/", "quux", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3}}},
 		{"/gab/", "/guub", []api.ObjectMetadata{}},

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -275,10 +275,10 @@ func TestUploadDownloadBasic(t *testing.T) {
 	file2 := make([]byte, rhpv2.SectorSize/12)
 	frand.Read(file1)
 	frand.Read(file2)
-	if err := w.UploadObject(context.Background(), bytes.NewReader(file1), "foo/file1"); err != nil {
+	if err := w.UploadObject(context.Background(), bytes.NewReader(file1), "fileś/file1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.UploadObject(context.Background(), bytes.NewReader(file2), "foo/file2"); err != nil {
+	if err := w.UploadObject(context.Background(), bytes.NewReader(file2), "fileś/file2"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -292,7 +292,7 @@ func TestUploadDownloadBasic(t *testing.T) {
 	}
 
 	// fetch entries with "file" prefix
-	_, entries, err = cluster.Bus.Object(context.Background(), "foo/", "file", 0, -1)
+	_, entries, err = cluster.Bus.Object(context.Background(), "fileś/", "file", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,8 +300,8 @@ func TestUploadDownloadBasic(t *testing.T) {
 		t.Fatal("expected two entry to be returned", len(entries))
 	}
 
-	// fetch entries with "foo" prefix
-	_, entries, err = cluster.Bus.Object(context.Background(), "foo/", "foo", 0, -1)
+	// fetch entries with "fileś" prefix
+	_, entries, err = cluster.Bus.Object(context.Background(), "fileś/", "foo", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes a query that failed for UTF-8 characters within the path name of an object.

Related to https://github.com/SiaFoundation/renterd/issues/308 but the UI probably also needs an update. I can manually create objects through the API that contain special characters and show up in the UI, but I can't create such dirs or files through the UI @alexfreska 