### PR TITLE
Debug `TestParallelDownload` NDF

### DIFF
--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -839,15 +839,15 @@ func TestParallelDownload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// upload the data
-	data := frand.Bytes(rhpv2.SectorSize)
-	if err := w.UploadObject(context.Background(), bytes.NewReader(data), "foo"); err != nil {
-		t.Fatal(err)
-	}
-
 	// Wait for accounts to be funded.
 	_, err = cluster.WaitForAccounts()
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	// upload the data
+	data := frand.Bytes(rhpv2.SectorSize)
+	if err := w.UploadObject(context.Background(), bytes.NewReader(data), "foo"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -83,14 +83,27 @@ func (t *transportV3) Close() error {
 }
 
 // DialStream dials a new stream on the transport.
-func (t *transportV3) DialStream() (*rhpv3.Stream, error) {
+func (t *transportV3) DialStream(ctx context.Context) (*rhpv3.Stream, error) {
 	t.mu.Lock()
 	transport := t.t
 	t.mu.Unlock()
 	if transport == nil {
 		return nil, errTransportClosed
 	}
-	return transport.DialStream(), nil
+
+	// Close the stream when the context is closed to unblock any reads or
+	// writes.
+	stream := transport.DialStream()
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			_ = stream.Close()
+		}
+	}()
+	return stream, nil
 }
 
 // transportPoolV3 is a pool of rhpv3.Transports which allows for reusing them.
@@ -143,19 +156,7 @@ func (p *transportPoolV3) withTransportV3(ctx context.Context, hostKey types.Pub
 	if err != nil {
 		return err
 	}
-	var once sync.Once
-	onceClose := func() { t.Close() }
-
-	done := make(chan struct{})
-	defer close(done)
-	go func() {
-		select {
-		case <-done:
-		case <-ctx.Done():
-			once.Do(onceClose)
-		}
-	}()
-	defer once.Do(onceClose)
+	defer t.Close()
 	return fn(t)
 }
 
