### PR TITLE
Upload packing support

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -241,6 +241,7 @@ type ObjectsResponse struct {
 type AddObjectRequest struct {
 	ContractSet   string                                   `json:"contractSet"`
 	Object        object.Object                            `json:"object"`
+	PartialSlab   *object.PartialSlab                      `json:"partialSlab"`
 	UsedContracts map[types.PublicKey]types.FileContractID `json:"usedContracts"`
 }
 
@@ -252,10 +253,8 @@ type MigrationSlabsRequest struct {
 }
 
 type PackedSlab struct {
-	BufferID    uint   `json:"bufferID"`
-	MinShards   uint8  `json:"minShards"`
-	TotalShards uint8  `json:"totalShards"`
-	Data        []byte `json:"data"`
+	BufferID uint   `json:"bufferID"`
+	Data     []byte `json:"data"`
 }
 
 type UploadedPackedSlab struct {
@@ -314,10 +313,24 @@ type AccountsAddBalanceRequest struct {
 	Amount  *big.Int        `json:"amount"`
 }
 
+type PackedSlabsRequestGET struct {
+	LockingDuration time.Duration `json:"lockingDuration"`
+	MinShards       uint8         `json:"minShards"`
+	TotalShards     uint8         `json:"totalShards"`
+	ContractSet     string        `json:"contractSet"`
+	Limit           int           `json:"limit"`
+}
+
+type PackedSlabsRequestPOST struct {
+	Slabs         []UploadedPackedSlab                     `json:"slabs"`
+	UsedContracts map[types.PublicKey]types.FileContractID `json:"usedContracts"`
+}
+
 // UploadParams contains the metadata needed by a worker to upload an object.
 type UploadParams struct {
-	CurrentHeight uint64
-	ContractSet   string
+	CurrentHeight  uint64
+	ContractSet    string
+	PartialUploads bool
 	GougingParams
 }
 

--- a/api/bus.go
+++ b/api/bus.go
@@ -241,7 +241,6 @@ type ObjectsResponse struct {
 type AddObjectRequest struct {
 	ContractSet   string                                   `json:"contractSet"`
 	Object        object.Object                            `json:"object"`
-	PartialSlab   *object.PartialSlab                      `json:"partialSlab"`
 	UsedContracts map[types.PublicKey]types.FileContractID `json:"usedContracts"`
 }
 
@@ -314,7 +313,7 @@ type AccountsAddBalanceRequest struct {
 }
 
 type PackedSlabsRequestGET struct {
-	LockingDuration time.Duration `json:"lockingDuration"`
+	LockingDuration ParamDuration `json:"lockingDuration"`
 	MinShards       uint8         `json:"minShards"`
 	TotalShards     uint8         `json:"totalShards"`
 	ContractSet     string        `json:"contractSet"`

--- a/api/bus.go
+++ b/api/bus.go
@@ -34,7 +34,7 @@ const (
 	SettingContractSet   = "contractset"
 	SettingGouging       = "gouging"
 	SettingRedundancy    = "redundancy"
-	SettingPartialUpload = "partialupload"
+	SettingUploadPacking = "uploadpacking"
 )
 
 var (
@@ -328,9 +328,9 @@ type PackedSlabsRequestPOST struct {
 
 // UploadParams contains the metadata needed by a worker to upload an object.
 type UploadParams struct {
-	CurrentHeight  uint64
-	ContractSet    string
-	PartialUploads bool
+	CurrentHeight uint64
+	ContractSet   string
+	UploadPacking bool
 	GougingParams
 }
 
@@ -413,7 +413,7 @@ type SearchHostsRequest struct {
 	KeyIn           []types.PublicKey `json:"keyIn"`
 }
 
-type PartialUploadSettings struct {
+type UploadPackingSettings struct {
 	Enabled bool `json:"enabled"`
 }
 

--- a/api/bus.go
+++ b/api/bus.go
@@ -31,9 +31,10 @@ const (
 )
 
 const (
-	SettingContractSet = "contractset"
-	SettingGouging     = "gouging"
-	SettingRedundancy  = "redundancy"
+	SettingContractSet   = "contractset"
+	SettingGouging       = "gouging"
+	SettingRedundancy    = "redundancy"
+	SettingPartialUpload = "partialupload"
 )
 
 var (
@@ -410,6 +411,10 @@ type SearchHostsRequest struct {
 	UsabilityMode   string            `json:"usabilityMode"`
 	AddressContains string            `json:"addressContains"`
 	KeyIn           []types.PublicKey `json:"keyIn"`
+}
+
+type PartialUploadSettings struct {
+	Enabled bool `json:"enabled"`
 }
 
 // RedundancySettings contain settings that dictate an object's redundancy.

--- a/build/env.go
+++ b/build/env.go
@@ -35,6 +35,12 @@ var (
 		MinMaxEphemeralAccountBalance: types.Siacoins(1),                                   // 1 SC
 	}
 
+	// DefaultPartialUploadSettings define the default partial upload settings
+	// the bus is configured with on startup.
+	DefaultPartialUploadSettings = api.PartialUploadSettings{
+		Enabled: false,
+	}
+
 	// DefaultRedundancySettings define the default redundancy settings the bus
 	// is configured with on startup. These values can be adjusted using the
 	// settings API.

--- a/build/env.go
+++ b/build/env.go
@@ -35,9 +35,9 @@ var (
 		MinMaxEphemeralAccountBalance: types.Siacoins(1),                                   // 1 SC
 	}
 
-	// DefaultPartialUploadSettings define the default partial upload settings
+	// DefaultUploadPackingSettings define the default upload packing settings
 	// the bus is configured with on startup.
-	DefaultPartialUploadSettings = api.PartialUploadSettings{
+	DefaultUploadPackingSettings = api.UploadPackingSettings{
 		Enabled: false,
 	}
 

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1017,25 +1017,25 @@ func (b *bus) paramsHandlerUploadGET(jc jape.Context) {
 		return
 	}
 
-	var partialUploads bool
-	val, err = b.ss.Setting(jc.Request.Context(), api.SettingPartialUpload)
+	var uploadPacking bool
+	val, err = b.ss.Setting(jc.Request.Context(), api.SettingUploadPacking)
 	if err == nil {
-		var pus api.PartialUploadSettings
+		var pus api.UploadPackingSettings
 		if err := json.Unmarshal([]byte(val), &pus); err != nil {
 			b.logger.Panicf("failed to unmarshal contract set settings '%s': %v", val, err)
 			return
 		}
-		partialUploads = pus.Enabled
+		uploadPacking = pus.Enabled
 	} else if err != nil && !errors.Is(err, api.ErrSettingNotFound) {
 		jc.Error(fmt.Errorf("could not get contract set settings: %w", err), http.StatusInternalServerError)
 		return
 	}
 
 	jc.Encode(api.UploadParams{
-		ContractSet:    contractSet,
-		CurrentHeight:  b.cm.TipState(jc.Request.Context()).Index.Height,
-		GougingParams:  gp,
-		PartialUploads: partialUploads,
+		ContractSet:   contractSet,
+		CurrentHeight: b.cm.TipState(jc.Request.Context()).Index.Height,
+		GougingParams: gp,
+		UploadPacking: uploadPacking,
 	})
 }
 
@@ -1304,7 +1304,7 @@ func New(s Syncer, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, as
 	for key, value := range map[string]interface{}{
 		api.SettingGouging:       build.DefaultGougingSettings,
 		api.SettingRedundancy:    build.DefaultRedundancySettings,
-		api.SettingPartialUpload: build.DefaultPartialUploadSettings,
+		api.SettingUploadPacking: build.DefaultUploadPackingSettings,
 	} {
 		if _, err := b.ss.Setting(ctx, key); errors.Is(err, api.ErrSettingNotFound) {
 			if bytes, err := json.Marshal(value); err != nil {

--- a/bus/client.go
+++ b/bus/client.go
@@ -556,11 +556,12 @@ func (c *Client) Object(ctx context.Context, path, prefix string, offset, limit 
 }
 
 // AddObject stores the provided object under the given path.
-func (c *Client) AddObject(ctx context.Context, path, contractSet string, o object.Object, usedContract map[types.PublicKey]types.FileContractID) (err error) {
+func (c *Client) AddObject(ctx context.Context, path, contractSet string, o object.Object, ps *object.PartialSlab, usedContract map[types.PublicKey]types.FileContractID) (err error) {
 	path = strings.TrimPrefix(path, "/")
 	err = c.c.WithContext(ctx).PUT(fmt.Sprintf("/objects/%s", path), api.AddObjectRequest{
 		ContractSet:   contractSet,
 		Object:        o,
+		PartialSlab:   ps,
 		UsedContracts: usedContract,
 	})
 	return
@@ -683,6 +684,16 @@ func (c *Client) ResetDrift(ctx context.Context, id rhpv3.Account) (err error) {
 // contract with a given payout.
 func (c *Client) FileContractTax(ctx context.Context, payout types.Currency) (tax types.Currency, err error) {
 	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/consensus/siafundfee/%s", api.ParamCurrency(payout)), &tax)
+	return
+}
+
+func (c *Client) PackedSlabsForUpload(ctx context.Context, lockingDuration time.Duration, minShards, totalShards uint8, set string, limit int) (slabs []api.PackedSlab, err error) {
+	err = c.c.WithContext(ctx).GET("/packedslabs", &slabs)
+	return
+}
+
+func (c *Client) MarkPackedSlabsUploaded(ctx context.Context, slabs []api.UploadedPackedSlab, usedContracts map[types.PublicKey]types.FileContractID) (err error) {
+	err = c.c.WithContext(ctx).POST("/packedslabs", &slabs, nil)
 	return
 }
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -508,6 +508,11 @@ func (c *Client) GougingSettings(ctx context.Context) (gs api.GougingSettings, e
 	return
 }
 
+func (c *Client) UploadPackingSettings(ctx context.Context) (ups api.UploadPackingSettings, err error) {
+	err = c.Setting(ctx, api.SettingUploadPacking, &ups)
+	return
+}
+
 // RedundancySettings returns the redundancy settings.
 func (c *Client) RedundancySettings(ctx context.Context) (rs api.RedundancySettings, err error) {
 	err = c.Setting(ctx, api.SettingRedundancy, &rs)

--- a/bus/client.go
+++ b/bus/client.go
@@ -556,12 +556,11 @@ func (c *Client) Object(ctx context.Context, path, prefix string, offset, limit 
 }
 
 // AddObject stores the provided object under the given path.
-func (c *Client) AddObject(ctx context.Context, path, contractSet string, o object.Object, ps *object.PartialSlab, usedContract map[types.PublicKey]types.FileContractID) (err error) {
+func (c *Client) AddObject(ctx context.Context, path, contractSet string, o object.Object, usedContract map[types.PublicKey]types.FileContractID) (err error) {
 	path = strings.TrimPrefix(path, "/")
 	err = c.c.WithContext(ctx).PUT(fmt.Sprintf("/objects/%s", path), api.AddObjectRequest{
 		ContractSet:   contractSet,
 		Object:        o,
-		PartialSlab:   ps,
 		UsedContracts: usedContract,
 	})
 	return
@@ -688,12 +687,18 @@ func (c *Client) FileContractTax(ctx context.Context, payout types.Currency) (ta
 }
 
 func (c *Client) PackedSlabsForUpload(ctx context.Context, lockingDuration time.Duration, minShards, totalShards uint8, set string, limit int) (slabs []api.PackedSlab, err error) {
-	err = c.c.WithContext(ctx).GET("/packedslabs", &slabs)
+	err = c.c.WithContext(ctx).POST("/slabbuffer/fetch", api.PackedSlabsRequestGET{
+		LockingDuration: api.ParamDuration(lockingDuration),
+		MinShards:       minShards,
+		TotalShards:     totalShards,
+		ContractSet:     set,
+		Limit:           limit,
+	}, &slabs)
 	return
 }
 
 func (c *Client) MarkPackedSlabsUploaded(ctx context.Context, slabs []api.UploadedPackedSlab, usedContracts map[types.PublicKey]types.FileContractID) (err error) {
-	err = c.c.WithContext(ctx).POST("/packedslabs", &slabs, nil)
+	err = c.c.WithContext(ctx).POST("/slabbuffer/done", &slabs, nil)
 	return
 }
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -698,7 +698,10 @@ func (c *Client) PackedSlabsForUpload(ctx context.Context, lockingDuration time.
 }
 
 func (c *Client) MarkPackedSlabsUploaded(ctx context.Context, slabs []api.UploadedPackedSlab, usedContracts map[types.PublicKey]types.FileContractID) (err error) {
-	err = c.c.WithContext(ctx).POST("/slabbuffer/done", &slabs, nil)
+	err = c.c.WithContext(ctx).POST("/slabbuffer/done", api.PackedSlabsRequestPOST{
+		Slabs:         slabs,
+		UsedContracts: usedContracts,
+	}, nil)
 	return
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -248,7 +248,8 @@ func NewBus(cfg BusConfig, dir string, seed types.PrivateKey, l *zap.Logger) (ht
 
 	sqlLogger := stores.NewSQLLogger(l.Named("db"), cfg.DBLoggerConfig)
 	walletAddr := wallet.StandardAddress(seed.PublicKey())
-	sqlStore, ccid, err := stores.NewSQLStore(dbConn, true, cfg.PersistInterval, walletAddr, sqlLogger)
+	sqlStoreDir := filepath.Join(dir, "partial_slabs")
+	sqlStore, ccid, err := stores.NewSQLStore(dbConn, sqlStoreDir, true, cfg.PersistInterval, walletAddr, sqlLogger)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -703,7 +703,7 @@ func TestUploadDownloadExtended(t *testing.T) {
 	if info.TotalObjectsSize != objectsSize {
 		t.Error("wrong size", info.TotalObjectsSize, len(small)+len(large))
 	}
-	sectorsSize := 15 * rhpv2.SectorSize
+	sectorsSize := 3 * rhpv2.SectorSize
 	if info.TotalSectorsSize != uint64(sectorsSize) {
 		t.Error("wrong size", info.TotalSectorsSize, sectorsSize)
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -62,7 +62,7 @@ func TestNewTestCluster(t *testing.T) {
 				Length: 0,
 			},
 		},
-	}, nil, map[types.PublicKey]types.FileContractID{})
+	}, map[types.PublicKey]types.FileContractID{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -575,7 +575,7 @@ func TestUploadDownloadBasic(t *testing.T) {
 
 	// assert it matches
 	if !bytes.Equal(data, buffer.Bytes()) {
-		t.Fatal("unexpected")
+		t.Fatal("unexpected", len(data), buffer.Len())
 	}
 
 	// download again, 32 bytes at a time.

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -703,7 +703,7 @@ func TestUploadDownloadExtended(t *testing.T) {
 	if info.TotalObjectsSize != objectsSize {
 		t.Error("wrong size", info.TotalObjectsSize, len(small)+len(large))
 	}
-	sectorsSize := 3 * rhpv2.SectorSize
+	sectorsSize := 15 * rhpv2.SectorSize
 	if info.TotalSectorsSize != uint64(sectorsSize) {
 		t.Error("wrong size", info.TotalSectorsSize, sectorsSize)
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -62,7 +62,7 @@ func TestNewTestCluster(t *testing.T) {
 				Length: 0,
 			},
 		},
-	}, map[types.PublicKey]types.FileContractID{})
+	}, nil, map[types.PublicKey]types.FileContractID{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -556,7 +556,7 @@ func TestUploadDownloadBasic(t *testing.T) {
 	}
 
 	// prepare a file
-	data := make([]byte, 128) //rhpv2.SectorSize/12
+	data := make([]byte, 128)
 	if _, err := frand.Read(data); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -48,6 +48,15 @@ func TestNewTestCluster(t *testing.T) {
 	b := cluster.Bus
 	w := cluster.Worker
 
+	// Upload packing should be disabled by default.
+	ups, err := b.UploadPackingSettings(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ups.Enabled {
+		t.Fatalf("expected upload packing to be disabled by default, got %v", ups.Enabled)
+	}
+
 	// Try talking to the bus API by adding an object.
 	err = b.AddObject(context.Background(), "foo", testAutopilotConfig.Contracts.Set, object.Object{
 		Key: object.GenerateEncryptionKey(),
@@ -1703,5 +1712,142 @@ func TestWalletTransactions(t *testing.T) {
 		if txn.Timestamp.Unix() < medianTxnTimestamp.Unix() {
 			t.Fatal("expected only transactions after median timestamp", medianTxnTimestamp.Unix())
 		}
+	}
+}
+
+func TestUploadPacking(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// sanity check the default settings
+	if testAutopilotConfig.Contracts.Amount < uint64(testRedundancySettings.MinShards) {
+		t.Fatal("too few hosts to support the redundancy settings")
+	}
+
+	// create a test cluster
+	cluster, err := newTestCluster(t.TempDir(), newTestLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := cluster.Shutdown(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	b := cluster.Bus
+	w := cluster.Worker
+	rs := testRedundancySettings
+
+	// Enable upload packing.
+	err = b.UpdateSetting(context.Background(), api.SettingUploadPacking, api.UploadPackingSettings{
+		Enabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// add hosts
+	if _, err := cluster.AddHostsBlocking(rs.TotalShards); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for accounts to be funded
+	if _, err := cluster.WaitForAccounts(); err != nil {
+		t.Fatal(err)
+	}
+
+	// prepare 3 files which are all smaller than a slab but together make up
+	// for 2 full slabs.
+	slabSize := rhpv2.SectorSize * rs.MinShards
+	totalDataSize := 2 * slabSize
+	data1 := make([]byte, (totalDataSize-(slabSize-256))/2)
+	data2 := make([]byte, slabSize-256) // large partial slab
+	data3 := make([]byte, (totalDataSize-(slabSize-256))/2)
+	frand.Read(data1)
+	frand.Read(data2)
+	frand.Read(data3)
+
+	// declare helpers
+	download := func(name string, data []byte, offset, length uint64) {
+		t.Helper()
+		var buffer bytes.Buffer
+		if err := w.DownloadObject(context.Background(), &buffer, name,
+			api.DownloadWithRange(offset, length)); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(data[offset:offset+length], buffer.Bytes()) {
+			t.Fatal("unexpected", len(data), buffer.Len())
+		}
+	}
+	uploadDownload := func(name string, data []byte) {
+		t.Helper()
+		if err := w.UploadObject(context.Background(), bytes.NewReader(data), name); err != nil {
+			t.Fatal(err)
+		}
+		download(name, data, 0, uint64(len(data)))
+	}
+
+	// upload file 1 and download it.
+	uploadDownload("file1", data1)
+
+	// download it 32 bytes at a time.
+	for i := uint64(0); i < 4; i++ {
+		download("file1", data1, 32*i, 32)
+	}
+
+	// upload file 2 and download it.
+	uploadDownload("file2", data2)
+
+	// file 1 should still be available.
+	for i := uint64(0); i < 4; i++ {
+		download("file1", data1, 32*i, 32)
+	}
+
+	// upload file 3 and download it.
+	uploadDownload("file3", data3)
+
+	// file 1 should still be available.
+	for i := uint64(0); i < 4; i++ {
+		download("file1", data1, 32*i, 32)
+	}
+
+	// file 2 should still be available. Download each half separately.
+	download("file2", data2, 0, uint64(len(data2)))
+	download("file2", data2, 0, uint64(len(data2))/2)
+	download("file2", data2, uint64(len(data2))/2, uint64(len(data2))/2)
+
+	// download file 3 32 bytes at a time as well.
+	for i := uint64(0); i < 4; i++ {
+		download("file3", data3, 32*i, 32)
+	}
+
+	// upload 2 more files which are half a slab each to test filling up a slab
+	// exactly.
+	data4 := make([]byte, slabSize/2)
+	data5 := make([]byte, slabSize/2)
+	uploadDownload("file4", data4)
+	uploadDownload("file5", data5)
+	download("file4", data4, 0, uint64(len(data4)))
+
+	// check the object stats
+	os, err := b.ObjectsStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.NumObjects != 5 {
+		t.Fatal("expected 5 objects, got", os.NumObjects)
+	}
+	totalObjectSize := uint64(3 * slabSize)
+	totalRedundantSize := totalObjectSize * uint64(rs.TotalShards) / uint64(rs.MinShards)
+	if os.TotalObjectsSize != totalObjectSize {
+		t.Fatalf("expected totalObjectSize of %v, got %v", totalObjectSize, os.TotalObjectsSize)
+	}
+	if os.TotalSectorsSize != uint64(totalRedundantSize) {
+		t.Errorf("expected totalSectorSize of %v, got %v", totalRedundantSize, os.TotalSectorsSize)
+	}
+	if os.TotalUploadedSize != uint64(totalRedundantSize) {
+		t.Errorf("expected totalUploadedSize of %v, got %v", totalRedundantSize, os.TotalUploadedSize)
 	}
 }

--- a/object/object.go
+++ b/object/object.go
@@ -90,6 +90,9 @@ func (o Object) Size() int64 {
 	for _, ss := range o.Slabs {
 		n += int64(ss.Length)
 	}
+	if o.PartialSlab != nil {
+		n += int64(len(o.PartialSlab.Data))
+	}
 	return n
 }
 

--- a/object/object.go
+++ b/object/object.go
@@ -72,8 +72,9 @@ func GenerateEncryptionKey() EncryptionKey {
 
 // An Object is a unit of data that has been stored on a host.
 type Object struct {
-	Key   EncryptionKey `json:"key"`
-	Slabs []SlabSlice   `json:"slabs"`
+	Key         EncryptionKey `json:"key"`
+	Slabs       []SlabSlice   `json:"slabs"`
+	PartialSlab *PartialSlab  `json:"partial_slab,omitempty"`
 }
 
 // NewObject returns a new Object with a random key.

--- a/object/slab.go
+++ b/object/slab.go
@@ -32,6 +32,18 @@ type PartialSlab struct {
 	Data        []byte `json:"data"`
 }
 
+func (ps *PartialSlab) Encrypt(key EncryptionKey) [][]byte {
+	slab := Slab{
+		Key:       key,
+		MinShards: ps.MinShards,
+		Shards:    make([]Sector, ps.TotalShards),
+	}
+	encodedShards := make([][]byte, ps.TotalShards)
+	slab.Encode(ps.Data, encodedShards)
+	slab.Encrypt(encodedShards)
+	return encodedShards
+}
+
 // NewSlab returns a new slab for the shards.
 func NewSlab(minShards uint8) Slab {
 	return Slab{

--- a/stores/autopilot_test.go
+++ b/stores/autopilot_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAutopilotStore(t *testing.T) {
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/hostdb_test.go
+++ b/stores/hostdb_test.go
@@ -31,7 +31,8 @@ func (s *SQLStore) insertTestAnnouncement(hk types.PublicKey, a hostdb.Announcem
 // TestSQLHostDB tests the basic functionality of SQLHostDB using an in-memory
 // SQLite DB.
 func TestSQLHostDB(t *testing.T) {
-	hdb, dbName, ccid, err := newTestSQLStore()
+	dir := t.TempDir()
+	hdb, dbName, ccid, err := newTestSQLStore(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +147,7 @@ func TestSQLHostDB(t *testing.T) {
 
 	// Connect to the same DB again.
 	conn2 := NewEphemeralSQLiteConnection(dbName)
-	hdb2, ccid, err := NewSQLStore(conn2, false, time.Second, types.Address{}, nil)
+	hdb2, ccid, err := NewSQLStore(conn2, dir, false, time.Second, types.Address{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +162,7 @@ func TestSQLHostDB(t *testing.T) {
 
 // TestRecordInteractions is a test for RecordInteractions.
 func TestRecordInteractions(t *testing.T) {
-	hdb, _, _, err := newTestSQLStore()
+	hdb, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +292,7 @@ func (s *SQLStore) addTestScan(hk types.PublicKey, t time.Time, err error, setti
 
 // TestSQLHosts tests the Hosts method of the SQLHostDB type.
 func TestSQLHosts(t *testing.T) {
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -375,7 +376,7 @@ func TestSQLHosts(t *testing.T) {
 
 // TestSearchHosts is a unit test for SearchHosts.
 func TestSearchHosts(t *testing.T) {
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -411,7 +412,7 @@ func TestSearchHosts(t *testing.T) {
 
 // TestRecordScan is a test for recording scans.
 func TestRecordScan(t *testing.T) {
-	hdb, _, _, err := newTestSQLStore()
+	hdb, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -536,7 +537,7 @@ func TestRecordScan(t *testing.T) {
 }
 
 func TestRemoveHosts(t *testing.T) {
-	hdb, _, _, err := newTestSQLStore()
+	hdb, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -641,7 +642,7 @@ func TestRemoveHosts(t *testing.T) {
 
 // TestInsertAnnouncements is a test for insertAnnouncements.
 func TestInsertAnnouncements(t *testing.T) {
-	hdb, _, _, err := newTestSQLStore()
+	hdb, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -726,7 +727,7 @@ func TestInsertAnnouncements(t *testing.T) {
 }
 
 func TestSQLHostAllowlist(t *testing.T) {
-	hdb, _, _, err := newTestSQLStore()
+	hdb, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -900,7 +901,7 @@ func TestSQLHostAllowlist(t *testing.T) {
 }
 
 func TestSQLHostBlocklist(t *testing.T) {
-	hdb, _, _, err := newTestSQLStore()
+	hdb, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1147,7 +1148,7 @@ func TestSQLHostBlocklist(t *testing.T) {
 }
 
 func TestSQLHostBlocklistBasic(t *testing.T) {
-	hdb, _, _, err := newTestSQLStore()
+	hdb, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -101,7 +101,6 @@ type (
 		Shards []dbSector `gorm:"constraint:OnDelete:CASCADE"` // CASCADE to delete shards too
 	}
 
-	// TODO: add a hook that deletes a buffer if the slab is deleted
 	dbSlabBuffer struct {
 		Model
 		DBSlab dbSlab

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1245,7 +1245,7 @@ func (s *SQLStore) object(ctx context.Context, txn *gorm.DB, path string) (rawOb
 		Joins("LEFT JOIN sectors sec ON sla.id = sec.`db_slab_id`").
 		Joins("LEFT JOIN buffered_slabs bs ON sla.db_slab_buffer_id = bs.`id`").
 		Where("o.object_id = ?", path).
-		Order("		sli.id ASC").
+		Order("sli.id ASC").
 		Order("sec.id ASC").
 		Scan(&rows)
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1307,8 +1307,9 @@ func (s *SQLStore) packedSlabsForUpload(lockingDuration time.Duration, minShards
 				INNER JOIN slabs sla ON sla.db_buffered_slab_id = buffered_slabs.id
 				INNER JOIN contract_sets cs ON cs.id = sla.db_contract_set_id
 				WHERE complete = ? AND locked_until < ? AND min_shards = ? AND total_shards = ? AND cs.name = ?
-				LIMIT ?)
-			)`,
+				LIMIT ?
+			) AS buffer_ids
+		)`,
 		now+int64(lockingDuration.Seconds()), lockID, true, now, minShards, totalShards, set, limit).
 		Error
 	if err != nil {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -322,7 +322,7 @@ func (raw rawObject) convert(tx *gorm.DB) (obj object.Object, _ error) {
 	if partialSlabSector != nil {
 		var buffer dbBufferedSlab
 		err := tx.Joins("DBSlab").
-			Where("DBSlab__ID", partialSlabSector.SlabID).
+			Where("DBSlab.id", partialSlabSector.SlabID).
 			Take(&buffer).Error
 		if err != nil {
 			return object.Object{}, err

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1567,6 +1567,9 @@ func deleteObject(tx *gorm.DB, path string) (numDeleted int64, _ error) {
 		return 0, tx.Error
 	}
 	numDeleted = tx.RowsAffected
+	if numDeleted == 0 {
+		return 0, nil // nothing to prune if no object was deleted
+	}
 	if err := pruneSlabs(tx); err != nil {
 		return 0, err
 	}

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1139,7 +1139,7 @@ func createSlabBuffer(tx *gorm.DB, objectID, contractSetID uint, partialSlab obj
 	}
 	// Create a new buffer and slab.
 	identifier := frand.Entropy256()
-	fileName := hex.EncodeToString(identifier[:])
+	fileName := fmt.Sprintf("%v:%v-%v", partialSlab.MinShards, partialSlab.TotalShards, hex.EncodeToString(identifier[:]))
 	file, err := os.Create(filepath.Join(partialSlabDir, fileName))
 	if err != nil {
 		return err

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1245,9 +1245,7 @@ func (s *SQLStore) object(ctx context.Context, txn *gorm.DB, path string) (rawOb
 		Joins("LEFT JOIN sectors sec ON sla.id = sec.`db_slab_id`").
 		Joins("LEFT JOIN buffered_slabs bs ON sla.db_slab_buffer_id = bs.`id`").
 		Where("o.object_id = ?", path).
-		Order("o.id ASC").
-		Order("sla.id ASC").
-		Order("sli.offset ASC").
+		Order("		sli.id ASC").
 		Order("sec.id ASC").
 		Scan(&rows)
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1363,7 +1363,7 @@ func (s *SQLStore) object(ctx context.Context, txn *gorm.DB, path string) (rawOb
 	// accordingly
 	var rows rawObject
 	tx := s.db.
-		Select("o.key as ObjectKey, o.object_id as ObjectName, o.size as ObjectSize, sli.id as SliceID, sli.offset as SliceOffset, sli.length as SliceLength, sla.id as SlabID, sla.health as SlabHealth, sla.key as SlabKey, sla.min_shards as SlabMinShards, bs.id IS NOT NULL AS SlabBuffered sec.id as SectorID, sec.root as SectorRoot, sec.latest_host as SectorHost").
+		Select("o.key as ObjectKey, o.object_id as ObjectName, o.size as ObjectSize, sli.id as SliceID, sli.offset as SliceOffset, sli.length as SliceLength, sla.id as SlabID, sla.health as SlabHealth, sla.key as SlabKey, sla.min_shards as SlabMinShards, bs.id IS NOT NULL AS SlabBuffered, sec.id as SectorID, sec.root as SectorRoot, sec.latest_host as SectorHost").
 		Model(&dbObject{}).
 		Table("objects o").
 		Joins("LEFT JOIN slices sli ON o.id = sli.`db_object_id`").

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -91,7 +91,7 @@ func TestObjectBasic(t *testing.T) {
 	}
 
 	// add the object
-	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want, nil, map[types.PublicKey]types.FileContractID{
+	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
 	}); err != nil {
@@ -130,7 +130,7 @@ func TestObjectBasic(t *testing.T) {
 	}
 
 	// add the object
-	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want2, nil, make(map[types.PublicKey]types.FileContractID)); err != nil {
+	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want2, make(map[types.PublicKey]types.FileContractID)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -487,7 +487,7 @@ func TestRenewedContract(t *testing.T) {
 	}
 
 	// add the object.
-	if err := cs.UpdateObject(context.Background(), "foo", testContractSet, obj, nil, map[types.PublicKey]types.FileContractID{
+	if err := cs.UpdateObject(context.Background(), "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk:  fcid1,
 		hk2: fcid2,
 	}); err != nil {
@@ -899,12 +899,12 @@ func TestSQLMetadataStore(t *testing.T) {
 	// Store it.
 	ctx := context.Background()
 	objID := "key1"
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, nil, usedHosts); err != nil {
+	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts); err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to store it again. Should work.
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, nil, usedHosts); err != nil {
+	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1063,7 +1063,7 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	// Remove the first slab of the object.
 	obj1.Slabs = obj1.Slabs[1:]
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, nil, usedHosts); err != nil {
+	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts); err != nil {
 		t.Fatal(err)
 	}
 	fullObj, err = db.Object(ctx, objID)
@@ -1141,7 +1141,7 @@ func TestObjectEntries(t *testing.T) {
 		obj, ucs := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		os.UpdateObject(ctx, o.path, testContractSet, obj, nil, ucs)
+		os.UpdateObject(ctx, o.path, testContractSet, obj, ucs)
 	}
 	tests := []struct {
 		path   string
@@ -1200,7 +1200,7 @@ func TestSearchObjects(t *testing.T) {
 		obj, ucs := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		os.UpdateObject(ctx, o.path, testContractSet, obj, nil, ucs)
+		os.UpdateObject(ctx, o.path, testContractSet, obj, ucs)
 	}
 	tests := []struct {
 		path string
@@ -1393,7 +1393,7 @@ func TestUnhealthySlabs(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, nil, map[types.PublicKey]types.FileContractID{
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
 		hk3: fcid3,
@@ -1498,7 +1498,7 @@ func TestUnhealthySlabsNegHealth(t *testing.T) {
 
 	// add the object
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, nil, map[types.PublicKey]types.FileContractID{hk1: fcid1}); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1559,7 +1559,7 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 
 	// add the object
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, nil, map[types.PublicKey]types.FileContractID{hk1: fcid1}); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1653,7 +1653,7 @@ func TestUnhealthySlabsNoRedundancy(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, nil, map[types.PublicKey]types.FileContractID{
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
 		hk3: fcid3,
@@ -1723,7 +1723,7 @@ func TestContractSectors(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, nil, usedContracts); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1749,7 +1749,7 @@ func TestContractSectors(t *testing.T) {
 	}
 
 	// Add the object again.
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, nil, usedContracts); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1814,7 +1814,7 @@ func TestPutSlab(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, nil, map[types.PublicKey]types.FileContractID{
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
 	}); err != nil {
@@ -2069,7 +2069,7 @@ func TestRenameObjects(t *testing.T) {
 	ctx := context.Background()
 	for _, path := range objects {
 		obj, ucs := newTestObject(1)
-		cs.UpdateObject(ctx, path, testContractSet, obj, nil, ucs)
+		cs.UpdateObject(ctx, path, testContractSet, obj, ucs)
 	}
 
 	// Try renaming objects that don't exist.
@@ -2165,7 +2165,7 @@ func TestObjectsStats(t *testing.T) {
 		}
 
 		key := hex.EncodeToString(frand.Bytes(32))
-		err := cs.UpdateObject(context.Background(), key, testContractSet, obj, nil, contracts)
+		err := cs.UpdateObject(context.Background(), key, testContractSet, obj, contracts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2262,13 +2262,13 @@ func TestPartialSlab(t *testing.T) {
 				Length: rhpv2.SectorSize,
 			},
 		},
+		PartialSlab: &object.PartialSlab{
+			MinShards:   1,
+			TotalShards: 2,
+			Data:        []byte{1, 2, 3, 4},
+		},
 	}
-	partialSlab := object.PartialSlab{
-		MinShards:   1,
-		TotalShards: 2,
-		Data:        []byte{1, 2, 3, 4},
-	}
-	err = db.UpdateObject(context.Background(), "key", testContractSet, obj, &partialSlab, usedContracts)
+	err = db.UpdateObject(context.Background(), "key", testContractSet, obj, usedContracts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2283,7 +2283,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 	// check the slice
 	storedSlice := storedObject.Slabs[1]
-	if storedSlice.Offset != 0 || storedSlice.Length != uint32(len(partialSlab.Data)) {
+	if storedSlice.Offset != 0 || storedSlice.Length != uint32(len(obj.PartialSlab.Data)) {
 		t.Fatalf("wrong offset/length: %v/%v", storedSlice.Offset, storedSlice.Length)
 	}
 	// check the slab
@@ -2300,22 +2300,39 @@ func TestPartialSlab(t *testing.T) {
 	expectedBuffer := dbSlabBuffer{
 		DBSlabID:    storedSlab.ID,
 		Complete:    false,
-		Data:        partialSlab.Data,
+		Data:        obj.PartialSlab.Data,
 		LockedUntil: 0,
 	}
 	if !reflect.DeepEqual(buffer, expectedBuffer) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer, expectedBuffer))
 	}
 
+	// fetch the object. This should fetch the partial slab too.
+	fullObj, err := db.Object(context.Background(), "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fullObj.Slabs) != 1 {
+		t.Fatalf("expected 1 slab, got %v", len(fullObj.Slabs))
+	}
+	if fullObj.PartialSlab == nil {
+		t.Fatal("expected partial slab")
+	}
+	if !reflect.DeepEqual(*fullObj.PartialSlab, *obj.PartialSlab) {
+		t.Fatal("invalid partial slab", cmp.Diff(fullObj.PartialSlab, obj.PartialSlab))
+	}
+
 	// add another object with a partial slab. This should append to the buffer.
 	fullSlabSize := slabSize(1, 2)
-	obj2 := object.Object{Key: object.GenerateEncryptionKey()}
-	partialSlab2 := object.PartialSlab{
-		MinShards:   1,
-		TotalShards: 2,
-		Data:        frand.Bytes(int(fullSlabSize) - len(partialSlab.Data) - 1), // leave 1 byte
+	obj2 := object.Object{
+		Key: object.GenerateEncryptionKey(),
+		PartialSlab: &object.PartialSlab{
+			MinShards:   1,
+			TotalShards: 2,
+			Data:        frand.Bytes(int(fullSlabSize) - len(obj.PartialSlab.Data) - 1), // leave 1 byte
+		},
 	}
-	err = db.UpdateObject(context.Background(), "key2", testContractSet, obj2, &partialSlab2, usedContracts)
+	err = db.UpdateObject(context.Background(), "key2", testContractSet, obj2, usedContracts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2328,7 +2345,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 	// check the slice
 	storedSlice2 := storedObject2.Slabs[0]
-	if storedSlice2.Offset != storedSlice.Length || storedSlice2.Length != uint32(len(partialSlab2.Data)) {
+	if storedSlice2.Offset != storedSlice.Length || storedSlice2.Length != uint32(len(obj2.PartialSlab.Data)) {
 		t.Fatalf("wrong offset/length: %v/%v", storedSlice2.Offset, storedSlice2.Length)
 	}
 	// check the slab
@@ -2341,19 +2358,21 @@ func TestPartialSlab(t *testing.T) {
 		t.Fatal(err)
 	}
 	buffer.Model = Model{}
-	expectedBuffer.Data = append(expectedBuffer.Data, partialSlab2.Data...)
+	expectedBuffer.Data = append(expectedBuffer.Data, obj2.PartialSlab.Data...)
 	if !reflect.DeepEqual(buffer, expectedBuffer) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer, expectedBuffer))
 	}
 
 	// add one last object. This should fill the buffer and create a new slab.
-	obj3 := object.Object{Key: object.GenerateEncryptionKey()}
-	partialSlab3 := object.PartialSlab{
-		MinShards:   1,
-		TotalShards: 2,
-		Data:        []byte{5, 6}, // 1 byte more than fits in the slab
+	obj3 := object.Object{
+		Key: object.GenerateEncryptionKey(),
+		PartialSlab: &object.PartialSlab{
+			MinShards:   1,
+			TotalShards: 2,
+			Data:        []byte{5, 6}, // 1 byte more than fits in the slab
+		},
 	}
-	err = db.UpdateObject(context.Background(), "key3", testContractSet, obj3, &partialSlab3, usedContracts)
+	err = db.UpdateObject(context.Background(), "key3", testContractSet, obj3, usedContracts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2383,7 +2402,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 	buffer.Model = Model{}
 	expectedBuffer.Complete = true // full now
-	expectedBuffer.Data = append(expectedBuffer.Data, partialSlab3.Data[0])
+	expectedBuffer.Data = append(expectedBuffer.Data, obj3.PartialSlab.Data[0])
 	if !reflect.DeepEqual(buffer, expectedBuffer) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer, expectedBuffer))
 	}
@@ -2397,7 +2416,7 @@ func TestPartialSlab(t *testing.T) {
 	expectedBuffer2 := dbSlabBuffer{
 		DBSlabID:    storedSlab.ID + 1,
 		Complete:    false,
-		Data:        partialSlab3.Data[1:],
+		Data:        obj3.PartialSlab.Data[1:],
 		LockedUntil: 0,
 	}
 	if !reflect.DeepEqual(buffer2, expectedBuffer2) {
@@ -2406,7 +2425,7 @@ func TestPartialSlab(t *testing.T) {
 
 	// fetch the buffer for uploading
 	now := time.Now().Unix()
-	buffers, err := db.packedSlabsForUpload(time.Hour, partialSlab.MinShards, partialSlab.TotalShards, testContractSet, 100)
+	buffers, err := db.packedSlabsForUpload(time.Hour, obj.PartialSlab.MinShards, obj.PartialSlab.TotalShards, testContractSet, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2425,7 +2444,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 
 	// try fetching it again. Should still be locked.
-	buffers, err = db.packedSlabsForUpload(time.Hour, partialSlab.MinShards, partialSlab.TotalShards, testContractSet, 100)
+	buffers, err = db.packedSlabsForUpload(time.Hour, obj.PartialSlab.MinShards, obj.PartialSlab.TotalShards, testContractSet, 100)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2323,7 +2323,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 
 	// add another object with a partial slab. This should append to the buffer.
-	fullSlabSize := slabSize(1, 2)
+	fullSlabSize := bufferedSlabSize(1)
 	obj2 := object.Object{
 		Key: object.GenerateEncryptionKey(),
 		PartialSlab: &object.PartialSlab{

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2293,12 +2293,12 @@ func TestPartialSlab(t *testing.T) {
 	}
 	// check the buffer
 	var buffer dbSlabBuffer
-	if err := db.db.Take(&buffer, "db_slab_id = ?", storedSlab.ID).Error; err != nil {
+	if err := db.db.Take(&buffer, "id = ?", storedSlab.DBSlabBufferID).Error; err != nil {
 		t.Fatal(err)
 	}
 	buffer.Model = Model{}
 	expectedBuffer := dbSlabBuffer{
-		DBSlabID:    storedSlab.ID,
+		DBSlab:      dbSlab{},
 		Complete:    false,
 		Data:        obj.PartialSlab.Data,
 		LockedUntil: 0,
@@ -2354,11 +2354,12 @@ func TestPartialSlab(t *testing.T) {
 		t.Fatal(err)
 	}
 	// check the buffer
-	if err := db.db.Take(&buffer, "db_slab_id = ?", storedSlab.ID).Error; err != nil {
+	if err := db.db.Joins("DBSlab").Take(&buffer, "DBSlab.ID = ?", storedSlab.ID).Error; err != nil {
 		t.Fatal(err)
 	}
 	buffer.Model = Model{}
 	expectedBuffer.Data = append(expectedBuffer.Data, obj2.PartialSlab.Data...)
+	buffer.DBSlab = dbSlab{} // exclude from comparison
 	if !reflect.DeepEqual(buffer, expectedBuffer) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer, expectedBuffer))
 	}
@@ -2397,28 +2398,29 @@ func TestPartialSlab(t *testing.T) {
 		t.Fatal(err)
 	}
 	// check the buffer
-	if err := db.db.Take(&buffer, "db_slab_id = ?", storedSlab.ID).Error; err != nil {
+	if err := db.db.Joins("DBSlab").Take(&buffer, "DBSlab.ID = ?", storedSlab.ID).Error; err != nil {
 		t.Fatal(err)
 	}
 	buffer.Model = Model{}
 	expectedBuffer.Complete = true // full now
 	expectedBuffer.Data = append(expectedBuffer.Data, obj3.PartialSlab.Data[0])
+	buffer.DBSlab = dbSlab{} // exclude from comparison
 	if !reflect.DeepEqual(buffer, expectedBuffer) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer, expectedBuffer))
 	}
 
 	// check the new buffer
 	var buffer2 dbSlabBuffer
-	if err := db.db.Take(&buffer2, "db_slab_id = ?", storedSlab.ID+1).Error; err != nil {
+	if err := db.db.Joins("DBSlab").Take(&buffer2, "DBSlab.ID = ?", storedSlab.ID+1).Error; err != nil {
 		t.Fatal(err)
 	}
 	buffer2.Model = Model{}
 	expectedBuffer2 := dbSlabBuffer{
-		DBSlabID:    storedSlab.ID + 1,
 		Complete:    false,
 		Data:        obj3.PartialSlab.Data[1:],
 		LockedUntil: 0,
 	}
+	buffer2.DBSlab = dbSlab{} // exclude from comparison
 	if !reflect.DeepEqual(buffer2, expectedBuffer2) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer2, expectedBuffer2))
 	}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2339,7 +2339,8 @@ func TestPartialSlab(t *testing.T) {
 	expectedBuffer := dbBufferedSlab{
 		DBSlab:      dbSlab{},
 		Complete:    false,
-		Data:        obj.PartialSlab.Data,
+		Path:        fmt.Sprintf("buffer-%v", storedSlab.Key),
+		Size:        4,
 		LockedUntil: 0,
 	}
 	if !reflect.DeepEqual(buffer, expectedBuffer) {
@@ -2397,7 +2398,8 @@ func TestPartialSlab(t *testing.T) {
 		t.Fatal(err)
 	}
 	buffer.Model = Model{}
-	expectedBuffer.Data = append(expectedBuffer.Data, obj2.PartialSlab.Data...)
+	//expectedBuffer.Data = append(expectedBuffer.Data, obj2.PartialSlab.Data...)
+	expectedBuffer.Size = 4194303
 	buffer.DBSlab = dbSlab{} // exclude from comparison
 	if !reflect.DeepEqual(buffer, expectedBuffer) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer, expectedBuffer))
@@ -2442,7 +2444,8 @@ func TestPartialSlab(t *testing.T) {
 	}
 	buffer.Model = Model{}
 	expectedBuffer.Complete = true // full now
-	expectedBuffer.Data = append(expectedBuffer.Data, obj3.PartialSlab.Data[0])
+	//expectedBuffer.Data = append(expectedBuffer.Data, obj3.PartialSlab.Data[0])
+	expectedBuffer.Size = 4194304
 	buffer.DBSlab = dbSlab{} // exclude from comparison
 	if !reflect.DeepEqual(buffer, expectedBuffer) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer, expectedBuffer))
@@ -2456,10 +2459,11 @@ func TestPartialSlab(t *testing.T) {
 	buffer2.Model = Model{}
 	expectedBuffer2 := dbBufferedSlab{
 		Complete:    false,
-		Data:        obj3.PartialSlab.Data[1:],
+		Size:        1,
 		LockedUntil: 0,
 	}
 	buffer2.DBSlab = dbSlab{} // exclude from comparison
+	buffer2.Path = ""         // don't check path
 	if !reflect.DeepEqual(buffer2, expectedBuffer2) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer2, expectedBuffer2))
 	}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2302,8 +2302,6 @@ func TestPartialSlab(t *testing.T) {
 		Complete:    false,
 		Data:        partialSlab.Data,
 		LockedUntil: 0,
-		MinShards:   partialSlab.MinShards,
-		TotalShards: partialSlab.TotalShards,
 	}
 	if !reflect.DeepEqual(buffer, expectedBuffer) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer, expectedBuffer))
@@ -2401,8 +2399,6 @@ func TestPartialSlab(t *testing.T) {
 		Complete:    false,
 		Data:        partialSlab3.Data[1:],
 		LockedUntil: 0,
-		MinShards:   partialSlab.MinShards,
-		TotalShards: partialSlab.TotalShards,
 	}
 	if !reflect.DeepEqual(buffer2, expectedBuffer2) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer2, expectedBuffer2))
@@ -2410,7 +2406,7 @@ func TestPartialSlab(t *testing.T) {
 
 	// fetch the buffer for uploading
 	now := time.Now().Unix()
-	buffers, err := db.packedSlabsForUpload(time.Hour, 100)
+	buffers, err := db.packedSlabsForUpload(time.Hour, partialSlab.MinShards, partialSlab.TotalShards, testContractSet, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2429,7 +2425,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 
 	// try fetching it again. Should still be locked.
-	buffers, err = db.packedSlabsForUpload(time.Hour, 100)
+	buffers, err = db.packedSlabsForUpload(time.Hour, partialSlab.MinShards, partialSlab.TotalShards, testContractSet, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2452,7 +2448,7 @@ func TestPartialSlab(t *testing.T) {
 			},
 		},
 	}
-	err = db.MarkPackedSlabsUploaded([]api.UploadedPackedSlab{packedSlab}, usedContracts)
+	err = db.MarkPackedSlabsUploaded(context.Background(), []api.UploadedPackedSlab{packedSlab}, usedContracts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -36,7 +36,7 @@ func generateMultisigUC(m, n uint64, salt string) types.UnlockConditions {
 // TestObjectBasic tests the hydration of raw objects works when we fetch
 // objects from the metadata store.
 func TestObjectBasic(t *testing.T) {
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +148,7 @@ func TestObjectBasic(t *testing.T) {
 
 // TestSQLContractStore tests SQLContractStore functionality.
 func TestSQLContractStore(t *testing.T) {
-	cs, _, _, err := newTestSQLStore()
+	cs, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -350,7 +350,7 @@ func TestSQLContractStore(t *testing.T) {
 
 func TestContractsForHost(t *testing.T) {
 	// create a SQL store
-	cs, _, _, err := newTestSQLStore()
+	cs, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestContractsForHost(t *testing.T) {
 
 // TestRenewContract is a test for AddRenewedContract.
 func TestRenewedContract(t *testing.T) {
-	cs, _, _, err := newTestSQLStore()
+	cs, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -654,7 +654,7 @@ func TestRenewedContract(t *testing.T) {
 // TestAncestorsContracts verifies that AncestorContracts returns the right
 // ancestors in the correct order.
 func TestAncestorsContracts(t *testing.T) {
-	cs, _, _, err := newTestSQLStore()
+	cs, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -701,7 +701,7 @@ func TestAncestorsContracts(t *testing.T) {
 }
 
 func TestArchiveContracts(t *testing.T) {
-	cs, _, _, err := newTestSQLStore()
+	cs, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -840,7 +840,7 @@ func testContractRevision(fcid types.FileContractID, hk types.PublicKey) rhpv2.C
 
 // TestSQLMetadataStore tests basic MetadataStore functionality.
 func TestSQLMetadataStore(t *testing.T) {
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1133,7 +1133,7 @@ func TestSQLMetadataStore(t *testing.T) {
 
 // TestObjectEntries is a test for the ObjectEntries method.
 func TestObjectEntries(t *testing.T) {
-	os, _, _, err := newTestSQLStore()
+	os, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1193,7 +1193,7 @@ func TestObjectEntries(t *testing.T) {
 
 // TestSearchObjects is a test for the SearchObjects method.
 func TestSearchObjects(t *testing.T) {
-	os, _, _, err := newTestSQLStore()
+	os, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1246,7 +1246,7 @@ func TestSearchObjects(t *testing.T) {
 // TestUnhealthySlabs tests the functionality of UnhealthySlabs.
 func TestUnhealthySlabs(t *testing.T) {
 	// create db
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1470,7 +1470,7 @@ func TestUnhealthySlabs(t *testing.T) {
 
 func TestUnhealthySlabsNegHealth(t *testing.T) {
 	// create db
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1538,7 +1538,7 @@ func TestUnhealthySlabsNegHealth(t *testing.T) {
 
 func TestUnhealthySlabsNoContracts(t *testing.T) {
 	// create db
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1620,7 +1620,7 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 // TestUnhealthySlabs tests the functionality of UnhealthySlabs on slabs that
 // don't have any redundancy.
 func TestUnhealthySlabsNoRedundancy(t *testing.T) {
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1713,7 +1713,7 @@ func TestUnhealthySlabsNoRedundancy(t *testing.T) {
 // TestContractSectors is a test for the contract_sectors join table. It
 // verifies that deleting contracts or sectors also cleans up the join table.
 func TestContractSectors(t *testing.T) {
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1805,7 +1805,7 @@ func TestContractSectors(t *testing.T) {
 
 // TestPutSlab verifies the functionality of PutSlab.
 func TestPutSlab(t *testing.T) {
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2011,7 +2011,7 @@ func newTestObject(slabs int) (object.Object, map[types.PublicKey]types.FileCont
 
 // TestRecordContractSpending tests RecordContractSpending.
 func TestRecordContractSpending(t *testing.T) {
-	cs, _, _, err := newTestSQLStore()
+	cs, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2088,7 +2088,7 @@ func TestRecordContractSpending(t *testing.T) {
 
 // TestRenameObjects is a unit test for RenameObject and RenameObjects.
 func TestRenameObjects(t *testing.T) {
-	cs, _, _, err := newTestSQLStore()
+	cs, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2169,7 +2169,7 @@ func TestRenameObjects(t *testing.T) {
 
 // TestObjectsStats is a unit test for ObjectsStats.
 func TestObjectsStats(t *testing.T) {
-	cs, _, _, err := newTestSQLStore()
+	cs, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2255,7 +2255,7 @@ func TestObjectsStats(t *testing.T) {
 }
 
 func TestPartialSlab(t *testing.T) {
-	db, _, _, err := newTestSQLStore()
+	db, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2335,11 +2335,14 @@ func TestPartialSlab(t *testing.T) {
 	if err := db.db.Take(&buffer, "id = ?", storedSlab.DBBufferedSlabID).Error; err != nil {
 		t.Fatal(err)
 	}
+	if buffer.Filename == "" {
+		t.Fatal("empty filename")
+	}
 	buffer.Model = Model{}
 	expectedBuffer := dbBufferedSlab{
 		DBSlab:      dbSlab{},
 		Complete:    false,
-		Path:        fmt.Sprintf("buffer-%v", storedSlab.Key),
+		Filename:    buffer.Filename, // use from buffer since it's random
 		Size:        4,
 		LockedUntil: 0,
 	}
@@ -2461,9 +2464,9 @@ func TestPartialSlab(t *testing.T) {
 		Complete:    false,
 		Size:        1,
 		LockedUntil: 0,
+		Filename:    buffer2.Filename,
 	}
 	buffer2.DBSlab = dbSlab{} // exclude from comparison
-	buffer2.Path = ""         // don't check path
 	if !reflect.DeepEqual(buffer2, expectedBuffer2) {
 		t.Fatal("invalid buffer", cmp.Diff(buffer2, expectedBuffer2))
 	}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2292,12 +2292,12 @@ func TestPartialSlab(t *testing.T) {
 		t.Fatal(err)
 	}
 	// check the buffer
-	var buffer dbSlabBuffer
-	if err := db.db.Take(&buffer, "id = ?", storedSlab.DBSlabBufferID).Error; err != nil {
+	var buffer dbBufferedSlab
+	if err := db.db.Take(&buffer, "id = ?", storedSlab.DBBufferedSlabID).Error; err != nil {
 		t.Fatal(err)
 	}
 	buffer.Model = Model{}
-	expectedBuffer := dbSlabBuffer{
+	expectedBuffer := dbBufferedSlab{
 		DBSlab:      dbSlab{},
 		Complete:    false,
 		Data:        obj.PartialSlab.Data,
@@ -2410,12 +2410,12 @@ func TestPartialSlab(t *testing.T) {
 	}
 
 	// check the new buffer
-	var buffer2 dbSlabBuffer
+	var buffer2 dbBufferedSlab
 	if err := db.db.Joins("DBSlab").Take(&buffer2, "DBSlab.ID = ?", storedSlab.ID+1).Error; err != nil {
 		t.Fatal(err)
 	}
 	buffer2.Model = Model{}
-	expectedBuffer2 := dbSlabBuffer{
+	expectedBuffer2 := dbBufferedSlab{
 		Complete:    false,
 		Data:        obj3.PartialSlab.Data[1:],
 		LockedUntil: 0,

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2593,7 +2593,6 @@ func TestPartialSlab(t *testing.T) {
 		t.Fatal(err)
 	}
 	buffer.Model = Model{}
-	//expectedBuffer.Data = append(expectedBuffer.Data, obj2.PartialSlab.Data...)
 	expectedBuffer.Size = 4194303
 	buffer.DBSlab = dbSlab{} // exclude from comparison
 	if !reflect.DeepEqual(buffer, expectedBuffer) {
@@ -2639,7 +2638,6 @@ func TestPartialSlab(t *testing.T) {
 	}
 	buffer.Model = Model{}
 	expectedBuffer.Complete = true // full now
-	//expectedBuffer.Data = append(expectedBuffer.Data, obj3.PartialSlab.Data[0])
 	expectedBuffer.Size = 4194304
 	buffer.DBSlab = dbSlab{} // exclude from comparison
 	if !reflect.DeepEqual(buffer, expectedBuffer) {

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2441,6 +2441,8 @@ func TestPartialSlab(t *testing.T) {
 	}
 	completedBuffer.LockedUntil = 0
 	completedBuffer.Model = Model{}
+	completedBuffer.LockID = 0
+	buffer.LockID = 0
 	if !reflect.DeepEqual(completedBuffer, buffer) {
 		t.Fatal("invalid buffer", cmp.Diff(completedBuffer, buffer))
 	}

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -16,10 +16,10 @@ var (
 		&dbContract{},
 		&dbContractSet{},
 		&dbObject{},
+		&dbBufferedSlab{},
 		&dbSlab{},
 		&dbSector{},
 		&dbSlice{},
-		&dbBufferedSlab{},
 
 		// bus.HostDB tables
 		&dbAnnouncement{},

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -358,13 +358,14 @@ func performMigration00004_uploadPacking(txn *gorm.DB, logger glogger.Interface)
 		}
 	}
 
-	if m.HasColumn(&dbBufferedSlab{}, "db_slab_id") {
+	if m.HasTable(&dbBufferedSlab{}) {
 		// Drop buffered slabs since the schema has changed and the table was
 		// unused so far.
-		if err := m.DropColumn(&dbBufferedSlab{}, "db_slab_id"); err != nil {
-			return fmt.Errorf("failed to drop column 'db_slab_id' from table 'buffered_slabs': %w", err)
+		if err := m.DropTable(&dbBufferedSlab{}); err != nil {
+			return fmt.Errorf("failed to drop table 'buffered_slabs': %w", err)
 		}
 	}
+
 	// Use AutoMigrate to add column to create buffered_slabs and add column to
 	// slabs.
 	if err := m.AutoMigrate(&dbBufferedSlab{}, &dbSlab{}); err != nil {

--- a/stores/settingsdb_test.go
+++ b/stores/settingsdb_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestSQLSettingStore tests the bus.SettingStore methods on the SQLSettingStore.
 func TestSQLSettingStore(t *testing.T) {
-	ss, _, _, err := newTestSQLStore()
+	ss, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -393,7 +393,7 @@ func (s *SQLStore) retryTransaction(fc func(tx *gorm.DB) error, opts ...*sql.TxO
 		if err == nil {
 			return nil
 		}
-		s.logger.Warn(context.Background(), fmt.Sprintf("transaction attempt %d/%d failed, retry in %v,  err: %v", i+1, 5, timeoutIntervals[i], err))
+		s.logger.Warn(context.Background(), fmt.Sprintf("transaction attempt %d/%d failed, retry in %v,  err: %v", i+1, len(timeoutIntervals), timeoutIntervals[i], err))
 		time.Sleep(timeoutIntervals[i])
 	}
 	return fmt.Errorf("retryTransaction failed: %w", err)

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -33,8 +33,9 @@ type (
 
 	// SQLStore is a helper type for interacting with a SQL-based backend.
 	SQLStore struct {
-		db     *gorm.DB
-		logger glogger.Interface
+		db             *gorm.DB
+		logger         glogger.Interface
+		partialSlabDir string
 
 		// Persistence buffer - related fields.
 		lastSave               time.Time
@@ -119,7 +120,7 @@ func DBConfigFromEnv() (uri, user, password, dbName string) {
 // NewSQLStore uses a given Dialector to connect to a SQL database.  NOTE: Only
 // pass migrate=true for the first instance of SQLHostDB if you connect via the
 // same Dialector multiple times.
-func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duration, walletAddress types.Address, logger glogger.Interface) (*SQLStore, modules.ConsensusChangeID, error) {
+func NewSQLStore(conn gorm.Dialector, partialSlabDir string, migrate bool, persistInterval time.Duration, walletAddress types.Address, logger glogger.Interface) (*SQLStore, modules.ConsensusChangeID, error) {
 	db, err := gorm.Open(conn, &gorm.Config{
 		Logger: logger, // custom logger
 	})
@@ -172,6 +173,7 @@ func NewSQLStore(conn gorm.Dialector, migrate bool, persistInterval time.Duratio
 		logger:             logger,
 		knownContracts:     isOurContract,
 		lastSave:           time.Now(),
+		partialSlabDir:     partialSlabDir,
 		persistInterval:    persistInterval,
 		hasAllowlist:       allowlistCnt > 0,
 		hasBlocklist:       blocklistCnt > 0,

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -121,6 +121,9 @@ func DBConfigFromEnv() (uri, user, password, dbName string) {
 // pass migrate=true for the first instance of SQLHostDB if you connect via the
 // same Dialector multiple times.
 func NewSQLStore(conn gorm.Dialector, partialSlabDir string, migrate bool, persistInterval time.Duration, walletAddress types.Address, logger glogger.Interface) (*SQLStore, modules.ConsensusChangeID, error) {
+	if err := os.MkdirAll(partialSlabDir, 0700); err != nil {
+		return nil, modules.ConsensusChangeID{}, fmt.Errorf("failed to create partial slab dir: %v", err)
+	}
 	db, err := gorm.Open(conn, &gorm.Config{
 		Logger: logger, // custom logger
 	})

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -22,11 +22,11 @@ const (
 )
 
 // newTestSQLStore creates a new SQLStore for testing.
-func newTestSQLStore() (*SQLStore, string, modules.ConsensusChangeID, error) {
+func newTestSQLStore(dir string) (*SQLStore, string, modules.ConsensusChangeID, error) {
 	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
 	conn := NewEphemeralSQLiteConnection(dbName)
 	walletAddrs := types.Address(frand.Entropy256())
-	sqlStore, ccid, err := NewSQLStore(conn, true, time.Second, walletAddrs, newTestLogger())
+	sqlStore, ccid, err := NewSQLStore(conn, dir, true, time.Second, walletAddrs, newTestLogger())
 	if err != nil {
 		return nil, "", modules.ConsensusChangeID{}, err
 	}
@@ -56,7 +56,7 @@ func newTestLogger() logger.Interface {
 
 // TestConsensusReset is a unit test for ResetConsensusSubscription.
 func TestConsensusReset(t *testing.T) {
-	db, _, ccid, err := newTestSQLStore()
+	db, _, ccid, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/worker/download.go
+++ b/worker/download.go
@@ -193,7 +193,14 @@ func (mgr *downloadManager) DownloadObject(ctx context.Context, w io.Writer, o o
 	id := newID()
 
 	// calculate what slabs we need
-	slabs := slabsForDownload(o.Slabs, offset, length)
+	ss := o.Slabs
+	if o.PartialSlab != nil {
+		ss = append(ss, object.SlabSlice{
+			Offset: 0,
+			Length: uint32(len(o.PartialSlab.Data)),
+		})
+	}
+	slabs := slabsForDownload(ss, offset, length)
 	if len(slabs) == 0 {
 		return nil
 	}
@@ -235,6 +242,13 @@ func (mgr *downloadManager) DownloadObject(ctx context.Context, w io.Writer, o o
 		for {
 			if slabIndex < len(slabs) && atomic.LoadUint64(&concurrentSlabs) < maxConcurrentSlabsPerDownload {
 				next := slabs[slabIndex]
+
+				// check if the next slab is a partial slab.
+				if slabIndex == len(slabs)-1 && o.PartialSlab != nil {
+					responseChan <- &slabDownloadResponse{index: slabIndex}
+					slabIndex++
+					continue // handle partial slab separately
+				}
 
 				// check if we have enough downloaders
 				var available uint8
@@ -289,13 +303,23 @@ outer:
 			responses[resp.index] = resp
 			for {
 				if next, exists := responses[respIndex]; exists {
-					slabs[respIndex].Decrypt(next.shards)
-					err := slabs[respIndex].Recover(cw, next.shards)
-					if err != nil {
-						mgr.logger.Errorf("failed to recover slab %v: %v", respIndex, err)
-						return err
+					if next.index == len(slabs)-1 && o.PartialSlab != nil {
+						// Partial slab.
+						s := slabs[respIndex]
+						_, err = cw.Write(o.PartialSlab.Data[s.Offset:][:s.Length])
+						if err != nil {
+							mgr.logger.Errorf("failed to send partial slab", respIndex, err)
+							return err
+						}
+					} else {
+						// Regular slab.
+						slabs[respIndex].Decrypt(next.shards)
+						err := slabs[respIndex].Recover(cw, next.shards)
+						if err != nil {
+							mgr.logger.Errorf("failed to recover slab %v: %v", respIndex, err)
+							return err
+						}
 					}
-
 					next = nil
 					delete(responses, respIndex)
 					respIndex++

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -341,7 +341,6 @@ loop:
 				<-nextSlabChan // trigger next iteration
 			} else {
 				// Otherwise we upload it.
-				go u.uploadSlab(ctx, rs, data, length, slabIndex, respChan, nextSlabChan)
 				wg.Add(1)
 				go func(rs api.RedundancySettings, data []byte, length, slabIndex int) {
 					u.uploadSlab(ctx, rs, data, length, slabIndex, respChan, nextSlabChan)

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -260,7 +260,7 @@ func (mgr *uploadManager) Stop() {
 	}
 }
 
-func (mgr *uploadManager) Upload(ctx context.Context, r io.Reader, rs api.RedundancySettings, contracts []api.ContractMetadata, bh uint64, partialUpload bool) (_ object.Object, err error) {
+func (mgr *uploadManager) Upload(ctx context.Context, r io.Reader, rs api.RedundancySettings, contracts []api.ContractMetadata, bh uint64, uploadPacking bool) (_ object.Object, err error) {
 	// cancel all in-flight requests when the upload is done
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -330,8 +330,8 @@ loop:
 			} else if err != nil && err != io.ErrUnexpectedEOF {
 				return object.Object{}, err
 			}
-			if partialUpload && errors.Is(err, io.ErrUnexpectedEOF) {
-				// If partialUpload is true, we return the partial slab without
+			if uploadPacking && errors.Is(err, io.ErrUnexpectedEOF) {
+				// If uploadPacking is true, we return the partial slab without
 				// uploading.
 				partialSlab = &object.PartialSlab{
 					MinShards:   uint8(rs.MinShards),

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -828,7 +828,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 		jc.Encode(entries)
 		return
 	}
-	if len(obj.Slabs) == 0 {
+	if len(obj.Slabs) == 0 && obj.PartialSlab == nil {
 		return
 	}
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -937,7 +937,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	}
 
 	// upload the object
-	obj, err := w.uploadManager.Upload(ctx, jc.Request.Body, rs, contracts, up.CurrentHeight, up.PartialUploads)
+	obj, err := w.uploadManager.Upload(ctx, jc.Request.Body, rs, contracts, up.CurrentHeight, up.UploadPacking)
 	if jc.Check("couldn't upload object", err) != nil {
 		return
 	}
@@ -960,7 +960,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	}
 
 	// if partial uploads are not enabled we are done.
-	if !up.PartialUploads {
+	if !up.UploadPacking {
 		return
 	}
 


### PR DESCRIPTION
This PR is the final upload packing PR. After merging it, users will be able to enable upload packing through the corresponding setting.

After some testing I decided to not store the partial slabs in the database and instead in a file. Storing them in the database worked but the performance was horrible. Individual 4 kib files took around 5-40s to be added to the MySQL buffer. MySQL also started printing warnings related to the redo log capacity.
Using separate files I was able to do 5+ files per second which is reasonable considering multiple fsyncs are required per file and considering that my test node was running off of HDDs and not SSDs.   