### PR TITLE
Add COALESCE to ObjectStats to avoid returning NULL if no slices exist

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -368,7 +368,7 @@ func (s *SQLStore) ObjectsStats(ctx context.Context) (api.ObjectsStats, error) {
 		if resp.NumObjects > 0 {
 			err = tx.
 				Model(&dbSlice{}).
-				Select("SUM(length)").
+				Select("COALESCE(SUM(length), 0)").
 				Scan(&resp.TotalObjectsSize).
 				Error
 			if err != nil {


### PR DESCRIPTION
If only empty objects exist, `NumObjects > 0` but we won't be able to find slices, resulting in an error.