### PR TITLE
Lower the ipv6FilterRange from 58 to 32

### DIFF
--- a/autopilot/ipfilter.go
+++ b/autopilot/ipfilter.go
@@ -14,7 +14,7 @@ import (
 const (
 	// number of unique bits the host IP must have to prevent it from being filtered
 	ipv4FilterRange = 24
-	ipv6FilterRange = 54
+	ipv6FilterRange = 32
 
 	// resolverLookupTimeout is the timeout we apply when resolving a host's IP address
 	resolverLookupTimeout = 5 * time.Second


### PR DESCRIPTION
Noticing that lots of ISPs hand out full /64 prefixes to customers I did some research to see the size of prefixes that ISPs themselves have available.

Here are two examples for Google and Hetzner:
https://radar.qrator.net/as24940/ipv6-prefixes
https://radar.qrator.net/as15169/ipv6-prefixes

Considering that we used 54 bits and some providers have /32 or even lower prefixes to hand IPs out from, that leaves us with potentially millions of hosts on the same ISP.

So this PR lowers that number to 32 to only allow for 1 host per /32 range.

