### PR TITLE
Add support for renaming objects in bus API

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -22,6 +22,9 @@ const (
 	ContractArchivalReasonRemoved    = "removed"
 	ContractArchivalReasonRenewed    = "renewed"
 
+	ObjectsRenameModeSingle = "single"
+	ObjectsRenameModeMulti  = "multi"
+
 	UsabilityFilterModeAll      = "all"
 	UsabilityFilterModeUsable   = "usable"
 	UsabilityFilterModeUnusable = "unusable"
@@ -124,6 +127,12 @@ type HostsRemoveRequest struct {
 type ObjectMetadata struct {
 	Name string `json:"name"`
 	Size int64  `json:"size"`
+}
+
+type ObjectsRenameRequest struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+	Mode string `json:"mode"`
 }
 
 // ObjectsStats is the response type for the /stats/objects endpoint.

--- a/bus/client.go
+++ b/bus/client.go
@@ -694,20 +694,19 @@ func (c *Client) ObjectsStats() (osr api.ObjectsStats, err error) {
 
 // RenameObject renames a single object.
 func (c *Client) RenameObject(ctx context.Context, from, to string) (err error) {
-	err = c.c.POST("/objects/rename", api.ObjectsRenameRequest{
-		From: from,
-		To:   to,
-		Mode: api.ObjectsRenameModeSingle,
-	}, nil)
-	return
+	return c.renameObjects(ctx, from, to, api.ObjectsRenameModeSingle)
 }
 
 // RenameObjects renames all objects with the prefix 'from' to the prefix 'to'.
 func (c *Client) RenameObjects(ctx context.Context, from, to string) (err error) {
+	return c.renameObjects(ctx, from, to, api.ObjectsRenameModeMulti)
+}
+
+func (c *Client) renameObjects(ctx context.Context, from, to, mode string) (err error) {
 	err = c.c.POST("/objects/rename", api.ObjectsRenameRequest{
 		From: from,
 		To:   to,
-		Mode: api.ObjectsRenameModeMulti,
+		Mode: mode,
 	}, nil)
 	return
 }

--- a/bus/client.go
+++ b/bus/client.go
@@ -692,6 +692,26 @@ func (c *Client) ObjectsStats() (osr api.ObjectsStats, err error) {
 	return
 }
 
+// RenameObject renames a single object.
+func (c *Client) RenameObject(ctx context.Context, from, to string) (err error) {
+	err = c.c.POST("/objects/rename", api.ObjectsRenameRequest{
+		From: from,
+		To:   to,
+		Mode: api.ObjectsRenameModeSingle,
+	}, nil)
+	return
+}
+
+// RenameObjects renames all objects with the prefix 'from' to the prefix 'to'.
+func (c *Client) RenameObjects(ctx context.Context, from, to string) (err error) {
+	err = c.c.POST("/objects/rename", api.ObjectsRenameRequest{
+		From: from,
+		To:   to,
+		Mode: api.ObjectsRenameModeMulti,
+	}, nil)
+	return
+}
+
 // NewClient returns a client that communicates with a renterd store server
 // listening on the specified address.
 func NewClient(addr, password string) *Client {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -634,6 +634,13 @@ func (s *SQLStore) SearchObjects(ctx context.Context, substring string, offset, 
 	return metadata, nil
 }
 
+func sqlConcat(db *gorm.DB, a, b string) string {
+	if isSQLite(db) {
+		return fmt.Sprintf("%s || %s", a, b)
+	}
+	return fmt.Sprintf("CONCAT(%s, %s)", a, b)
+}
+
 func (s *SQLStore) ObjectEntries(ctx context.Context, path, prefix string, offset, limit int) ([]api.ObjectMetadata, error) {
 	// sanity check we are passing a directory
 	if !strings.HasSuffix(path, "/") {
@@ -642,13 +649,6 @@ func (s *SQLStore) ObjectEntries(ctx context.Context, path, prefix string, offse
 
 	if limit <= -1 {
 		limit = math.MaxInt
-	}
-
-	concat := func(a, b string) string {
-		if isSQLite(s.db) {
-			return fmt.Sprintf("%s || %s", a, b)
-		}
-		return fmt.Sprintf("CONCAT(%s, %s)", a, b)
 	}
 
 	query := s.db.Raw(fmt.Sprintf(`
@@ -668,7 +668,7 @@ FROM (
 ) AS m
 GROUP BY name
 HAVING name LIKE ? AND name != ?
-LIMIT ? OFFSET ?`, concat("?", "trimmed"), concat("?", "substr(trimmed, 1, slashindex)")), path, path, utf8.RuneCountInString(path)+1, path+"%", fmt.Sprintf("%s%s", path, prefix+"%"), path, limit, offset)
+LIMIT ? OFFSET ?`, sqlConcat(s.db, "?", "trimmed"), sqlConcat(s.db, "?", "substr(trimmed, 1, slashindex)")), path, path, utf8.RuneCountInString(path)+1, path+"%", fmt.Sprintf("%s%s", path, prefix+"%"), path, limit, offset)
 
 	var metadata []api.ObjectMetadata
 	err := query.Scan(&metadata).Error
@@ -775,6 +775,29 @@ func fetchUsedContracts(tx *gorm.DB, usedContracts map[types.PublicKey]types.Fil
 		fetchedContracts[hostForFCID[types.FileContractID(c.FCID)]] = c
 	}
 	return fetchedContracts, nil
+}
+
+func (s *SQLStore) RenameObject(ctx context.Context, keyOld, keyNew string) error {
+	tx := s.db.Exec(`UPDATE objects SET object_id = ? WHERE object_id = ?`, keyNew, keyOld)
+	if tx.Error != nil {
+		return tx.Error
+	}
+	if tx.RowsAffected == 0 {
+		return fmt.Errorf("%w: key %v", api.ErrObjectNotFound, keyOld)
+	}
+	return nil
+}
+
+func (s *SQLStore) RenameObjects(ctx context.Context, prefixOld, prefixNew string) error {
+	tx := s.db.Exec("UPDATE objects SET object_id = "+sqlConcat(s.db, "?", "SUBSTR(object_id, ?)")+" WHERE object_id LIKE ?",
+		prefixNew, utf8.RuneCountInString(prefixOld)+1, prefixOld+"%")
+	if tx.Error != nil {
+		return tx.Error
+	}
+	if tx.RowsAffected == 0 {
+		return fmt.Errorf("%w: prefix %v", api.ErrObjectNotFound, prefixOld)
+	}
+	return nil
 }
 
 func (s *SQLStore) UpdateObject(ctx context.Context, path, contractSet string, o object.Object, partialSlab *object.PartialSlab, usedContracts map[types.PublicKey]types.FileContractID) error {


### PR DESCRIPTION
By popular demand this PR adds support for renaming objects atomically. 