### PR TITLE
Don't scan hosts while being offline and abort scan if endpoint returns an error

### DIFF
--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -266,10 +266,13 @@ func (s *scanner) launchScanWorkers(ctx context.Context, w scanWorker, reqs chan
 		go func() {
 			for req := range reqs {
 				if s.ap.isStopped() {
-					break
+					return // shutdown
 				}
 
 				scan, err := w.RHPScan(ctx, req.hostKey, req.hostIP, s.currentTimeout())
+				if err != nil {
+					return // abort
+				}
 				respChan <- scanResp{req.hostKey, scan.Settings, err}
 				s.tracker.addDataPoint(time.Duration(scan.Ping))
 			}

--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -266,12 +266,12 @@ func (s *scanner) launchScanWorkers(ctx context.Context, w scanWorker, reqs chan
 		go func() {
 			for req := range reqs {
 				if s.ap.isStopped() {
-					return // shutdown
+					break // shutdown
 				}
 
 				scan, err := w.RHPScan(ctx, req.hostKey, req.hostIP, s.currentTimeout())
 				if err != nil {
-					return // abort
+					break // abort
 				}
 				respChan <- scanResp{req.hostKey, scan.Settings, err}
 				s.tracker.addDataPoint(time.Duration(scan.Ping))

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -236,6 +236,8 @@ type Bus interface {
 	AccountStore
 	ContractLocker
 
+	SyncerPeers(ctx context.Context) (resp []string, err error)
+
 	BroadcastTransaction(ctx context.Context, txns []types.Transaction) error
 
 	Contracts(ctx context.Context) ([]api.ContractMetadata, error)
@@ -486,8 +488,17 @@ func (w *worker) rhpScanHandler(jc jape.Context) {
 		defer cancel()
 	}
 
+	// only scan hosts if we are online
+	peers, err := w.bus.SyncerPeers(jc.Request.Context())
+	if jc.Check("failed to fetch peers from bus", err) != nil {
+		return
+	}
+	if len(peers) == 0 {
+		jc.Error(errors.New("not connected to the internet"), http.StatusServiceUnavailable)
+		return
+	}
+
 	// defer scan result
-	var err error
 	var settings rhpv2.HostSettings
 	var priceTable rhpv3.HostPriceTable
 	defer func() {


### PR DESCRIPTION
As the title suggests we should abort scanning as soon as one scan fails since that should never be the case to begin with. The autopilot will then retry in the next iteration.

We also shouldn't scan if we don't consider ourselves as online. 