### PR TITLE
Have autopilot periodically submit contract revisions

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -78,6 +78,7 @@ type Bus interface {
 
 type Worker interface {
 	Account(ctx context.Context, hostKey types.PublicKey) (rhpv3.Account, error)
+	RHPBroadcast(ctx context.Context, fcid types.FileContractID) (err error)
 	Contracts(ctx context.Context, hostTimeout time.Duration) (api.ContractsResponse, error)
 	ID(ctx context.Context) (string, error)
 	MigrateSlab(ctx context.Context, s object.Slab, set string) error
@@ -537,7 +538,7 @@ func (ap *Autopilot) triggerHandlerPOST(jc jape.Context) {
 }
 
 // New initializes an Autopilot.
-func New(id string, bus Bus, workers []Worker, logger *zap.Logger, heartbeat time.Duration, scannerScanInterval time.Duration, scannerBatchSize, scannerMinRecentFailures, scannerNumThreads uint64, migrationHealthCutoff float64, accountsRefillInterval time.Duration, revisionSubmissionBuffer, migratorParallelSlabsPerWorker uint64) (*Autopilot, error) {
+func New(id string, bus Bus, workers []Worker, logger *zap.Logger, heartbeat time.Duration, scannerScanInterval time.Duration, scannerBatchSize, scannerMinRecentFailures, scannerNumThreads uint64, migrationHealthCutoff float64, accountsRefillInterval time.Duration, revisionSubmissionBuffer, migratorParallelSlabsPerWorker uint64, revisionBroadcastInterval time.Duration) (*Autopilot, error) {
 	ap := &Autopilot{
 		alerts:  alerts.NewManager(),
 		id:      id,
@@ -561,7 +562,7 @@ func New(id string, bus Bus, workers []Worker, logger *zap.Logger, heartbeat tim
 	}
 
 	ap.s = scanner
-	ap.c = newContractor(ap, revisionSubmissionBuffer)
+	ap.c = newContractor(ap, revisionSubmissionBuffer, revisionBroadcastInterval)
 	ap.m = newMigrator(ap, migrationHealthCutoff, migratorParallelSlabsPerWorker)
 	ap.a = newAccounts(ap, ap.bus, ap.bus, ap.workers, ap.logger, accountsRefillInterval)
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -892,6 +892,7 @@ func (c *contractor) runRevisionBroadcast(ctx context.Context, w Worker, allCont
 				"hk", contract.HostKey,
 				"fcid", contract.ID)
 			failed++
+			delete(c.revisionLastBroadcast, contract.ID) // reset to try again
 			continue
 		}
 		successful++

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -31,6 +31,9 @@ var (
 )
 
 const (
+	// targetBlockTime is the average block time of the Sia network
+	targetBlockTime = 10 * time.Minute
+
 	// estimatedFileContractTransactionSetSize is the estimated blockchain size
 	// of a transaction set between a renter and a host that contains a file
 	// contract.
@@ -871,7 +874,7 @@ func (c *contractor) runRevisionBroadcast(ctx context.Context, w Worker, allCont
 	successful, failed := 0, 0
 	for _, contract := range setContracts {
 		// check whether broadcasting is necessary
-		timeSinceRevisionHeight := 10 * time.Minute * time.Duration(bh-contract.RevisionNumber)
+		timeSinceRevisionHeight := targetBlockTime * time.Duration(bh-contract.RevisionHeight)
 		timeSinceLastTry := time.Since(c.revisionLastBroadcast[contract.ID])
 		if contract.RevisionHeight == math.MaxUint64 || timeSinceRevisionHeight < c.revisionBroadcastInterval || timeSinceLastTry < c.revisionBroadcastInterval {
 			continue // nothing to do

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -193,7 +193,7 @@ func main() {
 	flag.DurationVar(&autopilotCfg.AccountsRefillInterval, "autopilot.accountRefillInterval", defaultAccountRefillInterval, "interval at which the autopilot checks the workers' accounts balance and refills them if necessary")
 	flag.DurationVar(&autopilotCfg.Heartbeat, "autopilot.heartbeat", 30*time.Minute, "interval at which autopilot loop runs")
 	flag.Float64Var(&autopilotCfg.MigrationHealthCutoff, "autopilot.migrationHealthCutoff", 0.75, "health threshold below which slabs are migrated to new hosts")
-	flag.DurationVar(&autopilotCfg.RevisionBroadcastInterval, "autopilot.revisionBroadcastInterval", 24*time.Hour, "interval at which the autopilot broadcasts contract revisions to be mined - can be overwritten using the REVISION_BROADCAST_INTERVAL environment variable - setting it to 0 will disable this feature")
+	flag.DurationVar(&autopilotCfg.RevisionBroadcastInterval, "autopilot.revisionBroadcastInterval", 24*time.Hour, "interval at which the autopilot broadcasts contract revisions to be mined - can be overwritten using the RENTERD_AUTOPILOT_REVISION_BROADCAST_INTERVAL environment variable - setting it to 0 will disable this feature")
 	flag.Uint64Var(&autopilotCfg.ScannerBatchSize, "autopilot.scannerBatchSize", 1000, "size of the batch with which hosts are scanned")
 	flag.DurationVar(&autopilotCfg.ScannerInterval, "autopilot.scannerInterval", 24*time.Hour, "interval at which hosts are scanned")
 	flag.Uint64Var(&autopilotCfg.ScannerMinRecentFailures, "autopilot.scannerMinRecentFailures", 10, "minimum amount of consesutive failed scans a host must have before it is removed for exceeding the max downtime")
@@ -241,7 +241,7 @@ func main() {
 	parseEnvVar("RENTERD_WORKER_UNAUTHENTICATED_DOWNLOADS", &unauthenticatedDownloads)
 
 	parseEnvVar("RENTERD_AUTOPILOT_ENABLED", &autopilotCfg.enabled)
-	parseEnvVar("REVISION_BROADCAST_INTERVAL", &autopilotCfg.RevisionBroadcastInterval)
+	parseEnvVar("RENTERD_AUTOPILOT_REVISION_BROADCAST_INTERVAL", &autopilotCfg.RevisionBroadcastInterval)
 	parseEnvVar("RENTERD_MIGRATOR_PARALLEL_SLABS_PER_WORKER", &autopilotCfg.MigratorParallelSlabsPerWorker)
 
 	// Init db dialector

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -193,6 +193,7 @@ func main() {
 	flag.DurationVar(&autopilotCfg.AccountsRefillInterval, "autopilot.accountRefillInterval", defaultAccountRefillInterval, "interval at which the autopilot checks the workers' accounts balance and refills them if necessary")
 	flag.DurationVar(&autopilotCfg.Heartbeat, "autopilot.heartbeat", 30*time.Minute, "interval at which autopilot loop runs")
 	flag.Float64Var(&autopilotCfg.MigrationHealthCutoff, "autopilot.migrationHealthCutoff", 0.75, "health threshold below which slabs are migrated to new hosts")
+	flag.DurationVar(&autopilotCfg.RevisionBroadcastInterval, "autopilot.revisionBroadcastInterval", 24*time.Hour, "interval at which the autopilot broadcasts contract revisions to be mined - can be overwritten using the REVISION_BROADCAST_INTERVAL environment variable")
 	flag.Uint64Var(&autopilotCfg.ScannerBatchSize, "autopilot.scannerBatchSize", 1000, "size of the batch with which hosts are scanned")
 	flag.DurationVar(&autopilotCfg.ScannerInterval, "autopilot.scannerInterval", 24*time.Hour, "interval at which hosts are scanned")
 	flag.Uint64Var(&autopilotCfg.ScannerMinRecentFailures, "autopilot.scannerMinRecentFailures", 10, "minimum amount of consesutive failed scans a host must have before it is removed for exceeding the max downtime")
@@ -240,6 +241,7 @@ func main() {
 	parseEnvVar("RENTERD_WORKER_UNAUTHENTICATED_DOWNLOADS", &unauthenticatedDownloads)
 
 	parseEnvVar("RENTERD_AUTOPILOT_ENABLED", &autopilotCfg.enabled)
+	parseEnvVar("REVISION_BROADCAST_INTERVAL", &autopilotCfg.RevisionBroadcastInterval)
 	parseEnvVar("RENTERD_MIGRATOR_PARALLEL_SLABS_PER_WORKER", &autopilotCfg.MigratorParallelSlabsPerWorker)
 
 	// Init db dialector

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -193,7 +193,7 @@ func main() {
 	flag.DurationVar(&autopilotCfg.AccountsRefillInterval, "autopilot.accountRefillInterval", defaultAccountRefillInterval, "interval at which the autopilot checks the workers' accounts balance and refills them if necessary")
 	flag.DurationVar(&autopilotCfg.Heartbeat, "autopilot.heartbeat", 30*time.Minute, "interval at which autopilot loop runs")
 	flag.Float64Var(&autopilotCfg.MigrationHealthCutoff, "autopilot.migrationHealthCutoff", 0.75, "health threshold below which slabs are migrated to new hosts")
-	flag.DurationVar(&autopilotCfg.RevisionBroadcastInterval, "autopilot.revisionBroadcastInterval", 24*time.Hour, "interval at which the autopilot broadcasts contract revisions to be mined - can be overwritten using the REVISION_BROADCAST_INTERVAL environment variable")
+	flag.DurationVar(&autopilotCfg.RevisionBroadcastInterval, "autopilot.revisionBroadcastInterval", 24*time.Hour, "interval at which the autopilot broadcasts contract revisions to be mined - can be overwritten using the REVISION_BROADCAST_INTERVAL environment variable - setting it to 0 will disable this feature")
 	flag.Uint64Var(&autopilotCfg.ScannerBatchSize, "autopilot.scannerBatchSize", 1000, "size of the batch with which hosts are scanned")
 	flag.DurationVar(&autopilotCfg.ScannerInterval, "autopilot.scannerInterval", 24*time.Hour, "interval at which hosts are scanned")
 	flag.Uint64Var(&autopilotCfg.ScannerMinRecentFailures, "autopilot.scannerMinRecentFailures", 10, "minimum amount of consesutive failed scans a host must have before it is removed for exceeding the max downtime")

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -60,6 +60,7 @@ type AutopilotConfig struct {
 	AccountsRefillInterval         time.Duration
 	Heartbeat                      time.Duration
 	MigrationHealthCutoff          float64
+	RevisionBroadcastInterval      time.Duration
 	RevisionSubmissionBuffer       uint64
 	ScannerInterval                time.Duration
 	ScannerBatchSize               uint64
@@ -314,7 +315,7 @@ func NewWorker(cfg WorkerConfig, b worker.Bus, seed types.PrivateKey, l *zap.Log
 }
 
 func NewAutopilot(cfg AutopilotConfig, b autopilot.Bus, workers []autopilot.Worker, l *zap.Logger) (http.Handler, func() error, ShutdownFn, error) {
-	ap, err := autopilot.New(cfg.ID, b, workers, l, cfg.Heartbeat, cfg.ScannerInterval, cfg.ScannerBatchSize, cfg.ScannerMinRecentFailures, cfg.ScannerNumThreads, cfg.MigrationHealthCutoff, cfg.AccountsRefillInterval, cfg.RevisionSubmissionBuffer, cfg.MigratorParallelSlabsPerWorker)
+	ap, err := autopilot.New(cfg.ID, b, workers, l, cfg.Heartbeat, cfg.ScannerInterval, cfg.ScannerBatchSize, cfg.ScannerMinRecentFailures, cfg.ScannerNumThreads, cfg.MigrationHealthCutoff, cfg.AccountsRefillInterval, cfg.RevisionSubmissionBuffer, cfg.MigratorParallelSlabsPerWorker, cfg.RevisionBroadcastInterval)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -181,7 +181,19 @@ func (w *SingleAddressWallet) Height() uint64 {
 // UnspentOutputs returns the set of unspent Siacoin outputs controlled by the
 // wallet.
 func (w *SingleAddressWallet) UnspentOutputs() ([]SiacoinElement, error) {
-	return w.store.UnspentSiacoinElements(false)
+	sces, err := w.store.UnspentSiacoinElements(false)
+	if err != nil {
+		return nil, err
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	filtered := sces[:0]
+	for _, sce := range sces {
+		if !w.isOutputUsed(sce.ID) {
+			filtered = append(filtered, sce)
+		}
+	}
+	return filtered, nil
 }
 
 // Transactions returns up to max transactions relevant to the wallet that have


### PR DESCRIPTION
As the title suggests the autopilot will start broadcasting revisions periodically as part of the contract maintenance. By default this happens every 24 hours for now but it is configurable.