### PR TITLE
Fix Build

### DIFF
--- a/build/env_testnet.go
+++ b/build/env_testnet.go
@@ -37,6 +37,12 @@ var (
 		MinMaxEphemeralAccountBalance: types.Siacoins(1),                                   // 1 SC
 	}
 
+	// DefaultUploadPackingSettings define the default upload packing settings
+	// the bus is configured with on startup.
+	DefaultUploadPackingSettings = api.UploadPackingSettings{
+		Enabled: false,
+	}
+
 	// DefaultRedundancySettings define the default redundancy settings the bus
 	// is configured with on startup. These values can be adjusted using the
 	// settings API.


### PR DESCRIPTION
https://github.com/SiaFoundation/renterd/actions/runs/5818703799/job/15775652522

```
10.84 go: downloading github.com/golang/protobuf v1.5.2
10.84 go: downloading google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6
51.83 # go.sia.tech/renterd/bus
51.83 bus/bus.go:1368:35: undefined: build.DefaultUploadPackingSettings
------
Dockerfile.testnet:9
--------------------
   7 |     # Copy and build binary.
   8 |     COPY . .
   9 | >>> RUN go build -tags=testnet ./cmd/renterd
  10 |     
  11 |     # Build image that will be used to run renterd.
  ```
  
  we forgot to set `DefaultUploadPackingSettings` in the tesnet env