### PR TITLE
Remove QueryString Const

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -13,12 +13,6 @@ import (
 	"go.sia.tech/core/types"
 )
 
-const (
-	QueryStringParamContractSet = "contractset"
-	QueryStringParamMinShards   = "minshards"
-	QueryStringParamTotalShards = "totalshards"
-)
-
 // ErrConsensusNotSynced is returned by the worker API by endpoints that rely on
 // consensus and the consensus is not synced.
 var ErrConsensusNotSynced = errors.New("consensus is not synced")
@@ -186,15 +180,15 @@ type UploadOption func(url.Values)
 // upload
 func UploadWithRedundancy(minShards, totalShards int) UploadOption {
 	return func(v url.Values) {
-		v.Set(QueryStringParamMinShards, strconv.Itoa(minShards))
-		v.Set(QueryStringParamTotalShards, strconv.Itoa(totalShards))
+		v.Set("minshards", strconv.Itoa(minShards))
+		v.Set("totalshards", strconv.Itoa(totalShards))
 	}
 }
 
 // UploadWithContractSet sets the contract set that should be used for an upload
 func UploadWithContractSet(set string) UploadOption {
 	return func(v url.Values) {
-		v.Set(QueryStringParamContractSet, set)
+		v.Set("contractset", set)
 	}
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -729,7 +729,7 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 
 	// decode the contract set from the query string
 	var contractset string
-	if jc.DecodeForm(api.QueryStringParamContractSet, &contractset) != nil {
+	if jc.DecodeForm("contractset", &contractset) != nil {
 		return
 	} else if contractset != "" {
 		up.ContractSet = contractset
@@ -941,7 +941,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 
 	// decode the contract set from the query string
 	var contractset string
-	if jc.DecodeForm(api.QueryStringParamContractSet, &contractset) != nil {
+	if jc.DecodeForm("contractset", &contractset) != nil {
 		return
 	} else if contractset != "" {
 		up.ContractSet = contractset
@@ -962,10 +962,10 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 
 	// allow overriding the redundancy settings
 	rs := up.RedundancySettings
-	if jc.DecodeForm(api.QueryStringParamMinShards, &rs.MinShards) != nil {
+	if jc.DecodeForm("minshards", &rs.MinShards) != nil {
 		return
 	}
-	if jc.DecodeForm(api.QueryStringParamTotalShards, &rs.TotalShards) != nil {
+	if jc.DecodeForm("totalshards", &rs.TotalShards) != nil {
 		return
 	}
 	if jc.Check("invalid redundancy settings", rs.Validate()) != nil {


### PR DESCRIPTION
`jape` can't handle using constants from another package in `DecodeForm`, it panics with `panic: unhandled expr type (*ast.SelectorExpr)`. We should fix it in the analyzer but until that's fixed I decided to remove the query string constants since we were hardly consistent about using constants for query string params anyway.

edit: when all jape related fixes are merged it probably makes sense to do a full pass of our API and extract all query strings into constants as a `MINOR` improvement/cleanup