### PR TITLE
Contract Size

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -153,9 +153,14 @@ type ContractAcquireResponse struct {
 // ContractsPrunableDataResponse is the response type for the
 // /contracts/prunable endpoint.
 type ContractsPrunableDataResponse struct {
-	ContractSizes []ContractSize `json:"contractSizes"`
-	TotalPrunable uint64         `json:"totalPrunable"`
-	TotalSize     uint64         `json:"totalSize"`
+	Contracts     []ContractPrunableData `json:"contracts"`
+	TotalPrunable uint64                 `json:"totalPrunable"`
+	TotalSize     uint64                 `json:"totalSize"`
+}
+
+type ContractPrunableData struct {
+	ID types.FileContractID `json:"id"`
+	ContractSize
 }
 
 // HostsRemoveRequest is the request type for the /hosts/remove endpoint.

--- a/api/bus.go
+++ b/api/bus.go
@@ -154,7 +154,7 @@ type ContractAcquireResponse struct {
 // /contracts/prunable endpoint.
 type ContractsPrunableDataResponse struct {
 	ContractSizes []ContractSize `json:"contractSizes"`
-	PrunableData  uint64         `json:"prunableData"`
+	TotalPrunable uint64         `json:"totalPrunable"`
 	TotalSize     uint64         `json:"totalSize"`
 }
 

--- a/api/bus.go
+++ b/api/bus.go
@@ -150,6 +150,14 @@ type ContractAcquireResponse struct {
 	LockID uint64 `json:"lockID"`
 }
 
+// ContractsPrunableDataResponse is the response type for the
+// /contracts/prunable endpoint.
+type ContractsPrunableDataResponse struct {
+	ContractSizes []ContractSize `json:"contractSizes"`
+	PrunableData  uint64         `json:"prunableData"`
+	TotalSize     uint64         `json:"totalSize"`
+}
+
 // HostsRemoveRequest is the request type for the /hosts/remove endpoint.
 type HostsRemoveRequest struct {
 	MaxDowntimeHours      ParamDurationHour `json:"maxDowntimeHours"`

--- a/api/contract.go
+++ b/api/contract.go
@@ -12,6 +12,14 @@ type (
 		Revision *types.FileContractRevision `json:"revision"`
 	}
 
+	// ContractSize contains information about the size of the contract and
+	// about how much of the contract data can be pruned.
+	ContractSize struct {
+		ID       types.FileContractID `json:"id"`
+		Prunable uint64               `json:"prunable"`
+		Size     uint64               `json:"size"`
+	}
+
 	// ContractMetadata contains all metadata for a contract.
 	ContractMetadata struct {
 		ID         types.FileContractID `json:"id"`

--- a/api/contract.go
+++ b/api/contract.go
@@ -15,9 +15,8 @@ type (
 	// ContractSize contains information about the size of the contract and
 	// about how much of the contract data can be pruned.
 	ContractSize struct {
-		ID       types.FileContractID `json:"id"`
-		Prunable uint64               `json:"prunable"`
-		Size     uint64               `json:"size"`
+		Prunable uint64 `json:"prunable"`
+		Size     uint64 `json:"size"`
 	}
 
 	// ContractMetadata contains all metadata for a contract.

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -695,7 +695,7 @@ func (b *bus) contractsPrunableDataHandlerGET(jc jape.Context) {
 
 	// sort in descending fashion
 	sort.Slice(sizes, func(i, j int) bool {
-		return sizes[i].Size > sizes[j].Size
+		return sizes[i].Prunable > sizes[j].Prunable
 	})
 
 	var totalPrunable, totalSize uint64

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -692,15 +692,15 @@ func (b *bus) contractsPrunableDataHandlerGET(jc jape.Context) {
 		return
 	}
 
-	var totalSize, prunableData uint64
+	var totalPrunable, totalSize uint64
 	for _, size := range sizes {
+		totalPrunable += size.Prunable
 		totalSize += size.Size
-		prunableData += size.Prunable
 	}
 
 	jc.Encode(api.ContractsPrunableDataResponse{
 		ContractSizes: sizes,
-		PrunableData:  prunableData,
+		TotalPrunable: totalPrunable,
 		TotalSize:     totalSize,
 	})
 }

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -691,6 +692,11 @@ func (b *bus) contractsPrunableDataHandlerGET(jc jape.Context) {
 	if jc.Check("failed to fetch contract sizes", err) != nil {
 		return
 	}
+
+	// sort in descending fashion
+	sort.Slice(sizes, func(i, j int) bool {
+		return sizes[i].Size > sizes[j].Size
+	})
 
 	var totalPrunable, totalSize uint64
 	for _, size := range sizes {

--- a/bus/client.go
+++ b/bus/client.go
@@ -471,17 +471,16 @@ func (c *Client) ReleaseContract(ctx context.Context, fcid types.FileContractID,
 	return
 }
 
-// PrunableData returns the amount of data that can be pruned from all
-// contracts.
-func (c *Client) PrunableData(ctx context.Context) (prunable int64, err error) {
-	err = c.c.WithContext(ctx).GET("/contracts/prunable", &prunable)
+// PrunableData returns an overview of all contract sizes, the total size and
+// the amount of data that can be pruned.
+func (c *Client) PrunableData(ctx context.Context) (prunableData api.ContractsPrunableDataResponse, err error) {
+	err = c.c.WithContext(ctx).GET("/contracts/prunable", &prunableData)
 	return
 }
 
-// PrunableDataForContract returns the amount of data that can be pruned from
-// the contract with given id.
-func (c *Client) PrunableDataForContract(ctx context.Context, fcid types.FileContractID) (prunable int64, err error) {
-	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/contract/%s/prunable", fcid), &prunable)
+// ContractSize returns the contract's size.
+func (c *Client) ContractSize(ctx context.Context, fcid types.FileContractID) (size api.ContractSize, err error) {
+	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/contract/%s/size", fcid), &size)
 	return
 }
 

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -257,9 +257,9 @@ func TestSectorPruning(t *testing.T) {
 	b = cluster2.Bus
 
 	// assert prunable data is 0
-	if n, err := b.PrunableData(context.Background()); err != nil {
+	if res, err := b.PrunableData(context.Background()); err != nil {
 		t.Fatal(err)
-	} else if n != 0 {
+	} else if res.TotalPrunable != 0 {
 		t.Fatal("expected 0 prunable data", n)
 	}
 
@@ -272,9 +272,9 @@ func TestSectorPruning(t *testing.T) {
 	}
 
 	// assert amount of prunable data
-	if n, err := b.PrunableData(context.Background()); err != nil {
+	if res, err := b.PrunableData(context.Background()); err != nil {
 		t.Fatal(err)
-	} else if n != int64(5)*int64(rs.TotalShards)*rhpv2.SectorSize {
+	} else if res.TotalPrunable != 5*uint64(rs.TotalShards)*rhpv2.SectorSize {
 		t.Fatal("unexpected prunable data", n)
 	}
 }

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -660,40 +660,75 @@ func (s *SQLStore) ContractSets(ctx context.Context) ([]string, error) {
 	return sets, err
 }
 
-func (s *SQLStore) PrunableData(ctx context.Context) (prunable int64, err error) {
-	err = s.db.
-		Raw(`
-SELECT IFNULL(SUM(prunable), 0)
-FROM (
-    SELECT CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
-        SELECT IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
-        FROM contracts c
-        LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
-        GROUP BY c.id
-	) as i
-) as j`, rhpv2.SectorSize).
-		Scan(&prunable).
-		Error
-	return
-}
+func (s *SQLStore) ContractSizes(ctx context.Context) ([]api.ContractSize, error) {
+	rows := make([]struct {
+		Fcid     fileContractID `json:"fcid"`
+		Size     uint64         `json:"size"`
+		Prunable uint64         `json:"prunable"`
+	}, 0)
 
-func (s *SQLStore) PrunableDataForContract(ctx context.Context, id types.FileContractID) (prunable int64, err error) {
-	if !s.isKnownContract(id) {
-		return 0, api.ErrContractNotFound
+	if err := s.db.
+		Raw(`
+SELECT fcid, size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
+	SELECT fcid, MAX(c.size) as size, IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
+	FROM contracts c
+	LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
+	GROUP BY c.fcid
+) as i
+	`, rhpv2.SectorSize).
+		Scan(&rows).
+		Error; err != nil {
+		return nil, err
 	}
 
-	err = s.db.
+	sizes := make([]api.ContractSize, len(rows))
+	for i, row := range rows {
+		sizes[i] = api.ContractSize{
+			ID:       types.FileContractID(row.Fcid),
+			Size:     row.Size,
+			Prunable: row.Prunable,
+		}
+		if sizes[i].ID == (types.FileContractID{}) {
+			return nil, errors.New("invalid file contract id")
+		}
+	}
+	return sizes, nil
+}
+
+func (s *SQLStore) ContractSize(ctx context.Context, id types.FileContractID) (api.ContractSize, error) {
+	if !s.isKnownContract(id) {
+		return api.ContractSize{}, api.ErrContractNotFound
+	}
+
+	var size struct {
+		Fcid     fileContractID `json:"fcid"`
+		Size     uint64         `json:"size"`
+		Prunable uint64         `json:"prunable"`
+	}
+
+	if err := s.db.
 		Raw(`
-SELECT CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
-    SELECT IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
+SELECT fcid, size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
+    SELECT fcid, IFNULL(MAX(c.size), 0) as size, IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
     FROM contracts c
     LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
     WHERE c.fcid = ?
 ) as i
 `, rhpv2.SectorSize, fileContractID(id)).
-		Scan(&prunable).
-		Error
-	return
+		Take(&size).
+		Error; err != nil {
+		return api.ContractSize{}, err
+	}
+
+	if types.FileContractID(size.Fcid) == (types.FileContractID{}) {
+		return api.ContractSize{}, errors.New("invalid file contract id")
+	}
+
+	return api.ContractSize{
+		ID:       types.FileContractID(size.Fcid),
+		Size:     size.Size,
+		Prunable: size.Prunable,
+	}, nil
 }
 
 func (s *SQLStore) SetContractSet(ctx context.Context, name string, contractIds []types.FileContractID) error {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -660,7 +660,7 @@ func (s *SQLStore) ContractSets(ctx context.Context) ([]string, error) {
 	return sets, err
 }
 
-func (s *SQLStore) ContractSizes(ctx context.Context) ([]api.ContractSize, error) {
+func (s *SQLStore) ContractSizes(ctx context.Context) (map[types.FileContractID]api.ContractSize, error) {
 	rows := make([]struct {
 		Fcid     fileContractID `json:"fcid"`
 		Size     uint64         `json:"size"`
@@ -669,8 +669,8 @@ func (s *SQLStore) ContractSizes(ctx context.Context) ([]api.ContractSize, error
 
 	if err := s.db.
 		Raw(`
-SELECT fcid, size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
-	SELECT fcid, MAX(c.size) as size, IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
+SELECT size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
+	SELECT MAX(c.size) as size, IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
 	FROM contracts c
 	LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
 	GROUP BY c.fcid
@@ -681,15 +681,14 @@ SELECT fcid, size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FR
 		return nil, err
 	}
 
-	sizes := make([]api.ContractSize, len(rows))
-	for i, row := range rows {
-		sizes[i] = api.ContractSize{
-			ID:       types.FileContractID(row.Fcid),
+	sizes := make(map[types.FileContractID]api.ContractSize, len(rows))
+	for _, row := range rows {
+		if types.FileContractID(row.Fcid) == (types.FileContractID{}) {
+			return nil, errors.New("invalid file contract id")
+		}
+		sizes[types.FileContractID(row.Fcid)] = api.ContractSize{
 			Size:     row.Size,
 			Prunable: row.Prunable,
-		}
-		if sizes[i].ID == (types.FileContractID{}) {
-			return nil, errors.New("invalid file contract id")
 		}
 	}
 	return sizes, nil
@@ -701,15 +700,14 @@ func (s *SQLStore) ContractSize(ctx context.Context, id types.FileContractID) (a
 	}
 
 	var size struct {
-		Fcid     fileContractID `json:"fcid"`
-		Size     uint64         `json:"size"`
-		Prunable uint64         `json:"prunable"`
+		Size     uint64 `json:"size"`
+		Prunable uint64 `json:"prunable"`
 	}
 
 	if err := s.db.
 		Raw(`
-SELECT fcid, size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
-    SELECT fcid, IFNULL(MAX(c.size), 0) as size, IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
+SELECT size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
+    SELECT IFNULL(MAX(c.size), 0) as size, IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
     FROM contracts c
     LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
     WHERE c.fcid = ?
@@ -720,12 +718,7 @@ SELECT fcid, size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FR
 		return api.ContractSize{}, err
 	}
 
-	if types.FileContractID(size.Fcid) == (types.FileContractID{}) {
-		return api.ContractSize{}, errors.New("invalid file contract id")
-	}
-
 	return api.ContractSize{
-		ID:       types.FileContractID(size.Fcid),
 		Size:     size.Size,
 		Prunable: size.Prunable,
 	}, nil

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -669,8 +669,8 @@ func (s *SQLStore) ContractSizes(ctx context.Context) (map[types.FileContractID]
 
 	if err := s.db.
 		Raw(`
-SELECT size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
-	SELECT MAX(c.size) as size, IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
+SELECT fcid, size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
+	SELECT fcid, MAX(c.size) as size, IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
 	FROM contracts c
 	LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
 	GROUP BY c.fcid

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2871,8 +2871,8 @@ func TestContractSizes(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		for _, size := range sizes {
-			if fcid != nil && size.ID != *fcid {
+		for id, size := range sizes {
+			if fcid != nil && id != *fcid {
 				continue
 			}
 			n += size.Prunable


### PR DESCRIPTION
Debugging sector pruning I was a little annoyed with what the `bus` returned. I think we should perhaps slightly refactor it so the responses are a bit nicer to work with. 

- should be able to easily query a contract's size and the amount of data that's prunable
- I think we should keep `contract/prunable` but return a response rather than a number with an aggregated field + size breakdowns