### PR TITLE
Sector Deletion pt1 - prunable data

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -41,8 +41,8 @@ var (
 	// yet because it has been set too recently.
 	ErrRequiresSyncSetRecently = errors.New("account had 'requiresSync' flag set recently")
 
-	// ErrOBjectNotFound is returned if get is unable to retrieve an object from
-	// the database.
+	// ErrOBjectNotFound is returned when an object can't be retrieved from the
+	// database.
 	ErrObjectNotFound = errors.New("object not found")
 
 	// ErrObjectCorrupted is returned if we were unable to retrieve the object
@@ -53,7 +53,7 @@ var (
 	// the database.
 	ErrContractNotFound = errors.New("couldn't find contract")
 
-	// ErrContractSetNotFound is returned when a contract can't be retrieved
+	// ErrContractSetNotFound is returned when a contract set can't be retrieved
 	// from the database.
 	ErrContractSetNotFound = errors.New("couldn't find contract set")
 

--- a/api/bus.go
+++ b/api/bus.go
@@ -49,6 +49,10 @@ var (
 	// from the database.
 	ErrObjectCorrupted = errors.New("object corrupted")
 
+	// ErrContractNotFound is returned when a contract can't be retrieved from
+	// the database.
+	ErrContractNotFound = errors.New("couldn't find contract")
+
 	// ErrContractSetNotFound is returned when a contract can't be retrieved
 	// from the database.
 	ErrContractSetNotFound = errors.New("couldn't find contract set")

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -671,6 +671,10 @@ func (b *bus) contractPrunableDataHandlerGET(jc jape.Context) {
 	}
 
 	n, err := b.ms.PrunableDataForContract(jc.Request.Context(), id)
+	if errors.Is(err, api.ErrObjectNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	}
 	if jc.Check("failed to fetch prunable data for contract", err) == nil {
 		jc.Encode(n)
 	}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -671,7 +671,7 @@ func (b *bus) contractPrunableDataHandlerGET(jc jape.Context) {
 	}
 
 	n, err := b.ms.PrunableDataForContract(jc.Request.Context(), id)
-	if errors.Is(err, api.ErrObjectNotFound) {
+	if errors.Is(err, api.ErrContractNotFound) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -94,6 +94,9 @@ type (
 		RenewedContract(ctx context.Context, renewedFrom types.FileContractID) (api.ContractMetadata, error)
 		SetContractSet(ctx context.Context, set string, contracts []types.FileContractID) error
 
+		PrunableData(ctx context.Context) (int64, error)
+		PrunableDataForContract(ctx context.Context, id types.FileContractID) (int64, error)
+
 		Object(ctx context.Context, path string) (object.Object, error)
 		ObjectEntries(ctx context.Context, path, prefix string, offset, limit int) ([]api.ObjectMetadata, error)
 		SearchObjects(ctx context.Context, substring string, offset, limit int) ([]api.ObjectMetadata, error)
@@ -651,6 +654,25 @@ func (b *bus) contractKeepaliveHandlerPOST(jc jape.Context) {
 	err := b.contractLocks.KeepAlive(id, req.LockID, time.Duration(req.Duration))
 	if jc.Check("failed to extend lock duration", err) != nil {
 		return
+	}
+}
+
+func (b *bus) contractsPrunableDataHandlerGET(jc jape.Context) {
+	n, err := b.ms.PrunableData(jc.Request.Context())
+	if jc.Check("failed to fetch prunable data", err) == nil {
+		jc.Encode(n)
+	}
+}
+
+func (b *bus) contractPrunableDataHandlerGET(jc jape.Context) {
+	var id types.FileContractID
+	if jc.DecodeParam("id", &id) != nil {
+		return
+	}
+
+	n, err := b.ms.PrunableDataForContract(jc.Request.Context(), id)
+	if jc.Check("failed to fetch prunable data for contract", err) == nil {
+		jc.Encode(n)
 	}
 }
 
@@ -1402,6 +1424,7 @@ func (b *bus) Handler() http.Handler {
 		"GET    /contracts":              b.contractsHandlerGET,
 		"DELETE /contracts/all":          b.contractsAllHandlerDELETE,
 		"POST   /contracts/archive":      b.contractsArchiveHandlerPOST,
+		"GET    /contracts/prunable":     b.contractsPrunableDataHandlerGET,
 		"GET    /contracts/renewed/:id":  b.contractsRenewedIDHandlerGET,
 		"GET    /contracts/sets":         b.contractsSetsHandlerGET,
 		"GET    /contracts/set/:set":     b.contractsSetHandlerGET,
@@ -1415,6 +1438,7 @@ func (b *bus) Handler() http.Handler {
 		"POST   /contract/:id/acquire":   b.contractAcquireHandlerPOST,
 		"POST   /contract/:id/keepalive": b.contractKeepaliveHandlerPOST,
 		"POST   /contract/:id/release":   b.contractReleaseHandlerPOST,
+		"GET    /contract/:id/prunable":  b.contractPrunableDataHandlerGET,
 		"DELETE /contract/:id":           b.contractIDHandlerDELETE,
 
 		"POST /search/hosts":   b.searchHostsHandlerPOST,

--- a/bus/client.go
+++ b/bus/client.go
@@ -468,6 +468,20 @@ func (c *Client) ReleaseContract(ctx context.Context, fcid types.FileContractID,
 	return
 }
 
+// PrunableData returns the amount of data that can be pruned from all
+// contracts.
+func (c *Client) PrunableData(ctx context.Context) (prunable int64, err error) {
+	err = c.c.WithContext(ctx).GET("/contracts/prunable", &prunable)
+	return
+}
+
+// PrunableDataForContract returns the amount of data that can be pruned from
+// the contract with given id.
+func (c *Client) PrunableDataForContract(ctx context.Context, fcid types.FileContractID) (prunable int64, err error) {
+	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/contract/%s/prunable", fcid), &prunable)
+	return
+}
+
 // RecommendedFee returns the recommended fee for a txn.
 func (c *Client) RecommendedFee(ctx context.Context) (fee types.Currency, err error) {
 	err = c.c.WithContext(ctx).GET("/txpool/recommendedfee", &fee)

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/hostdb"
@@ -211,10 +212,10 @@ func TestSectorPruning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// assert prunable data is not 0
+	// assert amount of prunable data
 	if n, err := b.PrunableData(context.Background()); err != nil {
 		t.Fatal(err)
-	} else if n == 0 {
-		t.Fatal("expected prunable data", n)
+	} else if n != rhpv2.SectorSize*3 {
+		t.Fatal("unexpected prunable data", n)
 	}
 }

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -194,8 +194,10 @@ func TestSectorPruning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// make sure spending records are flushed
-	time.Sleep(testBusFlushInterval * 2)
+	// shut down the worker, ensuring spending records get flushed
+	if err := cluster.ShutdownWorker(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 
 	// assert prunable data is 0
 	if n, err := b.PrunableData(context.Background()); err != nil {
@@ -205,7 +207,7 @@ func TestSectorPruning(t *testing.T) {
 	}
 
 	// delete the object
-	if err := w.DeleteObject(context.Background(), "obj", false); err != nil {
+	if err := b.DeleteObject(context.Background(), "obj", false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -448,7 +448,7 @@ func (s *SQLStore) AddRenewedContract(ctx context.Context, c rhpv2.ContractRevis
 		}
 
 		// Overwrite the old contract with the new one.
-		newContract := newContract(oldContract.HostID, c.ID(), renewedFrom, totalCost, startHeight, c.Revision.WindowStart, c.Revision.WindowEnd, c.Revision.Filesize)
+		newContract := newContract(oldContract.HostID, c.ID(), renewedFrom, totalCost, startHeight, c.Revision.WindowStart, c.Revision.WindowEnd, oldContract.Size)
 		newContract.Model = oldContract.Model
 		err = tx.Save(&newContract).Error
 		if err != nil {
@@ -559,11 +559,13 @@ func (s *SQLStore) PrunableData(ctx context.Context) (prunable int64, err error)
 		Raw(`
 SELECT IFNULL(SUM(prunable), 0)
 FROM (
-    SELECT ABS(c.size - COUNT(cs.db_sector_id) * ?) as prunable
-    FROM contracts c
-    LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
-    GROUP BY c.id
-) as i`, rhpv2.SectorSize).
+    SELECT CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
+        SELECT IFNULL(c.size - COUNT(cs.db_sector_id) * ?, 0) as bytes
+        FROM contracts c
+        LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
+        GROUP BY c.id
+	) as i
+) as j`, rhpv2.SectorSize).
 		Scan(&prunable).
 		Error
 	return
@@ -576,10 +578,12 @@ func (s *SQLStore) PrunableDataForContract(ctx context.Context, id types.FileCon
 
 	err = s.db.
 		Raw(`
-SELECT IFNULL(ABS(c.size - COUNT(cs.db_sector_id) * ?), 0) as prunable
-FROM contracts c
-LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
-WHERE c.fcid = ?
+SELECT CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
+    SELECT IFNULL(c.size - COUNT(cs.db_sector_id) * 4194304, 0) as bytes
+    FROM contracts c
+    LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
+    WHERE c.fcid = ?
+) as i
 `, rhpv2.SectorSize, fileContractID(id)).
 		Scan(&prunable).
 		Error

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -560,7 +560,6 @@ func (s *SQLStore) ContractSets(ctx context.Context) ([]string, error) {
 
 func (s *SQLStore) PrunableData(ctx context.Context) (prunable int64, err error) {
 	err = s.db.
-		Debug().
 		Raw(`
 SELECT SUM(i.prunable)
 FROM (
@@ -576,7 +575,6 @@ FROM (
 
 func (s *SQLStore) PrunableDataForContract(ctx context.Context, id types.FileContractID) (prunable int64, err error) {
 	err = s.db.
-		Debug().
 		Raw(`
 SELECT SUM(prunable)
 FROM (

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1486,7 +1486,7 @@ func addContract(tx *gorm.DB, c rhpv2.ContractRevision, totalCost types.Currency
 	}
 
 	// Create contract.
-	contract := newContract(host.ID, fcid, renewedFrom, totalCost, startHeight, c.Revision.WindowStart, c.Revision.WindowEnd, 0)
+	contract := newContract(host.ID, fcid, renewedFrom, totalCost, startHeight, c.Revision.WindowStart, c.Revision.WindowEnd, c.Revision.Filesize)
 
 	// Insert contract.
 	err = tx.Create(&contract).Error

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -690,6 +690,7 @@ func TestAncestorsContracts(t *testing.T) {
 			HostKey:     hk,
 			RenewedTo:   fcids[len(fcids)-1-i],
 			StartHeight: 2,
+			Size:        4096,
 			WindowStart: 400,
 			WindowEnd:   500,
 		}) {
@@ -2609,6 +2610,26 @@ func TestPrunableData(t *testing.T) {
 		t.Fatal("unexpected amount of prunable data", n)
 	}
 	if n := prunableData(&fcids[1]); n != 0 {
+		t.Fatal("expected no prunable data", n)
+	}
+
+	// remove the second object
+	if err := db.RemoveObject(context.Background(), "obj_2"); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert there's now two sectors that can be pruned
+	if n := prunableData(nil); n != rhpv2.SectorSize*2 {
+		t.Fatal("unexpected amount of prunable data", n)
+	}
+
+	// archive all contracts
+	if err := db.ArchiveAllContracts(context.Background(), t.Name()); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert there's no data to be pruned
+	if n := prunableData(nil); n != 0 {
 		t.Fatal("expected no prunable data", n)
 	}
 }

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -706,7 +706,7 @@ func TestAncestorsContracts(t *testing.T) {
 			WindowStart: 400,
 			WindowEnd:   500,
 		}) {
-			t.Fatal("wrong contract", i)
+			t.Fatal("wrong contract", i, contracts[i])
 		}
 	}
 }

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -217,7 +217,7 @@ func TestSQLContractStore(t *testing.T) {
 	// Look it up. Should fail.
 	ctx := context.Background()
 	_, err = cs.Contract(ctx, c.ID())
-	if !errors.Is(err, ErrContractNotFound) {
+	if !errors.Is(err, api.ErrContractNotFound) {
 		t.Fatal(err)
 	}
 	contracts, err := cs.Contracts(ctx)
@@ -310,7 +310,7 @@ func TestSQLContractStore(t *testing.T) {
 
 	// Look it up. Should fail.
 	_, err = cs.Contract(ctx, c.ID())
-	if !errors.Is(err, ErrContractNotFound) {
+	if !errors.Is(err, api.ErrContractNotFound) {
 		t.Fatal(err)
 	}
 	contracts, err = cs.Contracts(ctx)
@@ -508,7 +508,7 @@ func TestRenewedContract(t *testing.T) {
 
 	// Assert we can't fetch the renewed contract.
 	_, err = cs.RenewedContract(context.Background(), fcid1)
-	if !errors.Is(err, ErrContractNotFound) {
+	if !errors.Is(err, api.ErrContractNotFound) {
 		t.Fatal("unexpected")
 	}
 
@@ -562,7 +562,7 @@ func TestRenewedContract(t *testing.T) {
 
 	// Contract should be gone from active contracts.
 	_, err = cs.Contract(ctx, fcid1)
-	if !errors.Is(err, ErrContractNotFound) {
+	if !errors.Is(err, api.ErrContractNotFound) {
 		t.Fatal(err)
 	}
 
@@ -2631,6 +2631,12 @@ func TestPrunableData(t *testing.T) {
 	// assert there's no data to be pruned
 	if n := prunableData(nil); n != 0 {
 		t.Fatal("expected no prunable data", n)
+	}
+
+	// assert passing a non-existent fcid returns an error
+	_, err = db.PrunableDataForContract(context.Background(), types.FileContractID{9})
+	if err != api.ErrContractNotFound {
+		t.Fatal(err)
 	}
 }
 

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -251,6 +251,7 @@ func TestSQLContractStore(t *testing.T) {
 			FundAccount: types.ZeroCurrency,
 		},
 		TotalCost: totalCost,
+		Size:      c.Revision.Filesize,
 	}
 	if !reflect.DeepEqual(returned, expected) {
 		t.Fatal("contract mismatch")
@@ -1014,6 +1015,7 @@ func TestSQLMetadataStore(t *testing.T) {
 							StartHeight:    startHeight1,
 							WindowStart:    400,
 							WindowEnd:      500,
+							Size:           4096,
 
 							UploadSpending:      zeroCurrency,
 							DownloadSpending:    zeroCurrency,
@@ -1050,6 +1052,7 @@ func TestSQLMetadataStore(t *testing.T) {
 							StartHeight:    startHeight2,
 							WindowStart:    400,
 							WindowEnd:      500,
+							Size:           4096,
 
 							UploadSpending:      zeroCurrency,
 							DownloadSpending:    zeroCurrency,

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -496,6 +496,14 @@ func TestRenewedContract(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// mock recording of spending records to ensure the cached fields get updated
+	if err := cs.RecordContractSpending(context.Background(), []api.ContractSpendingRecord{
+		{ContractID: fcid1, RevisionNumber: 1, Size: rhpv2.SectorSize},
+		{ContractID: fcid2, RevisionNumber: 1, Size: rhpv2.SectorSize},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	// no slabs should be unhealthy.
 	if err := cs.RefreshHealth(context.Background()); err != nil {
 		t.Fatal(err)
@@ -579,6 +587,7 @@ func TestRenewedContract(t *testing.T) {
 		HostKey:     hk,
 		StartHeight: newContractStartHeight,
 		RenewedFrom: fcid1,
+		Size:        rhpv2.SectorSize,
 		Spending: api.ContractSpending{
 			Uploads:     types.ZeroCurrency,
 			Downloads:   types.ZeroCurrency,
@@ -612,10 +621,11 @@ func TestRenewedContract(t *testing.T) {
 			TotalCost:      currency(oldContractTotal),
 			ProofHeight:    0,
 			RevisionHeight: 0,
-			RevisionNumber: "0",
+			RevisionNumber: "1",
 			StartHeight:    100,
 			WindowStart:    2,
 			WindowEnd:      3,
+			Size:           rhpv2.SectorSize,
 
 			UploadSpending:      zeroCurrency,
 			DownloadSpending:    zeroCurrency,

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -653,7 +653,7 @@ func (h *host) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte,
 
 	var cost types.Currency
 	err = h.transportPool.withTransportV3(ctx, h.HostKey(), h.siamuxAddr, func(ctx context.Context, t *transportV3) error {
-		root, cost, err = RPCAppendSector(ctx, t, h.renterKey, pt, rev, &payment, sector)
+		root, cost, err = RPCAppendSector(ctx, t, h.renterKey, pt, &rev, &payment, sector)
 		return err
 	})
 	if err != nil {
@@ -1194,7 +1194,7 @@ func RPCReadRegistry(ctx context.Context, t *transportV3, payment rhpv3.PaymentM
 	}, nil
 }
 
-func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.PrivateKey, pt rhpv3.HostPriceTable, rev types.FileContractRevision, payment rhpv3.PaymentMethod, sector *[rhpv2.SectorSize]byte) (sectorRoot types.Hash256, cost types.Currency, err error) {
+func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.PrivateKey, pt rhpv3.HostPriceTable, rev *types.FileContractRevision, payment rhpv3.PaymentMethod, sector *[rhpv2.SectorSize]byte) (sectorRoot types.Hash256, cost types.Currency, err error) {
 	defer wrapErr(&err, "AppendSector")
 
 	// sanity check revision first
@@ -1292,7 +1292,7 @@ func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.Privat
 
 	// finalize the program with a new revision.
 	newRevision := rev
-	newValid, newMissed, err := updateRevisionOutputs(&newRevision, types.ZeroCurrency, collateral)
+	newValid, newMissed, err := updateRevisionOutputs(newRevision, types.ZeroCurrency, collateral)
 	if err != nil {
 		return types.Hash256{}, types.ZeroCurrency, err
 	}
@@ -1301,7 +1301,7 @@ func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.Privat
 	newRevision.FileMerkleRoot = executeResp.NewMerkleRoot
 
 	finalizeReq := rhpv3.RPCFinalizeProgramRequest{
-		Signature:         renterKey.SignHash(hashRevision(newRevision)),
+		Signature:         renterKey.SignHash(hashRevision(*newRevision)),
 		ValidProofValues:  newValid,
 		MissedProofValues: newMissed,
 		RevisionNumber:    newRevision.RevisionNumber,

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -1291,8 +1291,8 @@ func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.Privat
 	}
 
 	// finalize the program with a new revision.
-	newRevision := rev
-	newValid, newMissed, err := updateRevisionOutputs(newRevision, types.ZeroCurrency, collateral)
+	newRevision := *rev
+	newValid, newMissed, err := updateRevisionOutputs(&newRevision, types.ZeroCurrency, collateral)
 	if err != nil {
 		return types.Hash256{}, types.ZeroCurrency, err
 	}
@@ -1301,7 +1301,7 @@ func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.Privat
 	newRevision.FileMerkleRoot = executeResp.NewMerkleRoot
 
 	finalizeReq := rhpv3.RPCFinalizeProgramRequest{
-		Signature:         renterKey.SignHash(hashRevision(*newRevision)),
+		Signature:         renterKey.SignHash(hashRevision(newRevision)),
 		ValidProofValues:  newValid,
 		MissedProofValues: newMissed,
 		RevisionNumber:    newRevision.RevisionNumber,
@@ -1328,6 +1328,8 @@ func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.Privat
 		err = errFinalise
 		return
 	}
+
+	*rev = newRevision
 	return
 }
 


### PR DESCRIPTION
This PR exposes two new routes in the `bus` API that return the amount of data that can be pruned from a contract (or across all contracts). I use the (cached) `size` field on the contract and compare it against the amount of contract sectors. These routes will have `POST` counterparts in the worker API to list the sectors from a contract and perform the actual sector deletion.

- `size` field was being set to the old revision file size, thus lagging one sector
- `size` wasn't being copied over to the renewed contract

`NOTE` naming was bothering me a bit in this PR but I couldn't find a better alternative