### PR TITLE
Download F/U

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1236,6 +1236,9 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 		return api.ContractMetadata{}, false, fmt.Errorf("insufficient budget: %s < %s", budget.String(), renterFunds.String())
 	}
 
+	if contract.EndHeight() < cs.BlockHeight {
+		fmt.Println("DEBUG PJ: contractor refreshContract", contract.EndHeight(), cs.BlockHeight)
+	}
 	// calculate the new collateral
 	expectedStorage := renterFundsToExpectedStorage(renterFunds, contract.EndHeight()-cs.BlockHeight, settings)
 	newCollateral := rhpv2.ContractRenewalCollateral(rev.FileContract, expectedStorage, settings, cs.BlockHeight, contract.EndHeight())

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1154,15 +1154,15 @@ func (c *contractor) renewContract(ctx context.Context, w Worker, ci contractInf
 		return api.ContractMetadata{}, false, errors.New("insufficient budget")
 	}
 
-	// calculate the host collateral
-	endHeight := endHeight(cfg, state.period)
-	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-cs.BlockHeight, settings)
-	newCollateral := rhpv2.ContractRenewalCollateral(rev.FileContract, expectedStorage, settings, cs.BlockHeight, endHeight)
-
 	// sanity check the endheight is not the same on renewals
+	endHeight := endHeight(cfg, state.period)
 	if endHeight == rev.EndHeight() {
 		return api.ContractMetadata{}, false, errors.New("renewal endheight is the same as the current contract endheight")
 	}
+
+	// calculate the host collateral
+	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-cs.BlockHeight, settings)
+	newCollateral := rhpv2.ContractRenewalCollateral(rev.FileContract, expectedStorage, settings, cs.BlockHeight, endHeight)
 
 	// renew the contract
 	newRevision, _, err := w.RHPRenew(ctx, fcid, endHeight, hk, contract.SiamuxAddr, settings.Address, state.address, renterFunds, newCollateral, settings.WindowSize)

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1236,9 +1236,6 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 		return api.ContractMetadata{}, false, fmt.Errorf("insufficient budget: %s < %s", budget.String(), renterFunds.String())
 	}
 
-	if contract.EndHeight() < cs.BlockHeight {
-		fmt.Println("DEBUG PJ: contractor refreshContract", contract.EndHeight(), cs.BlockHeight)
-	}
 	// calculate the new collateral
 	expectedStorage := renterFundsToExpectedStorage(renterFunds, contract.EndHeight()-cs.BlockHeight, settings)
 	newCollateral := rhpv2.ContractRenewalCollateral(rev.FileContract, expectedStorage, settings, cs.BlockHeight, contract.EndHeight())

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -233,6 +233,9 @@ func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, rente
 		refresh = false
 	}
 
+	if c.EndHeight() < bh {
+		fmt.Println("DEBUG PJ: isUsableContract", c.EndHeight(), bh)
+	}
 	if isOutOfCollateral(c, s, renterFunds, bh) {
 		reasons = append(reasons, errContractOutOfCollateral.Error())
 		renew = false

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -225,34 +225,30 @@ func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, rente
 		reasons = append(reasons, errContractExpired.Error())
 		renew = false
 		refresh = false
-	}
-
-	if c.Revision.RevisionNumber == math.MaxUint64 {
+	} else if c.Revision.RevisionNumber == math.MaxUint64 {
 		reasons = append(reasons, errContractMaxRevisionNumber.Error())
 		renew = false
 		refresh = false
+	} else {
+		if isOutOfCollateral(c, s, renterFunds, bh) {
+			reasons = append(reasons, errContractOutOfCollateral.Error())
+			renew = false
+			refresh = true
+		}
+		if isOutOfFunds(cfg, s, c) {
+			reasons = append(reasons, errContractOutOfFunds.Error())
+			renew = false
+			refresh = true
+		}
+		if shouldRenew, secondHalf := isUpForRenewal(cfg, *c.Revision, bh); shouldRenew {
+			if secondHalf {
+				reasons = append(reasons, errContractUpForRenewal.Error()) // only unusable if in second half of renew window
+			}
+			renew = true
+			refresh = false
+		}
 	}
 
