### PR TITLE
Autopilot Status

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -91,7 +91,13 @@ type (
 	// AutopilotStatusResponseGET is the response type for the /autopilot/status
 	// endpoint.
 	AutopilotStatusResponseGET struct {
-		CurrentPeriod uint64 `json:"currentPeriod"`
+		Configured         bool   `json:"configured"`
+		Migrating          bool   `json:"migrating"`
+		MigratingLastStart int64  `json:"migratingLastStart"`
+		Scanning           bool   `json:"scanning"`
+		ScanningLastStart  int64  `json:"scanningLastStart"`
+		Synced             bool   `json:"synced"`
+		UptimeMS           uint64 `json:"uptimeMS"`
 	}
 
 	// HostHandlerGET is the response type for the /host/:hostkey endpoint.

--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -88,20 +88,20 @@ type (
 		Triggered bool `json:"triggered"`
 	}
 
-	// AutopilotStatusResponseGET is the response type for the /autopilot/status
+	// AutopilotStatusResponse is the response type for the /autopilot/status
 	// endpoint.
-	AutopilotStatusResponseGET struct {
-		Configured         bool   `json:"configured"`
-		Migrating          bool   `json:"migrating"`
-		MigratingLastStart int64  `json:"migratingLastStart"`
-		Scanning           bool   `json:"scanning"`
-		ScanningLastStart  int64  `json:"scanningLastStart"`
-		Synced             bool   `json:"synced"`
-		UptimeMS           uint64 `json:"uptimeMS"`
+	AutopilotStatusResponse struct {
+		Configured         bool          `json:"configured"`
+		Migrating          bool          `json:"migrating"`
+		MigratingLastStart ParamTime     `json:"migratingLastStart"`
+		Scanning           bool          `json:"scanning"`
+		ScanningLastStart  ParamTime     `json:"scanningLastStart"`
+		Synced             bool          `json:"synced"`
+		UptimeMS           ParamDuration `json:"uptimeMS"`
 	}
 
-	// HostHandlerGET is the response type for the /host/:hostkey endpoint.
-	HostHandlerGET struct {
+	// HostHandlerResponse is the response type for the /host/:hostkey endpoint.
+	HostHandlerResponse struct {
 		Host hostdb.Host `json:"host"`
 
 		Gouging          bool                 `json:"gouging"`

--- a/api/params.go
+++ b/api/params.go
@@ -93,6 +93,16 @@ func (d *ParamDuration) UnmarshalText(b []byte) error {
 	return nil
 }
 
+// MarshalJSON implements json.Marshaler.
+func (d ParamDuration) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.FormatInt(time.Duration(d).Milliseconds(), 10)), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (d *ParamDuration) UnmarshalJSON(data []byte) error {
+	return d.UnmarshalText(data)
+}
+
 // String implements fmt.Stringer.
 func (d ParamDurationHour) String() string {
 	return strconv.Itoa(int(time.Duration(d).Hours()))

--- a/api/params.go
+++ b/api/params.go
@@ -21,8 +21,8 @@ type (
 	// that format the duration in hours.
 	ParamDurationHour time.Duration
 
-	// A ParamDuration is the elapsed time between two instants. ParamDurations
-	// are encoded as an integer number of milliseconds.
+	// A ParamDuration is a duration encoded as an integer number of
+	// milliseconds.
 	ParamDuration time.Duration
 
 	// ParamString is a helper type since jape expects query params to
@@ -67,6 +67,11 @@ func (t ParamTime) String() string { return url.QueryEscape((time.Time)(t).Forma
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (t *ParamTime) UnmarshalText(b []byte) error { return (*time.Time)(t).UnmarshalText(b) }
+
+// MarshalJSON implements json.Marshaler.
+func (t ParamTime) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, (time.Time)(t).Format(time.RFC3339))), nil
+}
 
 // String implements fmt.Stringer.
 func (d ParamDuration) String() string {

--- a/autopilot/client.go
+++ b/autopilot/client.go
@@ -32,12 +32,12 @@ func (c *Client) UpdateConfig(cfg api.AutopilotConfig) error {
 	return c.c.PUT("/config", cfg)
 }
 
-func (c *Client) HostInfo(hostKey types.PublicKey) (resp api.HostHandlerGET, err error) {
+func (c *Client) HostInfo(hostKey types.PublicKey) (resp api.HostHandlerResponse, err error) {
 	err = c.c.GET(fmt.Sprintf("/host/%s", hostKey), &resp)
 	return
 }
 
-func (c *Client) HostInfos(ctx context.Context, filterMode, usabilityMode string, addressContains string, keyIn []types.PublicKey, offset, limit int) (resp []api.HostHandlerGET, err error) {
+func (c *Client) HostInfos(ctx context.Context, filterMode, usabilityMode string, addressContains string, keyIn []types.PublicKey, offset, limit int) (resp []api.HostHandlerResponse, err error) {
 	err = c.c.POST("/hosts", api.SearchHostsRequest{
 		Offset:          offset,
 		Limit:           limit,
@@ -49,7 +49,7 @@ func (c *Client) HostInfos(ctx context.Context, filterMode, usabilityMode string
 	return
 }
 
-func (c *Client) Status() (resp api.AutopilotStatusResponseGET, err error) {
+func (c *Client) Status() (resp api.AutopilotStatusResponse, err error) {
 	err = c.c.GET("/status", &resp)
 	return
 }

--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -159,7 +159,7 @@ func (s *scanner) tryPerformHostScan(ctx context.Context, w scanWorker, force bo
 	}
 
 	s.mu.Lock()
-	if !(force || s.isScanRequired()) {
+	if !force && (s.scanning || !s.isScanRequired()) {
 		s.mu.Unlock()
 		return false
 	}

--- a/autopilot/scanner_test.go
+++ b/autopilot/scanner_test.go
@@ -130,6 +130,12 @@ func TestScanner(t *testing.T) {
 	}
 }
 
+func (s *scanner) isScanning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.scanning
+}
+
 func newTestScanner(b *mockBus, w *mockWorker) *scanner {
 	ap := &Autopilot{
 		stopChan: make(chan struct{}),

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -255,10 +255,10 @@ func TestNewTestCluster(t *testing.T) {
 	if !status.Configured {
 		t.Fatal("autopilot should be configured")
 	}
-	if status.MigratingLastStart == (time.Time{}.Unix()) {
+	if time.Time(status.MigratingLastStart).IsZero() {
 		t.Fatal("autopilot should have completed a migration")
 	}
-	if status.ScanningLastStart == (time.Time{}.Unix()) {
+	if time.Time(status.ScanningLastStart).IsZero() {
 		t.Fatal("autopilot should have completed a scan")
 	}
 	if !status.Synced {

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -246,6 +246,27 @@ func TestNewTestCluster(t *testing.T) {
 	if len(hostInfosUnusable) != 0 {
 		t.Fatal("there should be no unusable hosts", len(hostInfosUnusable))
 	}
+
+	// Fetch the autopilot status
+	status, err := cluster.Autopilot.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Configured {
+		t.Fatal("autopilot should be configured")
+	}
+	if status.MigratingLastStart == (time.Time{}.Unix()) {
+		t.Fatal("autopilot should have completed a migration")
+	}
+	if status.ScanningLastStart == (time.Time{}.Unix()) {
+		t.Fatal("autopilot should have completed a scan")
+	}
+	if !status.Synced {
+		t.Fatal("autopilot should be synced")
+	}
+	if status.UptimeMS == 0 {
+		t.Fatal("uptime should be set")
+	}
 }
 
 // TestUploadDownloadEmpty is an integration test that verifies empty objects


### PR DESCRIPTION
This PR updates the response returned by `/api/autopilot/status`. I went back and forth a lot on the response types but eventually just tried to stay consistent with the rest of the API (returning a `ParamDuration` and `ParamTime`, specifying the duration unit in milliseconds). 

Example status response

```json
{
        "configured": true,
        "migrating": false,
        "migratingLastStart": "0001-01-01T00:00:00Z",
        "scanning": false,
        "scanningLastStart": "2023-06-27T16:05:18+02:00",
        "synced": true,
        "uptimeMS": "39870"
}
```