### PR TITLE
Improve redundant IP check

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -690,7 +690,7 @@ func (c *contractor) runContractFormations(ctx context.Context, w Worker, hosts 
 		}
 
 		// check if we already have a contract with a host on that subnet
-		if f.isRedundantIP(host.NetAddress, host.PublicKey) {
+		if !state.cfg.Hosts.AllowRedundantIPs && f.isRedundantIP(host.NetAddress, host.PublicKey) {
 			continue
 		}
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -171,7 +171,7 @@ func (u *unusableHostResult) keysAndValues() []interface{} {
 
 // isUsableHost returns whether the given host is usable along with a list of
 // reasons why it was deemed unusable.
-func isUsableHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.GougingChecker, f *ipFilter, h hostdb.Host, minScore float64, storedData uint64) (bool, unusableHostResult) {
+func isUsableHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.GougingChecker, h hostdb.Host, minScore float64, storedData uint64) (bool, unusableHostResult) {
 	if rs.Validate() != nil {
 		panic("invalid redundancy settings were supplied - developer error")
 	}
@@ -210,12 +210,6 @@ func isUsableHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.
 			if scoreBreakdown.Score() < minScore {
 				errs = append(errs, fmt.Errorf("%w: %v < %v", errLowScore, scoreBreakdown.Score(), minScore))
 			}
-		}
-
-		// optional redundant IP check - always perform this last since it will
-		// update the ipFilter.
-		if f != nil && !cfg.Hosts.AllowRedundantIPs && f.isRedundantIP(h.NetAddress, h.PublicKey) {
-			errs = append(errs, errHostRedundantIP)
 		}
 	}
 

--- a/autopilot/hostinfo.go
+++ b/autopilot/hostinfo.go
@@ -46,13 +46,12 @@ func (c *contractor) HostInfo(ctx context.Context, hostKey types.PublicKey) (api
 	minScore := c.cachedMinScore
 	c.mu.Unlock()
 
-	f := newIPFilter(c.logger)
 	gc := worker.NewGougingChecker(gs, rs, cs, fee, cfg.Contracts.Period, cfg.Contracts.RenewWindow)
 
 	// ignore the pricetable's HostBlockHeight by setting it to our own blockheight
 	host.Host.PriceTable.HostBlockHeight = cs.BlockHeight
 
-	isUsable, unusableResult := isUsableHost(cfg, rs, gc, f, host.Host, minScore, storedData)
+	isUsable, unusableResult := isUsableHost(cfg, rs, gc, host.Host, minScore, storedData)
 	return api.HostHandlerGET{
 		Host: host.Host,
 


### PR DESCRIPTION
The redundant IP check should always be performed as the last check before determining whether a contract can be used or not. 

If we update the IP filter and the contract fails a later check, subsequent contracts might be blocked due to their IP address even though they should be used since the first contract on the subnet failed a different check anyway.

This PR also updates the order we use to look at contracts when checking them. We start with the ones having the most data to make sure that we drop the contract(s) with the least amount of data when a redundant ip range is detected.