### PR TITLE
Improve contract locking

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -107,6 +107,11 @@ type ContractAcquireRequest struct {
 	Priority int           `json:"priority"`
 }
 
+type ContractKeepaliveRequest struct {
+	Duration ParamDuration `json:"duration"`
+	LockID   uint64        `json:"lockID"`
+}
+
 // ContractAcquireRequest is the request type for the /contract/:id/release
 // endpoint.
 type ContractReleaseRequest struct {

--- a/bus/client.go
+++ b/bus/client.go
@@ -395,6 +395,15 @@ func (c *Client) AcquireContract(ctx context.Context, fcid types.FileContractID,
 	return
 }
 
+// ContractLockKeepalive extends the duration on an already acquired lock.
+func (c *Client) ContractLockKeepalive(ctx context.Context, fcid types.FileContractID, lockID uint64, d time.Duration) (err error) {
+	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/contract/%s/keepalive", fcid), api.ContractKeepaliveRequest{
+		Duration: api.ParamDuration(d),
+		LockID:   lockID,
+	}, nil)
+	return
+}
+
 // ReleaseContract releases a contract that was previously acquired using AcquireContract.
 func (c *Client) ReleaseContract(ctx context.Context, fcid types.FileContractID, lockID uint64) (err error) {
 	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/contract/%s/release", fcid), api.ContractReleaseRequest{

--- a/bus/client.go
+++ b/bus/client.go
@@ -395,8 +395,9 @@ func (c *Client) AcquireContract(ctx context.Context, fcid types.FileContractID,
 	return
 }
 
-// ContractLockKeepalive extends the duration on an already acquired lock.
-func (c *Client) ContractLockKeepalive(ctx context.Context, fcid types.FileContractID, lockID uint64, d time.Duration) (err error) {
+// KeepaliveContract extends the duration on an already acquired lock on a
+// contract.
+func (c *Client) KeepaliveContract(ctx context.Context, fcid types.FileContractID, lockID uint64, d time.Duration) (err error) {
 	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/contract/%s/keepalive", fcid), api.ContractKeepaliveRequest{
 		Duration: api.ParamDuration(d),
 		LockID:   lockID,

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -156,7 +156,7 @@ func main() {
 		apiPassword string
 		node.WorkerConfig
 	}
-	workerCfg.ContractLockingTimeout = 30 * time.Second
+	workerCfg.ContractLockTimeout = 30 * time.Second
 
 	var autopilotCfg struct {
 		enabled bool

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -156,6 +156,8 @@ func main() {
 		apiPassword string
 		node.WorkerConfig
 	}
+	workerCfg.ContractLockingTimeout = 30 * time.Second
+
 	var autopilotCfg struct {
 		enabled bool
 		node.AutopilotConfig

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -33,6 +33,7 @@ import (
 type WorkerConfig struct {
 	ID                      string
 	BusFlushInterval        time.Duration
+	ContractLockingTimeout  time.Duration
 	SessionLockTimeout      time.Duration
 	SessionReconnectTimeout time.Duration
 	SessionTTL              time.Duration
@@ -283,7 +284,7 @@ func NewBus(cfg BusConfig, dir string, seed types.PrivateKey, l *zap.Logger) (ht
 
 func NewWorker(cfg WorkerConfig, b worker.Bus, seed types.PrivateKey, l *zap.Logger) (http.Handler, ShutdownFn, error) {
 	workerKey := blake2b.Sum256(append([]byte("worker"), seed...))
-	w := worker.New(workerKey, cfg.ID, b, cfg.SessionLockTimeout, cfg.SessionReconnectTimeout, cfg.SessionTTL, cfg.BusFlushInterval, cfg.DownloadSectorTimeout, cfg.UploadSectorTimeout, cfg.DownloadMaxOverdrive, cfg.UploadMaxOverdrive, l)
+	w := worker.New(workerKey, cfg.ID, b, cfg.ContractLockingTimeout, cfg.SessionLockTimeout, cfg.SessionReconnectTimeout, cfg.SessionTTL, cfg.BusFlushInterval, cfg.DownloadSectorTimeout, cfg.UploadSectorTimeout, cfg.DownloadMaxOverdrive, cfg.UploadMaxOverdrive, l)
 	return w.Handler(), w.Shutdown, nil
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -33,7 +33,7 @@ import (
 type WorkerConfig struct {
 	ID                      string
 	BusFlushInterval        time.Duration
-	ContractLockingTimeout  time.Duration
+	ContractLockTimeout     time.Duration
 	SessionLockTimeout      time.Duration
 	SessionReconnectTimeout time.Duration
 	SessionTTL              time.Duration
@@ -284,7 +284,7 @@ func NewBus(cfg BusConfig, dir string, seed types.PrivateKey, l *zap.Logger) (ht
 
 func NewWorker(cfg WorkerConfig, b worker.Bus, seed types.PrivateKey, l *zap.Logger) (http.Handler, ShutdownFn, error) {
 	workerKey := blake2b.Sum256(append([]byte("worker"), seed...))
-	w := worker.New(workerKey, cfg.ID, b, cfg.ContractLockingTimeout, cfg.SessionLockTimeout, cfg.SessionReconnectTimeout, cfg.SessionTTL, cfg.BusFlushInterval, cfg.DownloadSectorTimeout, cfg.UploadSectorTimeout, cfg.DownloadMaxOverdrive, cfg.UploadMaxOverdrive, l)
+	w := worker.New(workerKey, cfg.ID, b, cfg.ContractLockTimeout, cfg.SessionLockTimeout, cfg.SessionReconnectTimeout, cfg.SessionTTL, cfg.BusFlushInterval, cfg.DownloadSectorTimeout, cfg.UploadSectorTimeout, cfg.DownloadMaxOverdrive, cfg.UploadMaxOverdrive, l)
 	return w.Handler(), w.Shutdown, nil
 }
 

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -702,6 +702,7 @@ func testBusCfg() node.BusConfig {
 
 func testWorkerCfg() node.WorkerConfig {
 	return node.WorkerConfig{
+		ContractLockingTimeout:  500 * time.Millisecond,
 		ID:                      "worker",
 		BusFlushInterval:        testBusFlushInterval,
 		SessionReconnectTimeout: 10 * time.Second,

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -702,7 +702,7 @@ func testBusCfg() node.BusConfig {
 
 func testWorkerCfg() node.WorkerConfig {
 	return node.WorkerConfig{
-		ContractLockingTimeout:  500 * time.Millisecond,
+		ContractLockTimeout:     500 * time.Millisecond,
 		ID:                      "worker",
 		BusFlushInterval:        testBusFlushInterval,
 		SessionReconnectTimeout: 10 * time.Second,

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -56,7 +56,7 @@ var (
 // FetchRevision fetches the latest revision of a contract and uses an account
 // as the primary payment method. If the account balance is insufficient, it
 // falls back to using the contract as a payment method.
-func (w *worker) FetchRevision(ctx context.Context, timeout time.Duration, contract api.ContractMetadata, bh uint64, lockPriority int, lockDuration time.Duration) (types.FileContractRevision, error) {
+func (w *worker) FetchRevision(ctx context.Context, timeout time.Duration, contract api.ContractMetadata, bh uint64, lockPriority int) (types.FileContractRevision, error) {
 	timeoutCtx := func() (context.Context, context.CancelFunc) {
 		if timeout > 0 {
 			return context.WithTimeout(ctx, timeout)
@@ -74,16 +74,10 @@ func (w *worker) FetchRevision(ctx context.Context, timeout time.Duration, contr
 		return rev, nil
 	}
 
-	// Adjust the lockDuration if FetchRevision is intended to time out before
-	// the full lock duration anyway.
-	if timeout != 0 && timeout < lockDuration {
-		lockDuration = timeout
-	}
-
 	// Fall back to using the contract to pay for the revision.
 	ctx, cancel = timeoutCtx()
 	defer cancel()
-	contractLock, err := w.AcquireContract(ctx, contract.ID, lockPriority, lockDuration)
+	contractLock, err := w.AcquireContract(ctx, contract.ID, lockPriority)
 	if err != nil {
 		return types.FileContractRevision{}, err
 	}

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -83,11 +83,11 @@ func (w *worker) FetchRevision(ctx context.Context, timeout time.Duration, contr
 	// Fall back to using the contract to pay for the revision.
 	ctx, cancel = timeoutCtx()
 	defer cancel()
-	lockID, err := w.AcquireContract(ctx, contract.ID, lockPriority, lockDuration)
+	contractLock, err := w.AcquireContract(ctx, contract.ID, lockPriority, lockDuration)
 	if err != nil {
 		return types.FileContractRevision{}, err
 	}
-	defer w.ReleaseContract(ctx, contract.ID, lockID)
+	defer contractLock.Release(ctx)
 	return w.FetchRevisionWithContract(ctx, contract.HostKey, contract.SiamuxAddr, contract.ID)
 }
 

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -78,7 +78,7 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 		go func(r req) {
 			defer close(doneChan)
 
-			lockID, err := locker.AcquireContract(ctx, contract.ID, lockingPriorityUpload, time.Minute)
+			contractLock, err := locker.AcquireContract(ctx, contract.ID, lockingPriorityUpload, time.Minute)
 			if err != nil {
 				respChan <- resp{hostIndex, r, types.Hash256{}, err}
 				span.SetStatus(codes.Error, "acquiring the contract failed")
@@ -100,8 +100,8 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 			}
 
 			// NOTE: we release before sending the response to ensure the context isn't cancelled
-			if err := locker.ReleaseContract(ctx, contract.ID, lockID); err != nil {
-				logger.Errorf("failed to release lock %v on contract %v, err: %v", lockID, contract.ID, err)
+			if err := contractLock.Release(ctx); err != nil {
+				logger.Errorf("failed to release lock %v on contract %v, err: %v", contractLock.lockID, contract.ID, err)
 			}
 			respChan <- res
 		}(r)

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -101,7 +101,7 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 
 			// NOTE: we release before sending the response to ensure the context isn't cancelled
 			if err := contractLock.Release(ctx); err != nil {
-				logger.Errorf("failed to release lock %v on contract %v, err: %v", contractLock.lockID, contract.ID, err)
+				logger.Errorf("failed to release lock on contract %v, err: %v", contract.ID, err)
 			}
 			respChan <- res
 		}(r)

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -78,7 +78,7 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 		go func(r req) {
 			defer close(doneChan)
 
-			contractLock, err := locker.AcquireContract(ctx, contract.ID, lockingPriorityUpload, time.Minute)
+			contractLock, err := locker.AcquireContract(ctx, contract.ID, lockingPriorityUpload)
 			if err != nil {
 				respChan <- resp{hostIndex, r, types.Hash256{}, err}
 				span.SetStatus(codes.Error, "acquiring the contract failed")

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"sync"
 	"testing"
-	"time"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
@@ -84,7 +83,7 @@ func (r *mockReleaser) Release(ctx context.Context) error {
 	return nil
 }
 
-func (l *mockContractLocker) AcquireContract(ctx context.Context, fcid types.FileContractID, priority int, d time.Duration) (lock contractReleaser, err error) {
+func (l *mockContractLocker) AcquireContract(ctx context.Context, fcid types.FileContractID, priority int) (lock contractReleaser, err error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.acquired++

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -83,6 +83,10 @@ func (l *noOpLocker) ReleaseContract(ctx context.Context, fcid types.FileContrac
 	return nil
 }
 
+func (l *noOpLocker) KeepaliveContract(ctx context.Context, _ types.FileContractID, _ uint64, _ time.Duration) error {
+	return nil
+}
+
 func (l *mockContractLocker) AcquireContract(ctx context.Context, fcid types.FileContractID, priority int, d time.Duration) (lock *contractLock, err error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -24,19 +24,19 @@ func (l *contextCheckingLocker) ReleaseContract(ctx context.Context, fcid types.
 	return nil
 }
 
-// TestReleaseContract is a test to verify that calling `ReleaseContract` on a
-// tracedContractLocker with an already cancelled context will not fail.
+// TestReleaseContract is a test to verify that calling `Release` on a
+// contractLock with an already cancelled context will not fail.
 func TestReleaseContract(t *testing.T) {
 	t.Parallel()
 
-	l := &tracedContractLocker{
-		l: &contextCheckingLocker{},
+	l := &contractLock{
+		locker: &contextCheckingLocker{},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if err := l.ReleaseContract(ctx, types.FileContractID{}, 0); err != nil {
+	if err := l.Release(ctx); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -15,6 +15,10 @@ func (l *contextCheckingLocker) AcquireContract(ctx context.Context, fcid types.
 	return 0, nil
 }
 
+func (l *contextCheckingLocker) KeepaliveContract(ctx context.Context, _ types.FileContractID, _ uint64, _ time.Duration) error {
+	return nil
+}
+
 func (l *contextCheckingLocker) ReleaseContract(ctx context.Context, fcid types.FileContractID, lockID uint64) (err error) {
 	select {
 	case <-ctx.Done():

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.sia.tech/core/types"
+	"go.uber.org/zap"
 )
 
 type contextCheckingLocker struct {
@@ -33,9 +34,7 @@ func (l *contextCheckingLocker) ReleaseContract(ctx context.Context, fcid types.
 func TestReleaseContract(t *testing.T) {
 	t.Parallel()
 
-	l := &contractLock{
-		locker: &contextCheckingLocker{},
-	}
+	l := newContractLock(context.Background(), types.FileContractID{}, 0, 0, &contextCheckingLocker{}, zap.NewNop().Sugar())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
Locking contracts is a bit fragile under a lot of load because there is no way to know how long the contract needs to be acquired for by a worker. If a host is very slow, the contract might be released before the worker is actually done using it.

To fix that, this PR adds a new endpoint that allows for extending the duration of an acquired lock. Locks will now be acquired for 30s by default and if the operation isn't done within half of that time, the duration is extended by another 15s. 