### PR TITLE
Increase download budget

### DIFF
--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	alertMigrationID = frand.Entropy256() // constnt across restarts
+	alertMigrationID = frand.Entropy256() // constant across restarts
 )
 
 const (

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -668,12 +668,15 @@ func (h *host) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte,
 // padBandwitdh pads the bandwidth to the next multiple of 1460 bytes.  1460
 // bytes is the maximum size of a TCP packet when using IPv4.
 func padBandwidth(pt rhpv3.HostPriceTable, rc rhpv3.ResourceCost) rhpv3.ResourceCost {
+	padCost := func(cost, paddingSize types.Currency) types.Currency {
+		if paddingSize.IsZero() {
+			return cost // might happen if bandwidth is free
+		}
+		return cost.Add(paddingSize).Sub(types.NewCurrency64(1)).Div(paddingSize).Mul(paddingSize)
+	}
 	minPacketSize := uint64(1460)
 	minIngress := pt.UploadBandwidthCost.Mul64(minPacketSize)
 	minEgress := pt.DownloadBandwidthCost.Mul64(minPacketSize)
-	padCost := func(cost, paddingSize types.Currency) types.Currency {
-		return cost.Add(paddingSize).Sub(types.NewCurrency64(1)).Div(paddingSize).Mul(paddingSize)
-	}
 	rc.Ingress = padCost(rc.Ingress, minIngress)
 	rc.Egress = padCost(rc.Egress, minEgress)
 	return rc

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -671,12 +671,12 @@ func readSectorCost(pt rhpv3.HostPriceTable, length uint64) (types.Currency, err
 	rc = rc.Add(pt.ReadSectorCost(length))
 	cost, _ := rc.Total()
 
-	// overestimate the cost by 5%
-	cost, overflow := cost.Mul64WithOverflow(21)
+	// overestimate the cost by 10%
+	cost, overflow := cost.Mul64WithOverflow(11)
 	if overflow {
 		return types.ZeroCurrency, errors.New("overflow occurred while adding leeway to read sector cost")
 	}
-	return cost.Div64(20), nil
+	return cost.Div64(10), nil
 }
 
 // uploadSectorCost returns an overestimate for the cost of uploading a sector
@@ -686,12 +686,12 @@ func uploadSectorCost(pt rhpv3.HostPriceTable, windowEnd uint64) (cost, collater
 	rc = rc.Add(pt.AppendSectorCost(windowEnd - pt.HostBlockHeight))
 	cost, collateral = rc.Total()
 
-	// overestimate the cost by 5%
-	cost, overflow := cost.Mul64WithOverflow(21)
+	// overestimate the cost by 10%
+	cost, overflow := cost.Mul64WithOverflow(11)
 	if overflow {
 		return types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, errors.New("overflow occurred while adding leeway to read sector cost")
 	}
-	return cost.Div64(20), collateral, rc.Storage, nil
+	return cost.Div64(10), collateral, rc.Storage, nil
 }
 
 // priceTableValidityLeeway is the number of time before the actual expiry of a


### PR DESCRIPTION
Fixes an issue with downloads on our Arequipa node

```
couldn't download object '/s5/H23lb7IatJJ0U_QX-kOTkF2enHrtaKXmyJ81CMKiBzKm': failed to download slab: completed=1, inflight=0, launched=30 downloaders=118 unused=0 errors=
3e37b161: ReadSector: remaining budget is insufficient
662dbfb2: ReadSector: remaining budget is insufficient
443c7ae7: ReadSector: remaining budget is insufficient
4074d176: ReadSector: ReadResponse: [failed to set budget limit on stream; insufficient budget for bandwidth]
9ce46fd4: ReadSector: ReadResponse: couldn't read subscription response: insufficient budget for bandwidth
4b804458: ReadSector: ReadResponse: [failed to set budget limit on stream; insufficient budget for bandwidth]
c8dc6403: ReadSector: remaining budget is insufficient
```