### PR TITLE
Make object_id case-sensitive

### DIFF
--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -319,6 +319,7 @@ func TestObjectEntries(t *testing.T) {
 		{"/fileś/śpecial", 6}, // utf8
 		{"//double/", 7},
 		{"///triple", 8},
+		{"/FOO/bar", 9}, // test case sensitivity
 	}
 
 	for _, upload := range uploads {
@@ -340,10 +341,11 @@ func TestObjectEntries(t *testing.T) {
 		prefix string
 		want   []api.ObjectMetadata
 	}{
-		{"/", "", []api.ObjectMetadata{{Name: "//", Size: 15}, {Name: "/fileś/", Size: 6}, {Name: "/foo/", Size: 10}, {Name: "/gab/", Size: 5}}},
+		{"/", "", []api.ObjectMetadata{{Name: "//", Size: 15}, {Name: "/FOO/", Size: 9}, {Name: "/fileś/", Size: 6}, {Name: "/foo/", Size: 10}, {Name: "/gab/", Size: 5}}},
 		{"//", "", []api.ObjectMetadata{{Name: "///", Size: 8}, {Name: "//double/", Size: 7}}},
 		{"///", "", []api.ObjectMetadata{{Name: "///triple", Size: 8}}},
 		{"/foo/", "", []api.ObjectMetadata{{Name: "/foo/bar", Size: 1}, {Name: "/foo/bat", Size: 2}, {Name: "/foo/baz/", Size: 7}}},
+		{"/FOO/", "", []api.ObjectMetadata{{Name: "/FOO/bar", Size: 9}}},
 		{"/foo/baz/", "", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3}, {Name: "/foo/baz/quuz", Size: 4}}},
 		{"/gab/", "", []api.ObjectMetadata{{Name: "/gab/guub", Size: 5}}},
 		{"/fileś/", "", []api.ObjectMetadata{{Name: "/fileś/śpecial", Size: 6}}},

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -674,12 +675,10 @@ FROM (
 		SELECT size, SUBSTR(object_id, ?) AS trimmed
 		FROM objects
 		WHERE ?
-		ORDER BY id ASC
 	) AS i
 ) AS m
 GROUP BY name
 HAVING ? AND name != ?
-ORDER BY name ASC
 LIMIT ? OFFSET ?`,
 		sqlConcat(s.db, "?", "trimmed"),
 		sqlConcat(s.db, "?", "substr(trimmed, 1, slashindex)")),
@@ -697,6 +696,10 @@ LIMIT ? OFFSET ?`,
 	if err != nil {
 		return nil, err
 	}
+	// Sort results outside of query to get consist ordering across dbs.
+	sort.Slice(metadata, func(i, j int) bool {
+		return metadata[i].Name < metadata[j].Name
+	})
 	return metadata, nil
 }
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -728,6 +727,7 @@ FROM (
 ) AS m
 GROUP BY name
 HAVING ? AND name != ?
+ORDER BY name ASC
 LIMIT ? OFFSET ?`,
 		sqlConcat(s.db, "?", "trimmed"),
 		sqlConcat(s.db, "?", "substr(trimmed, 1, slashindex)")),
@@ -745,10 +745,6 @@ LIMIT ? OFFSET ?`,
 	if err != nil {
 		return nil, err
 	}
-	// Sort results outside of query to get consistent ordering across dbs.
-	sort.Slice(metadata, func(i, j int) bool {
-		return metadata[i].Name < metadata[j].Name
-	})
 	return metadata, nil
 }
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -679,6 +679,7 @@ FROM (
 ) AS m
 GROUP BY name
 HAVING ? AND name != ?
