### PR TITLE
Queue batches of interactions to record instead of trying to apply them as they come in

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -204,6 +204,8 @@ func (b *bus) recordInteractions(ctx context.Context, interactions []hostdb.Inte
 	b.interactionsBufferMu.Unlock()
 
 	select {
+	case <-b.shutdown:
+		return errors.New("bus is shutting down")
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-pi.done:

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -203,6 +203,12 @@ func (b *bus) recordInteractions(ctx context.Context, interactions []hostdb.Inte
 	b.interactionsBuffer = append(b.interactionsBuffer, pi)
 	b.interactionsBufferMu.Unlock()
 
+	// notify recording loop
+	select {
+	case b.interactionsBufferSignal <- struct{}{}:
+	default:
+	}
+
 	select {
 	case <-b.shutdown:
 		return errors.New("bus is shutting down")

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1250,6 +1250,7 @@ func New(s Syncer, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, as
 		logger:        l.Sugar().Named("bus"),
 
 		interactionsBufferSignal: make(chan struct{}, 1),
+		shutdown:                 make(chan struct{}),
 	}
 	ctx, span := tracing.Tracer.Start(context.Background(), "bus.New")
 	defer span.End()


### PR DESCRIPTION
Since we batch quite a few interactions when recording them insertions sometimes take a couple of seconds.
When it takes longer, another worker or the even the same might try to record another batch.
When 2 batches are applied at the same time we run into locking failures on the table and due to the retry mechanism the transactions keep blocking each other while getting retried.

To fix that, this PR adds a queue for recording interactions to make sure batches don't compete with each other.