### PR TITLE
Refill Active Contracts

### DIFF
--- a/autopilot/accounts.go
+++ b/autopilot/accounts.go
@@ -137,8 +137,8 @@ func (a *accounts) refillWorkerAccounts(w Worker) {
 		go func(hk types.PublicKey, contracts []api.ContractMetadata) error {
 			defer a.markRefillDone(workerID, hk)
 
-			// decide whether one of the potentially multiple contrats is in the
-			// contract set, we only want to log errors if that is the case
+			// decide whether one of the potentially multiple contracts is in
+			// the contract set, we only want to log errors if that is the case
 			// because we expect refills to fail often for contracts that are
 			// not in the set
 			var hasContractSetContract bool

--- a/bus/client.go
+++ b/bus/client.go
@@ -280,7 +280,7 @@ func (c *Client) RecordInteractions(ctx context.Context, interactions []hostdb.I
 	return
 }
 
-// RecordContractSpending records contract spending metrics for contrats.
+// RecordContractSpending records contract spending metrics for contracts.
 func (c *Client) RecordContractSpending(ctx context.Context, records []api.ContractSpendingRecord) (err error) {
 	err = c.c.WithContext(ctx).POST("/contracts/spending", records, nil)
 	return

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -70,9 +70,8 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 		err       error
 	}
 	respChan := make(chan resp, 2*len(contracts)) // every host can send up to 2 responses
-	worker := func(r req, hostIndex int) {
+	worker := func(r req, hostIndex int, contract api.ContractMetadata) {
 		doneChan := make(chan struct{})
-		contract := contracts[hostIndex]
 
 		// Trace the upload.
 		ctx, span := tracing.Tracer.Start(r.finishedCtx, "upload-request")
@@ -154,7 +153,7 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 		if hostIndex == -1 {
 			return false
 		}
-		go worker(r, hostIndex)
+		go worker(r, hostIndex, contracts[hostIndex])
 		inflight++
 		return true
 	}


### PR DESCRIPTION
Now that we download from all active contracts, we refill all active contracts... this might lead to a lot of fund errors because active contracts are not necessarily suited to refill ephemeral accounts with.. the host might be offline, the host might be gouging etc etc.

This PR updates the refill code to 
a) try all contracts for any given host rather than randomly selecting one (this was a bug)
b) only log errors if the host has at least one contract that's in the contract set