-	if c.EndHeight() < bh {
-		fmt.Println("DEBUG PJ: isUsableContract", c.EndHeight(), bh)
-	}
-	if isOutOfCollateral(c, s, renterFunds, bh) {
-		reasons = append(reasons, errContractOutOfCollateral.Error())
-		renew = false
-		refresh = true
-	}
-	if isOutOfFunds(cfg, s, c) {
-		reasons = append(reasons, errContractOutOfFunds.Error())
-		renew = false
-		refresh = true
-	}
-	if shouldRenew, secondHalf := isUpForRenewal(cfg, *c.Revision, bh); shouldRenew {
-		if secondHalf {
-			reasons = append(reasons, errContractUpForRenewal.Error()) // only unusable if in second half of renew window
-		}
-		renew = true
-		refresh = false
-	}
 	// redundant IP check - always perform this last since it will update
 	// the ipFilter.
 	if !cfg.Hosts.AllowRedundantIPs && f.isRedundantIP(c.HostIP, c.HostKey) {

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -237,7 +237,7 @@ func TestNewTestCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(hostInfos, hostInfosUsable) {
-		t.Fatalf("result for 'usable' should match the result for '', got %+v want %+v", hostInfosUsable, hostInfos)
+		t.Fatal("result for 'usable' should match the result for ''")
 	}
 	hostInfosUnusable, err := cluster.Autopilot.HostInfos(context.Background(), api.HostFilterModeAll, api.UsabilityFilterModeUnusable, "", nil, 0, -1)
 	if err != nil {

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -237,7 +237,7 @@ func TestNewTestCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(hostInfos, hostInfosUsable) {
-		t.Fatal("result for 'usable' should match the result for ''")
+		t.Fatalf("result for 'usable' should match the result for '', got %+v want %+v", hostInfosUsable, hostInfos)
 	}
 	hostInfosUnusable, err := cluster.Autopilot.HostInfos(context.Background(), api.HostFilterModeAll, api.UsabilityFilterModeUnusable, "", nil, 0, -1)
 	if err != nil {

--- a/worker/download.go
+++ b/worker/download.go
@@ -45,7 +45,6 @@ type (
 		stopChan chan struct{}
 
 		mu            sync.Mutex
-		ongoing       map[slabID]struct{}
 		downloaders   map[types.PublicKey]*downloader
 		lastRecompute time.Time
 	}
@@ -113,7 +112,13 @@ type (
 
 		overdrive    bool
 		sectorIndex  int
-		responseChan chan sectorDownloadResp
+		responseChan *sectorResponseChan
+	}
+
+	sectorResponseChan struct {
+		ctx  context.Context
+		c    chan sectorDownloadResp
+		once sync.Once
 	}
 
 	sectorDownloadResp struct {
@@ -157,7 +162,6 @@ func newDownloadManager(hp hostProvider, maxOverdrive uint64, overdriveTimeout t
 
 		stopChan: make(chan struct{}),
 
-		ongoing:     make(map[slabID]struct{}),
 		downloaders: make(map[types.PublicKey]*downloader),
 	}
 }
@@ -193,10 +197,6 @@ func (mgr *downloadManager) DownloadObject(ctx context.Context, w io.Writer, o o
 		return nil
 	}
 
-	// ensure everything cancels if download is done
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	// refresh the downloaders
 	mgr.refreshDownloaders(contracts)
 
@@ -209,18 +209,35 @@ func (mgr *downloadManager) DownloadObject(ctx context.Context, w io.Writer, o o
 	// create the cipher writer
 	cw := o.Key.Decrypt(w, offset)
 
-	// create the trigger chan
+	// create response and trigger chan
 	nextSlabChan := make(chan struct{}, 1)
 	nextSlabChan <- struct{}{}
+	responseChan := make(chan *slabDownloadResponse)
+
+	// ensure channels are cleaned up properly
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		// make sure everything cancels if the download is done
+		cancel()
+		// wait for all goroutines to finish and cleanup resources
+		go func() {
+			wg.Wait()
+			close(responseChan)
+			close(nextSlabChan)
+		}()
+	}()
 
 	// launch a goroutine to launch consecutive slab downloads
-	responseChan := make(chan *slabDownloadResponse)
-	defer close(responseChan)
-	go func() {
-		var slabIndex int
+	var concurrentSlabs uint64
 
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		var slabIndex int
 		for {
-			if slabIndex < len(slabs) {
+			if slabIndex < len(slabs) && atomic.LoadUint64(&concurrentSlabs) < maxConcurrentSlabsPerDownload {
 				next := slabs[slabIndex]
 
 				// check if we have enough downloaders
@@ -236,7 +253,12 @@ func (mgr *downloadManager) DownloadObject(ctx context.Context, w io.Writer, o o
 				}
 
 				// launch the download
-				go mgr.downloadSlab(ctx, id, next, slabIndex, responseChan, nextSlabChan)
+				wg.Add(1)
+				go func(index int) {
+					mgr.downloadSlab(ctx, id, next, index, responseChan, nextSlabChan)
+					wg.Done()
+				}(slabIndex)
+				atomic.AddUint64(&concurrentSlabs, 1)
 				slabIndex++
 			}
 
@@ -251,8 +273,8 @@ func (mgr *downloadManager) DownloadObject(ctx context.Context, w io.Writer, o o
 
 	// collect the response, responses might come in out of order so we keep
 	// them in a map and return what we can when we can
-	responses := make(map[int]*slabDownloadResponse)
 	var respIndex int
+	responseBuffer := make(map[int]*slabDownloadResponse)
 outer:
 	for {
 		select {
@@ -261,23 +283,31 @@ outer:
 		case <-ctx.Done():
 			return errors.New("download timed out")
 		case resp := <-responseChan:
+			atomic.AddUint64(&concurrentSlabs, ^uint64(0))
+
 			if resp.err != nil {
 				mgr.logger.Errorf("download slab %v failed: %v", resp.index, resp.err)
 				return resp.err
 			}
 
-			responses[resp.index] = resp
+			responseBuffer[resp.index] = resp
 			for {
-				if next, exists := responses[respIndex]; exists {
+				if next, exists := responseBuffer[respIndex]; exists {
 					slabs[respIndex].Decrypt(next.shards)
-					err := slabs[respIndex].Recover(cw, next.shards)
-					if err != nil {
+					if err := slabs[respIndex].Recover(cw, next.shards); err != nil {
 						mgr.logger.Errorf("failed to recover slab %v: %v", respIndex, err)
 						return err
 					}
+
 					next = nil
-					delete(responses, respIndex)
+					delete(responseBuffer, respIndex)
 					respIndex++
+
+					select {
+					case nextSlabChan <- struct{}{}:
+					default:
+					}
+
 					continue
 				} else {
 					break
@@ -328,7 +358,12 @@ func (mgr *downloadManager) DownloadSlab(ctx context.Context, slab object.Slab, 
 		Offset: 0,
 		Length: uint32(slab.MinShards) * rhpv2.SectorSize,
 	}
-	go mgr.downloadSlab(ctx, id, slice, 0, responseChan, nextSlabChan)
+	go func() {
+		mgr.downloadSlab(ctx, id, slice, 0, responseChan, nextSlabChan)
+		// NOTE: when downloading 1 slab we can simply close both channels
+		close(responseChan)
+		close(nextSlabChan)
+	}()
 
 	// await the response
 	var resp *slabDownloadResponse
@@ -432,22 +467,10 @@ func (mgr *downloadManager) refreshDownloaders(contracts []api.ContractMetadata)
 	}
 }
 
-func (mgr *downloadManager) newSlabDownload(ctx context.Context, dID id, slice object.SlabSlice, slabIndex int) (*slabDownload, func()) {
+func (mgr *downloadManager) newSlabDownload(ctx context.Context, dID id, slice object.SlabSlice, slabIndex int) *slabDownload {
 	// create slab id
 	var sID slabID
 	frand.Read(sID[:])
-
-	// add slab to ongoing downloads
-	mgr.mu.Lock()
-	mgr.ongoing[sID] = struct{}{}
-	mgr.mu.Unlock()
-
-	// prepare a function to remove it from the ongoing downloads
-	finishFn := func() {
-		mgr.mu.Lock()
-		delete(mgr.ongoing, sID)
-		mgr.mu.Unlock()
-	}
 
 	// calculate the offset and length
 	offset, length := slice.SectorRegion()
@@ -474,13 +497,7 @@ func (mgr *downloadManager) newSlabDownload(ctx context.Context, dID id, slice o
 		used:          make(map[types.PublicKey]struct{}),
 
 		sectors: make([][]byte, len(slice.Shards)),
-	}, finishFn
-}
-
-func (mgr *downloadManager) ongoingDownloads() int {
-	mgr.mu.Lock()
-	defer mgr.mu.Unlock()
-	return len(mgr.ongoing)
+	}
 }
 
 func (mgr *downloadManager) downloadSlab(ctx context.Context, dID id, slice object.SlabSlice, index int, responseChan chan *slabDownloadResponse, nextSlabChan chan struct{}) {
@@ -488,9 +505,8 @@ func (mgr *downloadManager) downloadSlab(ctx context.Context, dID id, slice obje
 	ctx, span := tracing.Tracer.Start(ctx, "downloadSlab")
 	defer span.End()
 
-	// prepare the download
-	slab, finishFn := mgr.newSlabDownload(ctx, dID, slice, index)
-	defer finishFn()
+	// prepare the slab download
+	slab := mgr.newSlabDownload(ctx, dID, slice, index)
 
 	// download shards
 	resp := &slabDownloadResponse{index: index}
@@ -757,38 +773,33 @@ func (d *downloader) execute(req *sectorDownloadReq) (err error) {
 }
 
 func (req *sectorDownloadReq) succeed(sector []byte) {
-	select {
-	case <-req.ctx.Done():
-	case req.responseChan <- sectorDownloadResp{
+	req.responseChan.trySend(sectorDownloadResp{
 		hk:          req.hk,
 		overdrive:   req.overdrive,
 		sectorIndex: req.sectorIndex,
 		sector:      sector,
-	}:
-	}
+	})
 }
 
 func (req *sectorDownloadReq) fail(err error) {
-	select {
-	case <-req.ctx.Done():
-	case req.responseChan <- sectorDownloadResp{
+	req.responseChan.trySend(sectorDownloadResp{
 		err:       err,
 		hk:        req.hk,
 		overdrive: req.overdrive,
-	}:
-	}
+	})
 }
 
 func (req *sectorDownloadReq) done() bool {
 	select {
 	case <-req.ctx.Done():
+		req.responseChan.close()
 		return true
 	default:
 		return false
 	}
 }
 
-func (s *slabDownload) overdrive(ctx context.Context, respChan chan sectorDownloadResp) (resetTimer func()) {
+func (s *slabDownload) overdrive(ctx context.Context, respChan *sectorResponseChan) (resetTimer func()) {
 	// overdrive is disabled
 	if s.mgr.overdriveTimeout == 0 {
 		return func() {}
@@ -840,7 +851,14 @@ func (s *slabDownload) overdrive(ctx context.Context, respChan chan sectorDownlo
 				return
 			case <-timer.C:
 				if canOverdrive(timeout()) {
-					_ = s.launch(s.nextRequest(ctx, respChan, true)) // ignore error
+					for {
+						if req := s.nextRequest(ctx, respChan, true); req != nil {
+							if err := s.launch(req); err != nil {
+								continue // try the next request if this fails to launch
+							}
+						}
+						break
+					}
 				}
 				resetTimer()
 			}
@@ -850,7 +868,7 @@ func (s *slabDownload) overdrive(ctx context.Context, respChan chan sectorDownlo
 	return
 }
 
-func (s *slabDownload) nextRequest(ctx context.Context, responseChan chan sectorDownloadResp, overdrive bool) *sectorDownloadReq {
+func (s *slabDownload) nextRequest(ctx context.Context, responseChan *sectorResponseChan, overdrive bool) *sectorDownloadReq {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -909,7 +927,10 @@ func (s *slabDownload) downloadShards(ctx context.Context, nextSlabTrigger chan 
 	defer span.End()
 
 	// create the response channel
-	respChan := make(chan sectorDownloadResp)
+	respChan := &sectorResponseChan{
+		c:   make(chan sectorDownloadResp),
+		ctx: ctx,
+	}
 
 	// launch overdrive
 	resetOverdrive := s.overdrive(ctx, respChan)
@@ -933,30 +954,28 @@ func (s *slabDownload) downloadShards(ctx context.Context, nextSlabTrigger chan 
 			return nil, errors.New("download stopped")
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case resp = <-respChan:
+		case resp = <-respChan.c:
 		}
 
 		resetOverdrive()
 
 		done, next = s.receive(resp)
 		if !done && resp.err != nil {
-			_ = s.launch(s.nextRequest(ctx, respChan, true)) // ignore error
+			for {
+				if req := s.nextRequest(ctx, respChan, true); req != nil {
+					if err := s.launch(req); err != nil {
+						continue // try the next request if this fails to launch
+					}
+				}
+				break
+			}
 		}
-
-		if next && !triggered && s.mgr.ongoingDownloads() < maxConcurrentSlabsPerDownload {
+		if next && !triggered {
 			select {
 			case nextSlabTrigger <- struct{}{}:
 				triggered = true
 			default:
 			}
-		}
-	}
-
-	// make sure next slab is triggered
-	if done && !triggered {
-		select {
-		case nextSlabTrigger <- struct{}{}:
-		default:
 		}
 	}
 
@@ -991,7 +1010,13 @@ func (s *slabDownload) finish() ([][]byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.numCompleted < s.minShards {
-		return nil, fmt.Errorf("failed to download slab: completed=%d, inflight=%d, launched=%d downloaders=%d errors=%w", s.numCompleted, s.numInflight, s.numLaunched, s.mgr.numDownloaders(), s.errs)
+		var unused int
+		for host := range s.hostToSectors {
+			if _, used := s.used[host]; !used {
+				unused++
+			}
+		}
+		return nil, fmt.Errorf("failed to download slab: completed=%d, inflight=%d, launched=%d downloaders=%d unused=%d errors=%w", s.numCompleted, s.numInflight, s.numLaunched, s.mgr.numDownloaders(), unused, s.errs)
 	}
 	return s.sectors, nil
 }
@@ -1128,4 +1153,21 @@ func slabsForDownload(slabs []object.SlabSlice, offset, length uint64) []object.
 	}
 	slabs[len(slabs)-1].Length = cast32(lastLength)
 	return slabs
+}
+
+func (src *sectorResponseChan) trySend(resp sectorDownloadResp) {
+	select {
+	case <-src.ctx.Done():
+		src.close()
+	default:
+		select {
+		case <-src.ctx.Done():
+			src.close()
+		case src.c <- resp:
+		}
+	}
+}
+
+func (src *sectorResponseChan) close() {
+	src.once.Do(func() { close(src.c) })
 }


### PR DESCRIPTION
This PR will contain a couple of fixes to the download code we merged recently. It should drastically lower the memory footprint of `renterd` (on large downloads) because of how we handle concurrent slabs.

- [x] fix send down closed channel (wrong order of `defer` )
- [x] fetch next request for as long as it's not `nil` and launching the request fails
- [x] log any `unused` hosts if we `finish` a slab without completing the download 
- [x] update concurrent slabs code