### PR TITLE
Fix failure to broadcast renewal txns

### DIFF
--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -19,7 +19,6 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/hostdb"
-	"go.sia.tech/renterd/wallet"
 	"go.sia.tech/siad/crypto"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
@@ -1325,7 +1324,6 @@ func RPCRenew(ctx context.Context, rrr api.RHPRenewRequest, bus Bus, t *transpor
 		WholeTransaction: true,
 		Signatures:       []uint64{0, 1},
 	}
-	cf = wallet.ExplicitCoveredFields(txn)
 	if err := bus.WalletSign(ctx, &txn, wprr.ToSign, cf); err != nil {
 		return rhpv2.ContractRevision{}, nil, err
 	}

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -1357,6 +1357,7 @@ func RPCRenew(ctx context.Context, rrr api.RHPRenewRequest, bus Bus, t *transpor
 	if err = s.ReadResponse(&hostSigs, 4096); err != nil {
 		return rhpv2.ContractRevision{}, nil, err
 	}
+	txn.Signatures = append(txn.Signatures, hostSigs.TransactionSignatures...)
 
 	// Add the parents to get the full txnSet.
 	txnSet = append(parents, txn)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -655,7 +655,7 @@ func (w *worker) rhpFormHandler(jc jape.Context) {
 	// broadcast the transaction set
 	err = w.bus.BroadcastTransaction(jc.Request.Context(), txnSet)
 	if err != nil && !isErrDuplicateTransactionSet(err) {
-		w.logger.Warnf("failed to broadcast formation txn set: %v", err)
+		w.logger.Fatalf("failed to broadcast formation txn set: %v", err)
 	}
 
 	jc.Encode(api.RHPFormResponse{
@@ -694,7 +694,7 @@ func (w *worker) rhpRenewHandler(jc jape.Context) {
 	// broadcast the transaction set
 	err = w.bus.BroadcastTransaction(jc.Request.Context(), txnSet)
 	if err != nil && !isErrDuplicateTransactionSet(err) {
-		w.logger.Warnf("failed to broadcast renewal txn set: %v", err)
+		w.logger.Fatalf("failed to broadcast renewal txn set: %v", err)
 	}
 
 	// send the response

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -655,7 +655,7 @@ func (w *worker) rhpFormHandler(jc jape.Context) {
 	// broadcast the transaction set
 	err = w.bus.BroadcastTransaction(jc.Request.Context(), txnSet)
 	if err != nil && !isErrDuplicateTransactionSet(err) {
-		w.logger.Fatalf("failed to broadcast formation txn set: %v", err)
+		w.logger.Errorf("failed to broadcast formation txn set: %v", err)
 	}
 
 	jc.Encode(api.RHPFormResponse{
@@ -694,7 +694,7 @@ func (w *worker) rhpRenewHandler(jc jape.Context) {
 	// broadcast the transaction set
 	err = w.bus.BroadcastTransaction(jc.Request.Context(), txnSet)
 	if err != nil && !isErrDuplicateTransactionSet(err) {
-		w.logger.Fatalf("failed to broadcast renewal txn set: %v", err)
+		w.logger.Errorf("failed to broadcast renewal txn set: %v", err)
 	}
 
 	// send the response


### PR DESCRIPTION
After renewing a contract we weren't adding the host transaction to the txnSet. So broadcasting it would always fail. This PR fixes that.