### PR TITLE
Fix bug where uploads fail due to the buffered slab being missing from disk

### DIFF
--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -133,7 +133,7 @@ func (m *migrator) performMigrations(p *workerPool) {
 								Severity: alerts.SeverityCritical,
 								Message:  errMsg,
 								Data: map[string]interface{}{
-									"key": slab.Key.String(),
+									"slabKey": slab.Key.String(),
 								},
 								Timestamp: time.Now(),
 							})

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1446,11 +1446,10 @@ func (b *bus) uploadFinishedHandlerDELETE(jc jape.Context) {
 }
 
 // New returns a new Bus.
-func New(s Syncer, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, as AutopilotStore, ms MetadataStore, ss SettingStore, eas EphemeralAccountStore, l *zap.Logger) (*bus, error) {
-	alertMgr := alerts.NewManager()
+func New(s Syncer, am *alerts.Manager, cm ChainManager, tp TransactionPool, w Wallet, hdb HostDB, as AutopilotStore, ms MetadataStore, ss SettingStore, eas EphemeralAccountStore, l *zap.Logger) (*bus, error) {
 	b := &bus{
-		alerts:           alerts.WithOrigin(alertMgr, "bus"),
-		alertMgr:         alertMgr,
+		alerts:           alerts.WithOrigin(am, "bus"),
+		alertMgr:         am,
 		s:                s,
 		cm:               cm,
 		tp:               tp,

--- a/stores/hostdb_test.go
+++ b/stores/hostdb_test.go
@@ -12,6 +12,7 @@ import (
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/siad/modules"
@@ -147,7 +148,8 @@ func TestSQLHostDB(t *testing.T) {
 
 	// Connect to the same DB again.
 	conn2 := NewEphemeralSQLiteConnection(dbName)
-	hdb2, ccid, err := NewSQLStore(conn2, dir, false, time.Second, types.Address{}, 0, nil)
+	am := alerts.WithOrigin(alerts.NewManager(), "test")
+	hdb2, ccid, err := NewSQLStore(conn2, am, dir, false, time.Second, types.Address{}, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1538,6 +1538,10 @@ func (s *SQLStore) PackedSlabsForUpload(ctx context.Context, lockingDuration tim
 	slabs := make([]api.PackedSlab, len(buffers))
 	for i, buf := range buffers {
 		data, err := os.ReadFile(filepath.Join(s.partialSlabDir, buf.Filename))
+		if os.IsNotExist(err) {
+			s.logger.Error(ctx, fmt.Sprintf("buffered slab %v doesn't exist", buf.Filename))
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -1609,32 +1613,41 @@ func (s *SQLStore) MarkPackedSlabsUploaded(ctx context.Context, slabs []api.Uplo
 			}
 		}
 	}
-	return s.retryTransaction(func(tx *gorm.DB) error {
+	var filename string
+	err := s.retryTransaction(func(tx *gorm.DB) error {
 		contracts, err := fetchUsedContracts(tx, usedContracts)
 		if err != nil {
 			return err
 		}
 		for _, slab := range slabs {
-			if err := markPackedSlabUploaded(tx, slab, contracts, s.partialSlabDir); err != nil {
+			filename, err = markPackedSlabUploaded(tx, slab, contracts)
+			if err != nil {
 				return err
 			}
 		}
 		return nil
 	})
+	if err != nil {
+		return fmt.Errorf("marking slabs as uploaded in the db failed: %w", err)
+	}
+	if err := os.Remove(filepath.Join(s.partialSlabDir, filename)); err != nil {
+		return fmt.Errorf("removing buffer after marking it as uploaded failed: %w", err)
+	}
+	return nil
 }
 
-func markPackedSlabUploaded(tx *gorm.DB, slab api.UploadedPackedSlab, contracts map[types.PublicKey]dbContract, partialSlabDir string) error {
+func markPackedSlabUploaded(tx *gorm.DB, slab api.UploadedPackedSlab, contracts map[types.PublicKey]dbContract) (string, error) {
 	// find the slab
 	var sla dbSlab
 	if err := tx.Where("db_buffered_slab_id", slab.BufferID).
 		Take(&sla).Error; err != nil {
-		return err
+		return "", err
 	}
 
 	// update the slab
 	key, err := slab.Key.MarshalText()
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := tx.Model(&dbSlab{}).
 		Where("id", sla.ID).
@@ -1642,21 +1655,18 @@ func markPackedSlabUploaded(tx *gorm.DB, slab api.UploadedPackedSlab, contracts 
 			"key":                 key,
 			"db_buffered_slab_id": nil,
 		}).Error; err != nil {
-		return err
+		return "", err
 	}
 
 	// delete buffer
 	var buffer dbBufferedSlab
 	if err := tx.Take(&buffer, "id = ?", slab.BufferID).Error; err != nil {
-		return err
+		return "", err
 	}
 	err = tx.Delete(&buffer).
 		Error
 	if err != nil {
-		return err
-	}
-	if err := os.Remove(filepath.Join(partialSlabDir, buffer.Filename)); err != nil && !os.IsNotExist(err) {
-		return err
+		return "", err
 	}
 
 	// add the shards to the slab
@@ -1664,7 +1674,7 @@ func markPackedSlabUploaded(tx *gorm.DB, slab api.UploadedPackedSlab, contracts 
 	for i := range slab.Shards {
 		contract, exists := contracts[slab.Shards[i].Host]
 		if !exists {
-			return fmt.Errorf("missing contract for host %v", slab.Shards[i].Host)
+			return "", fmt.Errorf("missing contract for host %v", slab.Shards[i].Host)
 		}
 		shards = append(shards, dbSector{
 			DBSlabID:   sla.ID,
@@ -1673,7 +1683,7 @@ func markPackedSlabUploaded(tx *gorm.DB, slab api.UploadedPackedSlab, contracts 
 			Contracts:  []dbContract{contract},
 		})
 	}
-	return tx.Create(shards).Error
+	return buffer.Filename, tx.Create(shards).Error
 }
 
 // contract retrieves a contract from the store.

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/siad/modules"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/sqlite"
@@ -33,6 +34,7 @@ type (
 
 	// SQLStore is a helper type for interacting with a SQL-based backend.
 	SQLStore struct {
+		alerts         alerts.Alerter
 		db             *gorm.DB
 		logger         glogger.Interface
 		partialSlabDir string
@@ -122,7 +124,7 @@ func DBConfigFromEnv() (uri, user, password, dbName string) {
 // NewSQLStore uses a given Dialector to connect to a SQL database.  NOTE: Only
 // pass migrate=true for the first instance of SQLHostDB if you connect via the
 // same Dialector multiple times.
-func NewSQLStore(conn gorm.Dialector, partialSlabDir string, migrate bool, persistInterval time.Duration, walletAddress types.Address, slabBufferCompletionThreshold int64, logger glogger.Interface) (*SQLStore, modules.ConsensusChangeID, error) {
+func NewSQLStore(conn gorm.Dialector, alerts alerts.Alerter, partialSlabDir string, migrate bool, persistInterval time.Duration, walletAddress types.Address, slabBufferCompletionThreshold int64, logger glogger.Interface) (*SQLStore, modules.ConsensusChangeID, error) {
 	if err := os.MkdirAll(partialSlabDir, 0700); err != nil {
 		return nil, modules.ConsensusChangeID{}, fmt.Errorf("failed to create partial slab dir: %v", err)
 	}
@@ -177,6 +179,7 @@ func NewSQLStore(conn gorm.Dialector, partialSlabDir string, migrate bool, persi
 	}
 
 	ss := &SQLStore{
+		alerts:                          alerts,
 		db:                              db,
 		logger:                          logger,
 		knownContracts:                  isOurContract,

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/siad/modules"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -26,7 +27,8 @@ func newTestSQLStore(dir string) (*SQLStore, string, modules.ConsensusChangeID, 
 	dbName := hex.EncodeToString(frand.Bytes(32)) // random name for db
 	conn := NewEphemeralSQLiteConnection(dbName)
 	walletAddrs := types.Address(frand.Entropy256())
-	sqlStore, ccid, err := NewSQLStore(conn, dir, true, time.Second, walletAddrs, 0, newTestLogger())
+	alerts := alerts.WithOrigin(alerts.NewManager(), "test")
+	sqlStore, ccid, err := NewSQLStore(conn, alerts, dir, true, time.Second, walletAddrs, 0, newTestLogger())
 	if err != nil {
 		return nil, "", modules.ConsensusChangeID{}, err
 	}


### PR DESCRIPTION
On Arequipa an upload failed due to the database transaction being rolled back after the buffer was deleted on disk. To avoid that in the future, the buffer is removed after the transaction is applied to the db successfully. 