@@ -199,7 +200,7 @@ func (w *worker) FetchRevisionWithAccount(ctx context.Context, hostKey types.Pub
 	err = acc.WithWithdrawal(ctx, func() (types.Currency, error) {
 		var cost types.Currency
 		return cost, w.transportPoolV3.withTransportV3(ctx, hostKey, siamuxAddr, func(t *transportV3) (err error) {
-			rev, err = RPCLatestRevision(t, contractID, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
+			rev, err = RPCLatestRevision(ctx, t, contractID, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
 				// Fetch pt.
 				pt, err := w.priceTables.fetch(ctx, hostKey, nil)
 				if err != nil {
@@ -230,7 +231,7 @@ func (w *worker) FetchRevisionWithContract(ctx context.Context, hostKey types.Pu
 		return types.FileContractRevision{}, err
 	}
 	err = w.transportPoolV3.withTransportV3(ctx, hostKey, siamuxAddr, func(t *transportV3) (err error) {
-		rev, err = RPCLatestRevision(t, contractID, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
+		rev, err = RPCLatestRevision(ctx, t, contractID, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
 			// Fetch pt.
 			pt, err := w.priceTables.fetch(ctx, hostKey, revision)
 			if err != nil {
@@ -291,7 +292,7 @@ func (w *worker) fundAccount(ctx context.Context, hk types.PublicKey, siamuxAddr
 			if !ok {
 				return errors.New("insufficient funds")
 			}
-			if err := RPCFundAccount(t, &payment, account.id, pt.UID); err != nil {
+			if err := RPCFundAccount(ctx, t, &payment, account.id, pt.UID); err != nil {
 				return fmt.Errorf("failed to fund account with %v;%w", amount, err)
 			}
 			w.contractSpendingRecorder.Record(revision.ParentID, api.ContractSpending{FundAccount: cost})
@@ -317,7 +318,7 @@ func (w *worker) syncAccount(ctx context.Context, hk types.PublicKey, siamuxAddr
 		var balance types.Currency
 		err := w.transportPoolV3.withTransportV3(ctx, hk, siamuxAddr, func(t *transportV3) error {
 			payment := w.preparePayment(hk, pt.AccountBalanceCost, pt.HostBlockHeight)
-			balance, err = RPCAccountBalance(t, &payment, account.id, pt.UID)
+			balance, err = RPCAccountBalance(ctx, t, &payment, account.id, pt.UID)
 			return err
 		})
 		return balance, err
@@ -540,7 +541,7 @@ func (r *hostV3) DownloadSector(ctx context.Context, w io.Writer, root types.Has
 
 			var refund types.Currency
 			payment := rhpv3.PayByEphemeralAccount(r.acc.id, cost, r.bh+defaultWithdrawalExpiryBlocks, r.accountKey)
-			cost, refund, err = RPCReadSector(t, w, r.pt, &payment, offset, length, root, true)
+			cost, refund, err = RPCReadSector(ctx, t, w, r.pt, &payment, offset, length, root, true)
 			amount = cost.Sub(refund)
 			return err
 		})
@@ -571,7 +572,7 @@ func (r *hostV3) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byt
 
 			var refund types.Currency
 			payment := rhpv3.PayByEphemeralAccount(r.acc.id, cost, r.bh+defaultWithdrawalExpiryBlocks, r.accountKey)
-			sectorRoot, cost, refund, err = RPCAppendSector(t, r.renterKey, r.pt, rev, &payment, collateral, sector)
+			sectorRoot, cost, refund, err = RPCAppendSector(ctx, t, r.renterKey, r.pt, rev, &payment, collateral, sector)
 			amount = cost.Sub(refund)
 			return err
 		})
@@ -815,7 +816,7 @@ func (w *worker) Renew(ctx context.Context, rrr api.RHPRenewRequest, cs api.Cons
 	var txnSet []types.Transaction
 	var renewErr error
 	err = w.transportPoolV3.withTransportV3(ctx, rrr.HostKey, rrr.SiamuxAddr, func(t *transportV3) (err error) {
-		_, err = RPCLatestRevision(t, rrr.ContractID, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
+		_, err = RPCLatestRevision(ctx, t, rrr.ContractID, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
 			// Renew contract.
 			rev, txnSet, renewErr = w.RPCRenew(ctx, rrr, cs, t, revision, renterKey)
 			return rhpv3.HostPriceTable{}, nil, nil
@@ -829,9 +830,9 @@ func (w *worker) Renew(ctx context.Context, rrr api.RHPRenewRequest, cs api.Cons
 }
 
 // RPCPriceTable calls the UpdatePriceTable RPC.
-func RPCPriceTable(t *transportV3, paymentFunc PriceTablePaymentFunc) (pt rhpv3.HostPriceTable, err error) {
+func RPCPriceTable(ctx context.Context, t *transportV3, paymentFunc PriceTablePaymentFunc) (pt rhpv3.HostPriceTable, err error) {
 	defer wrapErr(&err, "PriceTable")
-	s, err := t.DialStream()
+	s, err := t.DialStream(ctx)
 	if err != nil {
 		return rhpv3.HostPriceTable{}, err
 	}
@@ -859,9 +860,9 @@ func RPCPriceTable(t *transportV3, paymentFunc PriceTablePaymentFunc) (pt rhpv3.
 }
 
 // RPCAccountBalance calls the AccountBalance RPC.
-func RPCAccountBalance(t *transportV3, payment rhpv3.PaymentMethod, account rhpv3.Account, settingsID rhpv3.SettingsID) (bal types.Currency, err error) {
+func RPCAccountBalance(ctx context.Context, t *transportV3, payment rhpv3.PaymentMethod, account rhpv3.Account, settingsID rhpv3.SettingsID) (bal types.Currency, err error) {
 	defer wrapErr(&err, "AccountBalance")
-	s, err := t.DialStream()
+	s, err := t.DialStream(ctx)
 	if err != nil {
 		return types.ZeroCurrency, err
 	}
@@ -884,9 +885,9 @@ func RPCAccountBalance(t *transportV3, payment rhpv3.PaymentMethod, account rhpv
 }
 
 // RPCFundAccount calls the FundAccount RPC.
-func RPCFundAccount(t *transportV3, payment rhpv3.PaymentMethod, account rhpv3.Account, settingsID rhpv3.SettingsID) (err error) {
+func RPCFundAccount(ctx context.Context, t *transportV3, payment rhpv3.PaymentMethod, account rhpv3.Account, settingsID rhpv3.SettingsID) (err error) {
 	defer wrapErr(&err, "FundAccount")
-	s, err := t.DialStream()
+	s, err := t.DialStream(ctx)
 	if err != nil {
 		return err
 	}
@@ -912,9 +913,9 @@ func RPCFundAccount(t *transportV3, payment rhpv3.PaymentMethod, account rhpv3.A
 // RPCLatestRevision calls the LatestRevision RPC. The paymentFunc allows for
 // fetching a pricetable using the fetched revision to pay for it. If
 // paymentFunc returns 'nil' as payment, the host is not paid.
-func RPCLatestRevision(t *transportV3, contractID types.FileContractID, paymentFunc func(rev *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error)) (_ types.FileContractRevision, err error) {
+func RPCLatestRevision(ctx context.Context, t *transportV3, contractID types.FileContractID, paymentFunc func(rev *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error)) (_ types.FileContractRevision, err error) {
 	defer wrapErr(&err, "LatestRevision")
-	s, err := t.DialStream()
+	s, err := t.DialStream(ctx)
 	if err != nil {
 		return types.FileContractRevision{}, err
 	}
@@ -938,9 +939,9 @@ func RPCLatestRevision(t *transportV3, contractID types.FileContractID, paymentF
 }
 
 // RPCReadSector calls the ExecuteProgram RPC with a ReadSector instruction.
-func RPCReadSector(t *transportV3, w io.Writer, pt rhpv3.HostPriceTable, payment rhpv3.PaymentMethod, offset, length uint64, merkleRoot types.Hash256, merkleProof bool) (cost, refund types.Currency, err error) {
+func RPCReadSector(ctx context.Context, t *transportV3, w io.Writer, pt rhpv3.HostPriceTable, payment rhpv3.PaymentMethod, offset, length uint64, merkleRoot types.Hash256, merkleProof bool) (cost, refund types.Currency, err error) {
 	defer wrapErr(&err, "ReadSector")
-	s, err := t.DialStream()
+	s, err := t.DialStream(ctx)
 	if err != nil {
 		return types.ZeroCurrency, types.ZeroCurrency, err
 	}
@@ -1005,9 +1006,9 @@ func RPCReadSector(t *transportV3, w io.Writer, pt rhpv3.HostPriceTable, payment
 
 // RPCReadRegistry calls the ExecuteProgram RPC with an MDM program that reads
 // the specified registry value.
-func RPCReadRegistry(t *transportV3, payment rhpv3.PaymentMethod, key rhpv3.RegistryKey) (rv rhpv3.RegistryValue, err error) {
+func RPCReadRegistry(ctx context.Context, t *transportV3, payment rhpv3.PaymentMethod, key rhpv3.RegistryKey) (rv rhpv3.RegistryValue, err error) {
 	defer wrapErr(&err, "ReadRegistry")
-	s, err := t.DialStream()
+	s, err := t.DialStream(ctx)
 	if err != nil {
 		return rhpv3.RegistryValue{}, err
 	}
@@ -1049,9 +1050,9 @@ func RPCReadRegistry(t *transportV3, payment rhpv3.PaymentMethod, key rhpv3.Regi
 	}, nil
 }
 
-func RPCAppendSector(t *transportV3, renterKey types.PrivateKey, pt rhpv3.HostPriceTable, rev *types.FileContractRevision, payment rhpv3.PaymentMethod, collateral types.Currency, sector *[rhpv2.SectorSize]byte) (sectorRoot types.Hash256, cost, refund types.Currency, err error) {
+func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.PrivateKey, pt rhpv3.HostPriceTable, rev *types.FileContractRevision, payment rhpv3.PaymentMethod, collateral types.Currency, sector *[rhpv2.SectorSize]byte) (sectorRoot types.Hash256, cost, refund types.Currency, err error) {
 	defer wrapErr(&err, "AppendSector")
-	s, err := t.DialStream()
+	s, err := t.DialStream(ctx)
 	if err != nil {
 		return types.Hash256{}, types.ZeroCurrency, types.ZeroCurrency, err
 	}
@@ -1131,7 +1132,7 @@ func RPCAppendSector(t *transportV3, renterKey types.PrivateKey, pt rhpv3.HostPr
 
 func (w *worker) RPCRenew(ctx context.Context, rrr api.RHPRenewRequest, cs api.ConsensusState, t *transportV3, rev *types.FileContractRevision, renterKey types.PrivateKey) (_ rhpv2.ContractRevision, _ []types.Transaction, err error) {
 	defer wrapErr(&err, "RPCRenew")
-	s, err := t.DialStream()
+	s, err := t.DialStream(ctx)
 	if err != nil {
 		return rhpv2.ContractRevision{}, nil, err
 	}
@@ -1305,9 +1306,9 @@ func initialRevision(formationTxn types.Transaction, hostPubKey, renterPubKey ty
 
 // RPCUpdateRegistry calls the ExecuteProgram RPC with an MDM program that
 // updates the specified registry value.
-func RPCUpdateRegistry(t *transportV3, payment rhpv3.PaymentMethod, key rhpv3.RegistryKey, value rhpv3.RegistryValue) (err error) {
+func RPCUpdateRegistry(ctx context.Context, t *transportV3, payment rhpv3.PaymentMethod, key rhpv3.RegistryKey, value rhpv3.RegistryValue) (err error) {
 	defer wrapErr(&err, "UpdateRegistry")
-	s, err := t.DialStream()
+	s, err := t.DialStream(ctx)
 	if err != nil {
 		return err
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -479,7 +479,7 @@ func (w *worker) rhpScanHandler(jc jape.Context) {
 	// fetch the host pricetable
 	if err == nil {
 		err = w.transportPoolV3.withTransportV3(ctx, rsr.HostKey, settings.SiamuxAddr(), func(t *transportV3) (err error) {
-			priceTable, err = RPCPriceTable(t, func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) { return nil, nil })
+			priceTable, err = RPCPriceTable(ctx, t, func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) { return nil, nil })
 			return err
 		})
 	}
@@ -546,7 +546,7 @@ func (w *worker) fetchPriceTable(ctx context.Context, hk types.PublicKey, siamux
 	// fetchPT is a helper function that performs the RPC given a payment function
 	fetchPT := func(paymentFn PriceTablePaymentFunc) (hpt hostdb.HostPriceTable, err error) {
 		err = w.transportPoolV3.withTransportV3(ctx, hk, siamuxAddr, func(t *transportV3) (err error) {
-			pt, err := RPCPriceTable(t, paymentFn)
+			pt, err := RPCPriceTable(ctx, t, paymentFn)
 			if err != nil {
 				return err
 			}
@@ -580,7 +580,7 @@ func (w *worker) rhpPriceTableHandler(jc jape.Context) {
 
 	var pt rhpv3.HostPriceTable
 	if jc.Check("could not get price table", w.transportPoolV3.withTransportV3(jc.Request.Context(), rptr.HostKey, rptr.SiamuxAddr, func(t *transportV3) (err error) {
-		pt, err = RPCPriceTable(t, func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) { return nil, nil })
+		pt, err = RPCPriceTable(jc.Request.Context(), t, func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) { return nil, nil })
 		return
 	})) != nil {
 		return
@@ -765,7 +765,7 @@ func (w *worker) rhpRegistryReadHandler(jc jape.Context) {
 	}
 	var value rhpv3.RegistryValue
 	err := w.transportPoolV3.withTransportV3(jc.Request.Context(), rrrr.HostKey, rrrr.SiamuxAddr, func(t *transportV3) (err error) {
-		value, err = RPCReadRegistry(t, &rrrr.Payment, rrrr.RegistryKey)
+		value, err = RPCReadRegistry(jc.Request.Context(), t, &rrrr.Payment, rrrr.RegistryKey)
 		return
 	})
 	if jc.Check("couldn't read registry", err) != nil {
@@ -784,7 +784,7 @@ func (w *worker) rhpRegistryUpdateHandler(jc jape.Context) {
 	cost, _ := rc.Total()
 	payment := w.preparePayment(rrur.HostKey, cost, pt.HostBlockHeight)
 	err := w.transportPoolV3.withTransportV3(jc.Request.Context(), rrur.HostKey, rrur.SiamuxAddr, func(t *transportV3) (err error) {
-		return RPCUpdateRegistry(t, &payment, rrur.RegistryKey, rrur.RegistryValue)
+		return RPCUpdateRegistry(jc.Request.Context(), t, &payment, rrur.RegistryKey, rrur.RegistryValue)
 	})
 	if jc.Check("couldn't update registry", err) != nil {
 		return


### PR DESCRIPTION
The test wasn't waiting for accounts to be funded. So the uploads would time out. Due to a bug the uploads wouldn't fail though and result in the downloads trying to download empty roots. Which caused the errors on the CI.

This PR fixes the bug and updates the test to wait for accounts to be funded.