### PR TITLE
Archive contracts when reaching the revision submission buffer of the host

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	// blocksPerDay defines the amount of blocks that are mined in a day (one
+	// BlocksPerDay defines the amount of blocks that are mined in a day (one
 	// block every 10 minutes roughly)
-	blocksPerDay = 144
+	BlocksPerDay = 144
 )
 
 var (
@@ -176,8 +176,8 @@ func DefaultAutopilotConfig() (c AutopilotConfig) {
 	c.Contracts.Set = "autopilot"
 	c.Contracts.Allowance = types.Siacoins(1000)
 	c.Contracts.Amount = 50
-	c.Contracts.Period = blocksPerDay * 7 * 6      // 6 weeks
-	c.Contracts.RenewWindow = blocksPerDay * 7 * 2 // 2 weeks
+	c.Contracts.Period = BlocksPerDay * 7 * 6      // 6 weeks
+	c.Contracts.RenewWindow = BlocksPerDay * 7 * 2 // 2 weeks
 	c.Contracts.Upload = 1 << 40                   // 1 TiB
 	c.Contracts.Download = 1 << 40                 // 1 TiB
 	c.Contracts.Storage = 1 << 42                  // 4 TiB

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -442,7 +442,7 @@ func (ap *Autopilot) triggerHandlerPOST(jc jape.Context) {
 }
 
 // New initializes an Autopilot.
-func New(store Store, bus Bus, workers []Worker, logger *zap.Logger, heartbeat time.Duration, scannerScanInterval time.Duration, scannerBatchSize, scannerMinRecentFailures, scannerNumThreads uint64, migrationHealthCutoff float64, accountsRefillInterval time.Duration) (*Autopilot, error) {
+func New(store Store, bus Bus, workers []Worker, logger *zap.Logger, heartbeat time.Duration, scannerScanInterval time.Duration, scannerBatchSize, scannerMinRecentFailures, scannerNumThreads uint64, migrationHealthCutoff float64, accountsRefillInterval time.Duration, revisionSubmissionBuffer uint64) (*Autopilot, error) {
 	ap := &Autopilot{
 		bus:     bus,
 		logger:  logger.Sugar().Named("autopilot"),
@@ -465,7 +465,7 @@ func New(store Store, bus Bus, workers []Worker, logger *zap.Logger, heartbeat t
 	}
 
 	ap.s = scanner
-	ap.c = newContractor(ap)
+	ap.c = newContractor(ap, revisionSubmissionBuffer)
 	ap.m = newMigrator(ap, migrationHealthCutoff)
 	ap.a = newAccounts(ap, ap.bus, ap.bus, ap.workers, ap.logger, accountsRefillInterval)
 	return ap, nil

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -509,7 +509,7 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 		fcid := contract.ID
 
 		// check if contract is ready to be archived.
-		if state.cs.BlockHeight > contract.EndHeight() {
+		if state.cs.BlockHeight > contract.EndHeight()-api.BlocksPerDay {
 			toArchive[fcid] = errContractExpired.Error()
 		} else if contract.Revision != nil && contract.Revision.RevisionNumber == math.MaxUint64 {
 			toArchive[fcid] = errContractMaxRevisionNumber.Error()

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -50,11 +50,11 @@ const (
 
 	// timeoutHostPriceTable is the amount of time we wait to receive a price
 	// table from the host
-	timeoutHostPriceTable = 30 * time.Second
+	timeoutHostPriceTable = time.Minute
 
 	// timeoutHostRevision is the amount of time we wait to receive the latest
 	// revision from the host
-	timeoutHostRevision = 30 * time.Second
+	timeoutHostRevision = time.Minute
 
 	// timeoutHostScan is the amount of time we wait for a host scan to be
 	// completed

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -16,6 +16,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/jape"
+	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/autopilot"
 	"go.sia.tech/renterd/build"
 	"go.sia.tech/renterd/bus"
@@ -145,6 +146,7 @@ func main() {
 		enabled bool
 		node.AutopilotConfig
 	}
+	autopilotCfg.RevisionSubmissionBuffer = api.BlocksPerDay
 	// node
 	apiAddr := flag.String("http", build.DefaultAPIAddress, "address to serve API on")
 	dir := flag.String("dir", ".", "directory to store node state in")

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -59,6 +59,7 @@ type AutopilotConfig struct {
 	AccountsRefillInterval   time.Duration
 	Heartbeat                time.Duration
 	MigrationHealthCutoff    float64
+	RevisionSubmissionBuffer uint64
 	ScannerInterval          time.Duration
 	ScannerBatchSize         uint64
 	ScannerMinRecentFailures uint64
@@ -309,7 +310,7 @@ func NewWorker(cfg WorkerConfig, b worker.Bus, seed types.PrivateKey, l *zap.Log
 }
 
 func NewAutopilot(cfg AutopilotConfig, s autopilot.Store, b autopilot.Bus, workers []autopilot.Worker, l *zap.Logger) (http.Handler, func() error, ShutdownFn, error) {
-	ap, err := autopilot.New(s, b, workers, l, cfg.Heartbeat, cfg.ScannerInterval, cfg.ScannerBatchSize, cfg.ScannerMinRecentFailures, cfg.ScannerNumThreads, cfg.MigrationHealthCutoff, cfg.AccountsRefillInterval)
+	ap, err := autopilot.New(s, b, workers, l, cfg.Heartbeat, cfg.ScannerInterval, cfg.ScannerBatchSize, cfg.ScannerMinRecentFailures, cfg.ScannerNumThreads, cfg.MigrationHealthCutoff, cfg.AccountsRefillInterval, cfg.RevisionSubmissionBuffer)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -789,6 +789,7 @@ func testApCfg() node.AutopilotConfig {
 		AccountsRefillInterval:   time.Second,
 		Heartbeat:                time.Second,
 		MigrationHealthCutoff:    0.99,
+		RevisionSubmissionBuffer: 0,
 		ScannerInterval:          time.Second,
 		ScannerBatchSize:         10,
 		ScannerNumThreads:        1,


### PR DESCRIPTION
To avoid keeping contracts around that we can't revise or renew anymore anyway.

The PR also increases 2 timeouts.