### PR TITLE
Return unconfirmed siacoins in /wallet endpoint

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -388,10 +388,11 @@ type GougingSettings struct {
 }
 
 type WalletResponse struct {
-	ScanHeight uint64         `json:"scanHeight"`
-	Address    types.Address  `json:"address"`
-	Spendable  types.Currency `json:"spendable"`
-	Confirmed  types.Currency `json:"confirmed"`
+	ScanHeight  uint64         `json:"scanHeight"`
+	Address     types.Address  `json:"address"`
+	Spendable   types.Currency `json:"spendable"`
+	Confirmed   types.Currency `json:"confirmed"`
+	Unconfirmed types.Currency `json:"unconfirmed"`
 }
 
 // Validate returns an error if the gouging settings are not considered valid.

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -269,6 +269,7 @@ func (b *bus) walletFundHandler(jc jape.Context) {
 	}
 	txn := wfr.Transaction
 	if len(txn.MinerFees) == 0 {
+		// if no fees are specified, we add some
 		fee := b.tp.RecommendedFee().Mul64(uint64(types.EncodedLen(txn)))
 		txn.MinerFees = []types.Currency{fee}
 	}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -53,7 +53,7 @@ type (
 	// A Wallet can spend and receive siacoins.
 	Wallet interface {
 		Address() types.Address
-		Balance() (spendable, confirmed types.Currency, _ error)
+		Balance() (spendable, confirmed, unconfirmed types.Currency, _ error)
 		FundTransaction(cs consensus.State, txn *types.Transaction, amount types.Currency, pool []types.Transaction) ([]types.Hash256, error)
 		Height() uint64
 		Redistribute(cs consensus.State, outputs int, amount, feePerByte types.Currency, pool []types.Transaction) (types.Transaction, []types.Hash256, error)
@@ -214,20 +214,21 @@ func (b *bus) txpoolBroadcastHandler(jc jape.Context) {
 
 func (b *bus) walletHandler(jc jape.Context) {
 	address := b.w.Address()
-	spendable, confirmed, err := b.w.Balance()
+	spendable, confirmed, unconfirmed, err := b.w.Balance()
 	if jc.Check("couldn't fetch wallet balance", err) != nil {
 		return
 	}
 	jc.Encode(api.WalletResponse{
-		ScanHeight: b.w.Height(),
-		Address:    address,
-		Confirmed:  confirmed,
-		Spendable:  spendable,
+		ScanHeight:  b.w.Height(),
+		Address:     address,
+		Confirmed:   confirmed,
+		Spendable:   spendable,
+		Unconfirmed: unconfirmed,
 	})
 }
 
 func (b *bus) walletBalanceHandler(jc jape.Context) {
-	_, balance, err := b.w.Balance()
+	_, balance, _, err := b.w.Balance()
 	if jc.Check("couldn't fetch wallet balance", err) != nil {
 		return
 	}
@@ -267,8 +268,10 @@ func (b *bus) walletFundHandler(jc jape.Context) {
 		return
 	}
 	txn := wfr.Transaction
-	fee := b.tp.RecommendedFee().Mul64(uint64(types.EncodedLen(txn)))
-	txn.MinerFees = []types.Currency{fee}
+	if len(txn.MinerFees) == 0 {
+		fee := b.tp.RecommendedFee().Mul64(uint64(types.EncodedLen(txn)))
+		txn.MinerFees = []types.Currency{fee}
+	}
 	toSign, err := b.w.FundTransaction(b.cm.TipState(jc.Request.Context()), &txn, wfr.Amount.Add(txn.MinerFees[0]), b.tp.Transactions())
 	if jc.Check("couldn't fund transaction", err) != nil {
 		return

--- a/bus/client.go
+++ b/bus/client.go
@@ -129,27 +129,14 @@ func (c *Client) WalletOutputs(ctx context.Context) (resp []wallet.SiacoinElemen
 	return
 }
 
-// estimatedSiacoinTxnSize estimates the txn size of a siacoin txn without file
-// contract given its number of outputs.
-func estimatedSiacoinTxnSize(nOutputs uint64) uint64 {
-	return 1000 + 60*nOutputs
-}
-
 // SendSiacoins is a helper method that sends siacoins to the given outputs.
 func (c *Client) SendSiacoins(ctx context.Context, scos []types.SiacoinOutput) (err error) {
-	fee, err := c.RecommendedFee(ctx)
-	if err != nil {
-		return err
-	}
-	fee = fee.Mul64(estimatedSiacoinTxnSize(uint64(len(scos))))
-
 	var value types.Currency
 	for _, sco := range scos {
 		value = value.Add(sco.Value)
 	}
 	txn := types.Transaction{
 		SiacoinOutputs: scos,
-		MinerFees:      []types.Currency{fee},
 	}
 	toSign, parents, err := c.WalletFund(ctx, &txn, value)
 	if err != nil {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -271,7 +271,8 @@ func NewBus(cfg BusConfig, dir string, seed types.PrivateKey, l *zap.Logger) (ht
 		}
 	}()
 
-	w := wallet.NewSingleAddressWallet(seed, sqlStore, cfg.UsedUTXOExpiry)
+	w := wallet.NewSingleAddressWallet(seed, sqlStore, cfg.UsedUTXOExpiry, zap.NewNop().Sugar())
+	tp.TransactionPoolSubscribe(w)
 
 	if m := cfg.Miner; m != nil {
 		if err := cs.ConsensusSetSubscribe(m, ccid, nil); err != nil {

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1811,7 +1811,7 @@ func TestWallet(t *testing.T) {
 	// The wallet should still have the same confirmed balance, a lower
 	// spendable balance and a greater unconfirmed balance.
 	var info api.WalletResponse
-	err = Retry(100, 100*time.Millisecond, func() error {
+	err = Retry(600, 100*time.Millisecond, func() error {
 		info, err = b.Wallet(context.Background())
 		if err != nil {
 			return err

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -8,6 +8,7 @@ import (
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/wallet"
+	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
 
@@ -50,7 +51,7 @@ func TestWalletRedistribute(t *testing.T) {
 		0,
 	}
 	s := &mockStore{utxos: []wallet.SiacoinElement{utxo}}
-	w := wallet.NewSingleAddressWallet(priv, s, 0)
+	w := wallet.NewSingleAddressWallet(priv, s, 0, zap.NewNop().Sugar())
 
 	numOutputsWithValue := func(v types.Currency) (c uint64) {
 		utxos, _ := w.UnspentOutputs()


### PR DESCRIPTION
Adds the "unconfirmed" field to the /wallet response.