### PR TITLE
Print seed to stdout instead of stderr with regular logging

### DIFF
--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -207,7 +207,8 @@ func main() {
 		log.Println("Build Date:", builddate)
 		return
 	} else if flag.Arg(0) == "seed" {
-		log.Println("Seed phrase:", wallet.NewSeedPhrase())
+		log.Println("Seed phrase:")
+		fmt.Println(wallet.NewSeedPhrase())
 		return
 	}
 


### PR DESCRIPTION
This PR changes `renterd seed` to print the actual seed to `stdout` while the remaining logging goes to `stderr` as usual. That way it's easier to use the output of `renterd seed` in scripts.

Closes https://github.com/SiaFoundation/renterd/issues/495