### PR TITLE
Add /rhp/broadcast/:id endpoint to worker

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -36,7 +36,6 @@ type Bus interface {
 	WalletAddress(ctx context.Context) (types.Address, error)
 	WalletBalance(ctx context.Context) (types.Currency, error)
 	WalletDiscard(ctx context.Context, txn types.Transaction) error
-	WalletFund(ctx context.Context, txn *types.Transaction, amount types.Currency) ([]types.Hash256, []types.Transaction, error)
 	WalletOutputs(ctx context.Context) (resp []wallet.SiacoinElement, err error)
 	WalletPending(ctx context.Context) (resp []types.Transaction, err error)
 	WalletRedistribute(ctx context.Context, outputs int, amount types.Currency) (id types.TransactionID, err error)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -397,6 +397,25 @@ func TestUploadDownloadBasic(t *testing.T) {
 	if err := cluster.MineBlocks(1); err != nil {
 		t.Fatal(err)
 	}
+
+	// check the revision height was updated.
+	err = Retry(100, 100*time.Millisecond, func() error {
+		// fetch the contracts.
+		contracts, err := cluster.Bus.Contracts(context.Background())
+		if err != nil {
+			return err
+		}
+		// assert the revision height was updated.
+		for _, c := range contracts {
+			if c.RevisionHeight == 0 {
+				return errors.New("revision height should be > 0")
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestUploadDownloadBasic is an integration test that verifies objects can be

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -375,6 +375,28 @@ func TestUploadDownloadBasic(t *testing.T) {
 	if !bytes.Equal(data, buffer.Bytes()) {
 		t.Fatal("unexpected")
 	}
+
+	// fetch the contracts.
+	contracts, err := cluster.Bus.Contracts(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// broadcast the revision for each contract and assert the revision height
+	// is 0.
+	for _, c := range contracts {
+		if c.RevisionHeight != 0 {
+			t.Fatal("revision height should be 0")
+		}
+		if err := w.RHPBroadcast(context.Background(), c.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// mine a block to get the revisions mined.
+	if err := cluster.MineBlocks(1); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestUploadDownloadBasic is an integration test that verifies objects can be

--- a/worker/client.go
+++ b/worker/client.go
@@ -31,6 +31,12 @@ func (c *Client) ID(ctx context.Context) (id string, err error) {
 	return
 }
 
+// RHPBroadcast broadcasts the latest revision for a contract.
+func (c *Client) RHPBroadcast(ctx context.Context, fcid types.FileContractID) (err error) {
+	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/rhp/broadcast/%s", fcid), nil, nil)
+	return
+}
+
 // RHPScan scans a host, returning its current settings.
 func (c *Client) RHPScan(ctx context.Context, hostKey types.PublicKey, hostIP string, timeout time.Duration) (resp api.RHPScanResponse, err error) {
 	err = c.c.WithContext(ctx).POST("/rhp/scan", api.RHPScanRequest{

--- a/worker/client.go
+++ b/worker/client.go
@@ -33,7 +33,7 @@ func (c *Client) ID(ctx context.Context) (id string, err error) {
 
 // RHPBroadcast broadcasts the latest revision for a contract.
 func (c *Client) RHPBroadcast(ctx context.Context, fcid types.FileContractID) (err error) {
-	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/contract/%s/broadcast", fcid), nil, nil)
+	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/rhp/contract/%s/broadcast", fcid), nil, nil)
 	return
 }
 

--- a/worker/client.go
+++ b/worker/client.go
@@ -33,7 +33,7 @@ func (c *Client) ID(ctx context.Context) (id string, err error) {
 
 // RHPBroadcast broadcasts the latest revision for a contract.
 func (c *Client) RHPBroadcast(ctx context.Context, fcid types.FileContractID) (err error) {
-	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/rhp/broadcast/%s", fcid), nil, nil)
+	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/contract/%s/broadcast", fcid), nil, nil)
 	return
 }
 

--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -238,7 +238,9 @@ func (w *worker) FetchSignedRevision(ctx context.Context, hostIP string, hostKey
 		defer t.WriteRequest(rhpv2.RPCUnlockID, nil)
 
 		// verify claimed revision
-		if len(resp.Signatures) != 2 {
+		if resp.Revision.RevisionNumber == math.MaxUint64 {
+			return ErrContractFinalized
+		} else if len(resp.Signatures) != 2 {
 			return fmt.Errorf("host returned wrong number of signatures (expected 2, got %v)", len(resp.Signatures))
 		} else if len(resp.Signatures[0].Signature) != 64 || len(resp.Signatures[1].Signature) != 64 {
 			return errors.New("signatures on claimed revision have wrong length")
@@ -250,8 +252,6 @@ func (w *worker) FetchSignedRevision(ctx context.Context, hostIP string, hostKey
 			return errors.New("host's signature on claimed revision is invalid")
 		} else if !resp.Acquired {
 			return ErrContractLocked
-		} else if resp.Revision.RevisionNumber == math.MaxUint64 {
-			return ErrContractFinalized
 		}
 		rev = rhpv2.ContractRevision{
 			Revision:   resp.Revision,

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -179,7 +179,7 @@ func newTransportPoolV3(w *worker) *transportPoolV3 {
 
 func dialTransport(ctx context.Context, siamuxAddr string, hostKey types.PublicKey) (*rhpv3.Transport, error) {
 	// Dial host.
-	conn, err := dial(ctx, siamuxAddr, hostKey)
+	conn, err := dial(ctx, siamuxAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1085,7 +1085,6 @@ func (w *worker) Handler() http.Handler {
 		"GET    /account/:hostkey": w.accountHandlerGET,
 		"GET    /id":               w.idHandlerGET,
 
-		"POST   /rhp/broadcast/:id":   w.rhpBroadcastHandler,
 		"GET    /rhp/contracts":       w.rhpContractsHandlerGET,
 		"POST   /rhp/scan":            w.rhpScanHandler,
 		"POST   /rhp/form":            w.rhpFormHandler,
@@ -1100,9 +1099,10 @@ func (w *worker) Handler() http.Handler {
 		"GET    /stats/uploads":   w.uploadsStatsHandlerGET,
 		"POST   /slab/migrate":    w.slabMigrateHandler,
 
-		"GET    /objects/*path": w.objectsHandlerGET,
-		"PUT    /objects/*path": w.objectsHandlerPUT,
-		"DELETE /objects/*path": w.objectsHandlerDELETE,
+		"POST   /contract/:id/broadcast": w.rhpBroadcastHandler,
+		"GET    /objects/*path":          w.objectsHandlerGET,
+		"PUT    /objects/*path":          w.objectsHandlerPUT,
+		"DELETE /objects/*path":          w.objectsHandlerDELETE,
 	}))
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -531,12 +531,7 @@ func (w *worker) rhpBroadcastHandler(jc jape.Context) {
 	if jc.Check("could not get contract", err) != nil {
 		return
 	}
-	gp, err := w.bus.GougingParams(ctx)
-	if jc.Check("could not get gouging parameters", err) != nil {
-		return
-	}
 	rk := w.deriveRenterKey(c.HostKey)
-	ctx = WithGougingChecker(ctx, w.bus, gp)
 
 	rev, err := w.FetchSignedRevision(ctx, c.HostIP, c.HostKey, rk, fcid, time.Minute)
 	if jc.Check("could not fetch revision", err) != nil {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1085,24 +1085,24 @@ func (w *worker) Handler() http.Handler {
 		"GET    /account/:hostkey": w.accountHandlerGET,
 		"GET    /id":               w.idHandlerGET,
 
-		"GET    /rhp/contracts":       w.rhpContractsHandlerGET,
-		"POST   /rhp/scan":            w.rhpScanHandler,
-		"POST   /rhp/form":            w.rhpFormHandler,
-		"POST   /rhp/renew":           w.rhpRenewHandler,
-		"POST   /rhp/fund":            w.rhpFundHandler,
-		"POST   /rhp/sync":            w.rhpSyncHandler,
-		"POST   /rhp/pricetable":      w.rhpPriceTableHandler,
-		"POST   /rhp/registry/read":   w.rhpRegistryReadHandler,
-		"POST   /rhp/registry/update": w.rhpRegistryUpdateHandler,
+		"GET    /rhp/contracts":              w.rhpContractsHandlerGET,
+		"POST   /rhp/contract/:id/broadcast": w.rhpBroadcastHandler,
+		"POST   /rhp/scan":                   w.rhpScanHandler,
+		"POST   /rhp/form":                   w.rhpFormHandler,
+		"POST   /rhp/renew":                  w.rhpRenewHandler,
+		"POST   /rhp/fund":                   w.rhpFundHandler,
+		"POST   /rhp/sync":                   w.rhpSyncHandler,
+		"POST   /rhp/pricetable":             w.rhpPriceTableHandler,
+		"POST   /rhp/registry/read":          w.rhpRegistryReadHandler,
+		"POST   /rhp/registry/update":        w.rhpRegistryUpdateHandler,
 
 		"GET    /stats/downloads": w.downloadsStatsHandlerGET,
 		"GET    /stats/uploads":   w.uploadsStatsHandlerGET,
 		"POST   /slab/migrate":    w.slabMigrateHandler,
 
-		"POST   /contract/:id/broadcast": w.rhpBroadcastHandler,
-		"GET    /objects/*path":          w.objectsHandlerGET,
-		"PUT    /objects/*path":          w.objectsHandlerPUT,
-		"DELETE /objects/*path":          w.objectsHandlerDELETE,
+		"GET    /objects/*path": w.objectsHandlerGET,
+		"PUT    /objects/*path": w.objectsHandlerPUT,
+		"DELETE /objects/*path": w.objectsHandlerDELETE,
 	}))
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -555,8 +555,7 @@ func (w *worker) rhpBroadcastHandler(jc jape.Context) {
 	}
 	// Sign the txn.
 	err = w.bus.WalletSign(ctx, &txn, toSign, types.CoveredFields{
-		FileContractRevisions: []uint64{0},
-		WholeTransaction:      true,
+		WholeTransaction: true,
 	})
 	if jc.Check("failed to sign transaction", err) != nil {
 		_ = w.bus.WalletDiscard(ctx, txn)


### PR DESCRIPTION
Adds a new endpoint to the worker which allows for submitting a contract's revision to the network.
This can serve multiple purposes such as periodically publishing revisions to limit a host's ability to submit an old revision in case they lose data. 