+ORDER BY name ASC
 LIMIT ? OFFSET ?`,
 		sqlConcat(s.db, "?", "trimmed"),
 		sqlConcat(s.db, "?", "substr(trimmed, 1, slashindex)")),

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -668,7 +668,7 @@ func (s *SQLStore) SearchObjects(ctx context.Context, substring string, offset, 
 
 	var objects []api.ObjectMetadata
 	err := s.db.
-		Select("o.object_id as name, o.size as size, MIN(sla.health) as health").
+		Select("o.object_id as name, MAX(o.size) as size, MIN(sla.health) as health").
 		Model(&dbObject{}).
 		Table("objects o").
 		Joins("LEFT JOIN slices sli ON o.id = sli.`db_object_id`").

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -73,7 +73,7 @@ type (
 		Model
 
 		Key      []byte
-		ObjectID string    `gorm:"index;unique;size:4096"`
+		ObjectID string    `gorm:"index;unique"`
 		Slabs    []dbSlice `gorm:"constraint:OnDelete:CASCADE"` // CASCADE to delete slices too
 		Size     int64
 	}

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -625,7 +625,7 @@ func (s *SQLStore) SearchObjects(ctx context.Context, substring string, offset, 
 
 	var objects []dbObject
 	err := s.db.Model(&dbObject{}).
-		Select("*, INSTR(object_id, ?) AS pos WHERE pos > 0", substring).
+		Where("INSTR(object_id, ?) > 0", substring).
 		Offset(offset).
 		Limit(limit).
 		Find(&objects).Error

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -674,6 +674,7 @@ FROM (
 		SELECT size, SUBSTR(object_id, ?) AS trimmed
 		FROM objects
 		WHERE ?
+		ORDER BY id ASC
 	) AS i
 ) AS m
 GROUP BY name

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -625,8 +625,7 @@ func (s *SQLStore) SearchObjects(ctx context.Context, substring string, offset, 
 
 	var objects []dbObject
 	err := s.db.Model(&dbObject{}).
-		Select("*, INSTR(object_id, ?) AS pos", substring).
-		Where("pos > 0").
+		Select("*, INSTR(object_id, ?) AS pos WHERE pos > 0", substring).
 		Offset(offset).
 		Limit(limit).
 		Find(&objects).Error
@@ -696,7 +695,7 @@ LIMIT ? OFFSET ?`,
 	if err != nil {
 		return nil, err
 	}
-	// Sort results outside of query to get consist ordering across dbs.
+	// Sort results outside of query to get consistent ordering across dbs.
 	sort.Slice(metadata, func(i, j int) bool {
 		return metadata[i].Name < metadata[j].Name
 	})

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -720,14 +720,10 @@ FROM (
 	FROM (
 		SELECT size, MIN(slabs.health) as health, SUBSTR(object_id, ?) AS trimmed
 		FROM objects
-<<<<<<< HEAD
-		WHERE ?
-=======
 		LEFT JOIN slices ON objects.id = slices.db_object_id
 		LEFT JOIN slabs ON slices.db_slab_id = slabs.id
-		WHERE object_id LIKE ?
+		WHERE ?
 		GROUP BY object_id
->>>>>>> master
 	) AS i
 ) AS m
 GROUP BY name

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -65,7 +65,7 @@ type (
 	dbContractSet struct {
 		Model
 
-		Name      string       `gorm:"unique;index"`
+		Name      string       `gorm:"unique;index:length:255;"`
 		Contracts []dbContract `gorm:"many2many:contract_set_contracts;constraint:OnDelete:CASCADE"`
 	}
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -73,7 +73,7 @@ type (
 		Model
 
 		Key      []byte
-		ObjectID string    `gorm:"index;unique"`
+		ObjectID string    `gorm:"index;unique;size:4096"`
 		Slabs    []dbSlice `gorm:"constraint:OnDelete:CASCADE"` // CASCADE to delete slices too
 		Size     int64
 	}

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -677,7 +677,7 @@ FROM (
 	) AS i
 ) AS m
 GROUP BY name
-HAVING name LIKE ? AND name != ?
+HAVING ? AND name != ?
 LIMIT ? OFFSET ?`,
 		sqlConcat(s.db, "?", "trimmed"),
 		sqlConcat(s.db, "?", "substr(trimmed, 1, slashindex)")),
@@ -685,7 +685,7 @@ LIMIT ? OFFSET ?`,
 		path,
 		utf8.RuneCountInString(path)+1,
 		sqlHasPrefix("object_id", path),
