### PR TITLE
Don't persist host settings and pricetable for every host interaction

### DIFF
--- a/hostdb/hostdb.go
+++ b/hostdb/hostdb.go
@@ -28,6 +28,12 @@ type ErrorResult struct {
 	Error string `json:"error,omitempty"`
 }
 
+type MetricResultCommon struct {
+	Address   string        `json:"address"`
+	Timestamp time.Time     `json:"timestamp"`
+	Elapsed   time.Duration `json:"elapsed"`
+}
+
 type ScanResult struct {
 	ErrorResult
 	PriceTable rhpv3.HostPriceTable `json:"priceTable,omitempty"`

--- a/worker/interactions.go
+++ b/worker/interactions.go
@@ -122,14 +122,8 @@ type metricCommon struct {
 	err       error
 }
 
-type metricResultCommon struct {
-	Address   string        `json:"address"`
-	Timestamp time.Time     `json:"timestamp"`
-	Elapsed   time.Duration `json:"elapsed"`
-}
-
-func (m metricCommon) commonResult() metricResultCommon {
-	return metricResultCommon{
+func (m metricCommon) commonResult() hostdb.MetricResultCommon {
+	return hostdb.MetricResultCommon{
 		Address:   m.address,
 		Timestamp: m.timestamp,
 		Elapsed:   m.elapsed,
@@ -154,12 +148,12 @@ func (m MetricPriceTableUpdate) Result() interface{} {
 	er := hostdb.ErrorResult{Error: errToStr(m.err)}
 	if m.err != nil {
 		return struct {
-			metricResultCommon
+			hostdb.MetricResultCommon
 			hostdb.ErrorResult
 		}{cr, er}
 	} else {
 		return struct {
-			metricResultCommon
+			hostdb.MetricResultCommon
 			hostdb.PriceTableUpdateResult
 		}{cr, hostdb.PriceTableUpdateResult{ErrorResult: er, PriceTable: m.pt}}
 	}
@@ -181,12 +175,12 @@ func (m MetricHostScan) Result() interface{} {
 	er := hostdb.ErrorResult{Error: errToStr(m.err)}
 	if m.err != nil {
 		return struct {
-			metricResultCommon
+			hostdb.MetricResultCommon
 			hostdb.ErrorResult
 		}{cr, er}
 	} else {
 		return struct {
-			metricResultCommon
+			hostdb.MetricResultCommon
 			hostdb.ScanResult
 		}{cr, hostdb.ScanResult{ErrorResult: er, PriceTable: m.pt, Settings: m.settings}}
 	}


### PR DESCRIPTION
Persisting every pricetable and host setting puts a lot of pressure on the database. Since we already persist settings and price tables in the hosts table, we stop doing so on every interaction.