### PR TITLE
Consider last block's timestamp in gouging

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -79,8 +79,9 @@ type AccountHandlerPOST struct {
 
 // ConsensusState holds the current blockheight and whether we are synced or not.
 type ConsensusState struct {
-	BlockHeight uint64
-	Synced      bool
+	BlockHeight   uint64    `json:"blockHeight"`
+	LastBlockTime time.Time `json:"lastBlockTime"`
+	Synced        bool      `json:"synced"`
 }
 
 // ConsensusNetwork holds the name of the network.

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -27,6 +27,7 @@ type (
 	// A ChainManager manages blockchain state.
 	ChainManager interface {
 		AcceptBlock(context.Context, types.Block) error
+		LastBlockTime() time.Time
 		Synced(ctx context.Context) bool
 		TipState(ctx context.Context) consensus.State
 	}
@@ -167,7 +168,7 @@ func (b *bus) syncerConnectHandler(jc jape.Context) {
 func (b *bus) consensusStateHandler(jc jape.Context) {
 	jc.Encode(api.ConsensusState{
 		BlockHeight:   b.cm.TipState(jc.Request.Context()).Index.Height,
-		LastBlockTime: b.cm.TipState(jc.Request.Context()).PrevTimestamps[10],
+		LastBlockTime: b.cm.LastBlockTime(),
 		Synced:        b.cm.Synced(jc.Request.Context()),
 	})
 }

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -166,8 +166,9 @@ func (b *bus) syncerConnectHandler(jc jape.Context) {
 
 func (b *bus) consensusStateHandler(jc jape.Context) {
 	jc.Encode(api.ConsensusState{
-		BlockHeight: b.cm.TipState(jc.Request.Context()).Index.Height,
-		Synced:      b.cm.Synced(jc.Request.Context()),
+		BlockHeight:   b.cm.TipState(jc.Request.Context()).Index.Height,
+		LastBlockTime: b.cm.TipState(jc.Request.Context()).PrevTimestamps[10],
+		Synced:        b.cm.Synced(jc.Request.Context()),
 	})
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -96,6 +96,10 @@ func (cm chainManager) AcceptBlock(ctx context.Context, b types.Block) error {
 	return cm.cs.AcceptBlock(sb)
 }
 
+func (cm chainManager) LastBlockTime() time.Time {
+	return time.Unix(int64(cm.cs.CurrentBlock().Timestamp), 0)
+}
+
 func (cm chainManager) Synced(ctx context.Context) bool {
 	return cm.cs.Synced()
 }

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -153,6 +153,9 @@ func TestNewTestCluster(t *testing.T) {
 	if err := cluster.Sync(); err != nil {
 		t.Fatal(err)
 	}
+	if cs.LastBlockTime.IsZero() {
+		t.Fatal("last block time not set")
+	}
 
 	// Now wait for the revision and proof to be caught by the hostdb.
 	err = Retry(20, time.Second, func() error {

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/bits"
+	"time"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
@@ -282,8 +283,10 @@ func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, txnFee t
 		return fmt.Errorf("RevisionBaseCost of %v exceeds 0H", pt.RevisionBaseCost)
 	}
 
-	// check block height
-	if !cs.Synced {
+	// check block height - if too much time has passed since the last block
+	// there is a chance we are not up-to-date anymore. So we only check whether
+	// the host's height is at least equal to ours.
+	if !cs.Synced || time.Since(cs.LastBlockTime) > time.Hour {
 		if pt.HostBlockHeight < cs.BlockHeight {
 			return fmt.Errorf("consensus not synced and host block height is lower, %v < %v", pt.HostBlockHeight, cs.BlockHeight)
 		}


### PR DESCRIPTION
To avoid accidentally nuking your contract set when your machine is on sleep or the VM you run renterd in is suspended, this PR adds the last block's timestamp to the consensus state.

If more than 60 minutes (6 block times) have passed since the latest block, we only check that the host is at least on the same block height as we are since we may no longer be synced.

Closes https://github.com/SiaFoundation/renterd/issues/367