### PR TITLE
Avoid overlapping locking between transport and transportpool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,17 @@ jobs:
         with:
           args: "-race;-short"
       - name: Test Integration
+        if: matrix.os != 'windows-latest'
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/testing/..."
           args: "-race;-tags='testing';-timeout=900s"
+      - name: Test Integration - NoRace
+        if: matrix.os == 'windows-latest'
+        uses: n8maninger/action-golang-test@v1
+        with:
+          package: "./internal/testing/..."
+          args: "-tags='testing';-timeout=900s"
       - name: Test Integration - MySQL
         if: matrix.os == 'ubuntu-latest'
         uses: n8maninger/action-golang-test@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,17 +39,10 @@ jobs:
         with:
           args: "-race;-short"
       - name: Test Integration
-        if: matrix.os != 'windows-latest'
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/testing/..."
           args: "-race;-tags='testing';-timeout=900s"
-      - name: Test Integration - NoRace
-        if: matrix.os == 'windows-latest'
-        uses: n8maninger/action-golang-test@v1
-        with:
-          package: "./internal/testing/..."
-          args: "-tags='testing';-timeout=900s"
       - name: Test Integration - MySQL
         if: matrix.os == 'ubuntu-latest'
         uses: n8maninger/action-golang-test@v1

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1081,9 +1081,9 @@ func TestParallelDownload(t *testing.T) {
 		return nil
 	}
 
-	// Upload in parallel
+	// Download in parallel
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1083,7 +1083,7 @@ func TestParallelDownload(t *testing.T) {
 
 	// Download in parallel
 	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -1285,7 +1285,7 @@ func TestUploadDownloadSameHost(t *testing.T) {
 	}
 
 	// upload a file
-	data := frand.Bytes(2*rhpv2.SectorSize + 1)
+	data := frand.Bytes(5*rhpv2.SectorSize + 1)
 	err = cluster.Worker.UploadObject(context.Background(), bytes.NewReader(data), "foo")
 	if err != nil {
 		t.Fatal(err)
@@ -1293,7 +1293,7 @@ func TestUploadDownloadSameHost(t *testing.T) {
 
 	// Download the file multiple times.
 	var wg sync.WaitGroup
-	for tt := 0; tt < 2; tt++ {
+	for tt := 0; tt < 3; tt++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1285,7 +1285,7 @@ func TestUploadDownloadSameHost(t *testing.T) {
 	}
 
 	// upload a file
-	data := frand.Bytes(5*rhpv2.SectorSize + 1)
+	data := frand.Bytes(2*rhpv2.SectorSize + 1)
 	err = cluster.Worker.UploadObject(context.Background(), bytes.NewReader(data), "foo")
 	if err != nil {
 		t.Fatal(err)
@@ -1293,7 +1293,7 @@ func TestUploadDownloadSameHost(t *testing.T) {
 
 	// Download the file multiple times.
 	var wg sync.WaitGroup
-	for tt := 0; tt < 3; tt++ {
+	for tt := 0; tt < 2; tt++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"math/big"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -72,10 +73,6 @@ var (
 	// requested sector.
 	errSectorNotFound = errors.New("sector not found")
 
-	// errTransportClosed is returned when using a transportV3 which was already
-	// closed.
-	errTransportClosed = errors.New("transport closed")
-
 	// errWithdrawalsInactive occurs when the host is (perhaps temporarily)
 	// unsynced and has disabled its account manager.
 	errWithdrawalsInactive = errors.New("ephemeral account withdrawals are inactive because the host is not synced")
@@ -83,7 +80,9 @@ var (
 
 func isBalanceInsufficient(err error) bool { return isError(err, errBalanceInsufficient) }
 func isBalanceMaxExceeded(err error) bool  { return isError(err, errBalanceMaxExceeded) }
-func isClosedStream(err error) bool        { return isError(err, mux.ErrClosedStream) }
+func isClosedStream(err error) bool {
+	return isError(err, mux.ErrClosedStream) || isError(err, net.ErrClosed)
+}
 func isInsufficientFunds(err error) bool   { return isError(err, ErrInsufficientFunds) }
 func isPriceTableExpired(err error) bool   { return isError(err, errPriceTableExpired) }
 func isPriceTableNotFound(err error) bool  { return isError(err, errPriceTableNotFound) }

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math"
 	"math/big"
-	"net"
 	"strings"
 	"sync"
 	"time"
@@ -234,9 +233,6 @@ func (p *transportPoolV3) withTransportV3(ctx context.Context, hostKey types.Pub
 
 	// Execute function.
 	err = fn(ctx, t)
-	if errors.Is(err, net.ErrClosed) {
-		fmt.Println("net.ErrClosed!!!")
-	}
 
 	// Decrement refcounter again and clean up pool.
 	p.mu.Lock()

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -228,6 +228,9 @@ func (p *transportPoolV3) withTransportV3(ctx context.Context, hostKey types.Pub
 	p.mu.Lock()
 	t.refCount--
 	if t.refCount == 0 {
+		// Cleanup
+		_ = t.t.Close()
+		t.t = nil
 		delete(p.pool, siamuxAddr)
 	}
 	p.mu.Unlock()

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -126,10 +126,11 @@ func (s *streamV3) Close() error {
 func (t *transportV3) DialStream(ctx context.Context) (*streamV3, error) {
 	t.mu.Lock()
 	if t.t == nil {
+		start := time.Now()
 		newTransport, err := dialTransport(ctx, t.siamuxAddr, t.hostKey)
 		if err != nil {
 			t.mu.Unlock()
-			return nil, fmt.Errorf("DialStream: could not dial transport: %w", err)
+			return nil, fmt.Errorf("DialStream: could not dial transport: %w (%v)", err, time.Since(start))
 		}
 		t.t = newTransport
 	}

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -229,8 +229,10 @@ func (p *transportPoolV3) withTransportV3(ctx context.Context, hostKey types.Pub
 	t.refCount--
 	if t.refCount == 0 {
 		// Cleanup
-		_ = t.t.Close()
-		t.t = nil
+		if t.t != nil {
+			_ = t.t.Close()
+			t.t = nil
+		}
 		delete(p.pool, siamuxAddr)
 	}
 	p.mu.Unlock()


### PR DESCRIPTION
The locking we have right now was acquiring a transport's lock while holding the lock of the pool. 
The transport dials a connection while holding that lock.

So if a transport is timing out on a dial and another thread is trying to dial the same host that is timing out at the moment, it will block on acquiring the transport lock while the pool lock is also acquired, preventing other threads from creating transports. 

After this PR, the locking will no longer overlap. So a transport timing out with host A can't block creating a transport with host B.