### PR TITLE
Change /rhp/contracts/active to return all contracts

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -74,34 +74,16 @@ func (c Contract) EndHeight() uint64 { return c.WindowStart }
 
 // FileSize returns the current Size of the contract.
 func (c Contract) FileSize() uint64 {
-	if c.Revision == nil {
-		return 0
-	}
 	return c.Revision.Filesize
-}
-
-// HostKey returns the public key of the host.
-func (c Contract) HostKey() (pk types.PublicKey) {
-	if c.Revision == nil {
-		return
-	}
-	copy(pk[:], c.Revision.UnlockConditions.PublicKeys[1].Key)
-	return
 }
 
 // RenterFunds returns the funds remaining in the contract's Renter payout.
 func (c Contract) RenterFunds() types.Currency {
-	if c.Revision == nil {
-		return types.ZeroCurrency
-	}
 	return c.Revision.ValidRenterPayout()
 }
 
 // RemainingCollateral returns the remaining collateral in the contract.
 func (c Contract) RemainingCollateral(s rhpv2.HostSettings) types.Currency {
-	if c.Revision == nil {
-		return types.ZeroCurrency
-	}
 	if c.Revision.MissedHostPayout().Cmp(s.ContractPrice) < 0 {
 		return types.ZeroCurrency
 	}

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -149,7 +149,7 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 	// get used hosts
 	usedHosts := make(map[types.PublicKey]struct{})
 	for _, contract := range contracts {
-		usedHosts[contract.HostKey()] = struct{}{}
+		usedHosts[contract.HostKey] = struct{}{}
 	}
 
 	// fetch all hosts
@@ -161,7 +161,9 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 	// compile map of stored data per host
 	storedData := make(map[types.PublicKey]uint64)
 	for _, c := range contracts {
-		storedData[c.HostKey()] += c.FileSize()
+		if c.Revision != nil {
+			storedData[c.HostKey] += c.FileSize()
+		}
 	}
 
 	// min score to pass checks.
@@ -259,7 +261,9 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 		// build sizemap
 		sizemap := make(map[types.FileContractID]uint64)
 		for _, c := range contracts {
-			sizemap[c.ID] = c.FileSize()
+			if c.Revision != nil {
+				sizemap[c.ID] = c.FileSize()
+			}
 		}
 
 		// sort by contract size
@@ -409,7 +413,7 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 		revision := contract.Revision
 
 		// fetch host from hostdb
-		hk := contract.HostKey()
+		hk := contract.HostKey
 		host, err := c.ap.bus.Host(ctx, hk)
 		if err != nil {
 			c.logger.Errorw(fmt.Sprintf("missing host, err: %v", err), "hk", hk)
@@ -914,7 +918,7 @@ func (c *contractor) renewContract(ctx context.Context, w Worker, ci contractInf
 			span.SetStatus(codes.Error, "failed to renew contract")
 		}
 	}()
-	span.SetAttributes(attribute.Stringer("host", ci.contract.HostKey()))
+	span.SetAttributes(attribute.Stringer("host", ci.contract.HostKey))
 	span.SetAttributes(attribute.Stringer("contract", ci.contract.ID))
 
 	// convenience variables
@@ -924,7 +928,7 @@ func (c *contractor) renewContract(ctx context.Context, w Worker, ci contractInf
 	settings := ci.settings
 	fcid := contract.ID
 	rev := contract.Revision
-	hk := contract.HostKey()
+	hk := contract.HostKey
 
 	// calculate the renter funds
 	renterFunds, err := c.renewFundingEstimate(ctx, ci, true)
@@ -986,7 +990,7 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 			span.SetStatus(codes.Error, "failed to refresh contract")
 		}
 	}()
-	span.SetAttributes(attribute.Stringer("host", ci.contract.HostKey()))
+	span.SetAttributes(attribute.Stringer("host", ci.contract.HostKey))
 	span.SetAttributes(attribute.Stringer("contract", ci.contract.ID))
 
 	// convenience variables
@@ -996,7 +1000,7 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 	settings := ci.settings
 	fcid := contract.ID
 	rev := contract.Revision
-	hk := contract.HostKey()
+	hk := contract.HostKey
 
 	// calculate the renter funds
 	renterFunds, err := c.refreshFundingEstimate(ctx, cfg, ci)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1032,7 +1032,7 @@ func TestUploadDownloadSameHost(t *testing.T) {
 	c := contracts[0]
 
 	// Form 2 more contracts with the same host.
-	rev2, _, err := cluster.Worker.RHPForm(context.Background(), c.WindowStart, c.HostKey(), c.HostIP, renterAddress, c.RenterFunds(), c.Revision.ValidHostPayout())
+	rev2, _, err := cluster.Worker.RHPForm(context.Background(), c.WindowStart, c.HostKey, c.HostIP, renterAddress, c.RenterFunds(), c.Revision.ValidHostPayout())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1040,7 +1040,7 @@ func TestUploadDownloadSameHost(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rev3, _, err := cluster.Worker.RHPForm(context.Background(), c.WindowStart, c.HostKey(), c.HostIP, renterAddress, c.RenterFunds(), c.Revision.ValidHostPayout())
+	rev3, _, err := cluster.Worker.RHPForm(context.Background(), c.WindowStart, c.HostKey, c.HostIP, renterAddress, c.RenterFunds(), c.Revision.ValidHostPayout())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR updates the worker's contracts endpoint to return all contracts and only attach a revision if possible. This cleans up the logic in the autopilot and makes it less prone to errors.

This should also fix contracts not expiring when a revision can't be fetched. 