-		fmt.Sprintf("%s%s", path, prefix+"%"),
+		sqlHasPrefix("name", path+prefix),
 		path,
 		limit,
 		offset)

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -673,7 +673,7 @@ func (s *SQLStore) SearchObjects(ctx context.Context, substring string, offset, 
 		Table("objects o").
 		Joins("LEFT JOIN slices sli ON o.id = sli.`db_object_id`").
 		Joins("LEFT JOIN slabs sla ON sli.db_slab_id = sla.`id`").
-		Where("INSTR(object_id, ?) > 0", substring).
+		Where("INSTR(o.object_id, ?) > 0", substring).
 		Group("o.object_id").
 		Offset(offset).
 		Limit(limit).

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -711,7 +711,7 @@ SELECT
 FROM (
 	SELECT size, health, trimmed, INSTR(trimmed, "/") AS slashindex
 	FROM (
-		SELECT size, MIN(slabs.health) as health, SUBSTR(object_id, ?) AS trimmed
+		SELECT MAX(size) AS size, MIN(slabs.health) as health, SUBSTR(object_id, ?) AS trimmed
 		FROM objects
 		LEFT JOIN slices ON objects.id = slices.db_object_id
 		LEFT JOIN slabs ON slices.db_slab_id = slabs.id

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1147,6 +1147,7 @@ func TestObjectEntries(t *testing.T) {
 		{"/foo/baz/quuz", 4},
 		{"/gab/guub", 5},
 		{"/fileś/śpecial", 6}, // utf8
+		{"/FOO/bar", 7},
 	}
 	ctx := context.Background()
 	for _, o := range objects {
@@ -1160,13 +1161,14 @@ func TestObjectEntries(t *testing.T) {
 		prefix string
 		want   []api.ObjectMetadata
 	}{
-		{"/", "", []api.ObjectMetadata{{Name: "/fileś/", Size: 6}, {Name: "/foo/", Size: 10}, {Name: "/gab/", Size: 5}}},
+		{"/", "", []api.ObjectMetadata{{Name: "/FOO/", Size: 7}, {Name: "/fileś/", Size: 6}, {Name: "/foo/", Size: 10}, {Name: "/gab/", Size: 5}}},
 		{"/foo/", "", []api.ObjectMetadata{{Name: "/foo/bar", Size: 1}, {Name: "/foo/bat", Size: 2}, {Name: "/foo/baz/", Size: 7}}},
 		{"/foo/baz/", "", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3}, {Name: "/foo/baz/quuz", Size: 4}}},
 		{"/gab/", "", []api.ObjectMetadata{{Name: "/gab/guub", Size: 5}}},
 		{"/fileś/", "", []api.ObjectMetadata{{Name: "/fileś/śpecial", Size: 6}}},
 
 		{"/", "f", []api.ObjectMetadata{{Name: "/fileś/", Size: 6}, {Name: "/foo/", Size: 10}}},
+		{"/", "F", []api.ObjectMetadata{{Name: "/FOO/", Size: 7}}},
 		{"/foo/", "fo", []api.ObjectMetadata{}},
 		{"/foo/baz/", "quux", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3}}},
 		{"/gab/", "/guub", []api.ObjectMetadata{}},

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1353,7 +1353,7 @@ func TestObjectEntries(t *testing.T) {
 		prefix string
 		want   []api.ObjectMetadata
 	}{
-		{"/", "", []api.ObjectMetadata{{Name: "/FOO/", Size: 7, Health: 1}, {Name: "/fileś/", Size: 6}, {Name: "/foo/", Size: 10}, {Name: "/gab/", Size: 5}}},
+		{"/", "", []api.ObjectMetadata{{Name: "/FOO/", Size: 7, Health: 1}, {Name: "/fileś/", Size: 6, Health: 1}, {Name: "/foo/", Size: 10, Health: 1}, {Name: "/gab/", Size: 5, Health: 1}}},
 		{"/foo/", "", []api.ObjectMetadata{{Name: "/foo/bar", Size: 1, Health: 1}, {Name: "/foo/bat", Size: 2, Health: 1}, {Name: "/foo/baz/", Size: 7, Health: 1}}},
 		{"/foo/baz/", "", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3, Health: 1}, {Name: "/foo/baz/quuz", Size: 4, Health: 1}}},
 		{"/gab/", "", []api.ObjectMetadata{{Name: "/gab/guub", Size: 5, Health: 1}}},
