### PR TITLE
Don't drop contracts that are usable and up for renewal from the set

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -721,11 +721,6 @@ func (c *contractor) runContractRenewals(ctx context.Context, w Worker, budget *
 			"budget", budget,
 		)
 	}()
-	// start renewing from the largest contract to lose the least amount of data
-	// in case we have more contracts than we need.
-	sort.Slice(toRenew, func(i, j int) bool {
-		return toRenew[i].contract.FileSize() > toRenew[j].contract.FileSize()
-	})
 
 	var nRenewed uint64
 	for _, ci := range toRenew {

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -252,7 +252,7 @@ func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, rente
 	}
 	// redundant IP check - always perform this last since it will update
 	// the ipFilter.
-	if !cfg.Hosts.AllowRedundantIPs && f.isRedundantIP(ci.contract.HostIP, ci.contract.HostKey) {
+	if !cfg.Hosts.AllowRedundantIPs && f.isRedundantIP(c.HostIP, c.HostKey) {
 		reasons = append(reasons, errHostRedundantIP.Error())
 		renew = false
 		refresh = false


### PR DESCRIPTION
Some contracts might be up for renewal but not considered unusable yet. These contracts should be kept in the set instead of dropping them if the renewal fails.

Contracts that are up for renewal will be dropped if they haven't renewed by the second half of the renewal window.