### PR TITLE
fix prunable data query (ONLY_FULL_GROUP_BY workaround)

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -573,7 +573,7 @@ func (s *SQLStore) PrunableData(ctx context.Context) (prunable int64, err error)
 SELECT IFNULL(SUM(prunable), 0)
 FROM (
     SELECT CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
-        SELECT IFNULL(c.size - COUNT(cs.db_sector_id) * ?, 0) as bytes
+        SELECT IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
         FROM contracts c
         LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
         GROUP BY c.id
@@ -592,7 +592,7 @@ func (s *SQLStore) PrunableDataForContract(ctx context.Context, id types.FileCon
 	err = s.db.
 		Raw(`
 SELECT CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
-    SELECT IFNULL(c.size - COUNT(cs.db_sector_id) * 4194304, 0) as bytes
+    SELECT IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * 4194304, 0) as bytes
     FROM contracts c
     LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
     WHERE c.fcid = ?

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2812,6 +2812,10 @@ func TestPrunableData(t *testing.T) {
 	// assert there's now two sectors that can be pruned
 	if n := prunableData(nil); n != rhpv2.SectorSize*2 {
 		t.Fatal("unexpected amount of prunable data", n)
+	} else if n := prunableData(&fcids[0]); n != rhpv2.SectorSize {
+		t.Fatal("unexpected amount of prunable data", n)
+	} else if n := prunableData(&fcids[1]); n != rhpv2.SectorSize {
+		t.Fatal("unexpected amount of prunable data", n)
 	}
 
 	// archive all contracts


### PR DESCRIPTION
MySQL has a setting now called `ONLY_FULL_GROUP_BY` (which I find a bit annoying) which does not allow selecting columns that are neither explicitly named in the group by or fields on which the aggregation is not dependant. I think it's fine to work around it by doing `MAX` on the `o.size`.

error:
```
SELECT list is not in GROUP BY clause and contains nonaggregated column 'f3asdfas8eee.o.size' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```