### PR TITLE
Allow for refreshing contracts with hosts that have a redundant IP subnet

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -87,14 +87,16 @@ type (
 	}
 
 	contractInfo struct {
-		contract api.Contract
-		settings rhpv2.HostSettings
-		usable   bool
+		contract    api.Contract
+		settings    rhpv2.HostSettings
+		recoverable bool
+		usable      bool
 	}
 
 	renewal struct {
 		from types.FileContractID
 		to   types.FileContractID
+		ci   contractInfo
 	}
 )
 
@@ -276,7 +278,9 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 		var toKeep []contractInfo
 		renewed, toKeep = c.runContractRenewals(ctx, w, toRenew, &remaining, uint64(limit))
 		for _, ri := range renewed {
-			updatedSet = append(updatedSet, ri.to)
+			if ri.ci.usable || ri.ci.recoverable {
+				updatedSet = append(updatedSet, ri.to)
+			}
 			contractData[ri.to] = contractData[ri.from]
 		}
 		for _, ci := range toKeep {
@@ -290,7 +294,9 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 		c.logger.Errorf("failed to refresh contracts, err: %v", err) // continue
 	} else {
 		for _, ri := range refreshed {
-			updatedSet = append(updatedSet, ri.to)
+			if ri.ci.usable || ri.ci.recoverable {
+				updatedSet = append(updatedSet, ri.to)
+			}
 			contractData[ri.to] = contractData[ri.from]
 		}
 	}
@@ -642,8 +648,9 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 			c.logger.Errorw(fmt.Sprintf("failed to compute renterFunds for contract: %v", err))
 		}
 
-		usable, refresh, renew, reasons := isUsableContract(state.cfg, ci, cs.BlockHeight, renterFunds, f)
+		usable, recoverable, refresh, renew, reasons := isUsableContract(state.cfg, ci, cs.BlockHeight, renterFunds, f)
 		ci.usable = usable
+		ci.recoverable = recoverable
 		if !usable {
 			toStopUsing[fcid] = strings.Join(reasons, ",")
 			c.logger.Infow(
@@ -807,7 +814,7 @@ func (c *contractor) runContractRenewals(ctx context.Context, w Worker, toRenew 
 
 		renewed, proceed, err := c.renewContract(ctx, w, ci, budget)
 		if err == nil {
-			renewals = append(renewals, renewal{from: ci.contract.ID, to: renewed.ID})
+			renewals = append(renewals, renewal{from: ci.contract.ID, to: renewed.ID, ci: ci})
 			nRenewed++
 		} else if ci.usable {
 			toKeep = append(toKeep, ci)
@@ -847,7 +854,7 @@ func (c *contractor) runContractRefreshes(ctx context.Context, w Worker, toRefre
 
 		renewed, proceed, err := c.refreshContract(ctx, w, ci, budget)
 		if err == nil {
-			refreshed = append(refreshed, renewal{from: ci.contract.ID, to: renewed.ID})
+			refreshed = append(refreshed, renewal{from: ci.contract.ID, to: renewed.ID, ci: ci})
 		}
 		if !proceed {
 			break

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -659,7 +659,7 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 			toRenew = append(toRenew, ci)
 		} else if refresh {
 			toRefresh = append(toRefresh, ci)
-		} else {
+		} else if usable {
 			toKeep = append(toKeep, ci.contract.ID)
 		}
 	}

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -216,29 +216,36 @@ func isUsableHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.
 	return len(errs) == 0, newUnusableHostResult(errs, gougingBreakdown, scoreBreakdown)
 }
 
-// isUsableContract returns whether the given contract is usable and whether it
-// can be renewed, along with a list of reasons why it was deemed unusable.
-func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, renterFunds types.Currency, f *ipFilter) (usable, refresh, renew bool, reasons []string) {
+// isUsableContract returns whether the given contract is
+// - usable -> can be used in the contract set
+// - recoverable -> can be usable in the contract set if it is refreshed/renewed
+// - refresh -> should be refreshed
+// - renew -> should be renewed
+func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, renterFunds types.Currency, f *ipFilter) (usable, recoverable, refresh, renew bool, reasons []string) {
 	c, s := ci.contract, ci.settings
 
 	if bh > c.EndHeight() {
 		reasons = append(reasons, errContractExpired.Error())
 		renew = false
 		refresh = false
+		recoverable = false
 	} else if c.Revision.RevisionNumber == math.MaxUint64 {
 		reasons = append(reasons, errContractMaxRevisionNumber.Error())
 		renew = false
 		refresh = false
+		recoverable = false
 	} else {
 		if isOutOfCollateral(c, s, renterFunds, bh) {
 			reasons = append(reasons, errContractOutOfCollateral.Error())
 			renew = false
 			refresh = true
+			recoverable = true
 		}
 		if isOutOfFunds(cfg, s, c) {
 			reasons = append(reasons, errContractOutOfFunds.Error())
 			renew = false
 			refresh = true
+			recoverable = true
 		}
 		if shouldRenew, secondHalf := isUpForRenewal(cfg, *c.Revision, bh); shouldRenew {
 			if secondHalf {
@@ -246,6 +253,7 @@ func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, rente
 			}
 			renew = true
 			refresh = false
+			recoverable = true
 		}
 	}
 
@@ -254,7 +262,9 @@ func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, rente
 	if !cfg.Hosts.AllowRedundantIPs && f.isRedundantIP(c.HostIP, c.HostKey) {
 		reasons = append(reasons, errHostRedundantIP.Error())
 		renew = false
-		// NOTE: we don't set refresh to false to continue funding accounts for download
+		// NOTE: we don't set refresh to false or recoverable to true. We fund
+		// the contract but don't want to use it in the set.
+		recoverable = false
 	}
 
 	usable = len(reasons) == 0

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -254,7 +254,7 @@ func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, rente
 	if !cfg.Hosts.AllowRedundantIPs && f.isRedundantIP(c.HostIP, c.HostKey) {
 		reasons = append(reasons, errHostRedundantIP.Error())
 		renew = false
-		refresh = false
+		// NOTE: we don't set refresh to false to continue funding accounts for download
 	}
 
 	usable = len(reasons) == 0


### PR DESCRIPTION
If we have a contract with a host that is on the same subnet as another one we want to migrate data away from it. We might not be able to do that if we stop refreshing the contract though since it might run out of funds while migrating the data.
So if a contract is meant to be refreshed but fails the redundant IP check, we still allow it to be refreshed. 