@@ -1413,7 +1413,7 @@ func TestSearchObjects(t *testing.T) {
 		path string
 		want []api.ObjectMetadata
 	}{
-		{"/", []api.ObjectMetadata{{Name: "/foo/bar", Size: 1, Health: 1}, {Name: "/foo/bat", Size: 2, Health: 1}, {Name: "/foo/baz/quux", Size: 3, Health: 1}, {Name: "/foo/baz/quuz", Size: 4, Health: 1}, {Name: "/gab/guub", Size: 5, Health: 1}, {Name: "/FOO/bar", Size: 6, Health: 1}}},
+		{"/", []api.ObjectMetadata{{Name: "/FOO/bar", Size: 6, Health: 1}, {Name: "/foo/bar", Size: 1, Health: 1}, {Name: "/foo/bat", Size: 2, Health: 1}, {Name: "/foo/baz/quux", Size: 3, Health: 1}, {Name: "/foo/baz/quuz", Size: 4, Health: 1}, {Name: "/gab/guub", Size: 5, Health: 1}}},
 		{"/foo/b", []api.ObjectMetadata{{Name: "/foo/bar", Size: 1, Health: 1}, {Name: "/foo/bat", Size: 2, Health: 1}, {Name: "/foo/baz/quux", Size: 3, Health: 1}, {Name: "/foo/baz/quuz", Size: 4, Health: 1}}},
 		{"o/baz/quu", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3, Health: 1}, {Name: "/foo/baz/quuz", Size: 4, Health: 1}}},
 		{"uu", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3, Health: 1}, {Name: "/foo/baz/quuz", Size: 4, Health: 1}, {Name: "/gab/guub", Size: 5, Health: 1}}},

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1206,6 +1206,7 @@ func TestSearchObjects(t *testing.T) {
 		{"/foo/baz/quux", 3},
 		{"/foo/baz/quuz", 4},
 		{"/gab/guub", 5},
+		{"/FOO/bar", 6}, // test case sensitivity
 	}
 	ctx := context.Background()
 	for _, o := range objects {
@@ -1218,7 +1219,7 @@ func TestSearchObjects(t *testing.T) {
 		path string
 		want []api.ObjectMetadata
 	}{
-		{"/", []api.ObjectMetadata{{Name: "/foo/bar", Size: 1}, {Name: "/foo/bat", Size: 2}, {Name: "/foo/baz/quux", Size: 3}, {Name: "/foo/baz/quuz", Size: 4}, {Name: "/gab/guub", Size: 5}}},
+		{"/", []api.ObjectMetadata{{Name: "/foo/bar", Size: 1}, {Name: "/foo/bat", Size: 2}, {Name: "/foo/baz/quux", Size: 3}, {Name: "/foo/baz/quuz", Size: 4}, {Name: "/gab/guub", Size: 5}, {Name: "/FOO/bar", Size: 6}}},
 		{"/foo/b", []api.ObjectMetadata{{Name: "/foo/bar", Size: 1}, {Name: "/foo/bat", Size: 2}, {Name: "/foo/baz/quux", Size: 3}, {Name: "/foo/baz/quuz", Size: 4}}},
 		{"o/baz/quu", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3}, {Name: "/foo/baz/quuz", Size: 4}}},
 		{"uu", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3}, {Name: "/foo/baz/quuz", Size: 4}, {Name: "/gab/guub", Size: 5}}},
