### PR TITLE
Ignore Signal

### DIFF
--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -111,6 +111,12 @@ func (m *migrator) performMigrations(p *workerPool, cfg api.AutopilotConfig) {
 	})
 	var toMigrate []api.UnhealthySlab
 
+	// ignore a potential signal before the first iteration of the 'OUTER' loop
+	select {
+	case <-m.signalMaintenanceFinished:
+	default:
+	}
+
 OUTER:
 	for {
 		// fetch slabs for migration


### PR DESCRIPTION
```
2023-06-20T15:58:02+02:00       DEBUG   autopilot.migrator      autopilot/migrator.go:122       281 potential slabs fetched for migration
2023-06-20T15:58:02+02:00       DEBUG   autopilot.migrator      autopilot/migrator.go:157       281 slabs to migrate
2023-06-20T15:58:02+02:00       INFO    autopilot.migrator      autopilot/migrator.go:169       migrations interrupted - updating slabs for migration
2023-06-20T15:58:07+02:00       DEBUG   autopilot.migrator      autopilot/migrator.go:122       281 potential slabs fetched for migration
2023-06-20T15:58:07+02:00       DEBUG   autopilot.migrator      autopilot/migrator.go:157       281 slabs to migrate
```

we have to ignore the signal right before starting the loop because we fetch slabs twice for no reason now (see timestamps)