### PR TITLE
Allow for scanning hosts without configuring autopilot or syncing blockchain

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -91,12 +91,10 @@ type (
 	// AutopilotStatusResponse is the response type for the /autopilot/status
 	// endpoint.
 	AutopilotStatusResponse struct {
-		Configured         bool          `json:"configured"`
 		Migrating          bool          `json:"migrating"`
 		MigratingLastStart ParamTime     `json:"migratingLastStart"`
 		Scanning           bool          `json:"scanning"`
 		ScanningLastStart  ParamTime     `json:"scanningLastStart"`
-		Synced             bool          `json:"synced"`
 		UptimeMS           ParamDuration `json:"uptimeMS"`
 	}
 

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -183,7 +183,7 @@ func (ap *Autopilot) Run() error {
 	}
 	ap.runningSince = time.Now()
 	ap.stopChan = make(chan struct{})
-	ap.triggerChan = make(chan bool)
+	ap.triggerChan = make(chan bool, 1)
 	ap.ticker = time.NewTicker(ap.tickerDuration)
 
 	ap.wg.Add(1)

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -114,7 +114,7 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 	defer span.End()
 
 	// skip contract maintenance if we're stopped or not synced
-	if c.ap.isStopped() || !c.ap.isSynced() {
+	if c.ap.isStopped() {
 		return false, nil
 	}
 	c.logger.Info("performing contract maintenance")
@@ -426,7 +426,7 @@ func (c *contractor) performWalletMaintenance(ctx context.Context) error {
 	ctx, span := tracing.Tracer.Start(ctx, "contractor.performWalletMaintenance")
 	defer span.End()
 
-	if c.ap.isStopped() || !c.ap.isSynced() {
+	if c.ap.isStopped() {
 		return nil // skip contract maintenance if we're not synced
 	}
 

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -255,17 +255,11 @@ func TestNewTestCluster(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !status.Configured {
-		t.Fatal("autopilot should be configured")
-	}
 	if time.Time(status.MigratingLastStart).IsZero() {
 		t.Fatal("autopilot should have completed a migration")
 	}
 	if time.Time(status.ScanningLastStart).IsZero() {
 		t.Fatal("autopilot should have completed a scan")
-	}
-	if !status.Synced {
-		t.Fatal("autopilot should be synced")
 	}
 	if status.UptimeMS == 0 {
 		t.Fatal("uptime should be set")

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -42,6 +42,7 @@ func TestHostPruning(t *testing.T) {
 	// create a helper function that records n failed interactions
 	now := time.Now()
 	recordFailedInteractions := func(n int, hk types.PublicKey) {
+		t.Helper()
 		his := make([]hostdb.Interaction, n)
 		for i := 0; i < n; i++ {
 			now = now.Add(time.Hour).Add(time.Minute) // 1m leeway
@@ -59,6 +60,7 @@ func TestHostPruning(t *testing.T) {
 
 	// create a helper function that waits for an autopilot loop to finish
 	waitForAutopilotLoop := func() {
+		t.Helper()
 		var nTriggered int
 		if err := Retry(10, 500*time.Millisecond, func() error {
 			if triggered, err := a.Trigger(true); err != nil {


### PR DESCRIPTION
This PR addresses one of the issues reported in https://github.com/SiaFoundation/renterd/issues/500.
Hosts can be scanned without configuring the autopilot or waiting for the consensus to be synced.