### PR TITLE
Fix Contractor Renewal Bug

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1184,6 +1184,7 @@ func (c *contractor) renewContract(ctx context.Context, w Worker, ci contractInf
 	// sanity check the endheight is not the same on renewals
 	endHeight := endHeight(cfg, state.period)
 	if endHeight <= rev.EndHeight() {
+		c.logger.Debugw("invalid renewal endheight", "oldEndheight", rev.EndHeight(), "newEndHeight", endHeight, "period", state.period, "bh", cs.BlockHeight)
 		return api.ContractMetadata{}, false, fmt.Errorf("renewal endheight should surpass the current contract endheight, %v <= %v", endHeight, rev.EndHeight())
 	}
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -653,7 +653,6 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 		ci.usable = usable
 		ci.recoverable = recoverable
 		if !usable {
-			toStopUsing[fcid] = strings.Join(reasons, ",")
 			c.logger.Infow(
 				"unusable contract",
 				"hk", hk,
@@ -664,6 +663,10 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 				"recoverable", recoverable,
 			)
 		}
+		if len(reasons) > 0 {
+			toStopUsing[fcid] = strings.Join(reasons, ",")
+		}
+
 		if renew {
 			toRenew = append(toRenew, ci)
 		} else if refresh {

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -224,6 +224,7 @@ func isUsableHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.
 func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, renterFunds types.Currency, f *ipFilter) (usable, recoverable, refresh, renew bool, reasons []string) {
 	c, s := ci.contract, ci.settings
 
+	usable = true
 	if bh > c.EndHeight() {
 		reasons = append(reasons, errContractExpired.Error())
 		usable = false

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -254,7 +254,7 @@ func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, rente
 		}
 		if shouldRenew, secondHalf := isUpForRenewal(cfg, *c.Revision, bh); shouldRenew {
 			reasons = append(reasons, fmt.Errorf("%w; second half: %t", errContractUpForRenewal, secondHalf).Error())
-			usable = !secondHalf // only unusable if in second half of renew window
+			usable = usable && !secondHalf // only unusable if in second half of renew window
 			recoverable = true
 			refresh = false
 			renew = true

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -252,8 +252,8 @@ func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, rente
 			renew = false
 		}
 		if shouldRenew, secondHalf := isUpForRenewal(cfg, *c.Revision, bh); shouldRenew {
-			reasons = append(reasons, errContractUpForRenewal.Error()) // only unusable if in second half of renew window
-			usable = !secondHalf
+			reasons = append(reasons, fmt.Errorf("%w; second half: %t", errContractUpForRenewal, secondHalf).Error())
+			usable = !secondHalf // only unusable if in second half of renew window
 			recoverable = true
 			refresh = false
 			renew = true

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -226,48 +226,48 @@ func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, rente
 
 	if bh > c.EndHeight() {
 		reasons = append(reasons, errContractExpired.Error())
-		renew = false
-		refresh = false
+		usable = false
 		recoverable = false
+		refresh = false
+		renew = false
 	} else if c.Revision.RevisionNumber == math.MaxUint64 {
 		reasons = append(reasons, errContractMaxRevisionNumber.Error())
-		renew = false
-		refresh = false
+		usable = false
 		recoverable = false
+		refresh = false
+		renew = false
 	} else {
 		if isOutOfCollateral(c, s, renterFunds, bh) {
 			reasons = append(reasons, errContractOutOfCollateral.Error())
-			renew = false
-			refresh = true
+			usable = false
 			recoverable = true
+			refresh = true
+			renew = false
 		}
 		if isOutOfFunds(cfg, s, c) {
 			reasons = append(reasons, errContractOutOfFunds.Error())
-			renew = false
-			refresh = true
+			usable = false
 			recoverable = true
+			refresh = true
+			renew = false
 		}
 		if shouldRenew, secondHalf := isUpForRenewal(cfg, *c.Revision, bh); shouldRenew {
-			if secondHalf {
-				reasons = append(reasons, errContractUpForRenewal.Error()) // only unusable if in second half of renew window
-			}
-			renew = true
-			refresh = false
+			reasons = append(reasons, errContractUpForRenewal.Error()) // only unusable if in second half of renew window
+			usable = !secondHalf
 			recoverable = true
+			refresh = false
+			renew = true
 		}
 	}
 
-	// redundant IP check - always perform this last since it will update
-	// the ipFilter.
-	if !cfg.Hosts.AllowRedundantIPs && f.isRedundantIP(c.HostIP, c.HostKey) {
+	// IP check should be last since it modifies the filter
+	if !cfg.Hosts.AllowRedundantIPs && (usable || recoverable) && f.isRedundantIP(c.HostIP, c.HostKey) {
 		reasons = append(reasons, errHostRedundantIP.Error())
-		renew = false
-		// NOTE: we don't set refresh to false or recoverable to true. We fund
-		// the contract but don't want to use it in the set.
-		recoverable = false
+		usable = false
+		recoverable = false // do not use in the contract set, but keep it around for downloads
+		renew = false       // do not renew, but allow refreshes so the contracts stays funded
 	}
 
-	usable = len(reasons) == 0
 	return
 }
 


### PR DESCRIPTION
When a contract needs to be renewed we divide them into two categories essentially, the ones in the first half of the renewal window and the ones in the second. We consider contracts still in the first half to be usable. Those usable contracts we want to keep regardless of whether renewals fails or were halted (e.g. because of insufficient balance or out-of-sync-periods). This was not happening causing a bunch of nasty side-effects.

If we don't keep those contracts, they drop off from the set without knowing the reason (`reason: "unknown"` in the logs), but not only that, we think we have to form new contracts since we don't end up with `cfg.amount` contracts after renews and refreshes.

On arequipa this led to two waves of contract churn, causing ~85% of the contract set to be replaced, leading to ~800k migrations. This PR fixes that by looping over the remaining renewals in `runContractRenewals` and appending them to the `toKeep` array if it's usable. Besides that I've made some added changes to improve the quality of the contractor log.

