### PR TITLE
Extend /bus/transactions endpoint with 'before' parameter

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
+	"net/url"
 	"time"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
@@ -190,6 +192,33 @@ type WalletPrepareRenewRequest struct {
 type WalletPrepareRenewResponse struct {
 	ToSign         []types.Hash256     `json:"toSign"`
 	TransactionSet []types.Transaction `json:"transactionSet"`
+}
+
+// WalletTransactionsOption is an option for the WalletTransactions method.
+type WalletTransactionsOption func(url.Values)
+
+func WalletTransactionsWithBefore(before time.Time) WalletTransactionsOption {
+	return func(q url.Values) {
+		q.Set("before", before.Format(time.RFC3339))
+	}
+}
+
+func WalletTransactionsWithSince(since time.Time) WalletTransactionsOption {
+	return func(q url.Values) {
+		q.Set("since", since.Format(time.RFC3339))
+	}
+}
+
+func WalletTransactionsWithLimit(limit int) WalletTransactionsOption {
+	return func(q url.Values) {
+		q.Set("limit", fmt.Sprint(limit))
+	}
+}
+
+func WalletTransactionsWithOffset(offset int) WalletTransactionsOption {
+	return func(q url.Values) {
+		q.Set("offset", fmt.Sprint(offset))
+	}
 }
 
 // ObjectsResponse is the response type for the /objects endpoint.

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -58,7 +58,7 @@ type (
 		Redistribute(cs consensus.State, outputs int, amount, feePerByte types.Currency, pool []types.Transaction) (types.Transaction, []types.Hash256, error)
 		ReleaseInputs(txn types.Transaction)
 		SignTransaction(cs consensus.State, txn *types.Transaction, toSign []types.Hash256, cf types.CoveredFields) error
-		Transactions(before, since time.Time, max int) ([]wallet.Transaction, error)
+		Transactions(before, since time.Time, offset, limit int) ([]wallet.Transaction, error)
 		UnspentOutputs() ([]wallet.SiacoinElement, error)
 	}
 
@@ -231,13 +231,15 @@ func (b *bus) walletAddressHandler(jc jape.Context) {
 
 func (b *bus) walletTransactionsHandler(jc jape.Context) {
 	var before, since time.Time
-	max := -1
+	offset := 0
+	limit := -1
 	if jc.DecodeForm("before", (*api.ParamTime)(&before)) != nil ||
 		jc.DecodeForm("since", (*api.ParamTime)(&since)) != nil ||
-		jc.DecodeForm("max", &max) != nil {
+		jc.DecodeForm("offset", &offset) != nil ||
+		jc.DecodeForm("limit", &limit) != nil {
 		return
 	}
-	txns, err := b.w.Transactions(before, since, max)
+	txns, err := b.w.Transactions(before, since, offset, limit)
 	if jc.Check("couldn't load transactions", err) == nil {
 		jc.Encode(txns)
 	}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -58,7 +58,7 @@ type (
 		Redistribute(cs consensus.State, outputs int, amount, feePerByte types.Currency, pool []types.Transaction) (types.Transaction, []types.Hash256, error)
 		ReleaseInputs(txn types.Transaction)
 		SignTransaction(cs consensus.State, txn *types.Transaction, toSign []types.Hash256, cf types.CoveredFields) error
-		Transactions(since time.Time, max int) ([]wallet.Transaction, error)
+		Transactions(before, since time.Time, max int) ([]wallet.Transaction, error)
 		UnspentOutputs() ([]wallet.SiacoinElement, error)
 	}
 
@@ -230,12 +230,14 @@ func (b *bus) walletAddressHandler(jc jape.Context) {
 }
 
 func (b *bus) walletTransactionsHandler(jc jape.Context) {
-	var since time.Time
+	var before, since time.Time
 	max := -1
-	if jc.DecodeForm("since", (*api.ParamTime)(&since)) != nil || jc.DecodeForm("max", &max) != nil {
+	if jc.DecodeForm("before", (*api.ParamTime)(&before)) != nil ||
+		jc.DecodeForm("since", (*api.ParamTime)(&since)) != nil ||
+		jc.DecodeForm("max", &max) != nil {
 		return
 	}
-	txns, err := b.w.Transactions(since, max)
+	txns, err := b.w.Transactions(before, since, max)
 	if jc.Check("couldn't load transactions", err) == nil {
 		jc.Encode(txns)
 	}

--- a/bus/client.go
+++ b/bus/client.go
@@ -164,9 +164,15 @@ func WalletTransactionsWithSince(since time.Time) WalletTransactionsOption {
 	}
 }
 
-func WalletTransactionsWithMax(max int) WalletTransactionsOption {
+func WalletTransactionsWithLimit(limit int) WalletTransactionsOption {
 	return func(q url.Values) {
-		q.Set("max", fmt.Sprint(max))
+		q.Set("limit", fmt.Sprint(limit))
+	}
+}
+
+func WalletTransactionsWithOffset(offset int) WalletTransactionsOption {
+	return func(q url.Values) {
+		q.Set("offset", fmt.Sprint(offset))
 	}
 }
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -172,6 +172,8 @@ func WalletTransactionsWithMax(max int) WalletTransactionsOption {
 
 // WalletTransactions returns all transactions relevant to the wallet.
 func (c *Client) WalletTransactions(ctx context.Context, opts ...WalletTransactionsOption) (resp []wallet.Transaction, err error) {
+	c.c.Custom("GET", "/wallet/transactions", nil, &resp)
+
 	values := url.Values{}
 	for _, opt := range opts {
 		opt(values)

--- a/bus/client.go
+++ b/bus/client.go
@@ -152,9 +152,9 @@ func (c *Client) SendSiacoins(ctx context.Context, scos []types.SiacoinOutput) (
 // WalletTransactionsOption is an option for the WalletTransactions method.
 type WalletTransactionsOption func(url.Values)
 
-func WalletTransactionsWithBefore(since time.Time) WalletTransactionsOption {
+func WalletTransactionsWithBefore(before time.Time) WalletTransactionsOption {
 	return func(q url.Values) {
-		q.Set("before", since.Format(time.RFC3339))
+		q.Set("before", before.Format(time.RFC3339))
 	}
 }
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -154,25 +154,25 @@ type WalletTransactionsOption func(url.Values)
 
 func WalletTransactionsWithBefore(since time.Time) WalletTransactionsOption {
 	return func(q url.Values) {
-		q.Set("before", api.ParamTime(since).String())
+		q.Set("before", since.Format(time.RFC3339))
 	}
 }
 
 func WalletTransactionsWithSince(since time.Time) WalletTransactionsOption {
 	return func(q url.Values) {
-		q.Set("since", api.ParamTime(since).String())
+		q.Set("since", since.Format(time.RFC3339))
 	}
 }
 
 func WalletTransactionsWithMax(max int) WalletTransactionsOption {
 	return func(q url.Values) {
-		q.Set("since", fmt.Sprint(max))
+		q.Set("max", fmt.Sprint(max))
 	}
 }
 
 // WalletTransactions returns all transactions relevant to the wallet.
 func (c *Client) WalletTransactions(ctx context.Context, opts ...WalletTransactionsOption) (resp []wallet.Transaction, err error) {
-	var values url.Values
+	values := url.Values{}
 	for _, opt := range opts {
 		opt(values)
 	}

--- a/bus/client.go
+++ b/bus/client.go
@@ -149,35 +149,8 @@ func (c *Client) SendSiacoins(ctx context.Context, scos []types.SiacoinOutput) (
 	return c.BroadcastTransaction(ctx, append(parents, txn))
 }
 
-// WalletTransactionsOption is an option for the WalletTransactions method.
-type WalletTransactionsOption func(url.Values)
-
-func WalletTransactionsWithBefore(before time.Time) WalletTransactionsOption {
-	return func(q url.Values) {
-		q.Set("before", before.Format(time.RFC3339))
-	}
-}
-
-func WalletTransactionsWithSince(since time.Time) WalletTransactionsOption {
-	return func(q url.Values) {
-		q.Set("since", since.Format(time.RFC3339))
-	}
-}
-
-func WalletTransactionsWithLimit(limit int) WalletTransactionsOption {
-	return func(q url.Values) {
-		q.Set("limit", fmt.Sprint(limit))
-	}
-}
-
-func WalletTransactionsWithOffset(offset int) WalletTransactionsOption {
-	return func(q url.Values) {
-		q.Set("offset", fmt.Sprint(offset))
-	}
-}
-
 // WalletTransactions returns all transactions relevant to the wallet.
-func (c *Client) WalletTransactions(ctx context.Context, opts ...WalletTransactionsOption) (resp []wallet.Transaction, err error) {
+func (c *Client) WalletTransactions(ctx context.Context, opts ...api.WalletTransactionsOption) (resp []wallet.Transaction, err error) {
 	c.c.Custom("GET", "/wallet/transactions", nil, &resp)
 
 	values := url.Values{}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1589,7 +1589,7 @@ func TestWalletTransactions(t *testing.T) {
 		t.Fatal("expected at least 1 transaction before median timestamp", medianTxnTimestamp.Unix())
 	}
 	for _, txn := range txns {
-		if txn.Timestamp.Unix() > medianTxnTimestamp.Unix() {
+		if txn.Timestamp.Unix() >= medianTxnTimestamp.Unix() {
 			t.Fatal("expected only transactions before median timestamp")
 		}
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -22,7 +22,6 @@ import (
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/bus"
 	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/object"
 	"go.uber.org/zap"
@@ -1551,7 +1550,7 @@ func TestWalletTransactions(t *testing.T) {
 	}
 
 	// Get the transactions at an offset and compare.
-	txns, err := b.WalletTransactions(context.Background(), bus.WalletTransactionsWithOffset(2))
+	txns, err := b.WalletTransactions(context.Background(), api.WalletTransactionsWithOffset(2))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1570,7 +1569,7 @@ func TestWalletTransactions(t *testing.T) {
 	medianTxnTimestamp := allTxns[txnIdx].Timestamp
 
 	// Limit the number of transactions to 5.
-	txns, err = b.WalletTransactions(context.Background(), bus.WalletTransactionsWithLimit(5))
+	txns, err = b.WalletTransactions(context.Background(), api.WalletTransactionsWithLimit(5))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1579,7 +1578,7 @@ func TestWalletTransactions(t *testing.T) {
 	}
 
 	// Fetch txns before and since median.
-	txns, err = b.WalletTransactions(context.Background(), bus.WalletTransactionsWithBefore(medianTxnTimestamp))
+	txns, err = b.WalletTransactions(context.Background(), api.WalletTransactionsWithBefore(medianTxnTimestamp))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1594,7 +1593,7 @@ func TestWalletTransactions(t *testing.T) {
 			t.Fatal("expected only transactions before median timestamp")
 		}
 	}
-	txns, err = b.WalletTransactions(context.Background(), bus.WalletTransactionsWithSince(medianTxnTimestamp))
+	txns, err = b.WalletTransactions(context.Background(), api.WalletTransactionsWithSince(medianTxnTimestamp))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1415,8 +1415,16 @@ func TestWalletTransactions(t *testing.T) {
 	}) {
 		t.Fatal("transactions are not sorted by timestamp")
 	}
-	medianTxnIdx := len(allTxns) / 2
-	medianTxnTimestamp := allTxns[medianTxnIdx].Timestamp
+
+	// Find the first index that has a different timestamp than the first.
+	var txnIdx int
+	for i := 1; i < len(allTxns); i++ {
+		if allTxns[i].Timestamp.Unix() != allTxns[0].Timestamp.Unix() {
+			txnIdx = i
+			break
+		}
+	}
+	medianTxnTimestamp := allTxns[txnIdx].Timestamp
 
 	// Limit the number of transactions to 5.
 	txns, err := b.WalletTransactions(context.Background(), bus.WalletTransactionsWithMax(5))

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1392,10 +1392,13 @@ func TestWalletTransactions(t *testing.T) {
 	}()
 	b := cluster.Bus
 
-	// Wait a bit and produce more transactions to get a nice spread of
-	// timestamps.
-	time.Sleep(100 * time.Millisecond)
-	if err := cluster.MineToRenewWindow(); err != nil {
+	// Make sure we get transactions that are spread out over multiple seconds.
+	time.Sleep(time.Second)
+	if err := cluster.MineBlocks(1); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Second)
+	if err := cluster.MineBlocks(1); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1416,6 +1416,15 @@ func TestWalletTransactions(t *testing.T) {
 		t.Fatal("transactions are not sorted by timestamp")
 	}
 
+	// Get the transactions at an offset and compare.
+	txns, err := b.WalletTransactions(context.Background(), bus.WalletTransactionsWithOffset(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(txns, allTxns[2:]) {
+		t.Fatal("transactions don't match")
+	}
+
 	// Find the first index that has a different timestamp than the first.
 	var txnIdx int
 	for i := 1; i < len(allTxns); i++ {
@@ -1427,7 +1436,7 @@ func TestWalletTransactions(t *testing.T) {
 	medianTxnTimestamp := allTxns[txnIdx].Timestamp
 
 	// Limit the number of transactions to 5.
-	txns, err := b.WalletTransactions(context.Background(), bus.WalletTransactionsWithMax(5))
+	txns, err = b.WalletTransactions(context.Background(), bus.WalletTransactionsWithLimit(5))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1403,23 +1403,23 @@ func TestWalletTransactions(t *testing.T) {
 	}
 
 	// Get all transactions of the wallet.
-	txns, err := b.WalletTransactions(context.Background())
+	allTxns, err := b.WalletTransactions(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(txns) < 5 {
-		t.Fatalf("expected at least 5 transactions, got %v", len(txns))
+	if len(allTxns) < 5 {
+		t.Fatalf("expected at least 5 transactions, got %v", len(allTxns))
 	}
-	if !sort.SliceIsSorted(txns, func(i, j int) bool {
-		return txns[i].Timestamp.Unix() > txns[j].Timestamp.Unix()
+	if !sort.SliceIsSorted(allTxns, func(i, j int) bool {
+		return allTxns[i].Timestamp.Unix() > allTxns[j].Timestamp.Unix()
 	}) {
 		t.Fatal("transactions are not sorted by timestamp")
 	}
-	medianTxnIdx := len(txns) / 2
-	medianTxnTimestamp := txns[medianTxnIdx].Timestamp
+	medianTxnIdx := len(allTxns) / 2
+	medianTxnTimestamp := allTxns[medianTxnIdx].Timestamp
 
 	// Limit the number of transactions to 5.
-	txns, err = b.WalletTransactions(context.Background(), bus.WalletTransactionsWithMax(5))
+	txns, err := b.WalletTransactions(context.Background(), bus.WalletTransactionsWithMax(5))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1433,7 +1433,10 @@ func TestWalletTransactions(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(txns) == 0 {
-		t.Fatal("expected at least 1 transaction before median timestamp")
+		for _, txn := range allTxns {
+			fmt.Println(txn.Timestamp.Unix())
+		}
+		t.Fatal("expected at least 1 transaction before median timestamp", medianTxnTimestamp.Unix())
 	}
 	for _, txn := range txns {
 		if txn.Timestamp.Unix() > medianTxnTimestamp.Unix() {
@@ -1445,11 +1448,14 @@ func TestWalletTransactions(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(txns) == 0 {
+		for _, txn := range allTxns {
+			fmt.Println(txn.Timestamp.Unix())
+		}
 		t.Fatal("expected at least 1 transaction after median timestamp")
 	}
 	for _, txn := range txns {
 		if txn.Timestamp.Unix() < medianTxnTimestamp.Unix() {
-			t.Fatal("expected only transactions after median timestamp")
+			t.Fatal("expected only transactions after median timestamp", medianTxnTimestamp.Unix())
 		}
 	}
 }

--- a/stores/wallet.go
+++ b/stores/wallet.go
@@ -103,8 +103,8 @@ func (s *SQLStore) Transactions(before, since time.Time, offset, limit int) ([]w
 	err := s.db.
 		Where("timestamp > ? AND timestamp < ?", sinceX, beforeX).
 		Order("timestamp DESC").
-		Limit(limit).
 		Offset(offset).
+		Limit(limit).
 		Find(&dbTxns).
 		Error
 	if err != nil {

--- a/stores/wallet.go
+++ b/stores/wallet.go
@@ -89,7 +89,7 @@ func (s *SQLStore) UnspentSiacoinElements() ([]wallet.SiacoinElement, error) {
 }
 
 // Transactions implements wallet.SingleAddressStore.
-func (s *SQLStore) Transactions(before, since time.Time, max int) ([]wallet.Transaction, error) {
+func (s *SQLStore) Transactions(before, since time.Time, offset, limit int) ([]wallet.Transaction, error) {
 	beforeX := int64(math.MaxInt64)
 	sinceX := int64(0)
 	if !before.IsZero() {
@@ -103,7 +103,8 @@ func (s *SQLStore) Transactions(before, since time.Time, max int) ([]wallet.Tran
 	err := s.db.
 		Where("timestamp > ? AND timestamp < ?", sinceX, beforeX).
 		Order("timestamp DESC").
-		Limit(max).
+		Limit(limit).
+		Offset(offset).
 		Find(&dbTxns).
 		Error
 	if err != nil {

--- a/stores/wallet.go
+++ b/stores/wallet.go
@@ -93,17 +93,18 @@ func (s *SQLStore) Transactions(before, since time.Time, max int) ([]wallet.Tran
 	beforeX := int64(math.MaxInt64)
 	sinceX := int64(0)
 	if !before.IsZero() {
-		beforeX = before.UnixNano()
+		beforeX = before.Unix()
 	}
 	if !since.IsZero() {
-		sinceX = since.UnixNano()
+		sinceX = since.Unix()
 	}
 
 	var dbTxns []dbTransaction
-	err := s.db.Find(&dbTxns).
+	err := s.db.
 		Where("timestamp > ? AND timestamp < ?", sinceX, beforeX).
-		Limit(max).
 		Order("timestamp DESC").
+		Limit(max).
+		Find(&dbTxns).
 		Error
 	if err != nil {
 		return nil, err

--- a/stores/wallet.go
+++ b/stores/wallet.go
@@ -100,12 +100,8 @@ func (s *SQLStore) Transactions(before, since time.Time, offset, limit int) ([]w
 	}
 
 	var dbTxns []dbTransaction
-	err := s.db.
-		Where("timestamp > ? AND timestamp < ?", sinceX, beforeX).
-		Order("timestamp DESC").
-		Offset(offset).
-		Limit(limit).
-		Find(&dbTxns).
+	err := s.db.Raw("SELECT * FROM transactions WHERE timestamp > ? AND timestamp < ? ORDER BY timestamp DESC LIMIT ? OFFSET ?",
+		sinceX, beforeX, limit, offset).Scan(&dbTxns).
 		Error
 	if err != nil {
 		return nil, err

--- a/stores/wallet.go
+++ b/stores/wallet.go
@@ -103,7 +103,7 @@ func (s *SQLStore) Transactions(before, since time.Time, offset, limit int) ([]w
 	}
 
 	var dbTxns []dbTransaction
-	err := s.db.Raw("SELECT * FROM transactions WHERE timestamp > ? AND timestamp < ? ORDER BY timestamp DESC LIMIT ? OFFSET ?",
+	err := s.db.Raw("SELECT * FROM transactions WHERE timestamp >= ? AND timestamp < ? ORDER BY timestamp DESC LIMIT ? OFFSET ?",
 		sinceX, beforeX, limit, offset).Scan(&dbTxns).
 		Error
 	if err != nil {

--- a/stores/wallet.go
+++ b/stores/wallet.go
@@ -98,6 +98,9 @@ func (s *SQLStore) Transactions(before, since time.Time, offset, limit int) ([]w
 	if !since.IsZero() {
 		sinceX = since.Unix()
 	}
+	if limit == 0 || limit == -1 {
+		limit = math.MaxInt64
+	}
 
 	var dbTxns []dbTransaction
 	err := s.db.Raw("SELECT * FROM transactions WHERE timestamp > ? AND timestamp < ? ORDER BY timestamp DESC LIMIT ? OFFSET ?",

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -109,7 +109,7 @@ type Transaction struct {
 type SingleAddressStore interface {
 	Balance() (types.Currency, error)
 	UnspentSiacoinElements() ([]SiacoinElement, error)
-	Transactions(since time.Time, max int) ([]Transaction, error)
+	Transactions(before, since time.Time, max int) ([]Transaction, error)
 }
 
 // A TransactionPool contains transactions that have not yet been included in a
@@ -154,8 +154,8 @@ func (w *SingleAddressWallet) UnspentOutputs() ([]SiacoinElement, error) {
 
 // Transactions returns up to max transactions relevant to the wallet that have
 // a timestamp later than since.
-func (w *SingleAddressWallet) Transactions(since time.Time, max int) ([]Transaction, error) {
-	return w.store.Transactions(since, max)
+func (w *SingleAddressWallet) Transactions(before, since time.Time, max int) ([]Transaction, error) {
+	return w.store.Transactions(before, since, max)
 }
 
 // FundTransaction adds siacoin inputs worth at least the requested amount to

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -109,7 +109,7 @@ type Transaction struct {
 type SingleAddressStore interface {
 	Balance() (types.Currency, error)
 	UnspentSiacoinElements() ([]SiacoinElement, error)
-	Transactions(before, since time.Time, max int) ([]Transaction, error)
+	Transactions(before, since time.Time, offset, limit int) ([]Transaction, error)
 }
 
 // A TransactionPool contains transactions that have not yet been included in a
@@ -154,8 +154,8 @@ func (w *SingleAddressWallet) UnspentOutputs() ([]SiacoinElement, error) {
 
 // Transactions returns up to max transactions relevant to the wallet that have
 // a timestamp later than since.
-func (w *SingleAddressWallet) Transactions(before, since time.Time, max int) ([]Transaction, error) {
-	return w.store.Transactions(before, since, max)
+func (w *SingleAddressWallet) Transactions(before, since time.Time, offset, limit int) ([]Transaction, error) {
+	return w.store.Transactions(before, since, offset, limit)
 }
 
 // FundTransaction adds siacoin inputs worth at least the requested amount to

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -19,7 +19,7 @@ type mockStore struct {
 
 func (s *mockStore) Balance() (types.Currency, error)                         { return types.ZeroCurrency, nil }
 func (s *mockStore) UnspentSiacoinElements() ([]wallet.SiacoinElement, error) { return s.utxos, nil }
-func (s *mockStore) Transactions(since time.Time, max int) ([]wallet.Transaction, error) {
+func (s *mockStore) Transactions(before, since time.Time, max int) ([]wallet.Transaction, error) {
 	return nil, nil
 }
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -19,7 +19,7 @@ type mockStore struct {
 
 func (s *mockStore) Balance() (types.Currency, error)                         { return types.ZeroCurrency, nil }
 func (s *mockStore) UnspentSiacoinElements() ([]wallet.SiacoinElement, error) { return s.utxos, nil }
-func (s *mockStore) Transactions(before, since time.Time, max int) ([]wallet.Transaction, error) {
+func (s *mockStore) Transactions(before, since time.Time, offset, limit int) ([]wallet.Transaction, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This PR updates the /bus/transactions endpoint with a 'before' parameter as well as forces it to return the latest transaction first. 

Closes https://github.com/SiaFoundation/renterd/issues/475