### PR TITLE
Use update in addRenewedContract instead of insertion

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -435,6 +435,7 @@ func (s *SQLStore) AddRenewedContract(ctx context.Context, c rhpv2.ContractRevis
 			return err
 		}
 		s.knownContracts[c.ID()] = struct{}{}
+		renewed = newContract
 		return nil
 	}); err != nil {
 		return api.ContractMetadata{}, err

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -436,6 +436,7 @@ func (s *SQLStore) AddRenewedContract(ctx context.Context, c rhpv2.ContractRevis
 		}
 		s.knownContracts[c.ID()] = struct{}{}
 		renewed = newContract
+		fmt.Println("renewed from", renewedFrom, "to", c.ID(), oldContract.ID)
 		return nil
 	}); err != nil {
 		return api.ContractMetadata{}, err

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -436,7 +436,6 @@ func (s *SQLStore) AddRenewedContract(ctx context.Context, c rhpv2.ContractRevis
 		}
 		s.knownContracts[c.ID()] = struct{}{}
 		renewed = newContract
-		fmt.Println("renewed from", renewedFrom, "to", c.ID(), oldContract.ID)
 		return nil
 	}); err != nil {
 		return api.ContractMetadata{}, err

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -429,7 +429,7 @@ func (s *SQLStore) AddRenewedContract(ctx context.Context, c rhpv2.ContractRevis
 
 		// Overwrite the old contract with the new one.
 		newContract := newContract(oldContract.HostID, c.ID(), renewedFrom, totalCost, startHeight, c.Revision.WindowStart, c.Revision.WindowEnd)
-		newContract.ID = oldContract.ID
+		newContract.Model = oldContract.Model
 		err = tx.Save(&newContract).Error
 		if err != nil {
 			return err


### PR DESCRIPTION
We ran into an issue where updating the `contract_sectors` table after renewing a contract would result in a UNIQUE constraint violation. After creating the archived contract and the new contract.

Since the method was updating the db quite inefficiently anyway we decided to refactor it.
Previously it would do:
1. Create archived contract
2. Create renewed contract by inserting a new row into the contracts table
3. Update contract set table
4. Update contract sectors join table
5. Delete old contract

Now it's doing:
1. Create archived contract
2. Update the old contract's row instead of inserting a new contract

This should be a lot faster since it touches only 2 tables without insertions and also doesn't update any foreign keys in a join table, potentially violating constraints.