### PR TITLE
Add Health field to Slab

### DIFF
--- a/object/slab.go
+++ b/object/slab.go
@@ -21,6 +21,7 @@ type Sector struct {
 // be used for each Slab, and should not be the same key used for the parent
 // Object.
 type Slab struct {
+	Health    float64       `json:"health"`
 	Key       EncryptionKey `json:"key"`
 	MinShards uint8         `json:"minShards"`
 	Shards    []Sector      `json:"shards"`

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -144,6 +144,7 @@ type (
 
 		// slab
 		SlabID        uint
+		SlabHealth    float64
 		SlabKey       []byte
 		SlabMinShards uint8
 
@@ -340,6 +341,7 @@ func (raw rawObject) toSlabSlice() (slice object.SlabSlice, _ error) {
 	}
 
 	// hydrate all fields
+	slice.Slab.Health = raw[0].SlabHealth
 	slice.Slab.Shards = sectors
 	slice.Slab.MinShards = raw[0].SlabMinShards
 	slice.Offset = raw[0].SliceOffset
@@ -1225,7 +1227,7 @@ func (s *SQLStore) object(ctx context.Context, path string) (rawObject, error) {
 	// accordingly
 	var rows rawObject
 	tx := s.db.
-		Select("o.key as ObjectKey, sli.id as SliceID, sli.offset as SliceOffset, sli.length as SliceLength, sla.id as SlabID, sla.key as SlabKey, sla.min_shards as SlabMinShards, sec.id as SectorID, sec.root as SectorRoot, sec.latest_host as SectorHost").
+		Select("o.key as ObjectKey, sli.id as SliceID, sli.offset as SliceOffset, sli.length as SliceLength, sla.id as SlabID, sla.health as SlabHealth, sla.key as SlabKey, sla.min_shards as SlabMinShards, sec.id as SectorID, sec.root as SectorRoot, sec.latest_host as SectorHost").
 		Model(&dbObject{}).
 		Table("objects o").
 		Joins("LEFT JOIN slices sli ON o.id = sli.`db_object_id`").
@@ -1237,7 +1239,6 @@ func (s *SQLStore) object(ctx context.Context, path string) (rawObject, error) {
 		Order("sli.offset ASC").
 		Order("sec.id ASC").
 		Scan(&rows)
-
 	if errors.Is(tx.Error, gorm.ErrRecordNotFound) || len(rows) == 0 {
 		return nil, api.ErrObjectNotFound
 	}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -875,6 +875,7 @@ func TestSQLMetadataStore(t *testing.T) {
 		Slabs: []object.SlabSlice{
 			{
 				Slab: object.Slab{
+					Health:    1,
 					Key:       object.GenerateEncryptionKey(),
 					MinShards: 1,
 					Shards: []object.Sector{
@@ -889,6 +890,7 @@ func TestSQLMetadataStore(t *testing.T) {
 			},
 			{
 				Slab: object.Slab{
+					Health:    1,
 					Key:       object.GenerateEncryptionKey(),
 					MinShards: 2,
 					Shards: []object.Sector{

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -61,6 +61,7 @@ func TestObjectBasic(t *testing.T) {
 		Slabs: []object.SlabSlice{
 			{
 				Slab: object.Slab{
+					Health:    1.0,
 					Key:       object.GenerateEncryptionKey(),
 					MinShards: 1,
 					Shards: []object.Sector{
@@ -75,6 +76,7 @@ func TestObjectBasic(t *testing.T) {
 			},
 			{
 				Slab: object.Slab{
+					Health:    1.0,
 					Key:       object.GenerateEncryptionKey(),
 					MinShards: 2,
 					Shards: []object.Sector{


### PR DESCRIPTION
Slabs returned through the API now contain their latest computed health. That way the UI doesn't need to compute the health on the client-side anymore and instead it is consistent with the health the autopilot uses for migrations.