### PR TITLE
Sector Deletion (pt 2) - backup deleted sector info

### DIFF
--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1753,15 +1753,20 @@ func TestContractSectors(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Check the join table. Should contain one entry.
+	if err := db.db.Find(&css).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(css) != 1 {
+		t.Fatal("table should contain one entry", len(css))
+	}
+
 	// Delete the object.
 	if err := db.RemoveObject(ctx, "foo"); err != nil {
 		t.Fatal(err)
 	}
 
-	// Delete the sector.
-	if err := db.db.Delete(&dbSector{Model: Model{ID: 1}}).Error; err != nil {
-		t.Fatal(err)
-	}
+	// Check the join table. Should be empty.
 	if err := db.db.Find(&css).Error; err != nil {
 		t.Fatal(err)
 	}

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -20,6 +20,7 @@ var (
 		&dbSector{},
 		&dbSlice{},
 		&dbSlabBuffer{},
+		dbDeletedSector{},
 
 		// bus.HostDB tables
 		&dbAnnouncement{},

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -148,6 +148,13 @@ func performMigrations(db *gorm.DB, logger glogger.Interface) error {
 			},
 			Rollback: nil,
 		},
+		{
+			ID: "00003_dropconstraintslabshards",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration00003_dropconstraintslabshards(tx, logger)
+			},
+			Rollback: nil,
+		},
 	}
 
 	// Create migrator.
@@ -307,6 +314,50 @@ func performMigration00002_dropconstraintslabcsid(txn *gorm.DB, logger glogger.I
 		logger.Info(ctx, "migration 00002_dropconstraintslabcsid: adding constraint on DBContractSet")
 		if err := m.CreateConstraint(&dbSlab{}, "DBContractSet"); err != nil {
 			return fmt.Errorf("failed to add constraint 'DBContractSet' to table 'slabs': %w", err)
+		}
+	}
+
+	// Enable foreign keys again.
+	if isSQLite(txn) {
+		if err := txn.Exec(`PRAGMA foreign_keys = 1`).Error; err != nil {
+			return err
+		}
+		if err := txn.Exec(`PRAGMA foreign_key_check(slabs)`).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func performMigration00003_dropconstraintslabshards(txn *gorm.DB, logger glogger.Interface) error {
+	ctx := context.Background()
+	m := txn.Migrator()
+
+	// Disable foreign keys in SQLite to avoid issues with updating constraints.
+	if isSQLite(txn) {
+		if err := txn.Exec(`PRAGMA foreign_keys = 0`).Error; err != nil {
+			return err
+		}
+	}
+
+	// Drop the constraint on Shards.
+	if m.HasConstraint(&dbSlab{}, "Shards") {
+		logger.Info(ctx, "migration 00003_dropconstraintslabshards: dropping constraint on Shards")
+		if err := m.DropConstraint(&dbSlab{}, "Shards"); err != nil {
+			return fmt.Errorf("failed to drop constraint 'Shards' from table 'slabs': %w", err)
+		}
+	}
+
+	// Perform auto migrations.
+	if err := txn.AutoMigrate(tables...); err != nil {
+		return err
+	}
+
+	// Add constraint back.
+	if !m.HasConstraint(&dbSlab{}, "Shards") {
+		logger.Info(ctx, "migration 00003_dropconstraintslabshards: adding constraint on Shards")
+		if err := m.CreateConstraint(&dbSlab{}, "Shards"); err != nil {
+			return fmt.Errorf("failed to add constraint 'Shards' to table 'slabs': %w", err)
 		}
 	}
 


### PR DESCRIPTION
To allow detaching removing sectors in the database from actually purging them from the contracts with the hosts, we have to keep track of the deleted sectors and their respective relationships to whatever contracts they were uploaded to. This PR adds to tables to accomplish this. Consecutive PRs will then expose routes to query the amount of data that can be purged from contracts as well as a route to effectively build MDM programs that effectively drop the sectors from the contracts.