### PR TITLE
Decay Upload Estimates

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -137,9 +137,9 @@ type RHPRegistryUpdateRequest struct {
 // UploadStatsResponse is the response type for the /stats/uploads endpoint.
 type UploadStatsResponse struct {
 	AvgSlabUploadSpeedMBPS float64         `json:"avgSlabUploadSpeedMBPS"`
+	AvgOverdrivePct        float64         `json:"avgOverdrivePct"`
 	HealthyUploaders       uint64          `json:"healthyUploaders"`
 	NumUploaders           uint64          `json:"numUploaders"`
-	OverdrivePct           float64         `json:"overdrivePct"`
 	UploadersStats         []UploaderStats `json:"uploadersStats"`
 }
 

--- a/api/worker.go
+++ b/api/worker.go
@@ -136,14 +136,14 @@ type RHPRegistryUpdateRequest struct {
 
 // UploadStatsResponse is the response type for the /stats/uploads endpoint.
 type UploadStatsResponse struct {
-	AvgUploadSpeedMBPS float64         `json:"avgUploadSpeedMBPS"`
-	HealthyUploaders   uint64          `json:"healthyUploaders"`
-	NumUploaders       uint64          `json:"numUploaders"`
-	OverdrivePct       float64         `json:"overdrivePct"`
-	UploadersStats     []UploaderStats `json:"uploadersStats"`
+	AvgSlabUploadSpeedMBPS float64         `json:"avgSlabUploadSpeedMBPS"`
+	HealthyUploaders       uint64          `json:"healthyUploaders"`
+	NumUploaders           uint64          `json:"numUploaders"`
+	OverdrivePct           float64         `json:"overdrivePct"`
+	UploadersStats         []UploaderStats `json:"uploadersStats"`
 }
 
 type UploaderStats struct {
-	HostKey            types.PublicKey `json:"hostKey"`
-	UploadSpeedP90MBPS float64         `json:"uploadSpeedP90MBPS"`
+	HostKey                  types.PublicKey `json:"hostKey"`
+	AvgSectorUploadSpeedMBPS float64         `json:"avgSectorUploadSpeedMBPS"`
 }

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -148,6 +148,7 @@ type (
 	dataPoints struct {
 		stats.Float64Data
 		halfLife time.Duration
+		size     int
 
 		mu            sync.Mutex
 		cnt           int
@@ -167,7 +168,8 @@ func (w *worker) initUploadManager() {
 
 func newDataPoints(halfLife time.Duration) *dataPoints {
 	return &dataPoints{
-		Float64Data: make([]float64, 20),
+		size:        20,
+		Float64Data: make([]float64, 0),
 		halfLife:    halfLife,
 		lastDecay:   time.Now(),
 	}
@@ -1098,8 +1100,13 @@ func (a *dataPoints) Track(p float64) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
+	if a.cnt < a.size {
+		a.Float64Data = append(a.Float64Data, p)
+	} else {
+		a.Float64Data[a.cnt%a.size] = p
+	}
+
 	a.lastDatapoint = time.Now()
-	a.Float64Data[a.cnt%len(a.Float64Data)] = p
 	a.cnt++
 }
 

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	statsDecayHalfTime        = 5 * time.Minute
+	statsDecayHalfTime        = time.Minute
 	statsRecomputeMinInterval = 10 * time.Second
 )
 
@@ -838,7 +838,7 @@ func (u *uploader) trackSectorUpload(err error, d time.Duration) {
 	defer u.mu.Unlock()
 	if err != nil {
 		u.consecutiveFailures++
-		u.statsEstimate.Track(math.MaxFloat64)
+		u.statsEstimate.Track(float64(time.Hour.Milliseconds()))
 	} else {
 		ms := d.Milliseconds()
 		u.consecutiveFailures = 0

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -422,18 +422,19 @@ func (mgr *uploadManager) uploader(shard *shardUpload) *uploader {
 
 loop:
 	for {
-		// if this slab does not have more than 1 parent, we resort the
-		// candidates and return the best one at the time
+		// if this slab does not have more than 1 parent, we return the best
+		// candidate
 		if len(shard.upload.parents(shard.sID)) <= 1 {
-			sort.Slice(candidates, func(i, j int) bool {
-				return candidates[i].estimate() < candidates[j].estimate()
-			})
 			return candidates[0]
 		}
 
-		// otherwise we wait, allowing the parents to complete
+		// otherwise we wait, allowing the parents to complete, after which we
+		// re-sort the candidates
 		select {
 		case <-shard.upload.doneShardTrigger:
+			sort.Slice(candidates, func(i, j int) bool {
+				return candidates[i].estimate() < candidates[j].estimate()
+			})
 			continue loop
 		case <-shard.ctx.Done():
 			break loop

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -138,9 +138,9 @@ type (
 
 	uploadManagerStats struct {
 		avgSlabUploadSpeedMBPS float64
+		avgOverdrivePct        float64
 		healthyUploaders       uint64
 		numUploaders           uint64
-		overdrivePct           float64
 		uploadSpeedsMBPS       map[types.PublicKey]float64
 	}
 
@@ -219,8 +219,8 @@ func (mgr *uploadManager) Stats() uploadManagerStats {
 	// prepare stats
 	return uploadManagerStats{
 		avgSlabUploadSpeedMBPS: mgr.statsSlabUploadSpeed.Average() * 0.008, // convert bytes per ms to mbps,
+		avgOverdrivePct:        mgr.statsOverdrive.Average(),
 		healthyUploaders:       uint64(numHealthy),
-		overdrivePct:           mgr.statsOverdrive.P90(),
 		numUploaders:           uint64(len(speeds)),
 		uploadSpeedsMBPS:       speeds,
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -899,23 +899,25 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 func (w *worker) uploadsStatshandlerGET(jc jape.Context) {
 	stats := w.uploadManager.Stats()
 
+	// prepare upload stats
 	var uss []api.UploaderStats
-	for hk, us := range stats.uploadSpeedsP90MBPS {
+	for hk, mbps := range stats.uploadSpeedsMBPS {
 		uss = append(uss, api.UploaderStats{
-			HostKey:            hk,
-			UploadSpeedP90MBPS: us,
+			HostKey:                  hk,
+			AvgSectorUploadSpeedMBPS: mbps,
 		})
 	}
 	sort.SliceStable(uss, func(i, j int) bool {
-		return uss[i].UploadSpeedP90MBPS > uss[j].UploadSpeedP90MBPS
+		return uss[i].AvgSectorUploadSpeedMBPS > uss[j].AvgSectorUploadSpeedMBPS
 	})
 
+	// encode response
 	jc.Encode(api.UploadStatsResponse{
-		AvgUploadSpeedMBPS: stats.avgUploadSpeedMBPS,
-		HealthyUploaders:   stats.healthyUploaders,
-		OverdrivePct:       math.Floor(stats.overdrivePct*100*100) / 100,
-		NumUploaders:       stats.numUploaders,
-		UploadersStats:     uss,
+		AvgSlabUploadSpeedMBPS: stats.avgSlabUploadSpeedMBPS,
+		HealthyUploaders:       stats.healthyUploaders,
+		OverdrivePct:           math.Floor(stats.overdrivePct*100*100) / 100,
+		NumUploaders:           stats.numUploaders,
+		UploadersStats:         uss,
 	})
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -913,9 +913,9 @@ func (w *worker) uploadsStatshandlerGET(jc jape.Context) {
 
 	// encode response
 	jc.Encode(api.UploadStatsResponse{
-		AvgSlabUploadSpeedMBPS: stats.avgSlabUploadSpeedMBPS,
+		AvgSlabUploadSpeedMBPS: math.Ceil(stats.avgSlabUploadSpeedMBPS*100) / 100,
+		AvgOverdrivePct:        math.Floor(stats.avgOverdrivePct*100*100) / 100,
 		HealthyUploaders:       stats.healthyUploaders,
-		OverdrivePct:           math.Floor(stats.overdrivePct*100*100) / 100,
 		NumUploaders:           stats.numUploaders,
 		UploadersStats:         uss,
 	})


### PR DESCRIPTION
Since we punish hosts for failing we need to apply a decay to their estimates to ensure they have a means to recover from errors, making sure they will eventually get picked again. I track sector upload estimates now, and only apply decay to those, ensuring that applying decay makes hosts more and more likely to get picked.

We do not apply decay to any statistic that gets exposed. There's some arbitrary constants being introduced here, I figure they're fine but maybe we want to tweak those. I've tweaked the stats slightly so it's very clear what they represent, some stats pertain to slab upload speeds while others give the more raw sector upload speeds.