### PR TITLE
Make Object method of bus client more user-friendly

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -205,3 +205,23 @@ func DownloadWithRange(offset, length uint64) DownloadObjectOption {
 		h.Set("Range", fmt.Sprintf("bytes=%v-%v", offset, offset+length-1))
 	}
 }
+
+type ObjectsOption func(url.Values)
+
+func ObjectsWithPrefix(prefix string) ObjectsOption {
+	return func(v url.Values) {
+		v.Set("prefix", url.QueryEscape(prefix))
+	}
+}
+
+func ObjectsWithOffset(offset int) ObjectsOption {
+	return func(v url.Values) {
+		v.Set("offset", fmt.Sprint(offset))
+	}
+}
+
+func ObjectsWithLimit(limit int) ObjectsOption {
+	return func(v url.Values) {
+		v.Set("limit", fmt.Sprint(limit))
+	}
+}

--- a/bus/client.go
+++ b/bus/client.go
@@ -536,14 +536,12 @@ func (c *Client) SearchObjects(ctx context.Context, key string, offset, limit in
 	return
 }
 
-// Object returns the object at the given path with the given prefix, or, if
-// path ends in '/', the entries under that path.
-func (c *Client) Object(ctx context.Context, path, prefix string, offset, limit int) (o object.Object, entries []api.ObjectMetadata, err error) {
+func (c *Client) Object(ctx context.Context, path string, opts ...api.ObjectsOption) (o object.Object, entries []api.ObjectMetadata, err error) {
 	path = strings.TrimPrefix(path, "/")
 	values := url.Values{}
-	values.Set("prefix", url.QueryEscape(prefix))
-	values.Set("offset", fmt.Sprint(offset))
-	values.Set("limit", fmt.Sprint(limit))
+	for _, opt := range opts {
+		opt(values)
+	}
 	path += "?" + values.Encode()
 	var or api.ObjectsResponse
 	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/objects/%s", path), &or)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -355,7 +355,7 @@ func TestObjectEntries(t *testing.T) {
 	}
 	for _, test := range tests {
 		// use the bus client
-		_, got, err := b.Object(context.Background(), test.path, test.prefix, 0, -1)
+		_, got, err := b.Object(context.Background(), test.path, api.ObjectsWithPrefix(test.prefix))
 		if err != nil {
 			t.Fatal(err, test.path)
 		}
@@ -363,7 +363,7 @@ func TestObjectEntries(t *testing.T) {
 			t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want)
 		}
 		for offset := 0; offset < len(test.want); offset++ {
-			_, got, err := b.Object(context.Background(), test.path, test.prefix, offset, 1)
+			_, got, err := b.Object(context.Background(), test.path, api.ObjectsWithPrefix(test.prefix), api.ObjectsWithOffset(offset), api.ObjectsWithLimit(1))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -652,7 +652,7 @@ func TestUploadDownloadExtended(t *testing.T) {
 	}
 
 	// fetch entries with "file" prefix
-	_, entries, err = cluster.Bus.Object(context.Background(), "fileś/", "file", 0, -1)
+	_, entries, err = cluster.Bus.Object(context.Background(), "fileś/", api.ObjectsWithPrefix("file"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -661,7 +661,7 @@ func TestUploadDownloadExtended(t *testing.T) {
 	}
 
 	// fetch entries with "fileś" prefix
-	_, entries, err = cluster.Bus.Object(context.Background(), "fileś/", "foo", 0, -1)
+	_, entries, err = cluster.Bus.Object(context.Background(), "fileś/", api.ObjectsWithPrefix("foo"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -864,7 +864,7 @@ func TestUploadDownloadSpending(t *testing.T) {
 			}
 
 			// Should be registered in bus.
-			_, entries, err := cluster.Bus.Object(context.Background(), "", "", 0, -1)
+			_, entries, err := cluster.Bus.Object(context.Background(), "")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/testing/migrations_test.go
+++ b/internal/testing/migrations_test.go
@@ -32,7 +32,7 @@ func TestMigrations(t *testing.T) {
 	// create a helper to fetch used hosts
 	usedHosts := func(path string) map[types.PublicKey]struct{} {
 		// fetch used hosts
-		obj, _, err := cluster.Bus.Object(context.Background(), path, "", 0, -1)
+		obj, _, err := cluster.Bus.Object(context.Background(), path)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -146,7 +146,7 @@ type Bus interface {
 	GougingParams(ctx context.Context) (api.GougingParams, error)
 	UploadParams(ctx context.Context) (api.UploadParams, error)
 
-	Object(ctx context.Context, path, prefix string, offset, limit int) (object.Object, []api.ObjectMetadata, error)
+	Object(ctx context.Context, path string, opts ...api.ObjectsOption) (object.Object, []api.ObjectMetadata, error)
 	AddObject(ctx context.Context, path, contractSet string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
 	DeleteObject(ctx context.Context, path string, batch bool) error
 
@@ -812,7 +812,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 	}
 
 	path := jc.PathParam("path")
-	obj, entries, err := w.bus.Object(ctx, path, prefix, off, limit)
+	obj, entries, err := w.bus.Object(ctx, path, api.ObjectsWithPrefix(prefix), api.ObjectsWithOffset(off), api.ObjectsWithLimit(limit))
 	if err != nil && strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
 		jc.Error(err, http.StatusNotFound)
 		return


### PR DESCRIPTION
This PR adopts the `opts ...FooOptions` pattern for the `Object` client method to make using it a bit more self-explanatory.