### PR TITLE
Health caching

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -67,7 +67,7 @@ type Bus interface {
 	ConsensusState(ctx context.Context) (api.ConsensusState, error)
 
 	// objects
-	RecomputeHealth(ctx context.Context) error
+	RefreshHealth(ctx context.Context) error
 	Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
 	SlabsForMigration(ctx context.Context, healthCutoff float64, set string, limit int) ([]api.UnhealthySlab, error)
 

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -67,6 +67,7 @@ type Bus interface {
 	ConsensusState(ctx context.Context) (api.ConsensusState, error)
 
 	// objects
+	RecomputeHealth(ctx context.Context) error
 	Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
 	SlabsForMigration(ctx context.Context, healthCutoff float64, set string, limit int) ([]api.UnhealthySlab, error)
 

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -155,6 +155,12 @@ OUTER:
 		// recompute health.
 		start := time.Now()
 		if err := b.RefreshHealth(ctx); err != nil {
+			m.ap.alerts.Register(alerts.Alert{
+				ID:        frand.Entropy256(),
+				Severity:  alerts.SeverityCritical,
+				Message:   fmt.Sprintf("migrations interrupted - failed to refresh cached slab health: %v", err),
+				Timestamp: time.Now(),
+			})
 			m.logger.Errorf("failed to recompute cached health before migration", err)
 			return
 		}

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -131,10 +131,12 @@ func (m *migrator) performMigrations(p *workerPool, set string) {
 OUTER:
 	for {
 		// recompute health first.
-		if err := b.RecomputeHealth(ctx); err != nil {
+		start := time.Now()
+		if err := b.RefreshHealth(ctx); err != nil {
 			m.logger.Errorf("failed to recompute cached health before migration", err)
 			return
 		}
+		m.logger.Debugf("recomputed slab health in %v", time.Since(start))
 
 		// fetch slabs for migration
 		toMigrateNew, err := b.SlabsForMigration(ctx, m.healthCutoff, set, migratorBatchSize)

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -130,6 +130,12 @@ func (m *migrator) performMigrations(p *workerPool, set string) {
 
 OUTER:
 	for {
+		// recompute health first.
+		if err := b.RecomputeHealth(ctx); err != nil {
+			m.logger.Errorf("failed to recompute cached health before migration", err)
+			return
+		}
+
 		// fetch slabs for migration
 		toMigrateNew, err := b.SlabsForMigration(ctx, m.healthCutoff, set, migratorBatchSize)
 		if err != nil {

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -102,7 +102,7 @@ type (
 		ObjectsStats(ctx context.Context) (api.ObjectsStats, error)
 
 		Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
-		RecomputeHealth(ctx context.Context) error
+		RefreshHealth(ctx context.Context) error
 		UnhealthySlabs(ctx context.Context, healthCutoff float64, set string, limit int) ([]api.UnhealthySlab, error)
 		UpdateSlab(ctx context.Context, s object.Slab, contractSet string, usedContracts map[types.PublicKey]types.FileContractID) error
 	}
@@ -819,8 +819,8 @@ func (b *bus) slabHandlerPUT(jc jape.Context) {
 	}
 }
 
-func (b *bus) slabsRecomputeHealthHandlerPOST(jc jape.Context) {
-	jc.Check("failed to recompute health", b.ms.RecomputeHealth(jc.Request.Context()))
+func (b *bus) slabsRefreshHealthHandlerPOST(jc jape.Context) {
+	jc.Check("failed to recompute health", b.ms.RefreshHealth(jc.Request.Context()))
 }
 
 func (b *bus) slabsMigrationHandlerPOST(jc jape.Context) {
@@ -1347,10 +1347,10 @@ func (b *bus) Handler() http.Handler {
 		"PUT    /objects/*path": b.objectsHandlerPUT,
 		"DELETE /objects/*path": b.objectsHandlerDELETE,
 
-		"POST   /slabs/migration":       b.slabsMigrationHandlerPOST,
-		"POST   /slabs/recomputehealth": b.slabsRecomputeHealthHandlerPOST,
-		"GET    /slab/:key":             b.slabHandlerGET,
-		"PUT    /slab":                  b.slabHandlerPUT,
+		"POST   /slabs/migration":     b.slabsMigrationHandlerPOST,
+		"POST   /slabs/refreshhealth": b.slabsRefreshHealthHandlerPOST,
+		"GET    /slab/:key":           b.slabHandlerGET,
+		"PUT    /slab":                b.slabHandlerPUT,
 
 		"GET    /settings":     b.settingsHandlerGET,
 		"GET    /setting/:key": b.settingKeyHandlerGET,

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -102,6 +102,7 @@ type (
 		ObjectsStats(ctx context.Context) (api.ObjectsStats, error)
 
 		Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
+		RecomputeHealth(ctx context.Context) error
 		UnhealthySlabs(ctx context.Context, healthCutoff float64, set string, limit int) ([]api.UnhealthySlab, error)
 		UpdateSlab(ctx context.Context, s object.Slab, contractSet string, usedContracts map[types.PublicKey]types.FileContractID) error
 	}
@@ -818,6 +819,10 @@ func (b *bus) slabHandlerPUT(jc jape.Context) {
 	}
 }
 
+func (b *bus) slabsRecomputeHealthHandlerPOST(jc jape.Context) {
+	jc.Check("failed to recompute health", b.ms.RecomputeHealth(jc.Request.Context()))
+}
+
 func (b *bus) slabsMigrationHandlerPOST(jc jape.Context) {
 	var msr api.MigrationSlabsRequest
 	if jc.Decode(&msr) == nil {
@@ -1342,9 +1347,10 @@ func (b *bus) Handler() http.Handler {
 		"PUT    /objects/*path": b.objectsHandlerPUT,
 		"DELETE /objects/*path": b.objectsHandlerDELETE,
 
-		"POST   /slabs/migration": b.slabsMigrationHandlerPOST,
-		"GET    /slab/:key":       b.slabHandlerGET,
-		"PUT    /slab":            b.slabHandlerPUT,
+		"POST   /slabs/migration":       b.slabsMigrationHandlerPOST,
+		"POST   /slabs/recomputehealth": b.slabsRecomputeHealthHandlerPOST,
+		"GET    /slab/:key":             b.slabHandlerGET,
+		"PUT    /slab":                  b.slabHandlerPUT,
 
 		"GET    /settings":     b.settingsHandlerGET,
 		"GET    /setting/:key": b.settingKeyHandlerGET,

--- a/bus/client.go
+++ b/bus/client.go
@@ -552,6 +552,11 @@ func (c *Client) DeleteObject(ctx context.Context, path string, batch bool) (err
 	return
 }
 
+// RecomputeHealth recomputes the cached health of all slabs.
+func (c *Client) RecomputeHealth(ctx context.Context) error {
+	return c.c.WithContext(ctx).POST("/slabs/recomputehealth", nil, nil)
+}
+
 // SlabsForMigration returns up to 'limit' slabs which require migration. A slab
 // needs to be migrated if it has sectors on contracts that are not part of the
 // given 'set'.

--- a/bus/client.go
+++ b/bus/client.go
@@ -553,8 +553,8 @@ func (c *Client) DeleteObject(ctx context.Context, path string, batch bool) (err
 }
 
 // RecomputeHealth recomputes the cached health of all slabs.
-func (c *Client) RecomputeHealth(ctx context.Context) error {
-	return c.c.WithContext(ctx).POST("/slabs/recomputehealth", nil, nil)
+func (c *Client) RefreshHealth(ctx context.Context) error {
+	return c.c.WithContext(ctx).POST("/slabs/refreshhealth", nil, nil)
 }
 
 // SlabsForMigration returns up to 'limit' slabs which require migration. A slab

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1111,13 +1111,20 @@ func (ss *SQLStore) UpdateSlab(ctx context.Context, s object.Slab, contractSet s
 
 func (s *SQLStore) UpdateHealth() error {
 	healthQuery := s.db.Raw(`
-SELECT slabs.id, slabs.db_contract_set_id, (CAST(COUNT(DISTINCT(CASE WHEN cs.name IS NULL THEN NULL ELSE c.host_id END)) AS FLOAT) - CAST(slabs.min_shards AS FLOAT)) / Cast(slabs.total_shards - slabs.min_shards AS FLOAT) AS health
+SELECT slabs.id, slabs.db_contract_set_id, CASE WHEN (slabs.min_shards = slabs.total_shards)
+THEN
+    CASE WHEN (COUNT(DISTINCT(CASE WHEN cs.name IS NULL THEN NULL ELSE c.host_id END)) < slabs.min_shards)
+    THEN -1
+    ELSE 1
+    END
+ELSE (CAST(COUNT(DISTINCT(CASE WHEN cs.name IS NULL THEN NULL ELSE c.host_id END)) AS FLOAT) - CAST(slabs.min_shards AS FLOAT)) / Cast(slabs.total_shards - slabs.min_shards AS FLOAT)
+END AS health
 FROM slabs
 INNER JOIN sectors s ON s.db_slab_id = slabs.id
-INNER JOIN contract_sectors se ON s.id = se.db_sector_id
-INNER JOIN contracts c ON se.db_contract_id = c.id
-INNER JOIN contract_set_contracts csc ON csc.db_contract_id = c.id AND csc.db_contract_set_id = slabs.db_contract_set_id
-INNER JOIN contract_sets cs ON cs.id = csc.db_contract_set_id
+LEFT JOIN contract_sectors se ON s.id = se.db_sector_id
+LEFT JOIN contracts c ON se.db_contract_id = c.id
+LEFT JOIN contract_set_contracts csc ON csc.db_contract_id = c.id AND csc.db_contract_set_id = slabs.db_contract_set_id
+LEFT JOIN contract_sets cs ON cs.id = csc.db_contract_set_id
 GROUP BY slabs.id
 `)
 	return s.retryTransaction(func(tx *gorm.DB) error {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1109,7 +1109,7 @@ func (ss *SQLStore) UpdateSlab(ctx context.Context, s object.Slab, contractSet s
 	})
 }
 
-func (s *SQLStore) RecomputeHealth(ctx context.Context) error {
+func (s *SQLStore) RefreshHealth(ctx context.Context) error {
 	healthQuery := s.db.Raw(`
 SELECT slabs.id, slabs.db_contract_set_id, CASE WHEN (slabs.min_shards = slabs.total_shards)
 THEN

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1150,8 +1150,8 @@ func (s *SQLStore) UnhealthySlabs(ctx context.Context, healthCutoff float64, set
 	}
 
 	if err := s.db.
-		Select("key, health").
-		Joins("JOIN contract_sets cs ON slabs.db_contract_set_id = cs.id").
+		Select("slabs.key, slabs.health").
+		Joins("INNER JOIN contract_sets cs ON slabs.db_contract_set_id = cs.id").
 		Model(&dbSlab{}).
 		Where("health <= ? AND cs.name = ?", healthCutoff, set).
 		Order("health ASC").

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1109,7 +1109,7 @@ func (ss *SQLStore) UpdateSlab(ctx context.Context, s object.Slab, contractSet s
 	})
 }
 
-func (s *SQLStore) UpdateHealth() error {
+func (s *SQLStore) RecomputeHealth(ctx context.Context) error {
 	healthQuery := s.db.Raw(`
 SELECT slabs.id, slabs.db_contract_set_id, CASE WHEN (slabs.min_shards = slabs.total_shards)
 THEN

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -495,7 +495,7 @@ func TestRenewedContract(t *testing.T) {
 	}
 
 	// no slabs should be unhealthy.
-	if err := cs.RecomputeHealth(context.Background()); err != nil {
+	if err := cs.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err := cs.UnhealthySlabs(context.Background(), 0.99, "test", 10)
@@ -534,7 +534,7 @@ func TestRenewedContract(t *testing.T) {
 	}
 
 	// slab should still be in good shape.
-	if err := cs.RecomputeHealth(context.Background()); err != nil {
+	if err := cs.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err = cs.UnhealthySlabs(context.Background(), 0.99, "test", 10)
@@ -1396,7 +1396,7 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := db.RecomputeHealth(context.Background()); err != nil {
+	if err := db.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1417,7 +1417,7 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatal("slabs are not returned in the correct order")
 	}
 
-	if err := db.RecomputeHealth(context.Background()); err != nil {
+	if err := db.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err = db.UnhealthySlabs(ctx, 0.49, testContractSet, -1)
@@ -1437,7 +1437,7 @@ func TestUnhealthySlabs(t *testing.T) {
 	}
 
 	// Fetch unhealthy slabs again but for different contract set.
-	if err := db.RecomputeHealth(context.Background()); err != nil {
+	if err := db.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err = db.UnhealthySlabs(ctx, 0.49, "foo", -1)
@@ -1505,7 +1505,7 @@ func TestUnhealthySlabsNegHealth(t *testing.T) {
 	}
 
 	// assert it's unhealthy
-	if err := db.RecomputeHealth(context.Background()); err != nil {
+	if err := db.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1569,7 +1569,7 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 	}
 
 	// assert it's healthy
-	if err := db.RecomputeHealth(context.Background()); err != nil {
+	if err := db.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1586,7 +1586,7 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 	}
 
 	// assert it's unhealthy
-	if err := db.RecomputeHealth(context.Background()); err != nil {
+	if err := db.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err = db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1672,7 +1672,7 @@ func TestUnhealthySlabsNoRedundancy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := db.RecomputeHealth(context.Background()); err != nil {
+	if err := db.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1881,7 +1881,7 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// fetch slabs for migration and assert there is only one
-	if err := db.RecomputeHealth(context.Background()); err != nil {
+	if err := db.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	toMigrate, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1940,7 +1940,7 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// fetch slabs for migration and assert there are none left
-	if err := db.RecomputeHealth(context.Background()); err != nil {
+	if err := db.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	toMigrate, err = db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -495,7 +495,7 @@ func TestRenewedContract(t *testing.T) {
 	}
 
 	// no slabs should be unhealthy.
-	if err := cs.UpdateHealth(); err != nil {
+	if err := cs.RecomputeHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err := cs.UnhealthySlabs(context.Background(), 0.99, "test", 10)
@@ -534,7 +534,7 @@ func TestRenewedContract(t *testing.T) {
 	}
 
 	// slab should still be in good shape.
-	if err := cs.UpdateHealth(); err != nil {
+	if err := cs.RecomputeHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err = cs.UnhealthySlabs(context.Background(), 0.99, "test", 10)
@@ -1396,7 +1396,7 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := db.UpdateHealth(); err != nil {
+	if err := db.RecomputeHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1417,7 +1417,7 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatal("slabs are not returned in the correct order")
 	}
 
-	if err := db.UpdateHealth(); err != nil {
+	if err := db.RecomputeHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err = db.UnhealthySlabs(ctx, 0.49, testContractSet, -1)
@@ -1437,7 +1437,7 @@ func TestUnhealthySlabs(t *testing.T) {
 	}
 
 	// Fetch unhealthy slabs again but for different contract set.
-	if err := db.UpdateHealth(); err != nil {
+	if err := db.RecomputeHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err = db.UnhealthySlabs(ctx, 0.49, "foo", -1)
@@ -1505,7 +1505,7 @@ func TestUnhealthySlabsNegHealth(t *testing.T) {
 	}
 
 	// assert it's unhealthy
-	if err := db.UpdateHealth(); err != nil {
+	if err := db.RecomputeHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1569,7 +1569,7 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 	}
 
 	// assert it's healthy
-	if err := db.UpdateHealth(); err != nil {
+	if err := db.RecomputeHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1586,7 +1586,7 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 	}
 
 	// assert it's unhealthy
-	if err := db.UpdateHealth(); err != nil {
+	if err := db.RecomputeHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err = db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1672,7 +1672,7 @@ func TestUnhealthySlabsNoRedundancy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := db.UpdateHealth(); err != nil {
+	if err := db.RecomputeHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1881,7 +1881,7 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// fetch slabs for migration and assert there is only one
-	if err := db.UpdateHealth(); err != nil {
+	if err := db.RecomputeHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	toMigrate, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
@@ -1940,7 +1940,7 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// fetch slabs for migration and assert there are none left
-	if err := db.UpdateHealth(); err != nil {
+	if err := db.RecomputeHealth(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	toMigrate, err = db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -960,6 +960,7 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	expectedObjSlab1 := dbSlab{
 		DBContractSetID: 1,
+		Health:          1,
 		Key:             obj1Slab0Key,
 		MinShards:       1,
 		TotalShards:     1,
@@ -996,6 +997,7 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	expectedObjSlab2 := dbSlab{
 		DBContractSetID: 1,
+		Health:          1,
 		Key:             obj1Slab1Key,
 		MinShards:       2,
 		TotalShards:     1,

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -495,6 +495,9 @@ func TestRenewedContract(t *testing.T) {
 	}
 
 	// no slabs should be unhealthy.
+	if err := cs.UpdateHealth(); err != nil {
+		t.Fatal(err)
+	}
 	slabs, err := cs.UnhealthySlabs(context.Background(), 0.99, "test", 10)
 	if err != nil {
 		t.Fatal(err)
@@ -531,6 +534,9 @@ func TestRenewedContract(t *testing.T) {
 	}
 
 	// slab should still be in good shape.
+	if err := cs.UpdateHealth(); err != nil {
+		t.Fatal(err)
+	}
 	slabs, err = cs.UnhealthySlabs(context.Background(), 0.99, "test", 10)
 	if err != nil {
 		t.Fatal(err)
@@ -1388,6 +1394,9 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if err := db.UpdateHealth(); err != nil {
+		t.Fatal(err)
+	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -1406,6 +1415,9 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatal("slabs are not returned in the correct order")
 	}
 
+	if err := db.UpdateHealth(); err != nil {
+		t.Fatal(err)
+	}
 	slabs, err = db.UnhealthySlabs(ctx, 0.49, testContractSet, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -1423,6 +1435,9 @@ func TestUnhealthySlabs(t *testing.T) {
 	}
 
 	// Fetch unhealthy slabs again but for different contract set.
+	if err := db.UpdateHealth(); err != nil {
+		t.Fatal(err)
+	}
 	slabs, err = db.UnhealthySlabs(ctx, 0.49, "foo", -1)
 	if err != nil {
 		t.Fatal(err)
@@ -1488,6 +1503,9 @@ func TestUnhealthySlabsNegHealth(t *testing.T) {
 	}
 
 	// assert it's unhealthy
+	if err := db.UpdateHealth(); err != nil {
+		t.Fatal(err)
+	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -1549,6 +1567,9 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 	}
 
 	// assert it's healthy
+	if err := db.UpdateHealth(); err != nil {
+		t.Fatal(err)
+	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -1563,6 +1584,9 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 	}
 
 	// assert it's unhealthy
+	if err := db.UpdateHealth(); err != nil {
+		t.Fatal(err)
+	}
 	slabs, err = db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -1646,6 +1670,9 @@ func TestUnhealthySlabsNoRedundancy(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if err := db.UpdateHealth(); err != nil {
+		t.Fatal(err)
+	}
 	slabs, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -1852,6 +1879,9 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// fetch slabs for migration and assert there is only one
+	if err := db.UpdateHealth(); err != nil {
+		t.Fatal(err)
+	}
 	toMigrate, err := db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -1908,6 +1938,9 @@ func TestPutSlab(t *testing.T) {
 	}
 
 	// fetch slabs for migration and assert there are none left
+	if err := db.UpdateHealth(); err != nil {
+		t.Fatal(err)
+	}
 	toMigrate, err = db.UnhealthySlabs(ctx, 0.99, testContractSet, -1)
 	if err != nil {
 		t.Fatal(err)

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -336,6 +336,6 @@ func performMigration00003_healthcache(txn *gorm.DB, logger glogger.Interface) e
 			return err
 		}
 	}
-	logger.Info(context.Background(), "migration 00002_healthcheck complete")
+	logger.Info(context.Background(), "migration 00003_healthcheck complete")
 	return nil
 }

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -142,6 +142,12 @@ func performMigrations(db *gorm.DB, logger glogger.Interface) error {
 			},
 			Rollback: nil,
 		},
+		{
+			ID: "00002_healthcache",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration00002_healthcache(tx, logger)
+			},
+		},
 	}
 
 	// Create migrator.
@@ -256,5 +262,14 @@ func performMigration00001_gormigrate(txn *gorm.DB, logger glogger.Interface) er
 			return err
 		}
 	}
+	return nil
+}
+
+func performMigration00002_healthcache(txn *gorm.DB, logger glogger.Interface) error {
+	logger.Info(context.Background(), "performing migration 00002_healthcheck")
+	if err := txn.Migrator().AddColumn(&dbSlab{}, "health"); err != nil {
+		return err
+	}
+	logger.Info(context.Background(), "migration 00002_healthcheck complete")
 	return nil
 }

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -266,9 +266,11 @@ func performMigration00001_gormigrate(txn *gorm.DB, logger glogger.Interface) er
 }
 
 func performMigration00002_healthcache(txn *gorm.DB, logger glogger.Interface) error {
-	logger.Info(context.Background(), "performing migration 00002_healthcheck")
-	if err := txn.Migrator().AddColumn(&dbSlab{}, "health"); err != nil {
-		return err
+	logger.Info(context.Background(), "performing migration 00002_healthcache")
+	if !txn.Migrator().HasColumn(&dbSlab{}, "health") {
+		if err := txn.Migrator().AddColumn(&dbSlab{}, "health"); err != nil {
+			return err
+		}
 	}
 	logger.Info(context.Background(), "migration 00002_healthcheck complete")
 	return nil


### PR DESCRIPTION
This PR adds a 'health' column to the slabs table which is periodically recomputed before migrations.

NOTE: tested on my node so far and updating the health of all 12k slabs takes around 4 seconds.