### PR TITLE
Fix bug in object deletion when using worker endpoint

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -756,7 +756,12 @@ func (b *bus) objectsHandlerPUT(jc jape.Context) {
 }
 
 func (b *bus) objectsHandlerDELETE(jc jape.Context) {
-	jc.Check("couldn't delete object", b.ms.RemoveObject(jc.Request.Context(), jc.PathParam("path")))
+	err := b.ms.RemoveObject(jc.Request.Context(), jc.PathParam("path"))
+	if errors.Is(err, api.ErrObjectNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	}
+	jc.Check("couldn't delete object", err)
 }
 
 func (b *bus) objectsStatshandlerGET(jc jape.Context) {

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -468,6 +468,11 @@ func TestUploadDownloadBasic(t *testing.T) {
 		if !bytes.Equal(data, buffer.Bytes()) {
 			t.Fatal("unexpected")
 		}
+
+		// delete the object
+		if err := w.DeleteObject(context.Background(), name); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -46,7 +46,7 @@ func TestNewTestCluster(t *testing.T) {
 	w := cluster.Worker
 
 	// Try talking to the bus API by adding an object.
-	err = b.AddObject(context.Background(), "/foo", object.Object{
+	err = b.AddObject(context.Background(), "foo", object.Object{
 		Key: object.GenerateEncryptionKey(),
 		Slabs: []object.SlabSlice{
 			{

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1138,7 +1138,13 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 }
 
 func (w *worker) objectsHandlerDELETE(jc jape.Context) {
-	jc.Check("couldn't delete object", w.bus.DeleteObject(jc.Request.Context(), jc.PathParam("path")))
+	path := strings.TrimPrefix(jc.PathParam("path"), "/")
+	err := w.bus.DeleteObject(jc.Request.Context(), path)
+	if err != nil && strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	}
+	jc.Check("couldn't delete object", err)
 }
 
 func (w *worker) rhpContractsHandlerGET(jc jape.Context) {


### PR DESCRIPTION
When deleting objects through the worker endpoint instead of the bus the "/" at the beginning of the key isn't trimmed, causing the deletion to not happen without an error.

This PR fixes this and makes sure a 404 is returned when deletion fails due to an unknown key.