### PR TITLE
Increase timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/testing/..."
-          args: "-race;-tags='testing';-timeout=900s"
+          args: "-race;-tags='testing';-timeout=30m"
       - name: Test Integration - MySQL
         if: matrix.os == 'ubuntu-latest'
         uses: n8maninger/action-golang-test@v1
@@ -52,7 +52,7 @@ jobs:
           RENTERD_DB_PASSWORD: test
         with:
           package: "./internal/testing/..."
-          args: "-race;-tags='testing';-timeout=900s"
+          args: "-race;-tags='testing';-timeout=30m"
       - name: Check Endpoints
         uses: SiaFoundation/action-golang-analysis@HEAD
         with:


### PR DESCRIPTION
We recently added some integration tests that push us over the 15' mark, although to be fair we've had some slow tests in the test suite for quite some time:

`TestUploadDownloadBasic passed in 52.07s`
`TestUploadDownloadExtended passed in 67.31s`
`TestParallelDownload passed in 70s`
`TestUploadPacking passed in 96.26s`
`TestSlabBufferStats passed in 52.98s`

In the future I guess we'll have to split up the suite into separate test suites and take a look at the slowest ones to see if we can't get rid if redundant test cases and/or just speed them up in general. I'm sure there's lots of room for improvement there but since we're still "only" at 15 minutes perhaps it's fine to increase the timeout for now.