### PR TITLE
Refactor metrics recording

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -111,6 +112,10 @@ type (
 		CurrentPeriod uint64 `json:"currentPeriod"`
 	}
 )
+
+func (sb HostScoreBreakdown) String() string {
+	return fmt.Sprintf("Age: %v, Col: %v, Int: %v, SR: %v, UT: %v, V: %v, Pr: %v", sb.Age, sb.Collateral, sb.Interactions, sb.StorageRemaining, sb.Uptime, sb.Version, sb.Prices)
+}
 
 func (hgb HostGougingBreakdown) Gouging() bool {
 	return hgb.V2.Gouging() || hgb.V3.Gouging()

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -208,7 +208,7 @@ func isUsableHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.
 			// cost
 			scoreBreakdown = hostScore(cfg, h, storedData, rs.Redundancy())
 			if scoreBreakdown.Score() < minScore {
-				errs = append(errs, fmt.Errorf("%w: %v < %v", errLowScore, scoreBreakdown.Score(), minScore))
+				errs = append(errs, fmt.Errorf("%w: (%s): %v < %v", errLowScore, scoreBreakdown.String(), scoreBreakdown.Score(), minScore))
 			}
 		}
 	}

--- a/hostdb/hostdb.go
+++ b/hostdb/hostdb.go
@@ -24,14 +24,18 @@ type hostAnnouncement struct {
 	Signature types.Signature
 }
 
