### PR TITLE
Contract Size Query

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -695,28 +695,29 @@ func (b *bus) contractsPrunableDataHandlerGET(jc jape.Context) {
 	}
 
 	// prepare the response
-	res := api.ContractsPrunableDataResponse{
-		Contracts:     make([]api.ContractPrunableData, len(sizes)),
-		TotalPrunable: 0,
-		TotalSize:     0,
-	}
+	var contracts []api.ContractPrunableData
+	var totalPrunable, totalSize uint64
 
 	// build the response
 	for fcid, size := range sizes {
-		res.Contracts = append(res.Contracts, api.ContractPrunableData{
+		contracts = append(contracts, api.ContractPrunableData{
 			ID:           fcid,
 			ContractSize: size,
 		})
-		res.TotalPrunable += size.Prunable
-		res.TotalSize += size.Size
+		totalPrunable += size.Prunable
+		totalSize += size.Size
 	}
 
 	// sort contracts by the amount of prunable data
-	sort.Slice(res.Contracts, func(i, j int) bool {
-		return res.Contracts[i].Prunable > res.Contracts[j].Prunable
+	sort.Slice(contracts, func(i, j int) bool {
+		return contracts[i].Prunable > contracts[j].Prunable
 	})
 
-	jc.Encode(res)
+	jc.Encode(api.ContractsPrunableDataResponse{
+		Contracts:     contracts,
+		TotalPrunable: totalPrunable,
+		TotalSize:     totalSize,
+	})
 }
 
 func (b *bus) contractSizeHandlerGET(jc jape.Context) {
@@ -729,8 +730,7 @@ func (b *bus) contractSizeHandlerGET(jc jape.Context) {
 	if errors.Is(err, api.ErrContractNotFound) {
 		jc.Error(err, http.StatusNotFound)
 		return
-	}
-	if jc.Check("failed to fetch contract size", err) == nil {
+	} else if jc.Check("failed to fetch contract size", err) == nil {
 		jc.Encode(size)
 	}
 }

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -670,8 +670,8 @@ func (s *SQLStore) ContractSizes(ctx context.Context) (map[types.FileContractID]
 
 	if err := s.db.
 		Raw(`
-SELECT fcid, size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
-	SELECT fcid, MAX(c.size) as size, IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
+SELECT fcid, size, CASE WHEN size>bytes THEN size-bytes ELSE 0 END as prunable FROM (
+	SELECT fcid, MAX(c.size) as size, COUNT(cs.db_sector_id) * ? as bytes
 	FROM contracts c
 	LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
 	GROUP BY c.fcid
@@ -682,7 +682,7 @@ SELECT fcid, size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FR
 		return nil, err
 	}
 
-	sizes := make(map[types.FileContractID]api.ContractSize, len(rows))
+	sizes := make(map[types.FileContractID]api.ContractSize)
 	for _, row := range rows {
 		if types.FileContractID(row.Fcid) == (types.FileContractID{}) {
 			return nil, errors.New("invalid file contract id")
@@ -707,8 +707,8 @@ func (s *SQLStore) ContractSize(ctx context.Context, id types.FileContractID) (a
 
 	if err := s.db.
 		Raw(`
-SELECT size, CASE SIGN(bytes) WHEN -1 THEN 0 ELSE bytes END as prunable FROM (
-    SELECT IFNULL(MAX(c.size), 0) as size, IFNULL(MAX(c.size) - COUNT(cs.db_sector_id) * ?, 0) as bytes
+SELECT size, CASE WHEN size>bytes THEN size-bytes ELSE 0 END as prunable FROM (
+    SELECT c.size, COUNT(cs.db_sector_id) * ? as bytes
     FROM contracts c
     LEFT JOIN contract_sectors cs ON cs.db_contract_id = c.id
     WHERE c.fcid = ?


### PR DESCRIPTION
This PR avoids usage of the `SIGN` function as well as avoid an underflow in the unsigned integer if the contract size is smaller than it's sector counts. This should be impossible but I've found two occurrences on my node where the size is 0 and the count is 1. 

On `arequipa` I noticed the response of `/contracts/prunable` contained some empty structs so rewrote the handler to ensure that's no longer possible