### PR TITLE
Add /objects PUT endpoint 

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -28,6 +28,11 @@ type AccountsUnlockHandlerRequest struct {
 	LockID uint64 `json:"lockID"`
 }
 
+type PackedObjectInfo struct {
+	Path   string `json:"path"`
+	Length uint64 `json:"length"`
+}
+
 // ContractsResponse is the response type for the /rhp/contracts endpoint.
 type ContractsResponse struct {
 	Contracts []Contract `json:"contracts"`

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -101,7 +101,7 @@ type (
 		Model
 		DBSliceID uint `gorm:"index"`
 
-		Key         []byte `gorm:"unique;NOT NULL;size:68"` // json string
+		Key         []byte `gorm:"NOT NULL;size:68"` // json string
 		MinShards   uint8
 		TotalShards uint8
 		Shards      []dbShard `gorm:"constraint:OnDelete:CASCADE"` // CASCADE to delete shards too

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1152,7 +1152,7 @@ func archiveContracts(tx *gorm.DB, contracts []dbContract, toArchive map[types.F
 
 			ContractCommon: contract.ContractCommon,
 		}).Error; err != nil {
-			return err
+			return fmt.Errorf("failed to archive contract %v: %w", contract.FCID, err)
 		}
 
 		// remove the contract


### PR DESCRIPTION
This PR adds a new `PUT /objects` endpoint on the worker for uploading data.
The difference to the existing endpoint is that instead of providing the object path as a path param, the uploaded data is prefixed with a json object that contains a list of paths and lengths which the uploaded data is then sliced to.

The main purpose of this endpoint is to package small files together to reduce wasted storage space. e.g. 1000 40kib files can be uploaded as a single 40 MiB slab that is referenced by 1000 objects. Instead of uploading 1000 slabs. 