### PR TITLE
Fix Account Spam

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -460,7 +460,7 @@ func New(store Store, bus Bus, workers []Worker, logger *zap.Logger, heartbeat t
 	ap.s = scanner
 	ap.c = newContractor(ap)
 	ap.m = newMigrator(ap, migrationHealthCutoff)
-	ap.a = newAccounts(ap, ap.bus, ap.c, ap.workers, ap.logger, accountsRefillInterval)
+	ap.a = newAccounts(ap, ap.bus, ap.bus, ap.workers, ap.logger, accountsRefillInterval)
 	return ap, nil
 }
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -68,13 +68,11 @@ type (
 
 		maintenanceTxnID types.TransactionID
 
-		mu                         sync.Mutex
-		cachedContracts            []api.Contract
-		cachedContractSetContracts map[string]map[types.FileContractID]struct{}
-		cachedHostInfo             map[types.PublicKey]hostInfo
-		cachedDataStored           map[types.PublicKey]uint64
-		cachedMinScore             float64
-		currPeriod                 uint64
+		mu               sync.Mutex
+		cachedHostInfo   map[types.PublicKey]hostInfo
+		cachedDataStored map[types.PublicKey]uint64
+		cachedMinScore   float64
+		currPeriod       uint64
 	}
 
 	hostInfo struct {
@@ -92,32 +90,7 @@ func newContractor(ap *Autopilot) *contractor {
 	return &contractor{
 		ap:     ap,
 		logger: ap.logger.Named("contractor"),
-
-		cachedContractSetContracts: make(map[string]map[types.FileContractID]struct{}),
 	}
-}
-
-func (c *contractor) Contracts(_ context.Context) ([]api.ContractMetadata, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	var contracts []api.ContractMetadata
-	for _, contract := range c.cachedContracts {
-		contracts = append(contracts, contract.ContractMetadata)
-	}
-	return contracts, nil
-}
-
-func (c *contractor) IsInContractSet(fcid types.FileContractID, set string) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	csc, exists := c.cachedContractSetContracts[set]
-	if !exists {
-		return false
-	}
-
-	_, exists = csc[fcid]
-	return exists
 }
 
 func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (err error) {
@@ -167,15 +140,6 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 	}
 	c.logger.Debugf("contract set '%s' holds %d contracts", state.cfg.Contracts.Set, len(currentSet))
 
-	// update contract set contracts
-	c.mu.Lock()
-	contractsMap := make(map[types.FileContractID]struct{})
-	for _, c := range currentSet {
-		contractsMap[c.ID] = struct{}{}
-	}
-	c.cachedContractSetContracts[state.cfg.Contracts.Set] = contractsMap
-	c.mu.Unlock()
-
 	// fetch all contracts from the worker.
 	start := time.Now()
 	resp, err := w.Contracts(ctx, timeoutHostRevision)
@@ -192,11 +156,6 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 	sort.Slice(contracts, func(i, j int) bool {
 		return contracts[i].FileSize() > contracts[j].FileSize()
 	})
-
-	// update contracts
-	c.mu.Lock()
-	c.cachedContracts = contracts
-	c.mu.Unlock()
 
 	// get used hosts
 	usedHosts := make(map[types.PublicKey]struct{})
@@ -369,20 +328,7 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 		err = errors.New("autopilot stopped before maintenance could be completed")
 		return
 	}
-	err = c.ap.bus.SetContractSet(ctx, state.cfg.Contracts.Set, updatedSet)
-	if err != nil {
-		return err
-	}
-
-	// update contract set contracts
-	c.mu.Lock()
-	contractsMap = make(map[types.FileContractID]struct{})
-	for _, id := range updatedSet {
-		contractsMap[id] = struct{}{}
-	}
-	c.cachedContractSetContracts[state.cfg.Contracts.Set] = contractsMap
-	c.mu.Unlock()
-	return
+	return c.ap.bus.SetContractSet(ctx, state.cfg.Contracts.Set, updatedSet)
 }
 
 func (c *contractor) performWalletMaintenance(ctx context.Context) error {


### PR DESCRIPTION
I recently added a contracts cache (of sorts) to the `contractor`. Turns out this generates quite some spam on production nodes, because it's trying to refill archived and renewed accounts. I ended up removing the cache all together simply because it gets messy and in the way of the contractor flow/readability.