### PR TITLE
AutoMigrations

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -100,7 +100,7 @@ type (
 		MinShards   uint8
 		TotalShards uint8
 
-		Slices []dbSlice  `gorm:"constraint:OnDelete:SET NULL"`
+		Slices []dbSlice
 		Shards []dbSector `gorm:"constraint:OnDelete:CASCADE"` // CASCADE to delete shards too
 	}
 

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -191,5 +191,10 @@ func performMigrations(db *gorm.DB, logger glogger.Interface) error {
 			return err
 		}
 	}
+	if m.HasConstraint(&dbSlab{}, "Slices") {
+		if err := m.DropConstraint(&dbSlab{}, "Slices"); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -191,10 +191,5 @@ func performMigrations(db *gorm.DB, logger glogger.Interface) error {
 			return err
 		}
 	}
-	if m.HasConstraint(&dbSlab{}, "Slices") {
-		if err := m.DropConstraint(&dbSlab{}, "Slices"); err != nil {
-			return err
-		}
-	}
 	return nil
 }

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -117,8 +117,9 @@ func DBConfigFromEnv() (uri, user, password, dbName string) {
 // same Dialector multiple times.
 func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duration, walletAddress types.Address, logger glogger.Interface) (*SQLStore, modules.ConsensusChangeID, error) {
 	db, err := gorm.Open(conn, &gorm.Config{
-		DisableNestedTransaction: true,   // disable nesting transactions
-		Logger:                   logger, // custom logger
+		DisableForeignKeyConstraintWhenMigrating: true,   // disable foreign key constraints when migrating
+		DisableNestedTransaction:                 true,   // disable nesting transactions
+		Logger:                                   logger, // custom logger
 	})
 	if err != nil {
 		return nil, modules.ConsensusChangeID{}, err


### PR DESCRIPTION
This PR disables foreign key checks during migrations and drops a constraint on `dbSlab`. This constraint caused mass object corruption where slices would detach from slabs, effectively rendering the object without any data and making them corrupt.

Fixes #447 