### PR TITLE
Increase timeouts for better account refills

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -52,11 +52,15 @@ const (
 
 	// timeoutHostPriceTable is the amount of time we wait to receive a price
 	// table from the host
-	timeoutHostPriceTable = 10 * time.Minute
+	timeoutHostPriceTable = 30 * time.Second
 
 	// timeoutHostRevision is the amount of time we wait to receive the latest
-	// revision from the host
-	timeoutHostRevision = 10 * time.Minute
+	// revision from the host. This is set to 4 minutes since siad currently
+	// blocks for 3 minutes when trying to fetch a revision and not having
+	// enough funds in the account used for fetching it. That way we are
+	// guaranteed to receive the host's ErrBalanceInsufficient.
+	// TODO: This can be lowered once the network uses hostd.
+	timeoutHostRevision = 4 * time.Minute
 
 	// timeoutHostScan is the amount of time we wait for a host scan to be
 	// completed

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -52,11 +52,11 @@ const (
 
 	// timeoutHostPriceTable is the amount of time we wait to receive a price
 	// table from the host
-	timeoutHostPriceTable = time.Minute
+	timeoutHostPriceTable = 10 * time.Minute
 
 	// timeoutHostRevision is the amount of time we wait to receive the latest
 	// revision from the host
-	timeoutHostRevision = time.Minute
+	timeoutHostRevision = 10 * time.Minute
 
 	// timeoutHostScan is the amount of time we wait for a host scan to be
 	// completed

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -187,7 +187,7 @@ func main() {
 
 	// autopilot
 	flag.DurationVar(&autopilotCfg.AccountsRefillInterval, "autopilot.accountRefillInterval", defaultAccountRefillInterval, "interval at which the autopilot checks the workers' accounts balance and refills them if necessary")
-	flag.DurationVar(&autopilotCfg.Heartbeat, "autopilot.heartbeat", 10*time.Minute, "interval at which autopilot loop runs")
+	flag.DurationVar(&autopilotCfg.Heartbeat, "autopilot.heartbeat", 30*time.Minute, "interval at which autopilot loop runs")
 	flag.Float64Var(&autopilotCfg.MigrationHealthCutoff, "autopilot.migrationHealthCutoff", 0.75, "health threshold below which slabs are migrated to new hosts")
 	flag.Uint64Var(&autopilotCfg.ScannerBatchSize, "autopilot.scannerBatchSize", 1000, "size of the batch with which hosts are scanned")
 	flag.DurationVar(&autopilotCfg.ScannerInterval, "autopilot.scannerInterval", 24*time.Hour, "interval at which hosts are scanned")

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -744,7 +744,8 @@ func TestEphemeralAccounts(t *testing.T) {
 		t.Fatal(err)
 	}
 	acc := accounts[0]
-	if acc.Balance.Cmp(types.Siacoins(1).Big()) != 0 {
+	minExpectedBalance := types.Siacoins(1).Sub(types.NewCurrency64(1))
+	if acc.Balance.Cmp(minExpectedBalance.Big()) < 0 {
 		t.Fatalf("wrong balance %v", acc.Balance)
 	}
 	if acc.ID == (rhpv3.Account{}) {
@@ -791,9 +792,11 @@ func TestEphemeralAccounts(t *testing.T) {
 		t.Fatal(err)
 	}
 	busAcc = busAccounts[0]
-	if busAcc.Drift.Cmp(newDrift) != 0 {
-		t.Fatalf("drift was %v but should be %v", busAcc.Drift, newDrift)
+	maxNewDrift := newDrift.Add(newDrift, types.NewCurrency64(1).Big())
+	if busAcc.Drift.Cmp(maxNewDrift) > 0 {
+		t.Fatalf("drift was %v but should be %v", busAcc.Drift, maxNewDrift)
 	}
+	newDrift = busAcc.Drift
 
 	// Reboot cluster.
 	cluster2, err := cluster.Reboot(context.Background())

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -792,7 +792,7 @@ func TestEphemeralAccounts(t *testing.T) {
 		t.Fatal(err)
 	}
 	busAcc = busAccounts[0]
-	maxNewDrift := newDrift.Add(newDrift, types.NewCurrency64(1).Big())
+	maxNewDrift := newDrift.Add(newDrift, types.NewCurrency64(2).Big()) // forgive 2H
 	if busAcc.Drift.Cmp(maxNewDrift) > 0 {
 		t.Fatalf("drift was %v but should be %v", busAcc.Drift, maxNewDrift)
 	}

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -510,7 +510,6 @@ func (a *account) WithWithdrawal(ctx context.Context, amtFn func() (types.Curren
 	// execute amtFn
 	amt, err := amtFn()
 	if isBalanceInsufficient(err) {
-		fmt.Println("schedule sync")
 		// in case of an insufficient balance, we schedule a sync
 		scheduleCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -260,7 +260,7 @@ func (h *host) fetchRevisionWithAccount(ctx context.Context, hostKey types.Publi
 				if err != nil {
 					return rhpv3.HostPriceTable{}, nil, fmt.Errorf("failed to fetch pricetable, err: %w", err)
 				}
-				cost = pt.LatestRevisionCost.Add(pt.UpdatePriceTableCost) // add cost of fetching the pricetable since we might need a new one and it's just 1H anyway.
+				cost = pt.LatestRevisionCost.Add(pt.UpdatePriceTableCost) // add cost of fetching the pricetable since we might need a new one and it's better to stay pessimistic
 				payment := rhpv3.PayByEphemeralAccount(h.acc.id, cost, bh+defaultWithdrawalExpiryBlocks, h.accountKey)
 				return pt, &payment, nil
 			})

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -118,7 +118,7 @@ func (t *transportV3) DialStream(ctx context.Context) (*streamV3, error) {
 	stream := transport.DialStream()
 
 	// Apply a sane timeout to the stream.
-	if err := stream.SetDeadline(time.Now().Add(10 * time.Minute)); err != nil {
+	if err := stream.SetDeadline(time.Now().Add(5 * time.Minute)); err != nil {
 		_ = stream.Close()
 		return nil, err
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -379,7 +379,7 @@ func (w *worker) fetchContracts(ctx context.Context, metadatas []api.ContractMet
 
 	// launch all workers
 	var wg sync.WaitGroup
-	for t := 0; t < 10 && t < len(metadatas); t++ {
+	for t := 0; t < 20 && t < len(metadatas); t++ {
 		wg.Add(1)
 		go func() {
 			worker()


### PR DESCRIPTION
This PR increases some timeouts to make sure the contract maintenance picks up on empty accounts and schedules them for a refill.