### PR TITLE
Apply contract spending updates in series

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"go.sia.tech/core/consensus"
@@ -145,20 +144,6 @@ type bus struct {
 	logger        *zap.SugaredLogger
 	accounts      *accounts
 	contractLocks *contractLocks
-
-	shutdown   chan struct{}
-	shutdownWG sync.WaitGroup
-
-	mu                       sync.Mutex
-	interactionsBufferSignal chan struct{}
-	interactionsBuffer       []pendingInteractions
-}
-
-type pendingInteractions struct {
-	ctx          context.Context
-	done         chan struct{}
-	err          error
-	interactions []hostdb.Interaction
 }
 
 func (b *bus) consensusAcceptBlock(jc jape.Context) {
@@ -511,7 +496,7 @@ func (b *bus) hostsPubkeyHandlerPOST(jc jape.Context) {
 	if jc.Decode(&interactions) != nil {
 		return
 	}
-	if jc.Check("failed to record interactions", b.recordInteractions(jc.Request.Context(), interactions)) != nil {
+	if jc.Check("failed to record interactions", b.hdb.RecordInteractions(jc.Request.Context(), interactions)) != nil {
 		return
 	}
 }
@@ -1198,9 +1183,6 @@ func New(s Syncer, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, as
 		eas:           eas,
 		contractLocks: newContractLocks(),
 		logger:        l.Sugar().Named("bus"),
-
-		interactionsBufferSignal: make(chan struct{}, 1),
-		shutdown:                 make(chan struct{}),
 	}
 	ctx, span := tracing.Tracer.Start(context.Background(), "bus.New")
 	defer span.End()
@@ -1275,13 +1257,6 @@ func New(s Syncer, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, as
 		return nil, err
 	}
 	b.accounts = newAccounts(accounts, b.logger)
-
-	// Start interaction buffer goroutine.
-	b.shutdownWG.Add(1)
-	go func() {
-		b.interactionRecordingLoop()
-		b.shutdownWG.Done()
-	}()
 	return b, nil
 }
 
@@ -1378,66 +1353,5 @@ func (b *bus) Handler() http.Handler {
 
 // Shutdown shuts down the bus.
 func (b *bus) Shutdown(ctx context.Context) error {
-	close(b.shutdown)
-	b.shutdownWG.Wait()
-
 	return b.eas.SaveAccounts(ctx, b.accounts.ToPersist())
-}
-
-func (b *bus) interactionRecordingLoop() {
-	for {
-		select {
-		case <-b.shutdown:
-			return
-		case <-b.interactionsBufferSignal:
-		}
-
-		// fetch next batch of interactions
-		b.mu.Lock()
-		if len(b.interactionsBuffer) == 0 {
-			b.mu.Unlock()
-			continue
-		}
-		var pi pendingInteractions
-		pi, b.interactionsBuffer = b.interactionsBuffer[0], b.interactionsBuffer[1:]
-		b.mu.Unlock()
-
-		// check if batch timed out in the meantime
-		select {
-		case <-pi.ctx.Done():
-			continue // timeout
-		default:
-		}
-
-		// record interactions
-		pi.err = b.hdb.RecordInteractions(pi.ctx, pi.interactions)
-		close(pi.done)
-		pi.interactions = nil
-	}
-}
-
-func (b *bus) recordInteractions(ctx context.Context, interactions []hostdb.Interaction) error {
-	pi := pendingInteractions{
-		ctx:          ctx,
-		done:         make(chan struct{}),
-		interactions: interactions,
-	}
-	b.mu.Lock()
-	b.interactionsBuffer = append(b.interactionsBuffer, pi)
-	b.mu.Unlock()
-
-	// notify recording loop
-	select {
-	case b.interactionsBufferSignal <- struct{}{}:
-	default:
-	}
-
-	select {
-	case <-b.shutdown:
-		return errors.New("bus is shutting down")
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-pi.done:
-		return pi.err
-	}
 }

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -702,6 +702,10 @@ func (ss *SQLStore) RecordInteractions(ctx context.Context, interactions []hostd
 		return nil // nothing to do
 	}
 
+	// Only allow for applying one batch of interactions at a time.
+	ss.interactionsMu.Lock()
+	defer ss.interactionsMu.Unlock()
+
 	// Get keys from input.
 	keyMap := make(map[publicKey]struct{})
 	var hks []publicKey

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -671,6 +671,8 @@ func (s *SQLStore) RecordContractSpending(ctx context.Context, records []api.Con
 	if len(records) == 0 {
 		return nil // nothing to do
 	}
+
+	// Only allow for applying one batch of spending records at a time.
 	s.spendingMu.Lock()
 	defer s.spendingMu.Unlock()
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -671,6 +671,9 @@ func (s *SQLStore) RecordContractSpending(ctx context.Context, records []api.Con
 	if len(records) == 0 {
 		return nil // nothing to do
 	}
+	s.spendingMu.Lock()
+	defer s.spendingMu.Unlock()
+
 	squashedRecords := make(map[types.FileContractID]api.ContractSpending)
 	latestRevision := make(map[types.FileContractID]uint64)
 	latestSize := make(map[types.FileContractID]uint64)

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -65,6 +65,9 @@ type (
 		closed       bool
 
 		knownContracts map[types.FileContractID]struct{}
+
+		spendingMu     sync.Mutex
+		interactionsMu sync.Mutex
 	}
 
 	revisionUpdate struct {


### PR DESCRIPTION
For the same reason as in https://github.com/SiaFoundation/renterd/pull/463 we are also applying spending updates in series to avoid a `retryTransaction` to block out another transaction for an extended period of time.