### PR TITLE
Deprecate CLI Flags

### DIFF
--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -152,11 +152,11 @@ func main() {
 	// TODO: the following flags will be deprecated in v1.0.0 in favor of
 	// environment variables to ensure we do not ask the user to pass sensitive
 	// information via CLI parameters.
-	flag.StringVar(&dbCfg.password, "db.password", "", "password for the database to use for the bus - can be overwritten using RENTERD_DB_PASSWORD environment variable")
-	flag.StringVar(&busCfg.apiPassword, "bus.apiPassword", "", "API password for remote bus service - can be overwritten using RENTERD_BUS_API_PASSWORD environment variable")
-	flag.StringVar(&busCfg.remoteAddr, "bus.remoteAddr", "", "URL of remote bus service - can be overwritten using RENTERD_BUS_REMOTE_ADDR environment variable")
-	flag.StringVar(&workerCfg.apiPassword, "worker.apiPassword", "", "API password for remote worker service")
-	flag.StringVar(&workerCfg.remoteAddrs, "worker.remoteAddrs", "", "URL of remote worker service(s). Multiple addresses can be provided by separating them with a semicolon. Can be overwritten using the RENTERD_WORKER_REMOTE_ADDRS environment variable")
+	flag.StringVar(&dbCfg.password, "db.password", "", "[DEPRECATED] password for the database to use for the bus - can be overwritten using RENTERD_DB_PASSWORD environment variable")
+	flag.StringVar(&busCfg.apiPassword, "bus.apiPassword", "", "[DEPRECATED] API password for remote bus service - can be overwritten using RENTERD_BUS_API_PASSWORD environment variable")
+	flag.StringVar(&busCfg.remoteAddr, "bus.remoteAddr", "", "[DEPRECATED] URL of remote bus service - can be overwritten using RENTERD_BUS_REMOTE_ADDR environment variable")
+	flag.StringVar(&workerCfg.apiPassword, "worker.apiPassword", "", "[DEPRECATED] API password for remote worker service")
+	flag.StringVar(&workerCfg.remoteAddrs, "worker.remoteAddrs", "", "[DEPRECATED] URL of remote worker service(s). Multiple addresses can be provided by separating them with a semicolon. Can be overwritten using the RENTERD_WORKER_REMOTE_ADDRS environment variable")
 
 	for _, flag := range []struct {
 		input    string

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -159,20 +159,23 @@ func main() {
 	flag.StringVar(&workerCfg.remoteAddrs, "worker.remoteAddrs", "", "URL of remote worker service(s). Multiple addresses can be provided by separating them with a semicolon. Can be overwritten using the RENTERD_WORKER_REMOTE_ADDRS environment variable")
 
 	for _, flag := range []struct {
+		input    string
 		name     string
 		env      string
 		insecure bool
 	}{
-		{"db.password", "RENTERD_DB_PASSWORD", true},
-		{"bus.apiPassword", "RENTERD_BUS_API_PASSWORD", true},
-		{"bus.remoteAddr", "RENTERD_BUS_REMOTE_ADDR", false},
-		{"worker.apiPassword", "RENTERD_WORKER_API_PASSWORDS", true},
-		{"worker.remoteAddrs", "RENTERD_WORKER_REMOTE_ADDRS", false},
+		{dbCfg.password, "db.password", "RENTERD_DB_PASSWORD", true},
+		{busCfg.apiPassword, "bus.apiPassword", "RENTERD_BUS_API_PASSWORD", true},
+		{busCfg.remoteAddr, "bus.remoteAddr", "RENTERD_BUS_REMOTE_ADDR", false},
+		{workerCfg.apiPassword, "worker.apiPassword", "RENTERD_WORKER_API_PASSWORDS", true},
+		{workerCfg.remoteAddrs, "worker.remoteAddrs", "RENTERD_WORKER_REMOTE_ADDRS", false},
 	} {
-		if flag.insecure {
-			log.Printf("WARNING: usage of CLI flag '%s' is considered insecure and will be deprecated in v1.0.0, please use the environment variable '%s' instead\n", flag.name, flag.env)
-		} else {
-			log.Printf("WARNING: CLI flag '%s' will be deprecated in v1.0.0, please use the environment variable '%s' instead\n", flag.name, flag.env)
+		if flag.input != "" {
+			if flag.insecure {
+				log.Printf("WARNING: usage of CLI flag '%s' is considered insecure and will be deprecated in v1.0.0, please use the environment variable '%s' instead\n", flag.name, flag.env)
+			} else {
+				log.Printf("WARNING: CLI flag '%s' will be deprecated in v1.0.0, please use the environment variable '%s' instead\n", flag.name, flag.env)
+			}
 		}
 	}
 


### PR DESCRIPTION
I think we should deprecate some CLI flags before v1.0.0 now that we still have the chance.

The following flags I think we should deprecate in favor of their environment variable:
- `db.password`
- `bus.apiPassword`
- `bus.remoteAddr`
- `worker.apiPassword`
- `worker.remoteAddrs`

I figured we'd best move the bus/worker remote addresses since we're expecting them to configure the passwords through the environment variables. It also separates _actual_ node config from infrastructure related configuration. Added bonus is we can make worker api password plural and accepts a different password per worker.

I'm fine with closing this PR all together by the way. I don't feel very strongly but at the same time I have this now-or-never feeling. If merged I'll immediately create a PR to make the change so we can have it sit there in the pull requests to ensure we don't forget merging it when we tag v1.0.0

Fixes #542 