### PR TITLE
Blocklist Fix

### DIFF
--- a/internal/testing/blocklist_test.go
+++ b/internal/testing/blocklist_test.go
@@ -125,4 +125,112 @@ func TestBlocklist(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+
+	// create a new host
+	h, err := cluster.NewHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// update blocklist to block just that host
+	err = b.UpdateHostBlocklist(context.Background(), []string{h.RHPv2Addr()}, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// add the host
+	err = cluster.AddHost(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// try and fetch the host
+	host, err := b.Host(context.Background(), h.PublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert it's blocked
+	if !host.Blocked {
+		t.Fatal("expected host to be blocked")
+	}
+
+	// clear blocklist
+	err = b.UpdateHostBlocklist(context.Background(), nil, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// try and fetch the host again
+	host, err = b.Host(context.Background(), h.PublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert it's no longer blocked
+	if host.Blocked {
+		t.Fatal("expected host not to be blocked")
+	}
+
+	// assert we have 4 hosts
+	hosts, err := b.Hosts(context.Background(), 0, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hosts) != 4 {
+		t.Fatal("unexpected number of hosts", len(hosts))
+	}
+
+	// create a new host
+	h, err = cluster.NewHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// update allowlist to allow just that host
+	err = b.UpdateHostAllowlist(context.Background(), []types.PublicKey{h.PublicKey()}, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// add the host
+	err = cluster.AddHost(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// try and fetch the host
+	host, err = b.Host(context.Background(), h.PublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert it's not blocked
+	if host.Blocked {
+		t.Fatal("expected host to not be blocked")
+	}
+
+	// assert all others are blocked
+	hosts, err = b.Hosts(context.Background(), 0, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hosts) != 1 {
+		t.Fatal("unexpected number of hosts", len(hosts))
+	}
+
+	// clear allowlist
+	err = b.UpdateHostAllowlist(context.Background(), nil, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert no hosts are blocked
+	hosts, err = b.Hosts(context.Background(), 0, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hosts) != 5 {
+		t.Fatal("unexpected number of hosts", len(hosts))
+	}
 }

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -621,7 +621,6 @@ func (c *TestCluster) AddHost(h *Host) error {
 // AddHosts adds n hosts to the cluster. These hosts will be funded and announce
 // themselves on the network, ready to form contracts.
 func (c *TestCluster) AddHosts(n int) ([]*Host, error) {
-	// Create hosts.
 	var newHosts []*Host
 	for i := 0; i < n; i++ {
 		h, err := c.NewHost()

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -537,6 +537,87 @@ func (c *TestCluster) RemoveHost(host *Host) error {
 	return nil
 }
 
+func (c *TestCluster) NewHost() (*Host, error) {
+	// Create host.
+	hostDir := filepath.Join(c.dir, "hosts", fmt.Sprint(len(c.hosts)+1))
+	h, err := NewHost(types.GeneratePrivateKey(), hostDir, false)
+	if err != nil {
+		return nil, err
+	}
+
+	// Connect gateways.
+	if err := c.Bus.SyncerConnect(context.Background(), h.GatewayAddr()); err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func (c *TestCluster) AddHost(h *Host) error {
+	// Add the host
+	c.hosts = append(c.hosts, h)
+
+	// Fund host from bus.
+	balance, err := c.Bus.WalletBalance(context.Background())
+	if err != nil {
+		return err
+	}
+	fundAmt := balance.Div64(2).Div64(uint64(len(c.hosts))) // 50% of bus balance
+	var scos []types.SiacoinOutput
+	for i := 0; i < 10; i++ {
+		scos = append(scos, types.SiacoinOutput{
+			Value:   fundAmt.Div64(10),
+			Address: h.WalletAddress(),
+		})
+	}
+	if err := c.Bus.SendSiacoins(context.Background(), scos); err != nil {
+		return err
+	}
+
+	// Mine transaction.
+	if err := c.MineBlocks(1); err != nil {
+		return err
+	}
+
+	// Wait for hosts to sync up with consensus.
+	hosts := []*Host{h}
+	if err := c.sync(hosts); err != nil {
+		return err
+	}
+
+	// Announce hosts.
+	if err := addStorageFolderToHost(hosts); err != nil {
+		return err
+	}
+	if err := announceHosts(hosts); err != nil {
+		return err
+	}
+
+	// Mine a few blocks. The host should show up eventually.
+	err = Retry(10, time.Second, func() error {
+		if err := c.MineBlocks(1); err != nil {
+			return err
+		}
+
+		_, err = c.Bus.Host(context.Background(), h.PublicKey())
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Wait for host to be synced.
+	if err := c.Sync(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // AddHosts adds n hosts to the cluster. These hosts will be funded and announce
 // themselves on the network, ready to form contracts.
 func (c *TestCluster) AddHosts(n int) ([]*Host, error) {

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -405,7 +405,7 @@ func (e *dbBlocklistEntry) BeforeCreate(tx *gorm.DB) (err error) {
 }
 
 func (e *dbBlocklistEntry) blocks(h dbHost) bool {
-	values := []string{e.Entry}
+	values := []string{h.NetAddress}
 	host, _, err := net.SplitHostPort(h.NetAddress)
 	if err == nil {
 		values = append(values, host)

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -405,12 +405,18 @@ func (e *dbBlocklistEntry) BeforeCreate(tx *gorm.DB) (err error) {
 }
 
 func (e *dbBlocklistEntry) blocks(h dbHost) bool {
+	values := []string{e.Entry}
 	host, _, err := net.SplitHostPort(h.NetAddress)
-	if err != nil {
-		return false // do nothing
+	if err == nil {
+		values = append(values, host)
 	}
 
-	return host == e.Entry || strings.HasSuffix(host, "."+e.Entry)
+	for _, value := range values {
+		if value == e.Entry || strings.HasSuffix(value, "."+e.Entry) {
+			return true
+		}
+	}
+	return false
 }
 
 // Host returns information about a host.


### PR DESCRIPTION
Turns out the blocklist doesn't work (in some cases) when the blocklist entry was added prior to the host being announced. This is because the code that executes when new hosts are being added, differs from the code that executed when allowlist/blocklist entries get updated (for performance reasons).

There wasn't any test for this because the test cluster allows adding `n` hosts, but doesn't allow creating a host, to then later add it, allowing for us to allowlist/blocklist the host before it announces. That's basically what I've added so I could extend the tests to cover this (not-so-)edge case.

The main change is in the `blocks` method where we used to split off the host from the `NetAddress` to check with the entry, which is the reason it was not working.

Fixes #401 