### PR TITLE
Fix revision mismatch errors

### DIFF
--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -17,6 +17,7 @@ import (
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
+	"go.sia.tech/mux/v1"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/siad/crypto"
@@ -1225,6 +1226,21 @@ func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.Privat
 	if err = s.WriteResponse(&finalizeReq); err != nil {
 		return
 	} else if err = s.ReadResponse(&finalizeResp, 64); err != nil {
+		return
+	}
+
+	// read one more time to receive a potential error in case finalising the
+	// contract fails after receiving the RPCFinalizeProgramResponse. This also
+	// guarantees that the program is finalised before we return.
+	// TODO: remove once most hosts use hostd.
+	errFinalise := s.ReadResponse(&finalizeResp, 64)
+	if errFinalise != nil &&
+		!errors.Is(errFinalise, io.EOF) &&
+		!errors.Is(errFinalise, mux.ErrClosedConn) &&
+		!errors.Is(errFinalise, mux.ErrClosedStream) &&
+		!errors.Is(errFinalise, mux.ErrPeerClosedStream) &&
+		!errors.Is(errFinalise, mux.ErrPeerClosedConn) {
+		err = errFinalise
 		return
 	}
 	return


### PR DESCRIPTION
The revision mismatch is caused due to an issue in `siad` which will be fixed in `hostd`. Until then, this change will serve as a workaround.

NOTE: The "proof verification failed" - error is a side-effect of the revision number mismatch. So it's also fixed by this PR.