### PR TITLE
Update Health Query

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -238,6 +238,15 @@ type UpdateSlabRequest struct {
 	UsedContracts map[types.PublicKey]types.FileContractID `json:"usedContracts"`
 }
 
+type UnhealthySlabsResponse struct {
+	Slabs []UnhealthySlab `json:"slabs"`
+}
+
+type UnhealthySlab struct {
+	Key    object.EncryptionKey `json:"key"`
+	Health float64              `json:"health"`
+}
+
 // UpdateAllowlistRequest is the request type for /hosts/allowlist endpoint.
 type UpdateAllowlistRequest struct {
 	Add    []types.PublicKey `json:"add"`

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -67,7 +67,8 @@ type Bus interface {
 	ConsensusState(ctx context.Context) (api.ConsensusState, error)
 
 	// objects
-	SlabsForMigration(ctx context.Context, healthCutoff float64, set string, limit int) ([]object.Slab, error)
+	Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
+	SlabsForMigration(ctx context.Context, healthCutoff float64, set string, limit int) ([]api.UnhealthySlab, error)
 
 	// settings
 	UpdateSetting(ctx context.Context, key string, value interface{}) error

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -914,11 +914,11 @@ func (s *SQLStore) UnhealthySlabs(ctx context.Context, healthCutoff float64, set
 		Joins("INNER JOIN sectors s ON s.db_slab_id = slabs.id").
 		Joins("LEFT JOIN contract_sectors se ON s.id = se.db_sector_id").
 		Joins("LEFT JOIN contracts c ON se.db_contract_id = c.id").
-		Joins("INNER JOIN contract_set_contracts csc ON csc.db_contract_id = c.id").
-		Joins("INNER JOIN contract_sets cs ON cs.id = csc.db_contract_set_id").
-		Where("cs.name = ?", set).
+		Joins("LEFT JOIN contract_set_contracts csc ON csc.db_contract_id = c.id").
+		Joins("LEFT JOIN contract_sets cs ON cs.id = csc.db_contract_set_id").
+		Where("cs.name = ? OR cs.name IS NULL", set).
 		Group("slabs.id").
-		Having("health >= 0 AND health <= ?", healthCutoff).
+		Having("health <= ?", healthCutoff).
 		Order("health ASC").
 		Limit(limit).
 		Preload("Shards").

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -804,6 +804,21 @@ func (s *SQLStore) RemoveObject(ctx context.Context, key string) error {
 	return deleteObject(s.db, key)
 }
 
+func (s *SQLStore) Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error) {
+	k, err := key.MarshalText()
+	if err != nil {
+		return object.Slab{}, err
+	}
+	var slab dbSlab
+	tx := s.db.Where(&dbSlab{Key: k}).
+		Preload("Shards.Contracts.Host").
+		Take(&slab)
+	if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
+		return object.Slab{}, api.ErrObjectNotFound
+	}
+	return slab.convert()
+}
+
 func (ss *SQLStore) UpdateSlab(ctx context.Context, s object.Slab, usedContracts map[types.PublicKey]types.FileContractID) error {
 	// sanity check the shards don't contain an empty root
 	for _, s := range s.Shards {
@@ -887,16 +902,18 @@ func (ss *SQLStore) UpdateSlab(ctx context.Context, s object.Slab, usedContracts
 // UnhealthySlabs returns up to 'limit' slabs that do not reach full redundancy
 // in the given contract set. These slabs need to be migrated to good contracts
 // so they are restored to full health.
-func (s *SQLStore) UnhealthySlabs(ctx context.Context, healthCutoff float64, set string, limit int) ([]object.Slab, error) {
+func (s *SQLStore) UnhealthySlabs(ctx context.Context, healthCutoff float64, set string, limit int) ([]api.UnhealthySlab, error) {
 	if limit <= -1 {
 		limit = math.MaxInt
 	}
 
-	var dbBatch []dbSlab
-	var slabs []object.Slab
+	var rows []struct {
+		Key    []byte
+		Health float64
+	}
 
 	if err := s.db.
-		Select(`slabs.*,
+		Select(`slabs.Key,
 CASE WHEN (slabs.min_shards = slabs.total_shards)
 THEN
     CASE WHEN (COUNT(DISTINCT(CASE WHEN cs.name IS NULL THEN NULL ELSE c.host_id END)) < slabs.min_shards)
@@ -915,21 +932,22 @@ END AS health`).
 		Having("health <= ?", healthCutoff).
 		Order("health ASC").
 		Limit(limit).
-		Preload("Shards").
-		FindInBatches(&dbBatch, slabRetrievalBatchSize, func(tx *gorm.DB, batch int) error {
-			for _, dbSlab := range dbBatch {
-				if slab, err := dbSlab.convert(); err == nil {
-					slabs = append(slabs, slab)
-				} else {
-					panic(err)
-				}
-			}
-			return nil
-		}).
+		Find(&rows).
 		Error; err != nil {
 		return nil, err
 	}
 
+	slabs := make([]api.UnhealthySlab, len(rows))
+	for i, row := range rows {
+		var key object.EncryptionKey
+		if err := key.UnmarshalText(row.Key); err != nil {
+			return nil, err
+		}
+		slabs[i] = api.UnhealthySlab{
+			Key:    key,
+			Health: row.Health,
+		}
+	}
 	return slabs, nil
 }
 

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1356,11 +1356,11 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatalf("unexpected amount of slabs to migrate, %v!=4", len(slabs))
 	}
 
-	expected := []object.Slab{
-		obj.Slabs[2].Slab,
-		obj.Slabs[4].Slab,
-		obj.Slabs[1].Slab,
-		obj.Slabs[3].Slab,
+	expected := []api.UnhealthySlab{
+		{Key: obj.Slabs[2].Key, Health: 0},
+		{Key: obj.Slabs[4].Key, Health: 0},
+		{Key: obj.Slabs[1].Key, Health: 0.5},
+		{Key: obj.Slabs[3].Key, Health: 0.5},
 	}
 	if !reflect.DeepEqual(slabs, expected) {
 		t.Fatal("slabs are not returned in the correct order")
@@ -1374,12 +1374,12 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatalf("unexpected amount of slabs to migrate, %v!=2", len(slabs))
 	}
 
-	expected = []object.Slab{
-		obj.Slabs[2].Slab,
-		obj.Slabs[4].Slab,
+	expected = []api.UnhealthySlab{
+		{Key: obj.Slabs[2].Key, Health: 0},
+		{Key: obj.Slabs[4].Key, Health: 0},
 	}
 	if !reflect.DeepEqual(slabs, expected) {
-		t.Fatal("slabs are not returned in the correct order")
+		t.Fatal("slabs are not returned in the correct order", slabs, expected)
 	}
 }
 
@@ -1810,7 +1810,7 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// migrate the sector from h2 to h3
-	slab := toMigrate[0]
+	slab := obj.Slabs[0].Slab
 	slab.Shards[1] = object.Sector{
 		Host: hk3,
 		Root: types.Hash256{2},

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1177,7 +1177,7 @@ func TestSearchObjects(t *testing.T) {
 }
 
 // TestUnhealthySlabs tests the functionality of UnhealthySlabs.
-func TestUnhealthySlabs(t *testing.T) {
+func TestUnhealthySlabs1(t *testing.T) {
 	db, _, _, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)
@@ -1351,6 +1351,7 @@ func TestUnhealthySlabs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log(slabs)
 	if len(slabs) != 4 {
 		t.Fatalf("unexpected amount of slabs to migrate, %v!=4", len(slabs))
 	}
@@ -1379,6 +1380,146 @@ func TestUnhealthySlabs(t *testing.T) {
 	}
 	if reflect.DeepEqual(slabs, expected) {
 		t.Fatal("slabs are not returned in the correct order")
+	}
+}
+
+func TestUnhealthySlabsNegHealth(t *testing.T) {
+	// create db
+	db, _, _, err := newTestSQLStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// add a host
+	hks, err := db.addTestHosts(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hk1 := hks[0]
+
+	// add a contract
+	fcids, _, err := db.addTestContracts(hks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fcid1 := fcids[0]
+
+	// add it to the contract set
+	if err := db.SetContractSet(context.Background(), "autopilot", fcids); err != nil {
+		t.Fatal(err)
+	}
+
+	// create an object
+	obj := object.Object{
+		Key: object.GenerateEncryptionKey(),
+		Slabs: []object.SlabSlice{
+			{
+				Slab: object.Slab{
+					Key:       object.GenerateEncryptionKey(),
+					MinShards: 2,
+					Shards: []object.Sector{
+						{
+							Host: hk1,
+							Root: types.Hash256{1},
+						},
+						{
+							Host: hk1,
+							Root: types.Hash256{2},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// add the object
+	ctx := context.Background()
+	if err := db.UpdateObject(ctx, "foo", obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert it's unhealthy
+	slabs, err := db.UnhealthySlabs(ctx, 0.99, "autopilot", -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slabs) != 1 {
+		t.Fatalf("unexpected amount of slabs to migrate, %v!=1", len(slabs))
+	}
+}
+
+func TestUnhealthySlabsNoContracts(t *testing.T) {
+	// create db
+	db, _, _, err := newTestSQLStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// add a host
+	hks, err := db.addTestHosts(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hk1 := hks[0]
+
+	// add a contract
+	fcids, _, err := db.addTestContracts(hks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fcid1 := fcids[0]
+
+	// add it to the contract set
+	if err := db.SetContractSet(context.Background(), "autopilot", fcids); err != nil {
+		t.Fatal(err)
+	}
+
+	// create an object
+	obj := object.Object{
+		Key: object.GenerateEncryptionKey(),
+		Slabs: []object.SlabSlice{
+			{
+				Slab: object.Slab{
+					Key:       object.GenerateEncryptionKey(),
+					MinShards: 1,
+					Shards: []object.Sector{
+						{
+							Host: hk1,
+							Root: types.Hash256{1},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// add the object
+	ctx := context.Background()
+	if err := db.UpdateObject(ctx, "foo", obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert it's healthy
+	slabs, err := db.UnhealthySlabs(ctx, 0.99, "autopilot", -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slabs) != 0 {
+		t.Fatalf("unexpected amount of slabs to migrate, %v!=0", len(slabs))
+	}
+
+	// delete the sector
+	if err := db.db.Table("contract_sectors").Where("TRUE").Delete(&dbContractSector{}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	// assert it's unhealthy
+	slabs, err = db.UnhealthySlabs(ctx, 0.99, "autopilot", -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slabs) != 1 {
+		t.Fatalf("unexpected amount of slabs to migrate, %v!=1", len(slabs))
 	}
 }
 

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1177,7 +1177,8 @@ func TestSearchObjects(t *testing.T) {
 }
 
 // TestUnhealthySlabs tests the functionality of UnhealthySlabs.
-func TestUnhealthySlabs1(t *testing.T) {
+func TestUnhealthySlabs(t *testing.T) {
+	// create db
 	db, _, _, err := newTestSQLStore()
 	if err != nil {
 		t.Fatal(err)
@@ -1351,18 +1352,17 @@ func TestUnhealthySlabs1(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(slabs)
 	if len(slabs) != 4 {
 		t.Fatalf("unexpected amount of slabs to migrate, %v!=4", len(slabs))
 	}
 
-	expected := []object.SlabSlice{
-		obj.Slabs[4],
-		obj.Slabs[2],
-		obj.Slabs[1],
-		obj.Slabs[3],
+	expected := []object.Slab{
+		obj.Slabs[2].Slab,
+		obj.Slabs[4].Slab,
+		obj.Slabs[1].Slab,
+		obj.Slabs[3].Slab,
 	}
-	if reflect.DeepEqual(slabs, expected) {
+	if !reflect.DeepEqual(slabs, expected) {
 		t.Fatal("slabs are not returned in the correct order")
 	}
 
@@ -1374,11 +1374,11 @@ func TestUnhealthySlabs1(t *testing.T) {
 		t.Fatalf("unexpected amount of slabs to migrate, %v!=2", len(slabs))
 	}
 
-	expected = []object.SlabSlice{
-		obj.Slabs[4],
-		obj.Slabs[2],
+	expected = []object.Slab{
+		obj.Slabs[2].Slab,
+		obj.Slabs[4].Slab,
 	}
-	if reflect.DeepEqual(slabs, expected) {
+	if !reflect.DeepEqual(slabs, expected) {
 		t.Fatal("slabs are not returned in the correct order")
 	}
 }
@@ -1601,14 +1601,12 @@ func TestUnhealthySlabsNoRedundancy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(slabs) != 0 {
-		t.Fatalf("unexpected amount of slabs to migrate, %v!=0", len(slabs))
+	if len(slabs) != 1 {
+		t.Fatalf("unexpected amount of slabs to migrate, %v!=1", len(slabs))
 	}
 
-	expected := []object.SlabSlice{
-		obj.Slabs[0],
-	}
-	if reflect.DeepEqual(slabs, expected) {
+	expected := []object.Slab{obj.Slabs[1].Slab}
+	if !reflect.DeepEqual(slabs, expected) {
 		t.Fatal("slabs are not returned in the correct order")
 	}
 }

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1605,7 +1605,9 @@ func TestUnhealthySlabsNoRedundancy(t *testing.T) {
 		t.Fatalf("unexpected amount of slabs to migrate, %v!=1", len(slabs))
 	}
 
-	expected := []object.Slab{obj.Slabs[1].Slab}
+	expected := []api.UnhealthySlab{
+		{Key: obj.Slabs[1].Slab.Key, Health: -1},
+	}
 	if !reflect.DeepEqual(slabs, expected) {
 		t.Fatal("slabs are not returned in the correct order")
 	}

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -391,7 +391,8 @@ func migrateSlab(ctx context.Context, u *uploadManager, hp hostProvider, s *obje
 		return nil
 	}
 
-	// subtract the number of shards that
+	// subtract the number of shards that are on hosts with contracts and might
+	// therefore be used for downloading from.
 	missingShards := len(shardIndices)
 	for _, si := range shardIndices {
 		_, hasContract := h2c[s.Shards[si].Host]

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -391,10 +391,10 @@ func migrateSlab(ctx context.Context, u *uploadManager, hp hostProvider, s *obje
 		return nil
 	}
 
-	// perform some sanity check
-	//	if len(s.Shards)-len(shardIndices) < int(s.MinShards) {
-	//		return fmt.Errorf("not enough hosts to download unhealthy shard, %d<%d", len(s.Shards)-len(shardIndices), int(s.MinShards))
-	//	}
+	// sanity check that we have enough hosts to reach minimum redundancy.
+	if len(s.Shards)-len(shardIndices) < int(s.MinShards) {
+		return fmt.Errorf("not enough hosts to download unhealthy shard, totalShards: %d, minShards: %d, missingShards: %d, totalContracts: %d", len(s.Shards), int(s.MinShards), len(shardIndices), len(ulContracts))
+	}
 
 	// download + reconstruct slab
 	ss := object.SlabSlice{

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -392,9 +392,9 @@ func migrateSlab(ctx context.Context, u *uploadManager, hp hostProvider, s *obje
 	}
 
 	// perform some sanity check
-	if len(s.Shards)-len(shardIndices) < int(s.MinShards) {
-		return fmt.Errorf("not enough hosts to download unhealthy shard, %d<%d", len(s.Shards)-len(shardIndices), int(s.MinShards))
-	}
+	//	if len(s.Shards)-len(shardIndices) < int(s.MinShards) {
+	//		return fmt.Errorf("not enough hosts to download unhealthy shard, %d<%d", len(s.Shards)-len(shardIndices), int(s.MinShards))
+	//	}
 
 	// download + reconstruct slab
 	ss := object.SlabSlice{


### PR DESCRIPTION
This PR updates `UnhealthySlabs` which is crucial for migrations. We were not returning slabs with a negative health, which is unlikely but possible if the slab has lots of sectors on the same hosts. We were also not returning any slabs that have sectors that don't belong to a contract. This shouldn't happen but we witnessed it first hand on our own nodes...

This PR will be followed up with more health related changes to improve both the performance of this query as well as trying to simplify health in general because it's getting hard to wrap your head around all the various edge cases.