### PR TITLE
Unsynced Renterd

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -398,6 +398,12 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 			continue
 		}
 
+		// set the host's block height to ours to disable the height check in
+		// the gouging checks, in certain edge cases the renter might unsync and
+		// would therefor label all hosts as unusable and go on to create a
+		// whole new set of contracts with new hosts
+		host.PriceTable.HostBlockHeight = state.cs.BlockHeight
+
 		// decide whether the host is still good
 		usable, unusableResult := isUsableHost(state.cfg, state.rs, gc, f, host.Host, minScore, contract.FileSize())
 		if !usable {


### PR DESCRIPTION
If `renterd` becomes unsynced, it will keep thinking it is synced and label hosts as unusable because their blockheight exceeds a certain leeway number of blocks. This results in the contractor creating an entirely new contract set because it labels all hosts we currently have a contract with as gouging... That is not good so I think we should disable the height check, it is only important that we check the host's height in the worker and I think it is unlikely this would ever result in a contract being unusable for a long period of time, taking up a place in the contract set.