@@ -2098,6 +2099,8 @@ func TestRenameObjects(t *testing.T) {
 		"/fileś/1a",
 		"/fileś/2a",
 		"/fileś/3a",
+		"/fileś/CASE",
+		"/fileś/case",
 		"/fileś/dir/1b",
 		"/fileś/dir/2b",
 		"/fileś/dir/3b",
@@ -2132,6 +2135,12 @@ func TestRenameObjects(t *testing.T) {
 	if err := cs.RenameObject(ctx, "/baz", "/fileś/baz"); err != nil {
 		t.Fatal(err)
 	}
+	if err := cs.RenameObjects(ctx, "/fileś/case", "/fileś/case1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cs.RenameObjects(ctx, "/fileś/CASE", "/fileś/case2"); err != nil {
+		t.Fatal(err)
+	}
 
 	// Paths after.
 	objectsAfter := []string{
@@ -2144,6 +2153,8 @@ func TestRenameObjects(t *testing.T) {
 		"/fileś/foo",
 		"/fileś/bar",
 		"/fileś/baz",
+		"/fileś/case1",
+		"/fileś/case2",
 	}
 	objectsAfterMap := make(map[string]struct{})
 	for _, path := range objectsAfter {

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -184,7 +184,7 @@ func initSchema(tx *gorm.DB) error {
 	}
 	// Change the object_id colum to use case sensitive collation.
 	if !isSQLite(tx) {
-		return tx.Exec("ALTER TABLE objects MODIFY COLUMN object_id VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;").Error
+		return tx.Exec("ALTER TABLE objects MODIFY COLUMN object_id VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;").Error
 	}
 	return nil
 }

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -178,7 +178,15 @@ func performMigrations(db *gorm.DB, logger glogger.Interface) error {
 // initSchema is executed only on a clean database. Otherwise the individual
 // migrations are executed.
 func initSchema(tx *gorm.DB) error {
-	return tx.AutoMigrate(tables...)
+	err := tx.AutoMigrate(tables...)
+	if err != nil {
+		return err
+	}
+	// Change the object_id colum to use case sensitive collation.
+	if !isSQLite(tx) {
+		return tx.Exec("ALTER TABLE objects MODIFY object_id CHARACTER SET utf8mb4 COLLATE utf8mb4_bin").Error
+	}
+	return nil
 }
 
 // performMigration00001_gormigrate performs the first migration before

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -356,13 +356,12 @@ func performMigration00003_healthcache(txn *gorm.DB, logger glogger.Interface) e
 }
 
 func performMigration00004_objectID_collation(txn *gorm.DB, logger glogger.Interface) error {
-	if isSQLite(txn) {
-		return nil // nothing to do
-	}
 	logger.Info(context.Background(), "performing migration 00004_objectID_collation")
-	err := txn.Exec("ALTER TABLE objects MODIFY COLUMN object_id VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;").Error
-	if err != nil {
-		return err
+	if !isSQLite(txn) {
+		err := txn.Exec("ALTER TABLE objects MODIFY COLUMN object_id VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;").Error
+		if err != nil {
+			return err
+		}
 	}
 	logger.Info(context.Background(), "migration 00004_objectID_collation complete")
 	return nil

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -155,6 +155,13 @@ func performMigrations(db *gorm.DB, logger glogger.Interface) error {
 			},
 			Rollback: nil,
 		},
+		{
+			ID: "00004_objectID_collation",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration00004_objectID_collation(tx, logger)
+			},
+			Rollback: nil,
+		},
 	}
 
 	// Create migrator.
@@ -345,5 +352,18 @@ func performMigration00003_healthcache(txn *gorm.DB, logger glogger.Interface) e
 		}
 	}
 	logger.Info(context.Background(), "migration 00003_healthcheck complete")
+	return nil
+}
+
+func performMigration00004_objectID_collation(txn *gorm.DB, logger glogger.Interface) error {
+	if isSQLite(txn) {
+		return nil // nothing to do
+	}
+	logger.Info(context.Background(), "performing migration 00004_objectID_collation")
+	err := txn.Exec("ALTER TABLE objects MODIFY COLUMN object_id VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;").Error
+	if err != nil {
+		return err
+	}
+	logger.Info(context.Background(), "migration 00004_objectID_collation complete")
 	return nil
 }

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -184,7 +184,7 @@ func initSchema(tx *gorm.DB) error {
 	}
 	// Change the object_id colum to use case sensitive collation.
 	if !isSQLite(tx) {
-		return tx.Exec("ALTER TABLE objects MODIFY object_id CHARACTER SET utf8mb4 COLLATE utf8mb4_bin").Error
+		return tx.Exec("ALTER TABLE objects MODIFY COLUMN object_id VARCHAR(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;").Error
 	}
 	return nil
 }


### PR DESCRIPTION
Some endpoints behaved incorrectly due to the `LIKE` operator in SQL not being case-sensitive. 
This PR fixes that and extends the test suite with relevant testing.

Closes https://github.com/SiaFoundation/renterd/issues/501