### PR TITLE
Drop owner column from ephemeral accounts table

### DIFF
--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -122,6 +122,13 @@ func performMigrations(db *gorm.DB, logger glogger.Interface) error {
 	}
 	fillSlabContractSetID := !m.HasColumn(&dbSlab{}, "db_contract_set_id")
 
+	// Drop owner column from accounts table.
+	if m.HasColumn(&dbAccount{}, "owner") {
+		if err := m.DropColumn(&dbAccount{}, "owner"); err != nil {
+			return err
+		}
+	}
+
 	// Perform auto migrations.
 	tables := []interface{}{
 		// bus.MetadataStore tables


### PR DESCRIPTION
Older versions of `renterd` that upgraded might experience `bus/bus.go:1294	NOT NULL constraint failed: ephemeral_accounts.owner` since the `owner` column is no longer in use but still exists.

This PR drops it.