+type ErrorResult struct {
+	Error string `json:"error,omitempty"`
+}
+
 type ScanResult struct {
-	Error      string               `json:"error,omitempty"`
+	ErrorResult
 	PriceTable rhpv3.HostPriceTable `json:"priceTable,omitempty"`
 	Settings   rhpv2.HostSettings   `json:"settings,omitempty"`
 }
 
 type PriceTableUpdateResult struct {
-	Error      string         `json:"error,omitempty"`
+	ErrorResult
 	PriceTable HostPriceTable `json:"priceTable,omitempty"`
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -2,12 +2,18 @@ package metrics
 
 import (
 	"context"
+	"time"
+
+	"go.sia.tech/core/types"
 )
 
 // A Metric contains metadata pertaining to a particular operation.
 type Metric interface {
-	IsMetric()
+	HostKey() types.PublicKey
+	Result() interface{}
 	IsSuccess() bool
+	Timestamp() time.Time
+	Type() string
 }
 
 // A MetricsRecorder records metrics.

--- a/worker/interactions.go
+++ b/worker/interactions.go
@@ -1,0 +1,236 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	rhpv2 "go.sia.tech/core/rhp/v2"
+	rhpv3 "go.sia.tech/core/rhp/v3"
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/hostdb"
+	"go.sia.tech/renterd/metrics"
+	"go.sia.tech/renterd/tracing"
+)
+
+func errToStr(err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+// recordInteractions adds some interactions to the worker's interaction buffer
+// which is periodically flushed to the bus.
+func (w *worker) recordInteractions(interactions []hostdb.Interaction) {
+	w.interactionsMu.Lock()
+	defer w.interactionsMu.Unlock()
+
+	// Append interactions to buffer.
+	w.interactions = append(w.interactions, interactions...)
+
+	// If a thread was scheduled to flush the buffer we are done.
+	if w.interactionsFlushTimer != nil {
+		return
+	}
+	// Otherwise we schedule a flush.
+	w.interactionsFlushTimer = time.AfterFunc(w.busFlushInterval, func() {
+		w.interactionsMu.Lock()
+		w.flushInteractions()
+		w.interactionsMu.Unlock()
+	})
+}
+
+// flushInteractions flushes the worker's interaction buffer to the bus.
+func (w *worker) flushInteractions() {
+	if len(w.interactions) > 0 {
+		ctx, span := tracing.Tracer.Start(context.Background(), "worker: flushInteractions")
+		defer span.End()
+		if err := w.bus.RecordInteractions(ctx, w.interactions); err != nil {
+			w.logger.Errorw(fmt.Sprintf("failed to record interactions: %v", err))
+		} else {
+			w.interactions = nil
+		}
+	}
+	w.interactionsFlushTimer = nil
+}
+
+// recordPriceTableUpdate records a price table metric.
+func recordPriceTableUpdate(mr metrics.MetricsRecorder, siamuxAddr string, hostKey types.PublicKey, pt hostdb.HostPriceTable, err *error) func() {
+	startTime := time.Now()
+	return func() {
+		now := time.Now()
+		mr.RecordMetric(MetricPriceTableUpdate{
+			metricCommon: metricCommon{
+				address:   siamuxAddr,
+				hostKey:   hostKey,
+				timestamp: now,
+				elapsed:   now.Sub(startTime),
+				err:       *err,
+			},
+			pt: pt,
+		})
+	}
+}
+
+// recordScan records a scan metric.
+func recordScan(mr metrics.MetricsRecorder, elapsed time.Duration, hostIP string, hostKey types.PublicKey, pt rhpv3.HostPriceTable, settings rhpv2.HostSettings, err error) {
+	mr.RecordMetric(MetricHostScan{
+		metricCommon: metricCommon{
+			address:   hostIP,
+			hostKey:   hostKey,
+			timestamp: time.Now(),
+			elapsed:   elapsed,
+			err:       err,
+		},
+		pt:       pt,
+		settings: settings,
+	})
+}
+
+// ephemeralMetricsRecorder can be used to record metrics in memory.
+type ephemeralMetricsRecorder struct {
+	ms []metrics.Metric
+	mu sync.Mutex
+}
+
+func (mr *ephemeralMetricsRecorder) RecordMetric(m metrics.Metric) {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+	mr.ms = append(mr.ms, m)
+}
+
+func (mr *ephemeralMetricsRecorder) interactions() []hostdb.Interaction {
+	// TODO: merge/filter metrics?
+	var his []hostdb.Interaction
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+	for _, m := range mr.ms {
+		his = append(his, metricToInteraction(m))
+	}
+	return his
+}
+
+// metricCommon contains the common fields of all metrics.
+type metricCommon struct {
+	hostKey   types.PublicKey
+	address   string
+	timestamp time.Time
+	elapsed   time.Duration
+	err       error
+}
+
+type metricResultCommon struct {
+	Address   string        `json:"address"`
+	Timestamp time.Time     `json:"timestamp"`
+	Elapsed   time.Duration `json:"elapsed"`
+}
+
+func (m metricCommon) commonResult() metricResultCommon {
+	return metricResultCommon{
+		Address:   m.address,
+		Timestamp: m.timestamp,
+		Elapsed:   m.elapsed,
+	}
+}
+func (m metricCommon) HostKey() types.PublicKey { return m.hostKey }
+func (m metricCommon) Timestamp() time.Time     { return m.timestamp }
+
+func (m metricCommon) IsSuccess() bool {
+	return isSuccessfulInteraction(m.err)
+}
+
+// MetricHostDial is a metric that contains the result of a dial attempt.
+type MetricHostDial struct {
+	metricCommon
+}
+
+func (m MetricHostDial) Result() interface{} {
+	return m.commonResult()
+}
+
+func (m MetricHostDial) Type() string { return "dial" }
+
+// MetricPriceTableUpdate is a metric that contains the result of fetching a
+// price table.
+type MetricPriceTableUpdate struct {
+	metricCommon
+	pt hostdb.HostPriceTable
+}
+
+func (m MetricPriceTableUpdate) Result() interface{} {
+	cr := m.commonResult()
+	er := hostdb.ErrorResult{Error: errToStr(m.err)}
+	if m.err != nil {
+		return struct {
+			metricResultCommon
+			hostdb.ErrorResult
+		}{cr, er}
+	} else {
+		return struct {
+			metricResultCommon
+			hostdb.PriceTableUpdateResult
+		}{cr, hostdb.PriceTableUpdateResult{ErrorResult: er, PriceTable: m.pt}}
+	}
+}
+
+func (m MetricPriceTableUpdate) Type() string {
+	return hostdb.InteractionTypePriceTableUpdate
+}
+
+// MetricHostScan is a metric that contains the result of a host scan.
+type MetricHostScan struct {
+	metricCommon
+	pt       rhpv3.HostPriceTable
+	settings rhpv2.HostSettings
+}
+
+func (m MetricHostScan) Result() interface{} {
+	cr := m.commonResult()
+	er := hostdb.ErrorResult{Error: errToStr(m.err)}
+	if m.err != nil {
+		return struct {
+			metricResultCommon
+			hostdb.ErrorResult
+		}{cr, er}
+	} else {
+		return struct {
+			metricResultCommon
+			hostdb.ScanResult
+		}{cr, hostdb.ScanResult{ErrorResult: er, PriceTable: m.pt, Settings: m.settings}}
+	}
+}
+
+func (m MetricHostScan) Type() string {
+	return hostdb.InteractionTypeScan
+}
+
+func isSuccessfulInteraction(err error) bool {
+	// No error always means success.
+	if err == nil {
+		return true
+	}
+	// List of errors that are considered successful interactions.
+	if errors.Is(err, ErrInsufficientFunds) || strings.Contains(err.Error(), ErrInsufficientFunds.Error()) {
+		return true
+	}
+	if isBalanceInsufficient(err) {
+		return true
+	}
+	return false
+}
+
+func metricToInteraction(m metrics.Metric) hostdb.Interaction {
+	res, _ := json.Marshal(m.Result())
+	return hostdb.Interaction{
+		Host:      m.HostKey(),
+		Result:    res,
+		Success:   m.IsSuccess(),
+		Timestamp: m.Timestamp(),
+		Type:      m.Type(),
+	}
+}

--- a/worker/interactions.go
+++ b/worker/interactions.go
@@ -60,11 +60,11 @@ func (w *worker) flushInteractions() {
 }
 
 // recordPriceTableUpdate records a price table metric.
-func recordPriceTableUpdate(mr metrics.MetricsRecorder, siamuxAddr string, hostKey types.PublicKey, pt hostdb.HostPriceTable, err *error) func() {
+func recordPriceTableUpdate(ctx context.Context, siamuxAddr string, hostKey types.PublicKey, pt hostdb.HostPriceTable, err *error) func() {
 	startTime := time.Now()
 	return func() {
 		now := time.Now()
-		mr.RecordMetric(MetricPriceTableUpdate{
+		metrics.Record(ctx, MetricPriceTableUpdate{
 			metricCommon: metricCommon{
 				address:   siamuxAddr,
 				hostKey:   hostKey,

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -426,6 +426,13 @@ func (w *worker) initAccounts(as AccountStore) {
 	}
 }
 
+func (w *worker) initTransportPool() {
+	if w.transportPoolV3 != nil {
+		panic("transport pool already initialized") // developer error
+	}
+	w.transportPoolV3 = newTransportPoolV3(w)
+}
+
 // ForHost returns an account to use for a given host. If the account
 // doesn't exist, a new one is created.
 func (a *accounts) ForHost(hk types.PublicKey) *account {

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -887,7 +887,7 @@ func (h *host) Renew(ctx context.Context, rrr api.RHPRenewRequest) (_ rhpv2.Cont
 }
 
 func (h *host) FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error) {
-	defer recordPriceTableUpdate(h.mr, h.siamuxAddr, h.HostKey(), hpt, &err)
+	defer recordPriceTableUpdate(h.mr, h.siamuxAddr, h.HostKey(), hpt, &err)()
 
 	// fetchPT is a helper function that performs the RPC given a payment function
 	fetchPT := func(paymentFn PriceTablePaymentFunc) (hpt hostdb.HostPriceTable, err error) {

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -43,7 +43,7 @@ type hostV3 interface {
 }
 
 type hostProvider interface {
-	newHostV3(types.FileContractID, types.PublicKey, string) (hostV3, func())
+	newHostV3(types.FileContractID, types.PublicKey, string) hostV3
 }
 
 func parallelDownloadSlab(ctx context.Context, hp hostProvider, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, maxOverdrive uint64, logger *zap.SugaredLogger) ([][]byte, []int64, error) {
@@ -103,8 +103,7 @@ func parallelDownloadSlab(ctx context.Context, hp hostProvider, ss object.SlabSl
 
 			buf := bytes.NewBuffer(make([]byte, 0, rhpv2.SectorSize))
 			err := func() error {
-				h, done := hp.newHostV3(contract.ID, contract.HostKey, contract.SiamuxAddr)
-				defer done()
+				h := hp.newHostV3(contract.ID, contract.HostKey, contract.SiamuxAddr)
 				err := h.DownloadSector(ctx, buf, shard.Root, r.offset, r.length)
 				if err != nil {
 					span.SetStatus(codes.Error, "downloading the sector failed")

--- a/worker/transfer.go
+++ b/worker/transfer.go
@@ -30,25 +30,21 @@ var (
 	errDownloadSectorTimeout = errors.New("download sector timed out")
 )
 
-type hostV2 interface {
-	Contract() types.FileContractID
-	HostKey() types.PublicKey
-}
-
 type hostV3 interface {
-	hostV2
-
+	io.Closer
+	Contract() types.FileContractID
 	DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint64) error
 	FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error)
 	FetchRevision(ctx context.Context, fetchTimeout time.Duration, blockHeight uint64) (types.FileContractRevision, error)
 	FundAccount(ctx context.Context, balance types.Currency, rev *types.FileContractRevision) error
+	HostKey() types.PublicKey
 	Renew(ctx context.Context, rrr api.RHPRenewRequest) (_ rhpv2.ContractRevision, _ []types.Transaction, err error)
 	SyncAccount(ctx context.Context, rev *types.FileContractRevision) error
 	UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte, rev types.FileContractRevision) (types.Hash256, error)
 }
 
 type hostProvider interface {
-	newHostV3(context.Context, types.FileContractID, types.PublicKey, string) (_ hostV3, err error)
+	newHostV3(types.FileContractID, types.PublicKey, string) (_ hostV3, err error)
 }
 
 func parallelDownloadSlab(ctx context.Context, hp hostProvider, ss object.SlabSlice, contracts []api.ContractMetadata, downloadSectorTimeout time.Duration, maxOverdrive uint64, logger *zap.SugaredLogger) ([][]byte, []int64, error) {
@@ -108,10 +104,11 @@ func parallelDownloadSlab(ctx context.Context, hp hostProvider, ss object.SlabSl
 
 			buf := bytes.NewBuffer(make([]byte, 0, rhpv2.SectorSize))
 			err := func() error {
-				h, err := hp.newHostV3(ctx, contract.ID, contract.HostKey, contract.SiamuxAddr)
+				h, err := hp.newHostV3(contract.ID, contract.HostKey, contract.SiamuxAddr)
 				if err != nil {
 					return err
 				}
+				defer h.Close()
 				err = h.DownloadSector(ctx, buf, shard.Root, r.offset, r.length)
 				if err != nil {
 					span.SetStatus(codes.Error, "downloading the sector failed")

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -105,12 +105,12 @@ func newMockHostProvider(hosts []hostV3) *mockHostProvider {
 	return sp
 }
 
-func (sp *mockHostProvider) newHostV3(contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string) (hostV3, func()) {
+func (sp *mockHostProvider) newHostV3(contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string) hostV3 {
 	h, exists := sp.hosts[hostKey]
 	if !exists {
 		panic("doesn't exist")
 	}
-	return h, func() {}
+	return h
 }
 
 func TestMultipleObjects(t *testing.T) {

--- a/worker/transfer_test.go
+++ b/worker/transfer_test.go
@@ -51,6 +51,8 @@ func (h *mockHost) DownloadSector(_ context.Context, w io.Writer, root types.Has
 	return err
 }
 
+func (sp *mockHost) Close() error { return nil }
+
 func (h *mockHost) FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error) {
 	panic("not implemented")
 }
@@ -103,7 +105,7 @@ func newMockHostProvider(hosts []hostV3) *mockHostProvider {
 	return sp
 }
 
-func (sp *mockHostProvider) newHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string) (_ hostV3, err error) {
+func (sp *mockHostProvider) newHostV3(contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string) (_ hostV3, err error) {
 	h, exists := sp.hosts[hostKey]
 	if !exists {
 		panic("doesn't exist")

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -730,8 +730,7 @@ func (u *uploader) execute(req *sectorUploadReq, rev types.FileContractRevision)
 	span.AddEvent("execute")
 
 	// create a host
-	h, done := req.upload.mgr.hp.newHostV3(u.fcid, u.hk, u.siamuxAddr)
-	defer done()
+	h := req.upload.mgr.hp.newHostV3(u.fcid, u.hk, u.siamuxAddr)
 
 	// upload the sector
 	start := time.Now()

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -873,10 +873,11 @@ func (upload *shardUpload) execute(hp hostProvider, rev types.FileContractRevisi
 	span.AddEvent("execute")
 
 	// create a host
-	h, err := hp.newHostV3(upload.ctx, upload.fcid, upload.hk, upload.siamuxAddr)
+	h, err := hp.newHostV3(upload.fcid, upload.hk, upload.siamuxAddr)
 	if err != nil {
 		return types.Hash256{}, err
 	}
+	defer h.Close()
 
 	// upload the sector
 	start := time.Now()

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -415,7 +415,7 @@ func (w *worker) rhpPriceTableHandler(jc jape.Context) {
 
 	var pt rhpv3.HostPriceTable
 	if jc.Check("could not get price table", w.transportPoolV3.withTransportV3(jc.Request.Context(), rptr.HostKey, rptr.SiamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
-		pt, err = RPCPriceTable(jc.Request.Context(), t, func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) { return nil, nil })
+		pt, err = RPCPriceTable(ctx, t, func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) { return nil, nil })
 		return
 	})) != nil {
 		return
@@ -591,7 +591,7 @@ func (w *worker) rhpRegistryReadHandler(jc jape.Context) {
 	}
 	var value rhpv3.RegistryValue
 	err := w.transportPoolV3.withTransportV3(jc.Request.Context(), rrrr.HostKey, rrrr.SiamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
-		value, err = RPCReadRegistry(jc.Request.Context(), t, &rrrr.Payment, rrrr.RegistryKey)
+		value, err = RPCReadRegistry(ctx, t, &rrrr.Payment, rrrr.RegistryKey)
 		return
 	})
 	if jc.Check("couldn't read registry", err) != nil {
@@ -611,7 +611,7 @@ func (w *worker) rhpRegistryUpdateHandler(jc jape.Context) {
 	// TODO: refactor to a w.RegistryUpdate method that calls host.RegistryUpdate.
 	payment := preparePayment(w.accounts.deriveAccountKey(rrur.HostKey), cost, pt.HostBlockHeight)
 	err := w.transportPoolV3.withTransportV3(jc.Request.Context(), rrur.HostKey, rrur.SiamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
-		return RPCUpdateRegistry(jc.Request.Context(), t, &payment, rrur.RegistryKey, rrur.RegistryValue)
+		return RPCUpdateRegistry(ctx, t, &payment, rrur.RegistryKey, rrur.RegistryValue)
 	})
 	if jc.Check("couldn't update registry", err) != nil {
 		return
@@ -1036,7 +1036,7 @@ func New(masterKey [32]byte, id string, b Bus, contractLockingDuration, busFlush
 		downloadMaxOverdrive:    downloadMaxOverdrive,
 		logger:                  l.Sugar().Named("worker").Named(id),
 	}
-	w.transportPoolV3 = newTransportPoolV3(w)
+	w.initTransportPool()
 	w.initAccounts(b)
 	w.initContractSpendingRecorder()
 	w.initPriceTables()

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -93,105 +92,6 @@ func (rw *rangedResponseWriter) Header() http.Header {
 func (rw *rangedResponseWriter) WriteHeader(statusCode int) {
 	rw.headerWritten = true
 	rw.rw.WriteHeader(statusCode)
-}
-
-func errToStr(err error) string {
-	if err != nil {
-		return err.Error()
-	}
-	return ""
-}
-
-type InteractionResult struct {
-	Error string `json:"error,omitempty"`
-}
-
-type ephemeralMetricsRecorder struct {
-	ms []metrics.Metric
-	mu sync.Mutex
-}
-
-func (mr *ephemeralMetricsRecorder) RecordMetric(m metrics.Metric) {
-	mr.mu.Lock()
-	defer mr.mu.Unlock()
-	mr.ms = append(mr.ms, m)
-}
-
-func (mr *ephemeralMetricsRecorder) interactions() []hostdb.Interaction {
-	// TODO: merge/filter metrics?
-	var his []hostdb.Interaction
-	mr.mu.Lock()
-	defer mr.mu.Unlock()
-	for _, m := range mr.ms {
-		if hi, ok := toHostInteraction(m); ok {
-			his = append(his, hi)
-		}
-	}
-	return his
-}
-
-// MetricHostDial contains metrics relating to a host dial.
-type MetricHostDial struct {
-	HostKey   types.PublicKey
-	HostIP    string
-	Timestamp time.Time
-	Elapsed   time.Duration
-	Err       error
-}
-
-// IsMetric implements metrics.Metric.
-func (MetricHostDial) IsMetric() {}
-
-// IsSuccess implements metrics.Metric.
-func (m MetricHostDial) IsSuccess() bool { return m.Err == nil }
-
-func dial(ctx context.Context, hostIP string, hostKey types.PublicKey) (net.Conn, error) {
-	start := time.Now()
-	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", hostIP)
-	metrics.Record(ctx, MetricHostDial{
-		HostKey:   hostKey,
-		HostIP:    hostIP,
-		Timestamp: start,
-		Elapsed:   time.Since(start),
-		Err:       err,
-	})
-	return conn, err
-}
-
-func toHostInteraction(m metrics.Metric) (hostdb.Interaction, bool) {
-	transform := func(hk types.PublicKey, timestamp time.Time, typ string, err error, res interface{}) (hostdb.Interaction, bool) {
-		b, _ := json.Marshal(InteractionResult{Error: errToStr(err)})
-		hi := hostdb.Interaction{
-			Host:      hk,
-			Timestamp: timestamp,
-			Type:      typ,
-			Result:    json.RawMessage(b),
-			Success:   err == nil,
-		}
-		return hi, true
-	}
-
-	switch m := m.(type) {
-	case MetricHostDial:
-		return transform(m.HostKey, m.Timestamp, "dial", m.Err, struct {
-			HostIP    string        `json:"hostIP"`
-			Timestamp time.Time     `json:"timestamp"`
-			Elapsed   time.Duration `json:"elapsed"`
-		}{m.HostIP, m.Timestamp, m.Elapsed})
-	case MetricRPC:
-		return transform(m.HostKey, m.Timestamp, "rhpv2 rpc", m.Err, struct {
-			RPC        string         `json:"RPC"`
-			Timestamp  time.Time      `json:"timestamp"`
-			Elapsed    time.Duration  `json:"elapsed"`
-			Contract   string         `json:"contract"`
-			Uploaded   uint64         `json:"uploaded"`
-			Downloaded uint64         `json:"downloaded"`
-			Cost       types.Currency `json:"cost"`
-			Collateral types.Currency `json:"collateral"`
-		}{m.RPC.String(), m.Timestamp, m.Elapsed, m.Contract.String(), m.Uploaded, m.Downloaded, m.Cost, m.Collateral})
-	default:
-		return hostdb.Interaction{}, false
-	}
 }
 
 type AccountStore interface {
@@ -324,43 +224,19 @@ type worker struct {
 	logger          *zap.SugaredLogger
 }
 
-func (w *worker) recordPriceTableUpdate(hostKey types.PublicKey, pt hostdb.HostPriceTable, err error) {
-	hi := hostdb.Interaction{
-		Host:      hostKey,
-		Timestamp: time.Now(),
-		Type:      hostdb.InteractionTypePriceTableUpdate,
-		Success:   err == nil,
-	}
-	if err == nil {
-		hi.Result, _ = json.Marshal(hostdb.PriceTableUpdateResult{
-			PriceTable: pt,
-		})
-	} else {
-		hi.Result, _ = json.Marshal(hostdb.PriceTableUpdateResult{
-			Error: errToStr(err),
-		})
-	}
-	w.recordInteractions([]hostdb.Interaction{hi})
-}
-
-func (w *worker) recordScan(hostKey types.PublicKey, pt rhpv3.HostPriceTable, settings rhpv2.HostSettings, err error) {
-	hi := hostdb.Interaction{
-		Host:      hostKey,
-		Timestamp: time.Now(),
-		Type:      hostdb.InteractionTypeScan,
-		Success:   err == nil,
-	}
-	if err == nil {
-		hi.Result, _ = json.Marshal(hostdb.ScanResult{
-			PriceTable: pt,
-			Settings:   settings,
-		})
-	} else {
-		hi.Result, _ = json.Marshal(hostdb.ScanResult{
-			Error: errToStr(err),
-		})
-	}
-	w.recordInteractions([]hostdb.Interaction{hi})
+func dial(ctx context.Context, hostIP string, hostKey types.PublicKey) (net.Conn, error) {
+	start := time.Now()
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", hostIP)
+	metrics.Record(ctx, MetricHostDial{
+		metricCommon: metricCommon{
+			address:   hostIP,
+			hostKey:   hostKey,
+			timestamp: start,
+			elapsed:   time.Since(start),
+			err:       err,
+		},
+	})
+	return conn, err
 }
 
 func (w *worker) withTransportV2(ctx context.Context, hostKey types.PublicKey, hostIP string, fn func(*rhpv2.Transport) error) (err error) {
@@ -395,7 +271,7 @@ func (w *worker) withTransportV2(ctx context.Context, hostKey types.PublicKey, h
 	return fn(t)
 }
 
-func (w *worker) newHostV3(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string) (_ hostV3, err error) {
+func (w *worker) newHostV3(contractID types.FileContractID, hostKey types.PublicKey, siamuxAddr string) (_ hostV3, err error) {
 	acc, err := w.accounts.ForHost(hostKey)
 	if err != nil {
 		return nil, err
@@ -405,8 +281,10 @@ func (w *worker) newHostV3(ctx context.Context, contractID types.FileContractID,
 		acc:                      acc,
 		bus:                      w.bus,
 		contractSpendingRecorder: w.contractSpendingRecorder,
+		mr:                       &ephemeralMetricsRecorder{},
 		logger:                   w.logger.Named(hostKey.String()[:4]),
 		fcid:                     contractID,
+		recordInteractions:       w.recordInteractions,
 		siamuxAddr:               siamuxAddr,
 		renterKey:                w.deriveRenterKey(hostKey),
 		accountKey:               w.accounts.deriveAccountKey(hostKey),
@@ -427,10 +305,11 @@ func (w *worker) withRevision(ctx context.Context, fetchTimeout time.Duration, c
 		cancel()
 	}()
 
-	h, err := w.newHostV3(ctx, contractID, hk, siamuxAddr)
+	h, err := w.newHostV3(contractID, hk, siamuxAddr)
 	if err != nil {
 		return err
 	}
+	defer h.Close()
 	rev, err := h.FetchRevision(ctx, fetchTimeout, blockHeight)
 	if err != nil {
 		return err
@@ -462,19 +341,17 @@ func (w *worker) rhpScanHandler(jc jape.Context) {
 		return
 	}
 
-	// defer scan result
-	var settings rhpv2.HostSettings
-	var priceTable rhpv3.HostPriceTable
-	defer func() {
-		w.recordScan(rsr.HostKey, priceTable, settings, err)
-	}()
-
 	// scan host
 	var errStr string
 	settings, priceTable, elapsed, err := w.scanHost(ctx, rsr.HostKey, rsr.HostIP)
 	if err != nil {
 		errStr = err.Error()
 	}
+
+	// record scan
+	var mr ephemeralMetricsRecorder
+	recordScan(&mr, elapsed, rsr.HostIP, rsr.HostKey, priceTable, settings, err)
+	w.recordInteractions(mr.interactions())
 
 	jc.Encode(api.RHPScanResponse{
 		Ping:      api.ParamDuration(elapsed),
@@ -534,12 +411,11 @@ func (w *worker) fetchContracts(ctx context.Context, metadatas []api.ContractMet
 }
 
 func (w *worker) fetchPriceTable(ctx context.Context, hk types.PublicKey, siamuxAddr string, rev *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error) {
-	defer func() { w.recordPriceTableUpdate(hk, hpt, err) }()
-
-	h, err := w.newHostV3(ctx, types.FileContractID{}, hk, siamuxAddr)
+	h, err := w.newHostV3(types.FileContractID{}, hk, siamuxAddr)
 	if err != nil {
 		return hostdb.HostPriceTable{}, err
 	}
+	defer h.Close()
 	hpt, err = h.FetchPriceTable(ctx, rev)
 	if err != nil {
 		return hostdb.HostPriceTable{}, err
@@ -657,10 +533,11 @@ func (w *worker) rhpRenewHandler(jc jape.Context) {
 	ctx = WithGougingChecker(ctx, w.bus, gp)
 
 	// renew the contract
-	h, err := w.newHostV3(ctx, rrr.ContractID, rrr.HostKey, rrr.SiamuxAddr)
+	h, err := w.newHostV3(rrr.ContractID, rrr.HostKey, rrr.SiamuxAddr)
 	if jc.Check("failed to create host for renewal", err) != nil {
 		return
 	}
+	defer h.Close()
 	renewed, txnSet, err := h.Renew(ctx, rrr)
 	if jc.Check("couldn't renew contract", err) != nil {
 		return
@@ -698,10 +575,11 @@ func (w *worker) rhpFundHandler(jc jape.Context) {
 
 	// fund the account
 	jc.Check("couldn't fund account", w.withRevision(ctx, defaultRevisionFetchTimeout, rfr.ContractID, rfr.HostKey, rfr.SiamuxAddr, lockingPriorityFunding, gp.ConsensusState.BlockHeight, func(rev types.FileContractRevision) (err error) {
-		h, err := w.newHostV3(ctx, rev.ParentID, rfr.HostKey, rfr.SiamuxAddr)
+		h, err := w.newHostV3(rev.ParentID, rfr.HostKey, rfr.SiamuxAddr)
 		if err != nil {
 			return err
 		}
+		defer h.Close()
 		err = h.FundAccount(ctx, rfr.Balance, &rev)
 		if isMaxBalanceExceeded(err) {
 			// sync the account
@@ -780,10 +658,11 @@ func (w *worker) rhpSyncHandler(jc jape.Context) {
 	ctx = WithGougingChecker(ctx, w.bus, up.GougingParams)
 
 	// sync the account
-	h, err := w.newHostV3(ctx, rsr.ContractID, rsr.HostKey, rsr.SiamuxAddr)
+	h, err := w.newHostV3(rsr.ContractID, rsr.HostKey, rsr.SiamuxAddr)
 	if jc.Check("failed to create host for renewal", err) != nil {
 		return
 	}
+	defer h.Close()
 	jc.Check("couldn't sync account", w.withRevision(ctx, defaultRevisionFetchTimeout, rsr.ContractID, rsr.HostKey, rsr.SiamuxAddr, lockingPrioritySyncing, up.CurrentHeight, func(rev types.FileContractRevision) error {
 		return h.SyncAccount(ctx, &rev)
 	}))
@@ -1233,38 +1112,6 @@ func (w *worker) Shutdown(_ context.Context) error {
 	// Stop the uploader.
 	w.uploadManager.Stop()
 	return nil
-}
-
-func (w *worker) recordInteractions(interactions []hostdb.Interaction) {
-	w.interactionsMu.Lock()
-	defer w.interactionsMu.Unlock()
-
-	// Append interactions to buffer.
-	w.interactions = append(w.interactions, interactions...)
-
-	// If a thread was scheduled to flush the buffer we are done.
-	if w.interactionsFlushTimer != nil {
-		return
-	}
-	// Otherwise we schedule a flush.
-	w.interactionsFlushTimer = time.AfterFunc(w.busFlushInterval, func() {
-		w.interactionsMu.Lock()
-		w.flushInteractions()
-		w.interactionsMu.Unlock()
-	})
-}
-
-func (w *worker) flushInteractions() {
-	if len(w.interactions) > 0 {
-		ctx, span := tracing.Tracer.Start(context.Background(), "worker: flushInteractions")
-		defer span.End()
-		if err := w.bus.RecordInteractions(ctx, w.interactions); err != nil {
-			w.logger.Errorw(fmt.Sprintf("failed to record interactions: %v", err))
-		} else {
-			w.interactions = nil
-		}
-	}
-	w.interactionsFlushTimer = nil
 }
 
 type contractLock struct {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -414,7 +414,7 @@ func (w *worker) rhpPriceTableHandler(jc jape.Context) {
 	}
 
 	var pt rhpv3.HostPriceTable
-	if jc.Check("could not get price table", w.transportPoolV3.withTransportV3(jc.Request.Context(), rptr.HostKey, rptr.SiamuxAddr, func(t *transportV3) (err error) {
+	if jc.Check("could not get price table", w.transportPoolV3.withTransportV3(jc.Request.Context(), rptr.HostKey, rptr.SiamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
 		pt, err = RPCPriceTable(jc.Request.Context(), t, func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) { return nil, nil })
 		return
 	})) != nil {
@@ -590,7 +590,7 @@ func (w *worker) rhpRegistryReadHandler(jc jape.Context) {
 		return
 	}
 	var value rhpv3.RegistryValue
-	err := w.transportPoolV3.withTransportV3(jc.Request.Context(), rrrr.HostKey, rrrr.SiamuxAddr, func(t *transportV3) (err error) {
+	err := w.transportPoolV3.withTransportV3(jc.Request.Context(), rrrr.HostKey, rrrr.SiamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
 		value, err = RPCReadRegistry(jc.Request.Context(), t, &rrrr.Payment, rrrr.RegistryKey)
 		return
 	})
@@ -610,7 +610,7 @@ func (w *worker) rhpRegistryUpdateHandler(jc jape.Context) {
 	cost, _ := rc.Total()
 	// TODO: refactor to a w.RegistryUpdate method that calls host.RegistryUpdate.
 	payment := preparePayment(w.accounts.deriveAccountKey(rrur.HostKey), cost, pt.HostBlockHeight)
-	err := w.transportPoolV3.withTransportV3(jc.Request.Context(), rrur.HostKey, rrur.SiamuxAddr, func(t *transportV3) (err error) {
+	err := w.transportPoolV3.withTransportV3(jc.Request.Context(), rrur.HostKey, rrur.SiamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
 		return RPCUpdateRegistry(jc.Request.Context(), t, &payment, rrur.RegistryKey, rrur.RegistryValue)
 	})
 	if jc.Check("couldn't update registry", err) != nil {
@@ -1206,7 +1206,7 @@ func (w *worker) scanHost(ctx context.Context, hostKey types.PublicKey, hostIP s
 	// fetch the host pricetable
 	var pt rhpv3.HostPriceTable
 	if err == nil {
-		err = w.transportPoolV3.withTransportV3(ctx, hostKey, settings.SiamuxAddr(), func(t *transportV3) (err error) {
+		err = w.transportPoolV3.withTransportV3(ctx, hostKey, settings.SiamuxAddr(), func(ctx context.Context, t *transportV3) (err error) {
 			pt, err = RPCPriceTable(ctx, t, func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error) { return nil, nil })
 			return err
 		})


### PR DESCRIPTION
This PR refactors metrics and interactions a bit in the worker.

Everything the worker records now goes through a metrics recorder as a metric.
The metric is then turned into an interaction which is sent to the bus.

Even scans and pricetable updates are now handled that way and contain metric information.

Whether a metric is considered a successful interaction is now determined by `isSuccessfulInteraction`. That way we can easily exclude some errors from causing an interaction to not be successful. 

This PR also removes the recording of metrics for rhpv2 RPCs. Because the only interaction that still happens over rhpv2 is scanning hosts which is explicitly recorded in the corresponding handler.