### PR TITLE
Don't record dial metrics in worker

### DIFF
--- a/worker/interactions.go
+++ b/worker/interactions.go
@@ -142,28 +142,6 @@ func (m metricCommon) IsSuccess() bool {
 	return isSuccessfulInteraction(m.err)
 }
 
-// MetricHostDial is a metric that contains the result of a dial attempt.
-type MetricHostDial struct {
-	metricCommon
-}
-
-func (m MetricHostDial) Result() interface{} {
-	cr := m.commonResult()
-	er := hostdb.ErrorResult{Error: errToStr(m.err)}
-	if m.err != nil {
-		return struct {
-			metricResultCommon
-			hostdb.ErrorResult
-		}{cr, er}
-	} else {
-		return struct {
-			metricResultCommon
-		}{cr}
-	}
-}
-
-func (m MetricHostDial) Type() string { return "dial" }
-
 // MetricPriceTableUpdate is a metric that contains the result of fetching a
 // price table.
 type MetricPriceTableUpdate struct {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -243,17 +243,7 @@ type worker struct {
 }
 
 func dial(ctx context.Context, hostIP string, hostKey types.PublicKey) (net.Conn, error) {
-	start := time.Now()
 	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", hostIP)
-	metrics.Record(ctx, MetricHostDial{
-		metricCommon: metricCommon{
-			address:   hostIP,
-			hostKey:   hostKey,
-			timestamp: start,
-			elapsed:   time.Since(start),
-			err:       err,
-		},
-	})
 	return conn, err
 }
 


### PR DESCRIPTION
We noticed some contract churn due to hosts getting a worse interaction score over time because of hundreds and thousands of failed dial interactions. 
The problem is that dial is a very low-level operation and we don't know whether it fails due to us closing the context because we don't need the connection anymore (e.g. overdrive when downloading) or because the host is actually timing out. So we are limiting recorded interactions to more high level ones such as fetching a pricetable, scanning a host or downloading a sector where we can say with certainty that the interaction failed due to the host or because we interrupted it.