### PR TITLE
Extend object encryption to support files larger than 256GiB

### DIFF
--- a/object/object.go
+++ b/object/object.go
@@ -2,10 +2,11 @@ package object
 
 import (
 	"bytes"
-	"crypto/cipher"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"io"
+	"math"
 
 	"golang.org/x/crypto/chacha20"
 	"lukechampine.com/frand"
@@ -38,19 +39,26 @@ func (k *EncryptionKey) UnmarshalText(b []byte) error {
 }
 
 // Encrypt returns a cipher.StreamReader that encrypts r with k.
-func (k EncryptionKey) Encrypt(r io.Reader) cipher.StreamReader {
+func (k EncryptionKey) Encrypt(r io.Reader) *streamReader {
 	c, _ := chacha20.NewUnauthenticatedCipher(k.entropy[:], make([]byte, 24))
-	return cipher.StreamReader{S: c, R: r}
+	return &streamReader{key: k.entropy[:], c: c, r: r}
 }
 
 // Decrypt returns a cipher.StreamWriter that decrypts w with k, starting at the
 // specified offset.
-func (k EncryptionKey) Decrypt(w io.Writer, offset uint64) cipher.StreamWriter {
-	c, _ := chacha20.NewUnauthenticatedCipher(k.entropy[:], make([]byte, 24))
+func (k EncryptionKey) Decrypt(w io.Writer, offset uint64) *streamWriter {
+	var nonce uint64
+	for offset > 64*math.MaxUint32 {
+		offset -= 64 * math.MaxUint32
+		nonce++
+	}
+	n := make([]byte, 24)
+	binary.LittleEndian.PutUint64(n[16:], nonce)
+	c, _ := chacha20.NewUnauthenticatedCipher(k.entropy[:], n)
 	c.SetCounter(uint32(offset / 64))
 	var buf [64]byte
 	c.XORKeyStream(buf[:offset%64], buf[:offset%64])
-	return cipher.StreamWriter{S: c, W: w}
+	return &streamWriter{key: k.entropy[:], c: c, w: w, counter: offset, nonce: nonce}
 }
 
 // GenerateEncryptionKey returns a random encryption key.
@@ -84,7 +92,7 @@ func (o Object) Size() int64 {
 
 // Encrypt wraps the given reader with a reader that encrypts the stream using
 // the object's key.
-func (o Object) Encrypt(r io.Reader) cipher.StreamReader {
+func (o Object) Encrypt(r io.Reader) *streamReader {
 	return o.Key.Encrypt(r)
 }
 
@@ -120,4 +128,84 @@ func SplitSlabs(slabs []Slab, lengths []int) [][]SlabSlice {
 // with the specified length.
 func SingleSlabs(slabs []Slab, length int) []SlabSlice {
 	return SplitSlabs(slabs, []int{length})[0]
+}
+
+type streamReader struct {
+	key []byte
+	c   *chacha20.Cipher
+	r   io.Reader
+
+	counter uint64 // bytes, not blocks
+	nonce   uint64
+}
+
+func (sr *streamReader) Read(p []byte) (int, error) {
+	n, err := sr.r.Read(p)
+	sr.counter += uint64(n)
+	if sr.counter < 64*math.MaxUint32 {
+		sr.c.XORKeyStream(p[:n], p[:n])
+		return n, err
+	}
+	// counter overflow; xor remaining bytes, then increment nonce and xor again
+	rem := 64*math.MaxUint32 - (sr.counter - uint64(n))
+	sr.counter -= 64 * math.MaxUint32
+	sr.c.XORKeyStream(p[:rem], p[:rem])
+	// NOTE: we increment the last 8 bytes because XChaCha uses the
+	// first 16 bytes to derive a new key; leaving them alone means
+	// the key will be stable, which might be useful.
+	sr.nonce++
+	nonce := make([]byte, 24)
+	binary.LittleEndian.PutUint64(nonce[16:], sr.nonce)
+	sr.c, _ = chacha20.NewUnauthenticatedCipher(sr.key, nonce)
+	sr.c.XORKeyStream(p[rem:], p[rem:])
+	return n, err
+}
+
+type streamWriter struct {
+	key []byte
+	c   *chacha20.Cipher
+	w   io.Writer
+
+	counter uint64
+	nonce   uint64
+}
+
+func (sw *streamWriter) Write(src []byte) (n int, err error) {
+	c := make([]byte, len(src))
+	if sw.counter+uint64(len(src)) < 64*math.MaxUint32 {
+		sw.c.XORKeyStream(c, src)
+		n, err = sw.w.Write(c)
+		sw.counter += uint64(n)
+		if n != len(src) && err == nil { // should never happen
+			err = io.ErrShortWrite
+		}
+		return
+	}
+	// counter overflow, xor remaining bytes, then increment nonce and xor again
+	rem := 64*math.MaxUint32 - sw.counter
+	sw.counter -= 64 * math.MaxUint32
+	sw.c.XORKeyStream(c[:rem], src[:rem])
+	// NOTE: we increment the last 8 bytes because XChaCha uses the
+	// first 16 bytes to derive a new key; leaving them alone means
+	// the key will be stable, which might be useful.
+	sw.nonce++
+	nonce := make([]byte, 24)
+	binary.LittleEndian.PutUint64(nonce[16:], sw.nonce)
+	sw.c, _ = chacha20.NewUnauthenticatedCipher(sw.key, nonce)
+	sw.c.XORKeyStream(c[rem:], src[rem:])
+	n, err = sw.w.Write(c)
+	sw.counter += uint64(n)
+	if n != len(src) && err == nil { // should never happen
+		err = io.ErrShortWrite
+	}
+	return
+}
+
+// Close closes the underlying Writer and returns its Close return value, if the Writer
+// is also an io.Closer. Otherwise it returns nil.
+func (w *streamWriter) Close() error {
+	if c, ok := w.w.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
 }

--- a/object/object.go
+++ b/object/object.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"bytes"
+	"crypto/cipher"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -39,26 +40,27 @@ func (k *EncryptionKey) UnmarshalText(b []byte) error {
 }
 
 // Encrypt returns a cipher.StreamReader that encrypts r with k.
-func (k EncryptionKey) Encrypt(r io.Reader) *streamReader {
+func (k EncryptionKey) Encrypt(r io.Reader) cipher.StreamReader {
 	c, _ := chacha20.NewUnauthenticatedCipher(k.entropy[:], make([]byte, 24))
-	return &streamReader{key: k.entropy[:], c: c, r: r}
+	rs := &rekeyStream{key: k.entropy[:], c: c}
+	return cipher.StreamReader{S: rs, R: r}
 }
 
 // Decrypt returns a cipher.StreamWriter that decrypts w with k, starting at the
 // specified offset.
-func (k EncryptionKey) Decrypt(w io.Writer, offset uint64) *streamWriter {
-	var nonce uint64
-	for offset > 64*math.MaxUint32 {
-		offset -= 64 * math.MaxUint32
-		nonce++
-	}
-	n := make([]byte, 24)
-	binary.LittleEndian.PutUint64(n[16:], nonce)
-	c, _ := chacha20.NewUnauthenticatedCipher(k.entropy[:], n)
+func (k EncryptionKey) Decrypt(w io.Writer, offset uint64) cipher.StreamWriter {
+	nonce64 := offset / (64 * math.MaxUint32)
+	offset %= 64 * math.MaxUint32
+
+	nonce := make([]byte, 24)
+	binary.LittleEndian.PutUint64(nonce[16:], nonce64)
+	c, _ := chacha20.NewUnauthenticatedCipher(k.entropy[:], nonce)
 	c.SetCounter(uint32(offset / 64))
+
 	var buf [64]byte
 	c.XORKeyStream(buf[:offset%64], buf[:offset%64])
-	return &streamWriter{key: k.entropy[:], c: c, w: w, counter: offset, nonce: nonce}
+	rs := &rekeyStream{key: k.entropy[:], c: c, counter: offset, nonce: nonce64}
+	return cipher.StreamWriter{S: rs, W: w}
 }
 
 // GenerateEncryptionKey returns a random encryption key.
@@ -92,7 +94,7 @@ func (o Object) Size() int64 {
 
 // Encrypt wraps the given reader with a reader that encrypts the stream using
 // the object's key.
-func (o Object) Encrypt(r io.Reader) *streamReader {
+func (o Object) Encrypt(r io.Reader) cipher.StreamReader {
 	return o.Key.Encrypt(r)
 }
 
@@ -130,82 +132,30 @@ func SingleSlabs(slabs []Slab, length int) []SlabSlice {
 	return SplitSlabs(slabs, []int{length})[0]
 }
 
-type streamReader struct {
+type rekeyStream struct {
 	key []byte
 	c   *chacha20.Cipher
-	r   io.Reader
-
-	counter uint64 // bytes, not blocks
-	nonce   uint64
-}
-
-func (sr *streamReader) Read(p []byte) (int, error) {
-	n, err := sr.r.Read(p)
-	sr.counter += uint64(n)
-	if sr.counter < 64*math.MaxUint32 {
-		sr.c.XORKeyStream(p[:n], p[:n])
-		return n, err
-	}
-	// counter overflow; xor remaining bytes, then increment nonce and xor again
-	rem := 64*math.MaxUint32 - (sr.counter - uint64(n))
-	sr.counter -= 64 * math.MaxUint32
-	sr.c.XORKeyStream(p[:rem], p[:rem])
-	// NOTE: we increment the last 8 bytes because XChaCha uses the
-	// first 16 bytes to derive a new key; leaving them alone means
-	// the key will be stable, which might be useful.
-	sr.nonce++
-	nonce := make([]byte, 24)
-	binary.LittleEndian.PutUint64(nonce[16:], sr.nonce)
-	sr.c, _ = chacha20.NewUnauthenticatedCipher(sr.key, nonce)
-	sr.c.XORKeyStream(p[rem:], p[rem:])
-	return n, err
-}
-
-type streamWriter struct {
-	key []byte
-	c   *chacha20.Cipher
-	w   io.Writer
 
 	counter uint64
 	nonce   uint64
 }
 
-func (sw *streamWriter) Write(src []byte) (n int, err error) {
-	c := make([]byte, len(src))
-	if sw.counter+uint64(len(src)) < 64*math.MaxUint32 {
-		sw.c.XORKeyStream(c, src)
-		n, err = sw.w.Write(c)
-		sw.counter += uint64(n)
-		if n != len(src) && err == nil { // should never happen
-			err = io.ErrShortWrite
-		}
+func (rs *rekeyStream) XORKeyStream(dst, src []byte) {
+	rs.counter += uint64(len(src))
+	if rs.counter < 64*math.MaxUint32 {
+		rs.c.XORKeyStream(dst, src)
 		return
 	}
-	// counter overflow, xor remaining bytes, then increment nonce and xor again
-	rem := 64*math.MaxUint32 - sw.counter
-	sw.counter -= (64*math.MaxUint32 - uint64(len(src)))
-	sw.c.XORKeyStream(c[:rem], src[:rem])
+	// counter overflow; xor remaining bytes, then increment nonce and xor again
+	rem := 64*math.MaxUint32 - (rs.counter - uint64(len(src)))
+	rs.counter -= 64 * math.MaxUint32
+	rs.c.XORKeyStream(dst[:rem], src[:rem])
 	// NOTE: we increment the last 8 bytes because XChaCha uses the
 	// first 16 bytes to derive a new key; leaving them alone means
 	// the key will be stable, which might be useful.
-	sw.nonce++
+	rs.nonce++
 	nonce := make([]byte, 24)
-	binary.LittleEndian.PutUint64(nonce[16:], sw.nonce)
-	sw.c, _ = chacha20.NewUnauthenticatedCipher(sw.key, nonce)
-	sw.c.XORKeyStream(c[rem:], src[rem:])
-	n, err = sw.w.Write(c)
-	sw.counter += uint64(n)
-	if n != len(src) && err == nil { // should never happen
-		err = io.ErrShortWrite
-	}
-	return
-}
-
-// Close closes the underlying Writer and returns its Close return value, if the Writer
-// is also an io.Closer. Otherwise it returns nil.
-func (w *streamWriter) Close() error {
-	if c, ok := w.w.(io.Closer); ok {
-		return c.Close()
-	}
-	return nil
+	binary.LittleEndian.PutUint64(nonce[16:], rs.nonce)
+	rs.c, _ = chacha20.NewUnauthenticatedCipher(rs.key, nonce)
+	rs.c.XORKeyStream(dst[rem:], src[rem:])
 }

--- a/object/object.go
+++ b/object/object.go
@@ -183,7 +183,7 @@ func (sw *streamWriter) Write(src []byte) (n int, err error) {
 	}
 	// counter overflow, xor remaining bytes, then increment nonce and xor again
 	rem := 64*math.MaxUint32 - sw.counter
-	sw.counter -= 64 * math.MaxUint32
+	sw.counter -= (64*math.MaxUint32 - uint64(len(src)))
 	sw.c.XORKeyStream(c[:rem], src[:rem])
 	// NOTE: we increment the last 8 bytes because XChaCha uses the
 	// first 16 bytes to derive a new key; leaving them alone means

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -15,11 +15,12 @@ func TestEncryptionOverflow(t *testing.T) {
 	sr := key.Encrypt(bytes.NewReader(data))
 
 	// Check that the streamreader is initialized correctly.
-	if sr.counter != 0 {
-		t.Fatalf("expected counter to be 0, got %v", sr.counter)
+	rs := sr.S.(*rekeyStream)
+	if rs.counter != 0 {
+		t.Fatalf("expected counter to be 0, got %v", rs.counter)
 	}
-	if sr.nonce != 0 {
-		t.Fatalf("expected nonce to be 0, got %v", sr.nonce)
+	if rs.nonce != 0 {
+		t.Fatalf("expected nonce to be 0, got %v", rs.nonce)
 	}
 
 	// Read 64 bytes.
@@ -33,11 +34,11 @@ func TestEncryptionOverflow(t *testing.T) {
 	}
 
 	// Assert counter was incremented correctly.
-	if sr.counter != 64 {
-		t.Fatalf("expected counter to be 10, got %v", sr.counter)
+	if rs.counter != 64 {
+		t.Fatalf("expected counter to be 10, got %v", rs.counter)
 	}
-	if sr.nonce != 0 {
-		t.Fatalf("expected nonce to be 0, got %v", sr.nonce)
+	if rs.nonce != 0 {
+		t.Fatalf("expected nonce to be 0, got %v", rs.nonce)
 	}
 
 	// Assert data matches.
@@ -53,10 +54,10 @@ func TestEncryptionOverflow(t *testing.T) {
 		t.Fatal("mismatch", buf.Bytes(), data[:10])
 	}
 
-	// Read 128 bytes. 64 before the overflow, 64 after.
+	// Move the counter 64 bytes before an overflow and read 128 bytes.
 	b = make([]byte, 128)
-	sr.counter = math.MaxUint32*64 - 64
-	sr.c.SetCounter(math.MaxUint32 - 1)
+	rs.counter = math.MaxUint32*64 - 64
+	rs.c.SetCounter(math.MaxUint32 - 1)
 	n, err = sr.Read(b)
 	if err != nil {
 		t.Fatal(err)
@@ -66,11 +67,11 @@ func TestEncryptionOverflow(t *testing.T) {
 	}
 
 	// Check that counter and nonce did overflow correctly.
-	if sr.counter != 64 {
-		t.Fatalf("expected counter to be 10, got %v", sr.counter)
+	if rs.counter != 64 {
+		t.Fatalf("expected counter to be 10, got %v", rs.counter)
 	}
-	if sr.nonce != 1 {
-		t.Fatalf("expected nonce to be 0, got %v", sr.nonce)
+	if rs.nonce != 1 {
+		t.Fatalf("expected nonce to be 0, got %v", rs.nonce)
 	}
 
 	// Assert data matches.
@@ -83,6 +84,6 @@ func TestEncryptionOverflow(t *testing.T) {
 		t.Fatal("unexpected")
 	}
 	if !bytes.Equal(buf.Bytes(), data[64:]) {
-		t.Fatal("mismatch", buf.Bytes(), data[64:])
+		t.Fatal("mismatch")
 	}
 }

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -1,0 +1,88 @@
+package object
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"lukechampine.com/frand"
+)
+
+func TestEncryptionOverflow(t *testing.T) {
+	// Create a random key.
+	key := GenerateEncryptionKey()
+	data := frand.Bytes(3 * 64)
+	sr := key.Encrypt(bytes.NewReader(data))
+
+	// Check that the streamreader is initialized correctly.
+	if sr.counter != 0 {
+		t.Fatalf("expected counter to be 0, got %v", sr.counter)
+	}
+	if sr.nonce != 0 {
+		t.Fatalf("expected nonce to be 0, got %v", sr.nonce)
+	}
+
+	// Read 64 bytes.
+	b := make([]byte, 64)
+	n, err := sr.Read(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(b) {
+		t.Fatalf("expected to read 10 bytes, got %v", n)
+	}
+
+	// Assert counter was incremented correctly.
+	if sr.counter != 64 {
+		t.Fatalf("expected counter to be 10, got %v", sr.counter)
+	}
+	if sr.nonce != 0 {
+		t.Fatalf("expected nonce to be 0, got %v", sr.nonce)
+	}
+
+	// Assert data matches.
+	buf := bytes.NewBuffer(nil)
+	written, err := key.Decrypt(buf, 0).Write(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != len(b) {
+		t.Fatal("unexpected")
+	}
+	if !bytes.Equal(buf.Bytes(), data[:64]) {
+		t.Fatal("mismatch", buf.Bytes(), data[:10])
+	}
+
+	// Read 128 bytes. 64 before the overflow, 64 after.
+	b = make([]byte, 128)
+	sr.counter = math.MaxUint32*64 - 64
+	sr.c.SetCounter(math.MaxUint32 - 1)
+	n, err = sr.Read(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(b) {
+		t.Fatalf("expected to read 10 bytes, got %v", n)
+	}
+
+	// Check that counter and nonce did overflow correctly.
+	if sr.counter != 64 {
+		t.Fatalf("expected counter to be 10, got %v", sr.counter)
+	}
+	if sr.nonce != 1 {
+		t.Fatalf("expected nonce to be 0, got %v", sr.nonce)
+	}
+
+	// Assert data matches.
+	buf = bytes.NewBuffer(nil)
+	written, err = key.Decrypt(buf, math.MaxUint32*64-64).Write(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != len(b) {
+		t.Fatal("unexpected")
+	}
+	if !bytes.Equal(buf.Bytes(), data[64:]) {
+		t.Fatal("mismatch", buf.Bytes(), data[64:])
+	}
+}


### PR DESCRIPTION
The implementation of ChaCha we use makes use of a `uint32` counter meaning that the maximum size of an object is `64 *  4GiB` which is `256GiB`. To work around this we overflow into the last 8 bytes of the `nonce` and reset the counter for every `256GiB`. 