### PR TITLE
Custom Error

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -39,6 +39,10 @@ var (
 	// the database.
 	ErrObjectNotFound = errors.New("object not found")
 
+	// ErrObjectCorrupted is returned if we were unable to retrieve the object
+	// from the database.
+	ErrObjectCorrupted = errors.New("object corrupted")
+
 	// ErrContractSetNotFound is returned when a contract can't be retrieved
 	// from the database.
 	ErrContractSetNotFound = errors.New("couldn't find contract set")

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -17,10 +17,6 @@ import (
 )
 
 var (
-	// ErrSlabNotFound is returned if get is unable to retrieve a slab from the
-	// database.
-	ErrSlabNotFound = errors.New("slab not found in database")
-
 	// ErrContractNotFound is returned when a contract can't be retrieved from
 	// the database.
 	ErrContractNotFound = errors.New("couldn't find contract")
@@ -289,8 +285,7 @@ func (raw rawObject) convert() (obj object.Object, _ error) {
 		return nil
 	}
 
-	// filter out slabs with invalid ID - this is possible if the object has no
-	// data and thus no slabs
+	// filter out slabs without slab ID - this is expected for an empty object
 	filtered := raw[:0]
 	for _, sector := range raw {
 		if sector.SlabID != 0 {
@@ -301,6 +296,9 @@ func (raw rawObject) convert() (obj object.Object, _ error) {
 	// hydrate all slabs
 	if len(filtered) > 0 {
 		for j, sector := range filtered {
+			if sector.SectorID == 0 {
+				return object.Object{}, api.ErrObjectCorrupted
+			}
 			if sector.SlabID != curr {
 				if err := addSlab(j, sector.SlabID); err != nil {
 					return object.Object{}, err
@@ -1174,6 +1172,7 @@ func (s *SQLStore) object(ctx context.Context, key string) (rawObject, error) {
 	if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
 		return nil, api.ErrObjectNotFound
 	}
+
 	return rows, nil
 }
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1154,6 +1154,10 @@ END AS health`).
 
 // object retrieves a raw object from the store.
 func (s *SQLStore) object(ctx context.Context, key string) (rawObject, error) {
+	// NOTE: we LEFT JOIN here because empty objects are valid and need to be
+	// included in the result set, when we convert the rawObject before
+	// returning it we'll check for SlabID and/or SectorID being 0 and act
+	// accordingly
 	var rows rawObject
 	tx := s.db.
 		Select("o.key as ObjectKey, sli.id as SliceID, sli.offset as SliceOffset, sli.length as SliceLength, sla.id as SlabID, sla.key as SlabKey, sla.min_shards as SlabMinShards, sec.id as SectorID, sec.root as SectorRoot, sec.latest_host as SectorHost").

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -210,7 +210,7 @@ func performMigration00001_gormigrate(txn *gorm.DB, logger glogger.Interface) er
 	}
 	if m.HasConstraint(&dbSlab{}, "Shards") {
 		if err := m.DropConstraint(&dbSlab{}, "Shards"); err != nil {
-			return fmt.Errorf("failed to drop constraint 'Slices' from table 'slabs': %w", err)
+			return fmt.Errorf("failed to drop constraint 'Shards' from table 'slabs': %w", err)
 		}
 	}
 

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -202,9 +202,14 @@ func performMigration00001_gormigrate(txn *gorm.DB, logger glogger.Interface) er
 		}
 	}
 
-	// Drop the constraint on Slices to avoid dropping slabs.
+	// Drop constraint on Slices to avoid dropping slabs and sectors.
 	if m.HasConstraint(&dbSlab{}, "Slices") {
 		if err := m.DropConstraint(&dbSlab{}, "Slices"); err != nil {
+			return fmt.Errorf("failed to drop constraint 'Slices' from table 'slabs': %w", err)
+		}
+	}
+	if m.HasConstraint(&dbSlab{}, "Shards") {
+		if err := m.DropConstraint(&dbSlab{}, "Shards"); err != nil {
 			return fmt.Errorf("failed to drop constraint 'Slices' from table 'slabs': %w", err)
 		}
 	}
@@ -214,10 +219,15 @@ func performMigration00001_gormigrate(txn *gorm.DB, logger glogger.Interface) er
 		return err
 	}
 
-	// Add constraint back.
+	// Re-add both constraints.
 	if !m.HasConstraint(&dbSlab{}, "Slices") {
 		if err := m.CreateConstraint(&dbSlab{}, "Slices"); err != nil {
 			return fmt.Errorf("failed to add constraint 'Slices' to table 'slabs': %w", err)
+		}
+	}
+	if !m.HasConstraint(&dbSlab{}, "Shards") {
+		if err := m.CreateConstraint(&dbSlab{}, "Shards"); err != nil {
+			return fmt.Errorf("failed to add constraint 'Shards' to table 'slabs': %w", err)
 		}
 	}
 


### PR DESCRIPTION
We will currently panic if we try and retrieve an object from the database that is connected to a slab but not to sectors. This was reported by a member from the community we had a corrupted slab in his database, see https://github.com/SiaFoundation/renterd/issues/447.

```
http: panic serving 127.0.0.1:58534: runtime error: cannot convert slice with length 0 to pointer to array with length 32
```

We now return a custom error for the UI to handle and I've also updated the migration code to drop the constraint on `Shards`, preventing the deletion of sectors. After running these updated migrations on an old database the file 

Fixes https://github.com/SiaFoundation/renterd/issues/447