### PR TITLE
GET /bus/wallet endpoint

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -383,6 +383,13 @@ type GougingSettings struct {
 	MinMaxEphemeralAccountBalance types.Currency `json:"minMaxEphemeralAccountBalance"`
 }
 
+type WalletResponse struct {
+	ScanHeight uint64         `json:"scanHeight"`
+	Address    types.Address  `json:"address"`
+	Spendable  types.Currency `json:"spendable"`
+	Confirmed  types.Currency `json:"confirmed"`
+}
+
 // Validate returns an error if the gouging settings are not considered valid.
 func (gs GougingSettings) Validate() error {
 	if gs.HostBlockHeightLeeway < 3 {

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -34,8 +34,7 @@ type Bus interface {
 	UpdateAutopilot(ctx context.Context, autopilot api.Autopilot) error
 
 	// wallet
-	WalletAddress(ctx context.Context) (types.Address, error)
-	WalletBalance(ctx context.Context) (types.Currency, error)
+	Wallet(ctx context.Context) (api.WalletResponse, error)
 	WalletDiscard(ctx context.Context, txn types.Transaction) error
 	WalletOutputs(ctx context.Context) (resp []wallet.SiacoinElement, err error)
 	WalletPending(ctx context.Context) (resp []types.Transaction, err error)
@@ -442,10 +441,11 @@ func (ap *Autopilot) updateState(ctx context.Context) error {
 	}
 
 	// fetch our wallet address
-	address, err := ap.bus.WalletAddress(ctx)
+	wi, err := ap.bus.Wallet(ctx)
 	if err != nil {
 		return fmt.Errorf("could not fetch wallet address, err: %v", err)
 	}
+	address := wi.Address
 
 	// update current period if necessary
 	if cs.Synced {

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -470,11 +470,12 @@ func (c *contractor) performWalletMaintenance(ctx context.Context) error {
 	}
 
 	// not enough balance - nothing to do
-	balance, err := b.WalletBalance(ctx)
+	wi, err := b.Wallet(ctx)
 	if err != nil {
 		l.Errorf("wallet maintenance skipped, fetching wallet balance failed with err: %v", err)
 		return err
 	}
+	balance := wi.Spendable
 	amount := cfg.Contracts.Allowance.Div64(cfg.Contracts.Amount)
 	outputs := balance.Div(amount).Big().Uint64()
 	if outputs < 2 {

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1392,7 +1392,7 @@ func (b *bus) Handler() http.Handler {
 		"GET    /txpool/transactions":   b.txpoolTransactionsHandler,
 		"POST   /txpool/broadcast":      b.txpoolBroadcastHandler,
 
-		"GET    /wallet":               b.walletBalanceHandler,
+		"GET    /wallet":               b.walletHandler,
 		"GET    /wallet/balance":       b.walletBalanceHandler,
 		"GET    /wallet/address":       b.walletAddressHandler,
 		"GET    /wallet/transactions":  b.walletTransactionsHandler,

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1393,8 +1393,8 @@ func (b *bus) Handler() http.Handler {
 		"POST   /txpool/broadcast":      b.txpoolBroadcastHandler,
 
 		"GET    /wallet":               b.walletHandler,
-		"GET    /wallet/balance":       b.walletBalanceHandler,
-		"GET    /wallet/address":       b.walletAddressHandler,
+		"GET    /wallet/balance":       b.walletBalanceHandler, // deprecated
+		"GET    /wallet/address":       b.walletAddressHandler, // deprecated
 		"GET    /wallet/transactions":  b.walletTransactionsHandler,
 		"GET    /wallet/outputs":       b.walletOutputsHandler,
 		"POST   /wallet/fund":          b.walletFundHandler,

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -53,8 +53,9 @@ type (
 	// A Wallet can spend and receive siacoins.
 	Wallet interface {
 		Address() types.Address
-		Balance() (types.Currency, error)
+		Balance() (spendable, confirmed types.Currency, _ error)
 		FundTransaction(cs consensus.State, txn *types.Transaction, amount types.Currency, pool []types.Transaction) ([]types.Hash256, error)
+		Height() uint64
 		Redistribute(cs consensus.State, outputs int, amount, feePerByte types.Currency, pool []types.Transaction) (types.Transaction, []types.Hash256, error)
 		ReleaseInputs(txn types.Transaction)
 		SignTransaction(cs consensus.State, txn *types.Transaction, toSign []types.Hash256, cf types.CoveredFields) error
@@ -208,8 +209,22 @@ func (b *bus) txpoolBroadcastHandler(jc jape.Context) {
 	}
 }
 
+func (b *bus) walletHandler(jc jape.Context) {
+	address := b.w.Address()
+	spendable, confirmed, err := b.w.Balance()
+	if jc.Check("couldn't fetch wallet balance", err) != nil {
+		return
+	}
+	jc.Encode(api.WalletResponse{
+		ScanHeight: b.w.Height(),
+		Address:    address,
+		Confirmed:  confirmed,
+		Spendable:  spendable,
+	})
+}
+
 func (b *bus) walletBalanceHandler(jc jape.Context) {
-	balance, err := b.w.Balance()
+	_, balance, err := b.w.Balance()
 	if jc.Check("couldn't fetch wallet balance", err) != nil {
 		return
 	}
@@ -1377,6 +1392,7 @@ func (b *bus) Handler() http.Handler {
 		"GET    /txpool/transactions":   b.txpoolTransactionsHandler,
 		"POST   /txpool/broadcast":      b.txpoolBroadcastHandler,
 
+		"GET    /wallet":               b.walletBalanceHandler,
 		"GET    /wallet/balance":       b.walletBalanceHandler,
 		"GET    /wallet/address":       b.walletAddressHandler,
 		"GET    /wallet/transactions":  b.walletTransactionsHandler,

--- a/bus/client.go
+++ b/bus/client.go
@@ -105,8 +105,8 @@ func (c *Client) BroadcastTransaction(ctx context.Context, txns []types.Transact
 	return c.c.WithContext(ctx).POST("/txpool/broadcast", txns, nil)
 }
 
-// WalletInfo calls the /wallet endpoint on the bus.
-func (c *Client) WalletInfo(ctx context.Context) (resp api.WalletResponse, err error) {
+// Wallet calls the /wallet endpoint on the bus.
+func (c *Client) Wallet(ctx context.Context) (resp api.WalletResponse, err error) {
 	err = c.c.WithContext(ctx).GET("/wallet", &resp)
 	return
 }

--- a/bus/client.go
+++ b/bus/client.go
@@ -105,6 +105,12 @@ func (c *Client) BroadcastTransaction(ctx context.Context, txns []types.Transact
 	return c.c.WithContext(ctx).POST("/txpool/broadcast", txns, nil)
 }
 
+// WalletInfo calls the /wallet endpoint on the bus.
+func (c *Client) WalletInfo(ctx context.Context) (resp api.WalletResponse, err error) {
+	err = c.c.WithContext(ctx).GET("/wallet", &resp)
+	return
+}
+
 // WalletBalance returns the current wallet balance.
 func (c *Client) WalletBalance(ctx context.Context) (bal types.Currency, err error) {
 	err = c.c.WithContext(ctx).GET("/wallet/balance", &bal)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -48,6 +48,24 @@ func TestNewTestCluster(t *testing.T) {
 	b := cluster.Bus
 	w := cluster.Worker
 
+	// Check wallet info is sane after startup.
+	wi, err := b.WalletInfo(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wi.ScanHeight == 0 {
+		t.Fatal("wallet scan height should not be 0")
+	}
+	if wi.Confirmed.IsZero() {
+		t.Fatal("wallet confirmed balance should not be zero")
+	}
+	if wi.Spendable.IsZero() {
+		t.Fatal("wallet spendable balance should not be zero")
+	}
+	if wi.Address == (types.Address{}) {
+		t.Fatal("wallet addresses should not be nil")
+	}
+
 	// Try talking to the bus API by adding an object.
 	err = b.AddObject(context.Background(), "foo", testAutopilotConfig.Contracts.Set, object.Object{
 		Key: object.GenerateEncryptionKey(),

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -49,7 +49,7 @@ func TestNewTestCluster(t *testing.T) {
 	w := cluster.Worker
 
 	// Check wallet info is sane after startup.
-	wi, err := b.WalletInfo(context.Background())
+	wi, err := b.Wallet(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,11 +59,11 @@ func TestNewTestCluster(t *testing.T) {
 	if wi.Confirmed.IsZero() {
 		t.Fatal("wallet confirmed balance should not be zero")
 	}
-	if wi.Spendable.IsZero() {
-		t.Fatal("wallet spendable balance should not be zero")
+	if !wi.Spendable.Equals(wi.Confirmed) {
+		t.Fatal("wallet spendable balance should match confirmed")
 	}
 	if wi.Address == (types.Address{}) {
-		t.Fatal("wallet addresses should not be nil")
+		t.Fatal("wallet address should be set")
 	}
 
 	// Try talking to the bus API by adding an object.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -107,8 +107,8 @@ type Transaction struct {
 // A SingleAddressStore stores the state of a single-address wallet.
 // Implementations are assumed to be thread safe.
 type SingleAddressStore interface {
-	Balance() (types.Currency, error)
-	UnspentSiacoinElements() ([]SiacoinElement, error)
+	Height() uint64
+	UnspentSiacoinElements(matured bool) ([]SiacoinElement, error)
 	Transactions(before, since time.Time, offset, limit int) ([]Transaction, error)
 }
 
@@ -142,14 +142,28 @@ func (w *SingleAddressWallet) Address() types.Address {
 }
 
 // Balance returns the balance of the wallet.
-func (w *SingleAddressWallet) Balance() (types.Currency, error) {
-	return w.store.Balance()
+func (w *SingleAddressWallet) Balance() (spendable, confirmed types.Currency, _ error) {
+	sces, err := w.store.UnspentSiacoinElements(true)
+	if err != nil {
+		return types.Currency{}, types.Currency{}, err
+	}
+	for _, sce := range sces {
+		if !w.isOutputUsed(sce.ID) {
+			spendable = spendable.Add(sce.Value)
+		}
+		confirmed = confirmed.Add(sce.Value)
+	}
+	return
+}
+
+func (w *SingleAddressWallet) Height() uint64 {
+	return w.store.Height()
 }
 
 // UnspentOutputs returns the set of unspent Siacoin outputs controlled by the
 // wallet.
 func (w *SingleAddressWallet) UnspentOutputs() ([]SiacoinElement, error) {
-	return w.store.UnspentSiacoinElements()
+	return w.store.UnspentSiacoinElements(false)
 }
 
 // Transactions returns up to max transactions relevant to the wallet that have
@@ -177,7 +191,7 @@ func (w *SingleAddressWallet) FundTransaction(cs consensus.State, txn *types.Tra
 		}
 	}
 
-	utxos, err := w.store.UnspentSiacoinElements()
+	utxos, err := w.store.UnspentSiacoinElements(false)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +292,7 @@ func (w *SingleAddressWallet) Redistribute(cs consensus.State, outputs int, amou
 	}
 
 	// fetch unspent transaction outputs
-	utxos, err := w.store.UnspentSiacoinElements()
+	utxos, err := w.store.UnspentSiacoinElements(false)
 	if err != nil {
 		return types.Transaction{}, nil, err
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -147,6 +147,8 @@ func (w *SingleAddressWallet) Balance() (spendable, confirmed types.Currency, _ 
 	if err != nil {
 		return types.Currency{}, types.Currency{}, err
 	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	for _, sce := range sces {
 		if !w.isOutputUsed(sce.ID) {
 			spendable = spendable.Add(sce.Value)

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -17,8 +17,11 @@ type mockStore struct {
 	utxos []wallet.SiacoinElement
 }
 
-func (s *mockStore) Balance() (types.Currency, error)                         { return types.ZeroCurrency, nil }
-func (s *mockStore) UnspentSiacoinElements() ([]wallet.SiacoinElement, error) { return s.utxos, nil }
+func (s *mockStore) Balance() (types.Currency, error) { return types.ZeroCurrency, nil }
+func (s *mockStore) Height() uint64                   { return 0 }
+func (s *mockStore) UnspentSiacoinElements(bool) ([]wallet.SiacoinElement, error) {
+	return s.utxos, nil
+}
 func (s *mockStore) Transactions(before, since time.Time, offset, limit int) ([]wallet.Transaction, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This PR adds a new GET endpoint to the bus called /wallet.
The idea is to have more consistency between the hostd and renterd APIs so the response matches the response of hostd's /wallet endpoint apart from one missing field which we can't populate yet.

This exposes the scan height of the wallet for the first time, gives more information about confirmed balance and actual spendable balance and makes 2 other endpoints (balance, address) obsolete. 

Closes https://github.com/SiaFoundation/renterd/issues/451