### PR TITLE
Rename SectorStore to HostV2|3

### DIFF
--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -332,7 +332,7 @@ type (
 		host types.PublicKey
 	}
 
-	hostV3 struct {
+	host struct {
 		acc           *account
 		bh            uint64
 		fcid          types.FileContractID
@@ -354,7 +354,7 @@ func (w *worker) initAccounts(as AccountStore) {
 	}
 }
 
-func (w *worker) withHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string, fn func(sectorStoreV3) error) (err error) {
+func (w *worker) withHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string, fn func(hostV3) error) (err error) {
 	acc, err := w.accounts.ForHost(hostKey)
 	if err != nil {
 		return err
@@ -365,7 +365,7 @@ func (w *worker) withHostV3(ctx context.Context, contractID types.FileContractID
 		return err
 	}
 
-	return fn(&hostV3{
+	return fn(&host{
 		acc:           acc,
 		bh:            pt.HostBlockHeight,
 		fcid:          contractID,
@@ -484,19 +484,19 @@ func (a *accounts) deriveAccountKey(hostKey types.PublicKey) types.PrivateKey {
 	return pk
 }
 
-func (r *hostV3) Contract() types.FileContractID {
+func (r *host) Contract() types.FileContractID {
 	return r.fcid
 }
 
-func (r *hostV3) HostKey() types.PublicKey {
+func (r *host) HostKey() types.PublicKey {
 	return r.acc.host
 }
 
-func (*hostV3) DeleteSectors(ctx context.Context, roots []types.Hash256) error {
+func (*host) DeleteSectors(ctx context.Context, roots []types.Hash256) error {
 	panic("not implemented")
 }
 
-func (r *hostV3) DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint64) (err error) {
+func (r *host) DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint64) (err error) {
 	// return errGougingHost if gouging checks fail
 	if breakdown := GougingCheckerFromContext(ctx).Check(nil, &r.pt); breakdown.Gouging() {
 		return fmt.Errorf("failed to download sector, %w: %v", errGougingHost, breakdown.Reasons())
@@ -526,7 +526,7 @@ func (r *hostV3) DownloadSector(ctx context.Context, w io.Writer, root types.Has
 }
 
 // UploadSector uploads a sector to the host.
-func (r *hostV3) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte, rev *types.FileContractRevision) (_ types.Hash256, err error) {
+func (r *host) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte, rev *types.FileContractRevision) (_ types.Hash256, err error) {
 	// return errGougingHost if gouging checks fail
 	if breakdown := GougingCheckerFromContext(ctx).Check(nil, &r.pt); breakdown.Gouging() {
 		return types.Hash256{}, fmt.Errorf("failed to upload sector, %w: %v", errGougingHost, breakdown.Reasons())

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -31,25 +31,24 @@ var (
 	errUploadSectorTimeout   = errors.New("upload sector timed out")
 )
 
-// A sectorStore stores contract data.
-type sectorStoreV2 interface {
+type hostV2 interface {
 	Contract() types.FileContractID
 	HostKey() types.PublicKey
 	DeleteSectors(ctx context.Context, roots []types.Hash256) error
 }
 
-type sectorStoreV3 interface {
-	sectorStoreV2
+type hostV3 interface {
+	hostV2
 	UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte, rev *types.FileContractRevision) (types.Hash256, error)
 	DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint64) error
 }
 
-type storeProvider interface {
-	withHostV2(context.Context, types.FileContractID, types.PublicKey, string, func(sectorStoreV2) error) (err error)
-	withHostV3(context.Context, types.FileContractID, types.PublicKey, string, func(sectorStoreV3) error) (err error)
+type hostProvider interface {
+	withHostV2(context.Context, types.FileContractID, types.PublicKey, string, func(hostV2) error) (err error)
+	withHostV3(context.Context, types.FileContractID, types.PublicKey, string, func(hostV3) error) (err error)
 }
 
-func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, contracts []api.ContractMetadata, locker revisionLocker, uploadSectorTimeout time.Duration, maxOverdrive uint64, logger *zap.SugaredLogger) ([]object.Sector, []int, error) {
+func parallelUploadSlab(ctx context.Context, hp hostProvider, shards [][]byte, contracts []api.ContractMetadata, locker revisionLocker, uploadSectorTimeout time.Duration, maxOverdrive uint64, logger *zap.SugaredLogger) ([]object.Sector, []int, error) {
 	// ensure the context is cancelled when the slab is uploaded
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -84,7 +83,7 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 			var root types.Hash256
 			var err error
 			err = locker.withRevision(ctx, defaultRevisionFetchTimeout, contract.ID, contract.HostKey, contract.SiamuxAddr, lockingPriorityUpload, func(rev types.FileContractRevision) error {
-				return sp.withHostV3(ctx, contract.ID, contract.HostKey, contract.SiamuxAddr, func(ss sectorStoreV3) error {
+				return hp.withHostV3(ctx, contract.ID, contract.HostKey, contract.SiamuxAddr, func(ss hostV3) error {
 					root, err = ss.UploadSector(ctx, (*[rhpv2.SectorSize]byte)(shards[r.shardIndex]), &rev)
 					return err
 				})
@@ -247,7 +246,7 @@ func parallelUploadSlab(ctx context.Context, sp storeProvider, shards [][]byte, 
 	return sectors, slowHosts, nil
 }
 
-func uploadSlab(ctx context.Context, sp storeProvider, r io.Reader, m, n uint8, contracts []api.ContractMetadata, locker revisionLocker, uploadSectorTimeout time.Duration, maxOverdrive uint64, logger *zap.SugaredLogger) (object.Slab, int, []int, error) {
+func uploadSlab(ctx context.Context, hp hostProvider, r io.Reader, m, n uint8, contracts []api.ContractMetadata, locker revisionLocker, uploadSectorTimeout time.Duration, maxOverdrive uint64, logger *zap.SugaredLogger) (object.Slab, int, []int, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "uploadSlab")
 	defer span.End()
 
@@ -264,7 +263,7 @@ func uploadSlab(ctx context.Context, sp storeProvider, r io.Reader, m, n uint8, 
 	s.Encode(buf, shards)
 	s.Encrypt(shards)
 
-	sectors, slowHosts, err := parallelUploadSlab(ctx, sp, shards, contracts, locker, uploadSectorTimeout, maxOverdrive, logger)
+	sectors, slowHosts, err := parallelUploadSlab(ctx, hp, shards, contracts, locker, uploadSectorTimeout, maxOverdrive, logger)
 	if err != nil {
 		return object.Slab{}, 0, nil, err
 	}
@@ -273,7 +272,7 @@ func uploadSlab(ctx context.Context, sp storeProvider, r io.Reader, m, n uint8, 
 	return s, length, slowHosts, nil
 }
 
-func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, maxOverdrive uint64, logger *zap.SugaredLogger) ([][]byte, []int64, error) {
+func parallelDownloadSlab(ctx context.Context, hp hostProvider, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, maxOverdrive uint64, logger *zap.SugaredLogger) ([][]byte, []int64, error) {
 	// prepopulate the timings with a value for all hosts to ensure unused hosts aren't necessarily favoured in consecutive downloads
 	timings := make([]int64, len(contracts))
 	for i := 0; i < len(contracts); i++ {
@@ -328,7 +327,7 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 			contract := contracts[hostIndex]
 			shard := &ss.Shards[r.shardIndex]
 
-			if err := sp.withHostV3(ctx, contract.ID, contract.HostKey, contract.SiamuxAddr, func(ss sectorStoreV3) error {
+			if err := hp.withHostV3(ctx, contract.ID, contract.HostKey, contract.SiamuxAddr, func(ss hostV3) error {
 				buf := bytes.NewBuffer(make([]byte, 0, rhpv2.SectorSize))
 				err := ss.DownloadSector(ctx, buf, shard.Root, r.offset, r.length)
 				if err != nil {
@@ -480,11 +479,11 @@ func parallelDownloadSlab(ctx context.Context, sp storeProvider, ss object.SlabS
 	return shards, timings, nil
 }
 
-func downloadSlab(ctx context.Context, sp storeProvider, out io.Writer, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, maxOverdrive uint64, logger *zap.SugaredLogger) ([]int64, error) {
+func downloadSlab(ctx context.Context, hp hostProvider, out io.Writer, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, maxOverdrive uint64, logger *zap.SugaredLogger) ([]int64, error) {
 	ctx, span := tracing.Tracer.Start(ctx, "parallelDownloadSlab")
 	defer span.End()
 
-	shards, timings, err := parallelDownloadSlab(ctx, sp, ss, contracts, downloadSectorTimeout, maxOverdrive, logger)
+	shards, timings, err := parallelDownloadSlab(ctx, hp, ss, contracts, downloadSectorTimeout, maxOverdrive, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -525,20 +524,20 @@ func slabsForDownload(slabs []object.SlabSlice, offset, length int64) []object.S
 	return slabs
 }
 
-func deleteSlabs(ctx context.Context, slabs []object.Slab, hosts []sectorStoreV2) error {
-	rootsBysectorStore := make(map[types.PublicKey][]types.Hash256)
+func deleteSlabs(ctx context.Context, slabs []object.Slab, hosts []hostV2) error {
+	rootsByHost := make(map[types.PublicKey][]types.Hash256)
 	for _, s := range slabs {
 		for _, sector := range s.Shards {
-			rootsBysectorStore[sector.Host] = append(rootsBysectorStore[sector.Host], sector.Root)
+			rootsByHost[sector.Host] = append(rootsByHost[sector.Host], sector.Root)
 		}
 	}
 
 	errChan := make(chan *HostError)
 	for _, h := range hosts {
-		go func(h sectorStoreV2) {
+		go func(h hostV2) {
 			// NOTE: if host is not storing any sectors, the map lookup will return
 			// nil, making this a no-op
-			err := h.DeleteSectors(ctx, rootsBysectorStore[h.HostKey()])
+			err := h.DeleteSectors(ctx, rootsByHost[h.HostKey()])
 			if err != nil {
 				errChan <- &HostError{h.HostKey(), err}
 			} else {
@@ -559,7 +558,7 @@ func deleteSlabs(ctx context.Context, slabs []object.Slab, hosts []sectorStoreV2
 	return nil
 }
 
-func migrateSlab(ctx context.Context, sp storeProvider, s *object.Slab, dlContracts, ulContracts []api.ContractMetadata, locker revisionLocker, downloadSectorTimeout, uploadSectorTimeout time.Duration, logger *zap.SugaredLogger) error {
+func migrateSlab(ctx context.Context, hp hostProvider, s *object.Slab, dlContracts, ulContracts []api.ContractMetadata, locker revisionLocker, downloadSectorTimeout, uploadSectorTimeout time.Duration, logger *zap.SugaredLogger) error {
 	ctx, span := tracing.Tracer.Start(ctx, "migrateSlab")
 	defer span.End()
 
@@ -606,7 +605,7 @@ func migrateSlab(ctx context.Context, sp storeProvider, s *object.Slab, dlContra
 		Offset: 0,
 		Length: uint32(s.MinShards) * rhpv2.SectorSize,
 	}
-	shards, _, err := parallelDownloadSlab(ctx, sp, ss, dlContracts, downloadSectorTimeout, 0, logger) // no overdrive for downloads
+	shards, _, err := parallelDownloadSlab(ctx, hp, ss, dlContracts, downloadSectorTimeout, 0, logger) // no overdrive for downloads
 	if err != nil {
 		return fmt.Errorf("failed to download slab for migration: %w", err)
 	}
@@ -635,7 +634,7 @@ func migrateSlab(ctx context.Context, sp storeProvider, s *object.Slab, dlContra
 
 	// reupload those shards. migrations are not time-sensitive, so we can use a
 	// max overdrive of 0.
-	uploaded, _, err := parallelUploadSlab(ctx, sp, shards, filtered, locker, uploadSectorTimeout, 0, logger)
+	uploaded, _, err := parallelUploadSlab(ctx, hp, shards, filtered, locker, uploadSectorTimeout, 0, logger)
 	if err != nil {
 		return fmt.Errorf("failed to upload slab for migration: %w", err)
 	}

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -80,12 +80,12 @@ func (l *mockRevisionLocker) withRevision(ctx context.Context, _ time.Duration, 
 }
 
 type mockStoreProvider struct {
-	hosts map[types.PublicKey]sectorStoreV3
+	hosts map[types.PublicKey]hostV3
 }
 
-func newMockStoreProvider(hosts []sectorStoreV3) *mockStoreProvider {
+func newMockStoreProvider(hosts []hostV3) *mockStoreProvider {
 	sp := &mockStoreProvider{
-		hosts: make(map[types.PublicKey]sectorStoreV3),
+		hosts: make(map[types.PublicKey]hostV3),
 	}
 	for _, h := range hosts {
 		sp.hosts[h.HostKey()] = h
@@ -93,7 +93,7 @@ func newMockStoreProvider(hosts []sectorStoreV3) *mockStoreProvider {
 	return sp
 }
 
-func (sp *mockStoreProvider) withHostV2(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP string, f func(sectorStoreV2) error) (err error) {
+func (sp *mockStoreProvider) withHostV2(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP string, f func(hostV2) error) (err error) {
 	h, exists := sp.hosts[hostKey]
 	if !exists {
 		panic("doesn't exist")
@@ -101,7 +101,7 @@ func (sp *mockStoreProvider) withHostV2(ctx context.Context, contractID types.Fi
 	return f(h)
 }
 
-func (sp *mockStoreProvider) withHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string, f func(sectorStoreV3) error) (err error) {
+func (sp *mockStoreProvider) withHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string, f func(hostV3) error) (err error) {
 	h, exists := sp.hosts[hostKey]
 	if !exists {
 		panic("doesn't exist")
@@ -130,7 +130,7 @@ func TestMultipleObjects(t *testing.T) {
 	r := io.MultiReader(rs...)
 
 	// Prepare hosts.
-	var hosts []sectorStoreV3
+	var hosts []hostV3
 	for i := 0; i < 10; i++ {
 		hosts = append(hosts, newMockHost())
 	}

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -79,12 +79,12 @@ func (l *mockRevisionLocker) withRevision(ctx context.Context, _ time.Duration, 
 	return fn(types.FileContractRevision{})
 }
 
-type mockStoreProvider struct {
+type mockHostProvider struct {
 	hosts map[types.PublicKey]hostV3
 }
 
-func newMockStoreProvider(hosts []hostV3) *mockStoreProvider {
-	sp := &mockStoreProvider{
+func newMockHostProvider(hosts []hostV3) *mockHostProvider {
+	sp := &mockHostProvider{
 		hosts: make(map[types.PublicKey]hostV3),
 	}
 	for _, h := range hosts {
@@ -93,7 +93,7 @@ func newMockStoreProvider(hosts []hostV3) *mockStoreProvider {
 	return sp
 }
 
-func (sp *mockStoreProvider) withHostV2(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP string, f func(hostV2) error) (err error) {
+func (sp *mockHostProvider) withHostV2(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP string, f func(hostV2) error) (err error) {
 	h, exists := sp.hosts[hostKey]
 	if !exists {
 		panic("doesn't exist")
@@ -101,7 +101,7 @@ func (sp *mockStoreProvider) withHostV2(ctx context.Context, contractID types.Fi
 	return f(h)
 }
 
-func (sp *mockStoreProvider) withHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string, f func(hostV3) error) (err error) {
+func (sp *mockHostProvider) withHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string, f func(hostV3) error) (err error) {
 	h, exists := sp.hosts[hostKey]
 	if !exists {
 		panic("doesn't exist")
@@ -134,7 +134,7 @@ func TestMultipleObjects(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		hosts = append(hosts, newMockHost())
 	}
-	sp := newMockStoreProvider(hosts)
+	sp := newMockHostProvider(hosts)
 	var contracts []api.ContractMetadata
 	for _, h := range hosts {
 		contracts = append(contracts, api.ContractMetadata{ID: h.Contract(), HostKey: h.HostKey()})

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -370,12 +370,12 @@ func (w *worker) withTransportV2(ctx context.Context, hostKey types.PublicKey, h
 	return fn(t)
 }
 
-func (w *worker) withHostV2(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP string, fn func(sectorStoreV2) error) (err error) {
+func (w *worker) withHostV2(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP string, fn func(hostV2) error) (err error) {
 	return w.withHostsV2(ctx, []api.ContractMetadata{{
 		ID:      contractID,
 		HostKey: hostKey,
 		HostIP:  hostIP,
-	}}, func(ss []sectorStoreV2) error {
+	}}, func(ss []hostV2) error {
 		return fn(ss[0])
 	})
 }
@@ -419,7 +419,7 @@ func (w *worker) withRevision(ctx context.Context, fetchTimeout time.Duration, c
 	return fn(rev)
 }
 
-func (w *worker) unlockHosts(hosts []sectorStoreV2) {
+func (w *worker) unlockHosts(hosts []hostV2) {
 	// apply a pessimistic timeout, ensuring unlocking the contract or force
 	// closing the session does not deadlock and keep this goroutine around
 	// forever. Use a background context as the parent to avoid timing out
@@ -438,8 +438,8 @@ func (w *worker) unlockHosts(hosts []sectorStoreV2) {
 	wg.Wait()
 }
 
-func (w *worker) withHostsV2(ctx context.Context, contracts []api.ContractMetadata, fn func([]sectorStoreV2) error) (err error) {
-	var hosts []sectorStoreV2
+func (w *worker) withHostsV2(ctx context.Context, contracts []api.ContractMetadata, fn func([]hostV2) error) (err error) {
+	var hosts []hostV2
 	for _, c := range contracts {
 		hosts = append(hosts, w.pool.session(c.HostKey, c.HostIP, c.ID, w.deriveRenterKey(c.HostKey)))
 	}


### PR DESCRIPTION
When we discuss the code internally we use the term host v2 and v3 and we don't really use the "sector store" abstraction anyway. It's not like the host is a composite of multiple stores or something so I figured it might make sense to rename `SectorStoreProvider` to `HostProvider` so `withHostV3` can return `HostV3` and things are easier to read.