### PR TITLE
Fix long running uploads failing due to host price gouging

### DIFF
--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -51,29 +51,35 @@ type (
 
 var _ GougingChecker = gougingChecker{}
 
-func GougingCheckerFromContext(ctx context.Context) GougingChecker {
-	gc, ok := ctx.Value(keyGougingChecker).(GougingChecker)
+func GougingCheckerFromContext(ctx context.Context) (GougingChecker, error) {
+	gc, ok := ctx.Value(keyGougingChecker).(func() (GougingChecker, error))
 	if !ok {
 		panic("no gouging checker attached to the context") // developer error
 	}
-	return gc
+	return gc()
 }
 
-func WithGougingChecker(ctx context.Context, gp api.GougingParams) context.Context {
-	return context.WithValue(ctx, keyGougingChecker, gougingChecker{
-		consensusState: gp.ConsensusState,
-		settings:       gp.GougingSettings,
-		redundancy:     gp.RedundancySettings,
-		txFee:          gp.TransactionFee,
+func WithGougingChecker(ctx context.Context, cs consensusState, gp api.GougingParams) context.Context {
+	return context.WithValue(ctx, keyGougingChecker, func() (gougingChecker, error) {
+		consensusState, err := cs.ConsensusState(ctx)
+		if err != nil {
+			return gougingChecker{}, fmt.Errorf("failed to get consensus state: %w", err)
+		}
+		return gougingChecker{
+			consensusState: consensusState,
+			settings:       gp.GougingSettings,
+			redundancy:     gp.RedundancySettings,
+			txFee:          gp.TransactionFee,
 
-		// NOTE:
-		//
-		// period and renew window are nil here and that's fine, gouging
-		// checkers in the workers don't have easy access to these settings and
-		// thus ignore them when perform gouging checks, the autopilot however
-		// does have those and will pass them when performing gouging checks
-		period:      nil,
-		renewWindow: nil,
+			// NOTE:
+			//
+			// period and renew window are nil here and that's fine, gouging
+			// checkers in the workers don't have easy access to these settings and
+			// thus ignore them when perform gouging checks, the autopilot however
+			// does have those and will pass them when performing gouging checks
+			period:      nil,
+			renewWindow: nil,
+		}, nil
 	})
 }
 

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -60,7 +60,7 @@ func GougingCheckerFromContext(ctx context.Context) (GougingChecker, error) {
 }
 
 func WithGougingChecker(ctx context.Context, cs consensusState, gp api.GougingParams) context.Context {
-	return context.WithValue(ctx, keyGougingChecker, func() (gougingChecker, error) {
+	return context.WithValue(ctx, keyGougingChecker, func() (GougingChecker, error) {
 		consensusState, err := cs.ConsensusState(ctx)
 		if err != nil {
 			return gougingChecker{}, fmt.Errorf("failed to get consensus state: %w", err)

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -21,6 +21,7 @@ import (
 	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/wallet"
 	"go.sia.tech/siad/crypto"
+	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
 
@@ -196,27 +197,49 @@ func (p *transportPoolV3) withTransportV3(ctx context.Context, hostKey types.Pub
 	return fn(t)
 }
 
-func (w *worker) FetchRevisionWithAccount(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, bh uint64, contractID types.FileContractID) (rev types.FileContractRevision, err error) {
-	acc, err := w.accounts.ForHost(hostKey)
+// FetchRevision tries to fetch a contract revision from the host. We pass in
+// the blockHeight instead of using the blockHeight from the pricetable since we
+// might not have a price table.
+func (h *host) FetchRevision(ctx context.Context, fetchTimeout time.Duration, blockHeight uint64) (types.FileContractRevision, error) {
+	timeoutCtx := func() (context.Context, context.CancelFunc) {
+		if fetchTimeout > 0 {
+			return context.WithTimeout(ctx, fetchTimeout)
+		}
+		return ctx, func() {}
+	}
+	// Try to fetch the revision with an account first.
+	ctx, cancel := timeoutCtx()
+	defer cancel()
+	rev, err := h.fetchRevisionWithAccount(ctx, h.HostKey(), h.siamuxAddr, blockHeight, h.fcid)
+	if err != nil && !isBalanceInsufficient(err) {
+		return types.FileContractRevision{}, err
+	} else if err == nil {
+		return rev, nil
+	}
+
+	// Fall back to using the contract to pay for the revision.
+	ctx, cancel = timeoutCtx()
+	defer cancel()
+	rev, err = h.fetchRevisionWithContract(ctx, h.HostKey(), h.siamuxAddr, h.fcid)
 	if err != nil {
 		return types.FileContractRevision{}, err
 	}
-	err = acc.WithWithdrawal(ctx, func() (types.Currency, error) {
+	return rev, nil
+}
+
+func (h *host) fetchRevisionWithAccount(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, bh uint64, contractID types.FileContractID) (rev types.FileContractRevision, err error) {
+	err = h.acc.WithWithdrawal(ctx, func() (types.Currency, error) {
 		var cost types.Currency
-		return cost, w.transportPoolV3.withTransportV3(ctx, hostKey, siamuxAddr, func(t *transportV3) (err error) {
+		return cost, h.transportPool.withTransportV3(ctx, hostKey, siamuxAddr, func(t *transportV3) (err error) {
 			rev, err = RPCLatestRevision(ctx, t, contractID, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
 				// Fetch pt.
-				pt, err := w.priceTables.fetch(ctx, hostKey, nil)
+				pt, err := h.priceTable(ctx, revision)
 				if err != nil {
 					return rhpv3.HostPriceTable{}, nil, fmt.Errorf("failed to fetch pricetable, err: %v", err)
 				}
-				// Check pt.
-				if breakdown := GougingCheckerFromContext(ctx).Check(nil, &pt.HostPriceTable); breakdown.Gouging() {
-					return rhpv3.HostPriceTable{}, nil, fmt.Errorf("failed to fetch revision, %w: %v", errGougingHost, breakdown.Reasons())
-				}
 				cost = pt.LatestRevisionCost
-				payment := rhpv3.PayByEphemeralAccount(acc.id, cost, bh+defaultWithdrawalExpiryBlocks, w.accounts.deriveAccountKey(hostKey))
-				return pt.HostPriceTable, &payment, nil
+				payment := rhpv3.PayByEphemeralAccount(h.acc.id, cost, bh+defaultWithdrawalExpiryBlocks, h.accountKey)
+				return pt, &payment, nil
 			})
 			if err != nil {
 				return err
@@ -229,49 +252,35 @@ func (w *worker) FetchRevisionWithAccount(ctx context.Context, hostKey types.Pub
 
 // FetchRevisionWithContract fetches the latest revision of a contract and uses
 // a contract to pay for it.
-func (w *worker) FetchRevisionWithContract(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, contractID types.FileContractID) (rev types.FileContractRevision, err error) {
-	acc, err := w.accounts.ForHost(hostKey)
-	if err != nil {
-		return types.FileContractRevision{}, err
-	}
-	err = w.transportPoolV3.withTransportV3(ctx, hostKey, siamuxAddr, func(t *transportV3) (err error) {
+func (h *host) fetchRevisionWithContract(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, contractID types.FileContractID) (rev types.FileContractRevision, err error) {
+	err = h.transportPool.withTransportV3(ctx, hostKey, siamuxAddr, func(t *transportV3) (err error) {
 		rev, err = RPCLatestRevision(ctx, t, contractID, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
 			// Fetch pt.
-			pt, err := w.priceTables.fetch(ctx, hostKey, revision)
+			pt, err := h.priceTable(ctx, revision)
 			if err != nil {
 				return rhpv3.HostPriceTable{}, nil, fmt.Errorf("failed to fetch pricetable, err: %v", err)
 			}
-			// Check pt.
-			if breakdown := GougingCheckerFromContext(ctx).Check(nil, &pt.HostPriceTable); breakdown.Gouging() {
-				return rhpv3.HostPriceTable{}, nil, fmt.Errorf("failed to fetch revision, %w: %v", errGougingHost, breakdown.Reasons())
-			}
 			// Pay for the revision.
-			payment, err := payByContract(revision, pt.LatestRevisionCost, acc.id, w.deriveRenterKey(hostKey))
+			payment, err := payByContract(revision, pt.LatestRevisionCost, h.acc.id, h.renterKey)
 			if err != nil {
 				return rhpv3.HostPriceTable{}, nil, err
 			}
-			return pt.HostPriceTable, &payment, nil
+			return pt, &payment, nil
 		})
 		return err
 	})
 	return rev, err
 }
 
-func (w *worker) fundAccount(ctx context.Context, hk types.PublicKey, siamuxAddr string, balance types.Currency, revision *types.FileContractRevision) error {
-	// fetch account
-	account, err := w.accounts.ForHost(hk)
-	if err != nil {
-		return err
-	}
-
+func (h *host) FundAccount(ctx context.Context, balance types.Currency, revision *types.FileContractRevision) error {
 	// fetch pricetable
-	pt, err := w.priceTables.fetch(ctx, hk, revision)
+	pt, err := h.priceTable(ctx, revision)
 	if err != nil {
 		return err
 	}
 
 	// calculate the amount to deposit
-	curr, err := account.Balance(ctx)
+	curr, err := h.acc.Balance(ctx)
 	if err != nil {
 		return err
 	}
@@ -288,41 +297,34 @@ func (w *worker) fundAccount(ctx context.Context, hk types.PublicKey, siamuxAddr
 		amount = maxAmount
 	}
 
-	return account.WithDeposit(ctx, func() (types.Currency, error) {
-		return amount, w.transportPoolV3.withTransportV3(ctx, hk, siamuxAddr, func(t *transportV3) (err error) {
-			rk := w.deriveRenterKey(hk)
+	return h.acc.WithDeposit(ctx, func() (types.Currency, error) {
+		return amount, h.transportPool.withTransportV3(ctx, h.HostKey(), h.siamuxAddr, func(t *transportV3) (err error) {
 			cost := amount.Add(pt.FundAccountCost)
-			payment, err := payByContract(revision, cost, rhpv3.Account{}, rk) // no account needed for funding
+			payment, err := payByContract(revision, cost, rhpv3.Account{}, h.renterKey) // no account needed for funding
 			if err != nil {
 				return err
 			}
-			if err := RPCFundAccount(ctx, t, &payment, account.id, pt.UID); err != nil {
+			if err := RPCFundAccount(ctx, t, &payment, h.acc.id, pt.UID); err != nil {
 				return fmt.Errorf("failed to fund account with %v;%w", amount, err)
 			}
-			w.contractSpendingRecorder.Record(revision.ParentID, api.ContractSpending{FundAccount: cost})
+			h.contractSpendingRecorder.Record(revision.ParentID, api.ContractSpending{FundAccount: cost})
 			return nil
 		})
 	})
 }
 
-func (w *worker) syncAccount(ctx context.Context, hk types.PublicKey, siamuxAddr string, revision *types.FileContractRevision) error {
-	// fetch the account
-	account, err := w.accounts.ForHost(hk)
-	if err != nil {
-		return err
-	}
-
+func (h *host) SyncAccount(ctx context.Context, revision *types.FileContractRevision) error {
 	// fetch pricetable
-	pt, err := w.priceTables.fetch(ctx, hk, revision)
+	pt, err := h.priceTable(ctx, revision)
 	if err != nil {
 		return err
 	}
 
-	return account.WithSync(ctx, func() (types.Currency, error) {
+	return h.acc.WithSync(ctx, func() (types.Currency, error) {
 		var balance types.Currency
-		err := w.transportPoolV3.withTransportV3(ctx, hk, siamuxAddr, func(t *transportV3) error {
-			payment := w.preparePayment(hk, pt.AccountBalanceCost, pt.HostBlockHeight)
-			balance, err = RPCAccountBalance(ctx, t, &payment, account.id, pt.UID)
+		err := h.transportPool.withTransportV3(ctx, h.HostKey(), h.siamuxAddr, func(t *transportV3) error {
+			payment := preparePayment(h.accountKey, pt.AccountBalanceCost, pt.HostBlockHeight)
+			balance, err = RPCAccountBalance(ctx, t, &payment, h.acc.id, pt.UID)
 			return err
 		})
 		return balance, err
@@ -366,14 +368,16 @@ type (
 	}
 
 	host struct {
-		acc           *account
-		bh            uint64
-		fcid          types.FileContractID
-		pt            rhpv3.HostPriceTable
-		siamuxAddr    string
-		renterKey     types.PrivateKey
-		accountKey    types.PrivateKey
-		transportPool *transportPoolV3
+		acc                      *account
+		bus                      Bus
+		contractSpendingRecorder *contractSpendingRecorder
+		logger                   *zap.SugaredLogger
+		fcid                     types.FileContractID
+		siamuxAddr               string
+		renterKey                types.PrivateKey
+		accountKey               types.PrivateKey
+		transportPool            *transportPoolV3
+		priceTables              *priceTables
 	}
 )
 
@@ -385,29 +389,6 @@ func (w *worker) initAccounts(as AccountStore) {
 		store: as,
 		key:   w.deriveSubKey("accountkey"),
 	}
-}
-
-func (w *worker) withHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string, fn func(hostV3) error) (err error) {
-	acc, err := w.accounts.ForHost(hostKey)
-	if err != nil {
-		return err
-	}
-
-	pt, err := w.priceTables.fetch(ctx, hostKey, nil)
-	if err != nil {
-		return err
-	}
-
-	return fn(&host{
-		acc:           acc,
-		bh:            pt.HostBlockHeight,
-		fcid:          contractID,
-		pt:            pt.HostPriceTable,
-		siamuxAddr:    siamuxAddr,
-		renterKey:     w.deriveRenterKey(hostKey),
-		accountKey:    w.accounts.deriveAccountKey(hostKey),
-		transportPool: w.transportPoolV3,
-	})
 }
 
 // ForHost returns an account to use for a given host. If the account
@@ -531,10 +512,28 @@ func (*host) DeleteSectors(ctx context.Context, roots []types.Hash256) error {
 	panic("not implemented")
 }
 
+// priceTable fetches a price table from the host. If a revision is provided, it
+// will be used to pay for the price table. The returned price table is
+// guaranteed to be safe to use.
+func (h *host) priceTable(ctx context.Context, rev *types.FileContractRevision) (rhpv3.HostPriceTable, error) {
+	pt, err := h.priceTables.fetch(ctx, h.HostKey(), rev)
+	if err != nil {
+		return rhpv3.HostPriceTable{}, err
+	}
+	gc, err := GougingCheckerFromContext(ctx)
+	if err != nil {
+		return rhpv3.HostPriceTable{}, err
+	}
+	if breakdown := gc.Check(nil, &pt.HostPriceTable); breakdown.Gouging() {
+		return rhpv3.HostPriceTable{}, fmt.Errorf("host price table gouging: %v", breakdown)
+	}
+	return pt.HostPriceTable, nil
+}
+
 func (r *host) DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint64) (err error) {
-	// return errGougingHost if gouging checks fail
-	if breakdown := GougingCheckerFromContext(ctx).Check(nil, &r.pt); breakdown.Gouging() {
-		return fmt.Errorf("failed to download sector, %w: %v", errGougingHost, breakdown.Reasons())
+	pt, err := r.priceTable(ctx, nil)
+	if err != nil {
+		return err
 	}
 	// return errBalanceInsufficient if balance insufficient
 	defer func() {
@@ -545,14 +544,14 @@ func (r *host) DownloadSector(ctx context.Context, w io.Writer, root types.Hash2
 
 	return r.acc.WithWithdrawal(ctx, func() (amount types.Currency, err error) {
 		err = r.transportPool.withTransportV3(ctx, r.HostKey(), r.siamuxAddr, func(t *transportV3) error {
-			cost, err := readSectorCost(r.pt)
+			cost, err := readSectorCost(pt)
 			if err != nil {
 				return err
 			}
 
 			var refund types.Currency
-			payment := rhpv3.PayByEphemeralAccount(r.acc.id, cost, r.bh+defaultWithdrawalExpiryBlocks, r.accountKey)
-			cost, refund, err = RPCReadSector(ctx, t, w, r.pt, &payment, offset, length, root, true)
+			payment := rhpv3.PayByEphemeralAccount(r.acc.id, cost, pt.HostBlockHeight+defaultWithdrawalExpiryBlocks, r.accountKey)
+			cost, refund, err = RPCReadSector(ctx, t, w, pt, &payment, offset, length, root, true)
 			amount = cost.Sub(refund)
 			return err
 		})
@@ -562,9 +561,9 @@ func (r *host) DownloadSector(ctx context.Context, w io.Writer, root types.Hash2
 
 // UploadSector uploads a sector to the host.
 func (r *host) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte, rev *types.FileContractRevision) (_ types.Hash256, err error) {
-	// return errGougingHost if gouging checks fail
-	if breakdown := GougingCheckerFromContext(ctx).Check(nil, &r.pt); breakdown.Gouging() {
-		return types.Hash256{}, fmt.Errorf("failed to upload sector, %w: %v", errGougingHost, breakdown.Reasons())
+	pt, err := r.priceTable(ctx, nil)
+	if err != nil {
+		return types.Hash256{}, err
 	}
 	// return errBalanceInsufficient if balance insufficient
 	defer func() {
@@ -577,12 +576,12 @@ func (r *host) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte,
 	return sectorRoot, r.acc.WithWithdrawal(ctx, func() (amount types.Currency, err error) {
 		err = r.transportPool.withTransportV3(ctx, r.HostKey(), r.siamuxAddr, func(t *transportV3) error {
 			var refund, cost types.Currency
-			expectedCost, _, _, err := uploadSectorCost(r.pt, rev.EndHeight())
+			expectedCost, _, _, err := uploadSectorCost(pt, rev.EndHeight())
 			if err != nil {
 				return err
 			}
-			payment := rhpv3.PayByEphemeralAccount(r.acc.id, expectedCost, r.bh+defaultWithdrawalExpiryBlocks, r.accountKey)
-			sectorRoot, cost, refund, err = RPCAppendSector(ctx, t, r.renterKey, r.pt, rev, &payment, sector)
+			payment := rhpv3.PayByEphemeralAccount(r.acc.id, expectedCost, pt.HostBlockHeight+defaultWithdrawalExpiryBlocks, r.accountKey)
+			sectorRoot, cost, refund, err = RPCAppendSector(ctx, t, r.renterKey, pt, rev, &payment, sector)
 			amount = cost.Sub(refund)
 			return err
 		})
@@ -757,13 +756,12 @@ func (p *priceTable) fetch(ctx context.Context, revision *types.FileContractRevi
 // NOTE: This way of paying for a price table should only be used if payment by
 // EA is not possible or if we already need a contract revision anyway. e.g.
 // funding an EA.
-func (w *worker) preparePriceTableContractPayment(hk types.PublicKey, revision *types.FileContractRevision) PriceTablePaymentFunc {
+func (h *host) preparePriceTableContractPayment(revision *types.FileContractRevision) PriceTablePaymentFunc {
 	return func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) {
 		// TODO: gouging check on price table
 
-		refundAccount := rhpv3.Account(w.accounts.deriveAccountKey(hk).PublicKey())
-		rk := w.deriveRenterKey(hk)
-		payment, err := payByContract(revision, pt.UpdatePriceTableCost, refundAccount, rk)
+		refundAccount := rhpv3.Account(h.accountKey.PublicKey())
+		payment, err := payByContract(revision, pt.UpdatePriceTableCost, refundAccount, h.renterKey)
 		if err != nil {
 			return nil, err
 		}
@@ -776,13 +774,12 @@ func (w *worker) preparePriceTableContractPayment(hk types.PublicKey, revision *
 //
 // NOTE: This is the preferred way of paying for a price table since it is
 // faster and doesn't require locking a contract.
-func (w *worker) preparePriceTableAccountPayment(hk types.PublicKey, bh uint64) PriceTablePaymentFunc {
+func (h *host) preparePriceTableAccountPayment(bh uint64) PriceTablePaymentFunc {
 	return func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) {
 		// TODO: gouging check on price table
 
-		accountKey := w.accounts.deriveAccountKey(hk)
-		account := rhpv3.Account(accountKey.PublicKey())
-		payment := rhpv3.PayByEphemeralAccount(account, pt.UpdatePriceTableCost, bh+defaultWithdrawalExpiryBlocks, accountKey)
+		account := rhpv3.Account(h.accountKey.PublicKey())
+		payment := rhpv3.PayByEphemeralAccount(account, pt.UpdatePriceTableCost, bh+defaultWithdrawalExpiryBlocks, h.accountKey)
 		return &payment, nil
 	}
 }
@@ -821,14 +818,25 @@ type PriceTablePaymentFunc func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, e
 // Renew renews a contract with a host. To avoid an edge case where the contract
 // is drained and can therefore not be used to pay for the revision, we simply
 // don't pay for it.
-func (w *worker) Renew(ctx context.Context, rrr api.RHPRenewRequest, cs api.ConsensusState, renterKey types.PrivateKey) (_ rhpv2.ContractRevision, _ []types.Transaction, err error) {
+func (h *host) Renew(ctx context.Context, rrr api.RHPRenewRequest) (_ rhpv2.ContractRevision, _ []types.Transaction, err error) {
+	// Try to get a valid pricetable.
+	ptCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	var pt *rhpv3.HostPriceTable
+	hpt, err := h.priceTables.fetch(ptCtx, h.HostKey(), nil)
+	if err == nil {
+		pt = &hpt.HostPriceTable
+	} else {
+		h.logger.Debugf("unable to fetch price table for renew: %v", err)
+	}
+
 	var rev rhpv2.ContractRevision
 	var txnSet []types.Transaction
 	var renewErr error
-	err = w.transportPoolV3.withTransportV3(ctx, rrr.HostKey, rrr.SiamuxAddr, func(t *transportV3) (err error) {
-		_, err = RPCLatestRevision(ctx, t, rrr.ContractID, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
+	err = h.transportPool.withTransportV3(ctx, h.HostKey(), h.siamuxAddr, func(t *transportV3) (err error) {
+		_, err = RPCLatestRevision(ctx, t, h.fcid, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
 			// Renew contract.
-			rev, txnSet, renewErr = w.RPCRenew(ctx, rrr, cs, t, revision, renterKey)
+			rev, txnSet, renewErr = RPCRenew(ctx, rrr, h.bus, t, pt, revision, h.renterKey, h.logger)
 			return rhpv3.HostPriceTable{}, nil, nil
 		})
 		return err
@@ -837,6 +845,36 @@ func (w *worker) Renew(ctx context.Context, rrr api.RHPRenewRequest, cs api.Cons
 		return rhpv2.ContractRevision{}, nil, err
 	}
 	return rev, txnSet, renewErr
+}
+
+func (h *host) FetchPriceTable(ctx context.Context, revision *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error) {
+	// fetchPT is a helper function that performs the RPC given a payment function
+	fetchPT := func(paymentFn PriceTablePaymentFunc) (hpt hostdb.HostPriceTable, err error) {
+		err = h.transportPool.withTransportV3(ctx, h.HostKey(), h.siamuxAddr, func(t *transportV3) (err error) {
+			pt, err := RPCPriceTable(ctx, t, paymentFn)
+			if err != nil {
+				return err
+			}
+			hpt = hostdb.HostPriceTable{
+				HostPriceTable: pt,
+				Expiry:         time.Now().Add(pt.Validity),
+			}
+			return nil
+		})
+		return
+	}
+
+	// pay by contract if a revision is given
+	if revision != nil {
+		return fetchPT(h.preparePriceTableContractPayment(revision))
+	}
+
+	// pay by account
+	cs, err := h.bus.ConsensusState(ctx)
+	if err != nil {
+		return hostdb.HostPriceTable{}, err
+	}
+	return fetchPT(h.preparePriceTableAccountPayment(cs.BlockHeight))
 }
 
 // RPCPriceTable calls the UpdatePriceTable RPC.
@@ -1154,7 +1192,7 @@ func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.Privat
 	return
 }
 
-func (w *worker) RPCRenew(ctx context.Context, rrr api.RHPRenewRequest, cs api.ConsensusState, t *transportV3, rev *types.FileContractRevision, renterKey types.PrivateKey) (_ rhpv2.ContractRevision, _ []types.Transaction, err error) {
+func RPCRenew(ctx context.Context, rrr api.RHPRenewRequest, bus Bus, t *transportV3, pt *rhpv3.HostPriceTable, rev *types.FileContractRevision, renterKey types.PrivateKey, l *zap.SugaredLogger) (_ rhpv2.ContractRevision, _ []types.Transaction, err error) {
 	defer wrapErr(&err, "RPCRenew")
 	s, err := t.DialStream(ctx)
 	if err != nil {
@@ -1162,20 +1200,11 @@ func (w *worker) RPCRenew(ctx context.Context, rrr api.RHPRenewRequest, cs api.C
 	}
 	defer s.Close()
 
-	// Try to get a valid pricetable.
-	var ptUID rhpv3.SettingsID
-	ptCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	var pt rhpv3.HostPriceTable
-	hpt, err := w.priceTables.fetch(ptCtx, rrr.HostKey, nil)
-	if err == nil {
-		pt = hpt.HostPriceTable
-		ptUID = hpt.UID
-	} else {
-		w.logger.Warnf("failed to fetch valid pricetable for renew: %v", err)
-	}
-
 	// Send the ptUID.
+	var ptUID rhpv3.SettingsID
+	if pt != nil {
+		ptUID = pt.UID
+	}
 	if err = s.WriteRequest(rhpv3.RPCRenewContractID, &ptUID); err != nil {
 		return rhpv2.ContractRevision{}, nil, err
 	}
@@ -1187,25 +1216,29 @@ func (w *worker) RPCRenew(ctx context.Context, rrr api.RHPRenewRequest, cs api.C
 		if err = s.ReadResponse(&ptResp, 4096); err != nil {
 			return rhpv2.ContractRevision{}, nil, err
 		}
-		if err = json.Unmarshal(ptResp.PriceTableJSON, &pt); err != nil {
+		if err = json.Unmarshal(ptResp.PriceTableJSON, pt); err != nil {
 			return rhpv2.ContractRevision{}, nil, err
 		}
 	}
 
 	// Perform gouging checks.
-	if gc := GougingCheckerFromContext(ctx).Check(nil, &pt); gc.Gouging() {
-		return rhpv2.ContractRevision{}, nil, fmt.Errorf("host gouging during renew: %v", gc.Reasons())
+	gc, err := GougingCheckerFromContext(ctx)
+	if err != nil {
+		return rhpv2.ContractRevision{}, nil, err
+	}
+	if breakdown := gc.Check(nil, pt); breakdown.Gouging() {
+		return rhpv2.ContractRevision{}, nil, fmt.Errorf("host gouging during renew: %v", breakdown.Reasons())
 	}
 
 	// Prepare the signed transaction that contains the final revision as well
 	// as the new contract
-	wprr, err := w.bus.WalletPrepareRenew(ctx, *rev, rrr.HostAddress, rrr.RenterAddress, renterKey, rrr.RenterFunds, rrr.NewCollateral, rrr.HostKey, pt, rrr.EndHeight, rrr.WindowSize)
+	wprr, err := bus.WalletPrepareRenew(ctx, *rev, rrr.HostAddress, rrr.RenterAddress, renterKey, rrr.RenterFunds, rrr.NewCollateral, rrr.HostKey, *pt, rrr.EndHeight, rrr.WindowSize)
 	if err != nil {
 		return rhpv2.ContractRevision{}, nil, err
 	}
 
 	// Starting from here, we need to make sure to release the txn on error.
-	defer w.discardTxnOnErr(ctx, wprr.TransactionSet[len(wprr.TransactionSet)-1], "RPCRenew", &err)
+	defer discardTxnOnErr(ctx, bus, l, wprr.TransactionSet[len(wprr.TransactionSet)-1], "RPCRenew", &err)
 
 	txnSet := wprr.TransactionSet
 	parents, txn := txnSet[:len(txnSet)-1], txnSet[len(txnSet)-1]
@@ -1262,7 +1295,7 @@ func (w *worker) RPCRenew(ctx context.Context, rrr api.RHPRenewRequest, cs api.C
 		Signatures:       []uint64{0, 1},
 	}
 	cf = wallet.ExplicitCoveredFields(txn)
-	if err := w.bus.WalletSign(ctx, &txn, wprr.ToSign, cf); err != nil {
+	if err := bus.WalletSign(ctx, &txn, wprr.ToSign, cf); err != nil {
 		return rhpv2.ContractRevision{}, nil, err
 	}
 

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -15,6 +15,7 @@ import (
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/object"
 	"go.sia.tech/renterd/tracing"
 	"go.uber.org/zap"
@@ -39,8 +40,13 @@ type hostV2 interface {
 
 type hostV3 interface {
 	hostV2
-	UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte, rev *types.FileContractRevision) (types.Hash256, error)
+	FetchPriceTable(ctx context.Context, revision *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error)
+	FetchRevision(ctx context.Context, fetchTimeout time.Duration, blockHeight uint64) (types.FileContractRevision, error)
+	FundAccount(ctx context.Context, balance types.Currency, revision *types.FileContractRevision) error
 	DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint64) error
+	Renew(ctx context.Context, rrr api.RHPRenewRequest) (_ rhpv2.ContractRevision, _ []types.Transaction, err error)
+	SyncAccount(ctx context.Context, revision *types.FileContractRevision) error
+	UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte, rev *types.FileContractRevision) (types.Hash256, error)
 }
 
 type hostProvider interface {

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -13,6 +13,7 @@ import (
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/object"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
@@ -55,6 +56,22 @@ func (h *mockHost) DeleteSectors(_ context.Context, roots []types.Hash256) error
 		delete(h.sectors, root)
 	}
 	return nil
+}
+
+func (h *mockHost) FetchPriceTable(ctx context.Context, revision *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error) {
+	panic("not implemented")
+}
+func (h *mockHost) FetchRevision(ctx context.Context, fetchTimeout time.Duration, blockHeight uint64) (_ types.FileContractRevision, _ error) {
+	panic("not implemented")
+}
+func (h *mockHost) FundAccount(ctx context.Context, balance types.Currency, revision *types.FileContractRevision) error {
+	panic("not implemented")
+}
+func (h *mockHost) Renew(ctx context.Context, rrr api.RHPRenewRequest) (_ rhpv2.ContractRevision, _ []types.Transaction, err error) {
+	panic("not implemented")
+}
+func (h *mockHost) SyncAccount(ctx context.Context, revision *types.FileContractRevision) error {
+	panic("not implemented")
 }
 
 func newMockHost() *mockHost {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -406,19 +406,6 @@ func (w *worker) withHostV3(ctx context.Context, contractID types.FileContractID
 		return err
 	}
 
-	pt, err := w.priceTables.fetch(ctx, hostKey, nil)
-	if err != nil {
-		return err
-	}
-
-	gc, err := GougingCheckerFromContext(ctx)
-	if err != nil {
-		return err
-	}
-	if breakdown := gc.Check(nil, &pt.HostPriceTable); breakdown.Gouging() {
-		return fmt.Errorf("host price table gouging detected: %v", breakdown)
-	}
-
 	return fn(&host{
 		acc:                      acc,
 		bus:                      w.bus,
@@ -576,7 +563,7 @@ func (w *worker) fetchPriceTable(ctx context.Context, hk types.PublicKey, siamux
 	defer func() { w.recordPriceTableUpdate(hk, hpt, err) }()
 
 	var pt hostdb.HostPriceTable
-	err = w.withHostV3(ctx, revision.ParentID, hk, siamuxAddr, func(h hostV3) error {
+	err = w.withHostV3(ctx, types.FileContractID{}, hk, siamuxAddr, func(h hostV3) error {
 		hpt, err := h.(*host).FetchPriceTable(ctx, revision)
 		if err != nil {
 			return err

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -435,7 +435,7 @@ func (w *worker) withRevision(ctx context.Context, fetchTimeout time.Duration, c
 
 	var rev types.FileContractRevision
 	err = w.withHostV3(ctx, contractID, hk, siamuxAddr, func(h hostV3) error {
-		rev, err = h.(*host).FetchRevision(ctx, fetchTimeout, cs.BlockHeight)
+		rev, err = h.FetchRevision(ctx, fetchTimeout, cs.BlockHeight)
 		return err
 	})
 	if err != nil {
@@ -564,7 +564,7 @@ func (w *worker) fetchPriceTable(ctx context.Context, hk types.PublicKey, siamux
 
 	var pt hostdb.HostPriceTable
 	err = w.withHostV3(ctx, types.FileContractID{}, hk, siamuxAddr, func(h hostV3) error {
-		hpt, err := h.(*host).FetchPriceTable(ctx, revision)
+		hpt, err := h.FetchPriceTable(ctx, revision)
 		if err != nil {
 			return err
 		}
@@ -1413,7 +1413,7 @@ func isErrDuplicateTransactionSet(err error) bool {
 
 func (w *worker) FundAccount(ctx context.Context, hk types.PublicKey, siamuxAddr string, balance types.Currency, revision *types.FileContractRevision) error {
 	return w.withHostV3(ctx, revision.ParentID, hk, siamuxAddr, func(h hostV3) error {
-		return h.(*host).FundAccount(ctx, balance, revision)
+		return h.FundAccount(ctx, balance, revision)
 	})
 }
 
@@ -1424,7 +1424,7 @@ func (w *worker) Renew(ctx context.Context, rrr api.RHPRenewRequest) (_ rhpv2.Co
 	var renewed rhpv2.ContractRevision
 	var txns []types.Transaction
 	err = w.withHostV3(ctx, rrr.ContractID, rrr.HostKey, rrr.SiamuxAddr, func(h hostV3) error {
-		renewed, txns, err = h.(*host).Renew(ctx, rrr)
+		renewed, txns, err = h.Renew(ctx, rrr)
 		return err
 	})
 	return renewed, txns, err
@@ -1432,6 +1432,6 @@ func (w *worker) Renew(ctx context.Context, rrr api.RHPRenewRequest) (_ rhpv2.Co
 
 func (w *worker) SyncAccount(ctx context.Context, hk types.PublicKey, siamuxAddr string, revision *types.FileContractRevision) error {
 	return w.withHostV3(ctx, revision.ParentID, hk, siamuxAddr, func(h hostV3) error {
-		return h.(*host).SyncAccount(ctx, revision)
+		return h.SyncAccount(ctx, revision)
 	})
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -192,13 +192,19 @@ type AccountStore interface {
 	ScheduleSync(ctx context.Context, id rhpv3.Account, hk types.PublicKey) error
 }
 
-type revisionUnlocker interface {
-	Release(context.Context) error
-}
+type (
+	consensusState interface {
+		ConsensusState(ctx context.Context) (api.ConsensusState, error)
+	}
 
-type revisionLocker interface {
-	withRevision(ctx context.Context, timeout time.Duration, contractID types.FileContractID, hk types.PublicKey, siamuxAddr string, lockPriority int, fn func(revision types.FileContractRevision) error) error
-}
+	revisionUnlocker interface {
+		Release(context.Context) error
+	}
+
+	revisionLocker interface {
+		withRevision(ctx context.Context, timeout time.Duration, contractID types.FileContractID, hk types.PublicKey, siamuxAddr string, lockPriority int, fn func(revision types.FileContractRevision) error) error
+	}
+)
 
 type ContractLocker interface {
 	AcquireContract(ctx context.Context, fcid types.FileContractID, priority int, d time.Duration) (lockID uint64, err error)
@@ -208,11 +214,12 @@ type ContractLocker interface {
 
 // A Bus is the source of truth within a renterd system.
 type Bus interface {
+	consensusState
+
 	AccountStore
 	ContractLocker
 
 	BroadcastTransaction(ctx context.Context, txns []types.Transaction) error
-	ConsensusState(ctx context.Context) (api.ConsensusState, error)
 
 	Contracts(ctx context.Context) ([]api.ContractMetadata, error)
 	ContractSetContracts(ctx context.Context, set string) ([]api.ContractMetadata, error)
@@ -371,22 +378,62 @@ func (w *worker) withTransportV2(ctx context.Context, hostKey types.PublicKey, h
 }
 
 func (w *worker) withHostV2(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP string, fn func(hostV2) error) (err error) {
-	return w.withHostsV2(ctx, []api.ContractMetadata{{
-		ID:      contractID,
-		HostKey: hostKey,
-		HostIP:  hostIP,
-	}}, func(ss []hostV2) error {
-		return fn(ss[0])
+	host := w.pool.session(hostKey, hostIP, contractID, w.deriveRenterKey(hostKey))
+	done := make(chan struct{})
+
+	// Unlock hosts either after the context is closed or the function is done
+	// executing.
+	go func() {
+		select {
+		case <-done:
+		case <-ctx.Done():
+		}
+		w.unlockHost(host)
+	}()
+	defer func() {
+		close(done)
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		}
+	}()
+	err = fn(host)
+	return err
+}
+
+func (w *worker) withHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string, fn func(hostV3) error) (err error) {
+	acc, err := w.accounts.ForHost(hostKey)
+	if err != nil {
+		return err
+	}
+
+	pt, err := w.priceTables.fetch(ctx, hostKey, nil)
+	if err != nil {
+		return err
+	}
+
+	gc, err := GougingCheckerFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	if breakdown := gc.Check(nil, &pt.HostPriceTable); breakdown.Gouging() {
+		return fmt.Errorf("host price table gouging detected: %v", breakdown)
+	}
+
+	return fn(&host{
+		acc:                      acc,
+		bus:                      w.bus,
+		contractSpendingRecorder: w.contractSpendingRecorder,
+		logger:                   w.logger.Named(hostKey.String()[:4]),
+		fcid:                     contractID,
+		siamuxAddr:               siamuxAddr,
+		renterKey:                w.deriveRenterKey(hostKey),
+		accountKey:               w.accounts.deriveAccountKey(hostKey),
+		transportPool:            w.transportPoolV3,
+		priceTables:              w.priceTables,
 	})
 }
 
 func (w *worker) withRevision(ctx context.Context, fetchTimeout time.Duration, contractID types.FileContractID, hk types.PublicKey, siamuxAddr string, lockPriority int, fn func(revision types.FileContractRevision) error) error {
-	timeoutCtx := func() (context.Context, context.CancelFunc) {
-		if fetchTimeout > 0 {
-			return context.WithTimeout(ctx, fetchTimeout)
-		}
-		return ctx, func() {}
-	}
 	cs, err := w.bus.ConsensusState(ctx)
 	if err != nil {
 		return err
@@ -399,27 +446,18 @@ func (w *worker) withRevision(ctx context.Context, fetchTimeout time.Duration, c
 	}
 	defer contractLock.Release(ctx)
 
-	// Try to fetch the revision with an account first.
-	ctx, cancel := timeoutCtx()
-	defer cancel()
-	rev, err := w.FetchRevisionWithAccount(ctx, hk, siamuxAddr, cs.BlockHeight, contractID)
-	if err != nil && !isBalanceInsufficient(err) {
+	var rev types.FileContractRevision
+	err = w.withHostV3(ctx, contractID, hk, siamuxAddr, func(h hostV3) error {
+		rev, err = h.(*host).FetchRevision(ctx, fetchTimeout, cs.BlockHeight)
 		return err
-	} else if err == nil {
-		return fn(rev)
-	}
-
-	// Fall back to using the contract to pay for the revision.
-	ctx, cancel = timeoutCtx()
-	defer cancel()
-	rev, err = w.FetchRevisionWithContract(ctx, hk, siamuxAddr, contractID)
+	})
 	if err != nil {
 		return err
 	}
 	return fn(rev)
 }
 
-func (w *worker) unlockHosts(hosts []hostV2) {
+func (w *worker) unlockHost(host hostV2) {
 	// apply a pessimistic timeout, ensuring unlocking the contract or force
 	// closing the session does not deadlock and keep this goroutine around
 	// forever. Use a background context as the parent to avoid timing out
@@ -427,41 +465,7 @@ func (w *worker) unlockHosts(hosts []hostV2) {
 	// closed.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
 	defer cancel()
-	var wg sync.WaitGroup
-	for _, h := range hosts {
-		wg.Add(1)
-		go func(ss *sharedSession) {
-			w.pool.unlockContract(ctx, ss)
-			wg.Done()
-		}(h.(*sharedSession))
-	}
-	wg.Wait()
-}
-
-func (w *worker) withHostsV2(ctx context.Context, contracts []api.ContractMetadata, fn func([]hostV2) error) (err error) {
-	var hosts []hostV2
-	for _, c := range contracts {
-		hosts = append(hosts, w.pool.session(c.HostKey, c.HostIP, c.ID, w.deriveRenterKey(c.HostKey)))
-	}
-	done := make(chan struct{})
-
-	// Unlock hosts either after the context is closed or the function is done
-	// executing.
-	go func() {
-		select {
-		case <-done:
-		case <-ctx.Done():
-		}
-		w.unlockHosts(hosts)
-	}()
-	defer func() {
-		close(done)
-		if ctx.Err() != nil {
-			err = ctx.Err()
-		}
-	}()
-	err = fn(hosts)
-	return err
+	w.pool.unlockContract(ctx, host.(*sharedSession))
 }
 
 func (w *worker) rhpScanHandler(jc jape.Context) {
@@ -571,33 +575,16 @@ func (w *worker) fetchContracts(ctx context.Context, metadatas []api.ContractMet
 func (w *worker) fetchPriceTable(ctx context.Context, hk types.PublicKey, siamuxAddr string, revision *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error) {
 	defer func() { w.recordPriceTableUpdate(hk, hpt, err) }()
 
-	// fetchPT is a helper function that performs the RPC given a payment function
-	fetchPT := func(paymentFn PriceTablePaymentFunc) (hpt hostdb.HostPriceTable, err error) {
-		err = w.transportPoolV3.withTransportV3(ctx, hk, siamuxAddr, func(t *transportV3) (err error) {
-			pt, err := RPCPriceTable(ctx, t, paymentFn)
-			if err != nil {
-				return err
-			}
-			hpt = hostdb.HostPriceTable{
-				HostPriceTable: pt,
-				Expiry:         time.Now().Add(pt.Validity),
-			}
-			return nil
-		})
-		return
-	}
-
-	// pay by contract if a revision is given
-	if revision != nil {
-		return fetchPT(w.preparePriceTableContractPayment(hk, revision))
-	}
-
-	// pay by account
-	cs, err := w.bus.ConsensusState(ctx)
-	if err != nil {
-		return hostdb.HostPriceTable{}, err
-	}
-	return fetchPT(w.preparePriceTableAccountPayment(hk, cs.BlockHeight))
+	var pt hostdb.HostPriceTable
+	err = w.withHostV3(ctx, revision.ParentID, hk, siamuxAddr, func(h hostV3) error {
+		hpt, err := h.(*host).FetchPriceTable(ctx, revision)
+		if err != nil {
+			return err
+		}
+		pt = hpt
+		return nil
+	})
+	return pt, err
 }
 
 func (w *worker) rhpPriceTableHandler(jc jape.Context) {
@@ -621,18 +608,7 @@ func (w *worker) rhpPriceTableHandler(jc jape.Context) {
 }
 
 func (w *worker) discardTxnOnErr(ctx context.Context, txn types.Transaction, errContext string, err *error) {
-	if *err == nil {
-		return
-	}
-	_, span := tracing.Tracer.Start(ctx, "discardTxn")
-	defer span.End()
-	// Attach the span to a new context derived from the background context.
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	timeoutCtx = trace.ContextWithSpan(timeoutCtx, span)
-	if err := w.bus.WalletDiscard(timeoutCtx, txn); err != nil {
-		w.logger.Errorf("%v: failed to discard txn: %v", err)
-	}
+	discardTxnOnErr(ctx, w.bus, w.logger, txn, errContext, err)
 }
 
 func (w *worker) rhpFormHandler(jc jape.Context) {
@@ -657,7 +633,7 @@ func (w *worker) rhpFormHandler(jc jape.Context) {
 
 	var contract rhpv2.ContractRevision
 	var txnSet []types.Transaction
-	ctx = WithGougingChecker(ctx, gp)
+	ctx = WithGougingChecker(ctx, w.bus, gp)
 	err = w.withTransportV2(ctx, rfr.HostKey, hostIP, func(t *rhpv2.Transport) (err error) {
 		hostSettings, err := RPCSettings(ctx, t)
 		if err != nil {
@@ -667,7 +643,11 @@ func (w *worker) rhpFormHandler(jc jape.Context) {
 		// just used it to dial the host we know it's valid
 		hostSettings.NetAddress = hostIP
 
-		if breakdown := GougingCheckerFromContext(ctx).Check(&hostSettings, nil); breakdown.Gouging() {
+		gc, err := GougingCheckerFromContext(ctx)
+		if err != nil {
+			return err
+		}
+		if breakdown := gc.Check(&hostSettings, nil); breakdown.Gouging() {
 			return fmt.Errorf("failed to form contract, gouging check failed: %v", breakdown.Reasons())
 		}
 
@@ -709,22 +689,15 @@ func (w *worker) rhpRenewHandler(jc jape.Context) {
 		return
 	}
 
-	// get consensus state
-	cs, err := w.bus.ConsensusState(ctx)
-	if jc.Check("could not get consensus state", err) != nil {
-		return
-	}
-
 	// attach gouging checker
 	gp, err := w.bus.GougingParams(ctx)
 	if jc.Check("could not get gouging parameters", err) != nil {
 		return
 	}
-	ctx = WithGougingChecker(ctx, gp)
-	rk := w.deriveRenterKey(rrr.HostKey)
+	ctx = WithGougingChecker(ctx, w.bus, gp)
 
 	// renew the contract
-	renewed, txnSet, err := w.Renew(ctx, rrr, cs, rk)
+	renewed, txnSet, err := w.Renew(ctx, rrr)
 	if jc.Check("couldn't renew contract", err) != nil {
 		return
 	}
@@ -757,21 +730,21 @@ func (w *worker) rhpFundHandler(jc jape.Context) {
 	if jc.Check("could not get gouging parameters", err) != nil {
 		return
 	}
-	ctx = WithGougingChecker(ctx, gp)
+	ctx = WithGougingChecker(ctx, w.bus, gp)
 
 	// fund the account
 	jc.Check("couldn't fund account", w.withRevision(ctx, defaultRevisionFetchTimeout, rfr.ContractID, rfr.HostKey, rfr.SiamuxAddr, lockingPriorityFunding, func(revision types.FileContractRevision) (err error) {
-		err = w.fundAccount(ctx, rfr.HostKey, rfr.SiamuxAddr, rfr.Balance, &revision)
+		err = w.FundAccount(ctx, rfr.HostKey, rfr.SiamuxAddr, rfr.Balance, &revision)
 		if isMaxBalanceExceeded(err) {
 			// sync the account
-			err = w.syncAccount(ctx, rfr.HostKey, rfr.SiamuxAddr, &revision)
+			err = w.SyncAccount(ctx, rfr.HostKey, rfr.SiamuxAddr, &revision)
 			if err != nil {
 				w.logger.Errorw(fmt.Sprintf("failed to sync account: %v", err), "host", rfr.HostKey)
 				return
 			}
 
 			// try funding the account again
-			err = w.fundAccount(ctx, rfr.HostKey, rfr.SiamuxAddr, rfr.Balance, &revision)
+			err = w.FundAccount(ctx, rfr.HostKey, rfr.SiamuxAddr, rfr.Balance, &revision)
 			if errors.Is(err, errBalanceSufficient) {
 				w.logger.Debugf("account balance for host %v restored after sync", rfr.HostKey)
 				return nil
@@ -810,7 +783,8 @@ func (w *worker) rhpRegistryUpdateHandler(jc jape.Context) {
 	var pt rhpv3.HostPriceTable   // TODO
 	rc := pt.UpdateRegistryCost() // TODO: handle refund
 	cost, _ := rc.Total()
-	payment := w.preparePayment(rrur.HostKey, cost, pt.HostBlockHeight)
+	// TODO: refactor to a w.RegistryUpdate method that calls host.RegistryUpdate.
+	payment := preparePayment(w.accounts.deriveAccountKey(rrur.HostKey), cost, pt.HostBlockHeight)
 	err := w.transportPoolV3.withTransportV3(jc.Request.Context(), rrur.HostKey, rrur.SiamuxAddr, func(t *transportV3) (err error) {
 		return RPCUpdateRegistry(jc.Request.Context(), t, &payment, rrur.RegistryKey, rrur.RegistryValue)
 	})
@@ -835,11 +809,11 @@ func (w *worker) rhpSyncHandler(jc jape.Context) {
 	}
 
 	// attach gouging checker to the context
-	ctx = WithGougingChecker(ctx, up.GougingParams)
+	ctx = WithGougingChecker(ctx, w.bus, up.GougingParams)
 
 	// sync the account
 	jc.Check("couldn't sync account", w.withRevision(ctx, defaultRevisionFetchTimeout, rsr.ContractID, rsr.HostKey, rsr.SiamuxAddr, lockingPrioritySyncing, func(revision types.FileContractRevision) error {
-		return w.syncAccount(ctx, rsr.HostKey, rsr.SiamuxAddr, &revision)
+		return w.SyncAccount(ctx, rsr.HostKey, rsr.SiamuxAddr, &revision)
 	}))
 }
 
@@ -872,7 +846,7 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 	}
 
 	// attach gouging checker to the context
-	ctx = WithGougingChecker(ctx, up.GougingParams)
+	ctx = WithGougingChecker(ctx, w.bus, up.GougingParams)
 
 	// attach contract spending recorder to the context.
 	ctx = WithContractSpendingRecorder(ctx, w.contractSpendingRecorder)
@@ -955,7 +929,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 	}
 
 	// attach gouging checker to the context
-	ctx = WithGougingChecker(ctx, gp)
+	ctx = WithGougingChecker(ctx, w.bus, gp)
 
 	// NOTE: ideally we would use http.ServeContent in this handler, but that
 	// has performance issues. If we implemented io.ReadSeeker in the most
@@ -1101,7 +1075,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	}
 
 	// attach gouging checker to the context
-	ctx = WithGougingChecker(ctx, up.GougingParams)
+	ctx = WithGougingChecker(ctx, w.bus, up.GougingParams)
 
 	// attach contract spending recorder to the context.
 	ctx = WithContractSpendingRecorder(ctx, w.contractSpendingRecorder)
@@ -1198,7 +1172,7 @@ func (w *worker) rhpContractsHandlerGET(jc jape.Context) {
 	if jc.Check("could not get gouging parameters", err) != nil {
 		return
 	}
-	ctx = WithGougingChecker(ctx, gp)
+	ctx = WithGougingChecker(ctx, w.bus, gp)
 
 	contracts, errs := w.fetchContracts(ctx, busContracts, hosttimeout)
 	resp := api.ContractsResponse{Contracts: contracts}
@@ -1208,9 +1182,8 @@ func (w *worker) rhpContractsHandlerGET(jc jape.Context) {
 	jc.Encode(resp)
 }
 
-func (w *worker) preparePayment(hk types.PublicKey, amt types.Currency, blockHeight uint64) rhpv3.PayByEphemeralAccountRequest {
-	pk := w.accounts.deriveAccountKey(hk)
-	return rhpv3.PayByEphemeralAccount(rhpv3.Account(pk.PublicKey()), amt, blockHeight+6, pk) // 1 hour valid
+func preparePayment(accountKey types.PrivateKey, amt types.Currency, blockHeight uint64) rhpv3.PayByEphemeralAccountRequest {
+	return rhpv3.PayByEphemeralAccount(rhpv3.Account(accountKey.PublicKey()), amt, blockHeight+6, accountKey) // 1 hour valid
 }
 
 func (w *worker) idHandlerGET(jc jape.Context) {
@@ -1432,6 +1405,46 @@ func (w *worker) acquireRevision(ctx context.Context, fcid types.FileContractID,
 	return cl, nil
 }
 
+func discardTxnOnErr(ctx context.Context, bus Bus, l *zap.SugaredLogger, txn types.Transaction, errContext string, err *error) {
+	if *err == nil {
+		return
+	}
+	_, span := tracing.Tracer.Start(ctx, "discardTxn")
+	defer span.End()
+	// Attach the span to a new context derived from the background context.
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	timeoutCtx = trace.ContextWithSpan(timeoutCtx, span)
+	if err := bus.WalletDiscard(timeoutCtx, txn); err != nil {
+		l.Errorf("%v: failed to discard txn: %v", err)
+	}
+}
+
 func isErrDuplicateTransactionSet(err error) bool {
 	return err != nil && strings.Contains(err.Error(), modules.ErrDuplicateTransactionSet.Error())
+}
+
+func (w *worker) FundAccount(ctx context.Context, hk types.PublicKey, siamuxAddr string, balance types.Currency, revision *types.FileContractRevision) error {
+	return w.withHostV3(ctx, revision.ParentID, hk, siamuxAddr, func(h hostV3) error {
+		return h.(*host).FundAccount(ctx, balance, revision)
+	})
+}
+
+// Renew renews a contract with a host. To avoid an edge case where the contract
+// is drained and can therefore not be used to pay for the revision, we simply
+// don't pay for it.
+func (w *worker) Renew(ctx context.Context, rrr api.RHPRenewRequest) (_ rhpv2.ContractRevision, _ []types.Transaction, err error) {
+	var renewed rhpv2.ContractRevision
+	var txns []types.Transaction
+	err = w.withHostV3(ctx, rrr.ContractID, rrr.HostKey, rrr.SiamuxAddr, func(h hostV3) error {
+		renewed, txns, err = h.(*host).Renew(ctx, rrr)
+		return err
+	})
+	return renewed, txns, err
+}
+
+func (w *worker) SyncAccount(ctx context.Context, hk types.PublicKey, siamuxAddr string, revision *types.FileContractRevision) error {
+	return w.withHostV3(ctx, revision.ParentID, hk, siamuxAddr, func(h hostV3) error {
+		return h.(*host).SyncAccount(ctx, revision)
+	})
 }


### PR DESCRIPTION
This PR fixes an issue where gouging checks fail after a while since we never update the consensus state within the gouging checker. So instead of attaching a gouging checker to the context, we attach a function to create a gouging checker on demand.

While going through the code to see what calls to update, I ended up doing a few refactors as well. Mostly to achieve the following structure for all endpoints calling RPCs.

1. The RPC is a function (not a method) located in `rhpv3.go`
2. The RPC is called by an exposed method on the `host` type. 
3. The method on the `host` is called by a method on the `worker` that has the same name but essentially only calls `withHost`.

There might be a few leftovers that also require updating but I think this really improves the overall readability since it is strictly `endpoint` calls `worker` calls `host` which performs `RPC` and not some mix.

