### PR TITLE
Return all hosts in /autopilot/hosts when FilterMode is 'all' without skipping the ones that aren't cached

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -104,6 +104,7 @@ type (
 	HostHandlerResponse struct {
 		Host hostdb.Host `json:"host"`
 
+		IsChecked        bool                 `json:"isChecked"`
 		Gouging          bool                 `json:"gouging"`
 		GougingBreakdown HostGougingBreakdown `json:"gougingBreakdown"`
 		Score            float64              `json:"score"`

--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -100,17 +100,19 @@ type (
 		UptimeMS           ParamDuration `json:"uptimeMS"`
 	}
 
-	// HostHandlerResponse is the response type for the /host/:hostkey endpoint.
-	HostHandlerResponse struct {
-		Host hostdb.Host `json:"host"`
-
-		IsChecked        bool                 `json:"isChecked"`
+	HostHandlerResponseChecks struct {
 		Gouging          bool                 `json:"gouging"`
 		GougingBreakdown HostGougingBreakdown `json:"gougingBreakdown"`
 		Score            float64              `json:"score"`
 		ScoreBreakdown   HostScoreBreakdown   `json:"scoreBreakdown"`
 		Usable           bool                 `json:"usable"`
 		UnusableReasons  []string             `json:"unusableReasons"`
+	}
+
+	// HostHandlerResponse is the response type for the /host/:hostkey endpoint.
+	HostHandlerResponse struct {
+		Host   hostdb.Host                `json:"host"`
+		Checks *HostHandlerResponseChecks `json:"checks,omitempty"`
 	}
 
 	HostGougingBreakdown struct {

--- a/autopilot/hostinfo.go
+++ b/autopilot/hostinfo.go
@@ -55,14 +55,14 @@ func (c *contractor) HostInfo(ctx context.Context, hostKey types.PublicKey) (api
 	isUsable, unusableResult := isUsableHost(state.cfg, rs, gc, host.Host, minScore, storedData)
 	return api.HostHandlerResponse{
 		Host: host.Host,
-
-		IsChecked:        true,
-		Gouging:          unusableResult.gougingBreakdown.Gouging(),
-		GougingBreakdown: unusableResult.gougingBreakdown,
-		Score:            unusableResult.scoreBreakdown.Score(),
-		ScoreBreakdown:   unusableResult.scoreBreakdown,
-		Usable:           isUsable,
-		UnusableReasons:  unusableResult.reasons(),
+		Checks: &api.HostHandlerResponseChecks{
+			Gouging:          unusableResult.gougingBreakdown.Gouging(),
+			GougingBreakdown: unusableResult.gougingBreakdown,
+			Score:            unusableResult.scoreBreakdown.Score(),
+			ScoreBreakdown:   unusableResult.scoreBreakdown,
+			Usable:           isUsable,
+			UnusableReasons:  unusableResult.reasons(),
+		},
 	}, nil
 }
 
@@ -115,8 +115,7 @@ func (c *contractor) HostInfos(ctx context.Context, filterMode, usabilityMode, a
 				// set IsChecked = false.
 				if usabilityMode == api.UsabilityFilterModeAll {
 					hostInfos = append(hostInfos, api.HostHandlerResponse{
-						IsChecked: false,
-						Host:      host,
+						Host: host,
 					})
 				}
 				continue
@@ -126,14 +125,14 @@ func (c *contractor) HostInfos(ctx context.Context, filterMode, usabilityMode, a
 			}
 			hostInfos = append(hostInfos, api.HostHandlerResponse{
 				Host: host,
-
-				IsChecked:        true,
-				Gouging:          hi.UnusableResult.gougingBreakdown.Gouging(),
-				GougingBreakdown: hi.UnusableResult.gougingBreakdown,
-				Score:            hi.UnusableResult.scoreBreakdown.Score(),
-				ScoreBreakdown:   hi.UnusableResult.scoreBreakdown,
-				Usable:           hi.Usable,
-				UnusableReasons:  hi.UnusableResult.reasons(),
+				Checks: &api.HostHandlerResponseChecks{
+					Gouging:          hi.UnusableResult.gougingBreakdown.Gouging(),
+					GougingBreakdown: hi.UnusableResult.gougingBreakdown,
+					Score:            hi.UnusableResult.scoreBreakdown.Score(),
+					ScoreBreakdown:   hi.UnusableResult.scoreBreakdown,
+					Usable:           hi.Usable,
+					UnusableReasons:  hi.UnusableResult.reasons(),
+				},
 			})
 			if wanted > 0 && len(hostInfos) == wanted {
 				return hostInfos, nil // we're done.

--- a/autopilot/hostinfo.go
+++ b/autopilot/hostinfo.go
@@ -56,6 +56,7 @@ func (c *contractor) HostInfo(ctx context.Context, hostKey types.PublicKey) (api
 	return api.HostHandlerResponse{
 		Host: host.Host,
 
+		IsChecked:        true,
 		Gouging:          unusableResult.gougingBreakdown.Gouging(),
 		GougingBreakdown: unusableResult.gougingBreakdown,
 		Score:            unusableResult.scoreBreakdown.Score(),
@@ -110,6 +111,14 @@ func (c *contractor) HostInfos(ctx context.Context, filterMode, usabilityMode, a
 		for _, host := range hosts {
 			hi, cached := hostInfo[host.PublicKey]
 			if !cached {
+				// when the filterMode is "all" we include uncached hosts and
+				// set IsChecked = false.
+				if usabilityMode == api.UsabilityFilterModeAll {
+					hostInfos = append(hostInfos, api.HostHandlerResponse{
+						IsChecked: false,
+						Host:      host,
+					})
+				}
 				continue
 			}
 			if !keep(hi.Usable) {
@@ -118,6 +127,7 @@ func (c *contractor) HostInfos(ctx context.Context, filterMode, usabilityMode, a
 			hostInfos = append(hostInfos, api.HostHandlerResponse{
 				Host: host,
 
+				IsChecked:        true,
 				Gouging:          hi.UnusableResult.gougingBreakdown.Gouging(),
 				GougingBreakdown: hi.UnusableResult.gougingBreakdown,
 				Score:            hi.UnusableResult.scoreBreakdown.Score(),

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -196,17 +196,17 @@ func TestNewTestCluster(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if hi.ScoreBreakdown.Score() == 0 {
-			js, _ := json.MarshalIndent(hi.ScoreBreakdown, "", "  ")
+		if hi.Checks.ScoreBreakdown.Score() == 0 {
+			js, _ := json.MarshalIndent(hi.Checks.ScoreBreakdown, "", "  ")
 			t.Fatalf("score shouldn't be 0 because that means one of the fields was 0: %s", string(js))
 		}
-		if hi.Score == 0 {
+		if hi.Checks.Score == 0 {
 			t.Fatal("score shouldn't be 0")
 		}
-		if !hi.Usable {
+		if !hi.Checks.Usable {
 			t.Fatal("host should be usable")
 		}
-		if len(hi.UnusableReasons) != 0 {
+		if len(hi.Checks.UnusableReasons) != 0 {
 			t.Fatal("usable hosts don't have any reasons set")
 		}
 		if reflect.DeepEqual(hi.Host, hostdb.HostInfo{}) {
@@ -218,17 +218,17 @@ func TestNewTestCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, hi := range hostInfos {
-		if hi.ScoreBreakdown.Score() == 0 {
-			js, _ := json.MarshalIndent(hi.ScoreBreakdown, "", "  ")
+		if hi.Checks.ScoreBreakdown.Score() == 0 {
+			js, _ := json.MarshalIndent(hi.Checks.ScoreBreakdown, "", "  ")
 			t.Fatalf("score shouldn't be 0 because that means one of the fields was 0: %s", string(js))
 		}
-		if hi.Score == 0 {
+		if hi.Checks.Score == 0 {
 			t.Fatal("score shouldn't be 0")
 		}
-		if !hi.Usable {
+		if !hi.Checks.Usable {
 			t.Fatal("host should be usable")
 		}
-		if len(hi.UnusableReasons) != 0 {
+		if len(hi.Checks.UnusableReasons) != 0 {
 			t.Fatal("usable hosts don't have any reasons set")
 		}
 		if reflect.DeepEqual(hi.Host, hostdb.HostInfo{}) {


### PR DESCRIPTION
This PR addresses part of https://github.com/SiaFoundation/renterd/issues/500. Instead of not returning hosts that we don't have in the autopilot cache yet we mark them as `IsChecked = 'false'` and still return them when the filter mode is set to 'all'.