### PR TITLE
Record size of a contract alongside spending metrics

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -22,6 +22,7 @@ type (
 		ProofHeight    uint64 `json:"proofHeight"`
 		RevisionHeight uint64 `json:"revisionHeight"`
 		RevisionNumber uint64 `json:"revisionNumber"`
+		Size           uint64 `json:"size"`
 		StartHeight    uint64 `json:"startHeight"`
 		WindowStart    uint64 `json:"windowStart"`
 		WindowEnd      uint64 `json:"windowEnd"`
@@ -42,6 +43,7 @@ type (
 		ContractSpending
 		ContractID     types.FileContractID `json:"contractID"`
 		RevisionNumber uint64               `json:"revisionNumber"`
+		Size           uint64               `json:"size"`
 	}
 
 	// An ArchivedContract contains all information about a contract with a host
@@ -55,6 +57,7 @@ type (
 		ProofHeight    uint64 `json:"proofHeight"`
 		RevisionHeight uint64 `json:"revisionHeight"`
 		RevisionNumber uint64 `json:"revisionNumber"`
+		Size           uint64 `json:"size"`
 		StartHeight    uint64 `json:"startHeight"`
 		WindowStart    uint64 `json:"windowStart"`
 		WindowEnd      uint64 `json:"windowEnd"`
@@ -76,7 +79,7 @@ func (c Contract) EndHeight() uint64 { return c.WindowStart }
 // FileSize returns the current Size of the contract.
 func (c Contract) FileSize() uint64 {
 	if c.Revision == nil {
-		return 0
+		return c.Size // use latest recorded value if we don't have a recent revision
 	}
 	return c.Revision.Filesize
 }

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -666,6 +666,12 @@ func TestUploadDownloadSpending(t *testing.T) {
 			if !c.Spending.Downloads.IsZero() {
 				t.Fatal("download spending should be zero")
 			}
+			if c.RevisionNumber == 0 {
+				t.Fatalf("revision number for contract wasn't recorded: %v", c.RevisionNumber)
+			}
+			if c.Size == 0 {
+				t.Fatalf("size for contract wasn't recorded: %v", c.Size)
+			}
 		}
 		return nil
 	})

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -876,6 +876,7 @@ func (ss *SQLStore) processConsensusChangeHostDB(cc modules.ConsensusChange) {
 					ss.unappliedRevisions[types.FileContractID(rev.ParentID)] = revisionUpdate{
 						height: height,
 						number: rev.NewRevisionNumber,
+						size:   rev.NewFileSize,
 					}
 				}
 			}
@@ -974,10 +975,11 @@ func insertAnnouncements(tx *gorm.DB, as []announcement) error {
 	return tx.Create(&hosts).Error
 }
 
-func updateRevisionNumberAndHeight(db *gorm.DB, fcid types.FileContractID, revisionHeight, revisionNumber uint64) error {
+func applyRevisionUpdate(db *gorm.DB, fcid types.FileContractID, rev revisionUpdate) error {
 	return updateActiveAndArchivedContract(db, fcid, map[string]interface{}{
-		"revision_height": revisionHeight,
-		"revision_number": fmt.Sprint(revisionNumber),
+		"revision_height": rev.height,
+		"revision_number": fmt.Sprint(rev.number),
+		"size":            rev.size,
 	})
 }
 

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -70,6 +70,7 @@ type (
 	revisionUpdate struct {
 		height uint64
 		number uint64
+		size   uint64
 	}
 )
 
@@ -339,7 +340,7 @@ func (ss *SQLStore) applyUpdates(force bool) (err error) {
 			}
 		}
 		for fcid, rev := range ss.unappliedRevisions {
-			if err := updateRevisionNumberAndHeight(tx, types.FileContractID(fcid), rev.height, rev.number); err != nil {
+			if err := applyRevisionUpdate(tx, types.FileContractID(fcid), rev); err != nil {
 				return fmt.Errorf("%w; failed to update revision number and height", err)
 			}
 		}

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -308,7 +308,7 @@ func (h *host) FundAccount(ctx context.Context, balance types.Currency, rev *typ
 			if err := RPCFundAccount(ctx, t, &payment, h.acc.id, pt.UID); err != nil {
 				return fmt.Errorf("failed to fund account with %v;%w", amount, err)
 			}
-			h.contractSpendingRecorder.Record(rev.ParentID, rev.RevisionNumber, api.ContractSpending{FundAccount: cost})
+			h.contractSpendingRecorder.Record(rev.ParentID, rev.RevisionNumber, rev.Filesize, api.ContractSpending{FundAccount: cost})
 			return nil
 		})
 	})
@@ -608,7 +608,7 @@ func (h *host) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte,
 	}
 
 	// record spending
-	h.contractSpendingRecorder.Record(rev.ParentID, rev.RevisionNumber, api.ContractSpending{Uploads: cost})
+	h.contractSpendingRecorder.Record(rev.ParentID, rev.RevisionNumber, rev.Filesize, api.ContractSpending{Uploads: cost})
 	return root, err
 }
 


### PR DESCRIPTION
That way we have a fallback value in the autopilot in case we can't fetch a revision but still want to perform some checks.