### PR TITLE
Drop interactions db in preparation for a dedicated database for time series 

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -164,8 +164,11 @@ type ContractPrunableData struct {
 	ContractSize
 }
 
-type HostsInteractionRequest struct {
-	Scans             []hostdb.HostScan         `json:"scans"`
+type HostsScanRequest struct {
+	Scans []hostdb.HostScan `json:"scans"`
+}
+
+type HostsPriceTableUpdateRequest struct {
 	PriceTableUpdates []hostdb.PriceTableUpdate `json:"priceTableUpdates"`
 }
 

--- a/api/bus.go
+++ b/api/bus.go
@@ -10,6 +10,7 @@ import (
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/object"
 )
 
@@ -161,6 +162,11 @@ type ContractsPrunableDataResponse struct {
 type ContractPrunableData struct {
 	ID types.FileContractID `json:"id"`
 	ContractSize
+}
+
+type HostsInteractionRequest struct {
+	Scans             []hostdb.HostScan         `json:"scans"`
+	PriceTableUpdates []hostdb.PriceTableUpdate `json:"priceTableUpdates"`
 }
 
 // HostsRemoveRequest is the request type for the /hosts/remove endpoint.

--- a/api/bus.go
+++ b/api/bus.go
@@ -168,7 +168,7 @@ type HostsScanRequest struct {
 	Scans []hostdb.HostScan `json:"scans"`
 }
 
-type HostsPriceTableUpdateRequest struct {
+type HostsPriceTablesRequest struct {
 	PriceTableUpdates []hostdb.PriceTableUpdate `json:"priceTableUpdates"`
 }
 

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -51,7 +51,7 @@ type Bus interface {
 	Hosts(ctx context.Context, offset, limit int) ([]hostdb.Host, error)
 	SearchHosts(ctx context.Context, filterMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]hostdb.Host, error)
 	HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) ([]hostdb.HostAddress, error)
-	RecordInteractions(ctx context.Context, interactions []hostdb.Interaction) error
+	RecordInteractions(ctx context.Context, scans []hostdb.HostScan, priceTableUpdate []hostdb.PriceTableUpdate) error
 	RemoveOfflineHosts(ctx context.Context, minRecentScanFailures uint64, maxDowntime time.Duration) (uint64, error)
 
 	// contracts

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -51,7 +51,6 @@ type Bus interface {
 	Hosts(ctx context.Context, offset, limit int) ([]hostdb.Host, error)
 	SearchHosts(ctx context.Context, filterMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]hostdb.Host, error)
 	HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) ([]hostdb.HostAddress, error)
-	RecordInteractions(ctx context.Context, scans []hostdb.HostScan, priceTableUpdate []hostdb.PriceTableUpdate) error
 	RemoveOfflineHosts(ctx context.Context, minRecentScanFailures uint64, maxDowntime time.Duration) (uint64, error)
 
 	// contracts

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -72,7 +72,7 @@ type (
 		Hosts(ctx context.Context, offset, limit int) ([]hostdb.Host, error)
 		SearchHosts(ctx context.Context, filterMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]hostdb.Host, error)
 		HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) ([]hostdb.HostAddress, error)
-		RecordInteractions(ctx context.Context, interactions []hostdb.Interaction) error
+		RecordInteractions(ctx context.Context, scans []hostdb.HostScan, priceTableUpdate []hostdb.PriceTableUpdate) error
 		RemoveOfflineHosts(ctx context.Context, minRecentScanFailures uint64, maxDowntime time.Duration) (uint64, error)
 
 		HostAllowlist(ctx context.Context) ([]types.PublicKey, error)
@@ -539,11 +539,11 @@ func (b *bus) hostsPubkeyHandlerGET(jc jape.Context) {
 }
 
 func (b *bus) hostsPubkeyHandlerPOST(jc jape.Context) {
-	var interactions []hostdb.Interaction
+	var interactions api.HostsInteractionRequest
 	if jc.Decode(&interactions) != nil {
 		return
 	}
-	if jc.Check("failed to record interactions", b.hdb.RecordInteractions(jc.Request.Context(), interactions)) != nil {
+	if jc.Check("failed to record interactions", b.hdb.RecordInteractions(jc.Request.Context(), interactions.Scans, interactions.PriceTableUpdates)) != nil {
 		return
 	}
 }

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -73,7 +73,7 @@ type (
 		SearchHosts(ctx context.Context, filterMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]hostdb.Host, error)
 		HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) ([]hostdb.HostAddress, error)
 		RecordHostScans(ctx context.Context, scans []hostdb.HostScan) error
-		RecordPriceTableUpdates(ctx context.Context, priceTableUpdate []hostdb.PriceTableUpdate) error
+		RecordPriceTables(ctx context.Context, priceTableUpdate []hostdb.PriceTableUpdate) error
 		RemoveOfflineHosts(ctx context.Context, minRecentScanFailures uint64, maxDowntime time.Duration) (uint64, error)
 
 		HostAllowlist(ctx context.Context) ([]types.PublicKey, error)
@@ -550,11 +550,11 @@ func (b *bus) hostsScanHandlerPOST(jc jape.Context) {
 }
 
 func (b *bus) hostsPricetableHandlerPOST(jc jape.Context) {
-	var req api.HostsPriceTableUpdateRequest
+	var req api.HostsPriceTablesRequest
 	if jc.Decode(&req) != nil {
 		return
 	}
-	if jc.Check("failed to record interactions", b.hdb.RecordPriceTableUpdates(jc.Request.Context(), req.PriceTableUpdates)) != nil {
+	if jc.Check("failed to record interactions", b.hdb.RecordPriceTables(jc.Request.Context(), req.PriceTableUpdates)) != nil {
 		return
 	}
 }
@@ -1644,16 +1644,16 @@ func (b *bus) Handler() http.Handler {
 		"POST   /wallet/prepare/renew": b.walletPrepareRenewHandler,
 		"GET    /wallet/pending":       b.walletPendingHandler,
 
-		"GET    /hosts":                   b.hostsHandlerGET,
-		"GET    /host/:hostkey":           b.hostsPubkeyHandlerGET,
-		"POST   /hosts/scans":             b.hostsScanHandlerPOST,
-		"POST   /hosts/pricetableupdates": b.hostsPricetableHandlerPOST,
-		"POST   /hosts/remove":            b.hostsRemoveHandlerPOST,
-		"GET    /hosts/allowlist":         b.hostsAllowlistHandlerGET,
-		"PUT    /hosts/allowlist":         b.hostsAllowlistHandlerPUT,
-		"GET    /hosts/blocklist":         b.hostsBlocklistHandlerGET,
-		"PUT    /hosts/blocklist":         b.hostsBlocklistHandlerPUT,
-		"GET    /hosts/scanning":          b.hostsScanningHandlerGET,
+		"GET    /hosts":             b.hostsHandlerGET,
+		"GET    /host/:hostkey":     b.hostsPubkeyHandlerGET,
+		"POST   /hosts/scans":       b.hostsScanHandlerPOST,
+		"POST   /hosts/pricetables": b.hostsPricetableHandlerPOST,
+		"POST   /hosts/remove":      b.hostsRemoveHandlerPOST,
+		"GET    /hosts/allowlist":   b.hostsAllowlistHandlerGET,
+		"PUT    /hosts/allowlist":   b.hostsAllowlistHandlerPUT,
+		"GET    /hosts/blocklist":   b.hostsBlocklistHandlerGET,
+		"PUT    /hosts/blocklist":   b.hostsBlocklistHandlerPUT,
+		"GET    /hosts/scanning":    b.hostsScanningHandlerGET,
 
 		"GET    /contracts":              b.contractsHandlerGET,
 		"DELETE /contracts/all":          b.contractsAllHandlerDELETE,

--- a/bus/client.go
+++ b/bus/client.go
@@ -361,8 +361,8 @@ func (c *Client) RecordHostScans(ctx context.Context, scans []hostdb.HostScan) (
 }
 
 // RecordHostInteraction records an interaction for the supplied host.
-func (c *Client) RecordPriceTableUpdates(ctx context.Context, priceTableUpdates []hostdb.PriceTableUpdate) (err error) {
-	err = c.c.WithContext(ctx).POST("/hosts/pricetableupdates", api.HostsPriceTableUpdateRequest{
+func (c *Client) RecordPriceTables(ctx context.Context, priceTableUpdates []hostdb.PriceTableUpdate) (err error) {
+	err = c.c.WithContext(ctx).POST("/hosts/pricetables", api.HostsPriceTablesRequest{
 		PriceTableUpdates: priceTableUpdates,
 	}, nil)
 	return

--- a/bus/client.go
+++ b/bus/client.go
@@ -353,8 +353,11 @@ func (c *Client) UpdateHostBlocklist(ctx context.Context, add, remove []string, 
 }
 
 // RecordHostInteraction records an interaction for the supplied host.
-func (c *Client) RecordInteractions(ctx context.Context, interactions []hostdb.Interaction) (err error) {
-	err = c.c.WithContext(ctx).POST("/hosts/interactions", interactions, nil)
+func (c *Client) RecordInteractions(ctx context.Context, scans []hostdb.HostScan, priceTableUpdates []hostdb.PriceTableUpdate) (err error) {
+	err = c.c.WithContext(ctx).POST("/hosts/interactions", api.HostsInteractionRequest{
+		Scans:             scans,
+		PriceTableUpdates: priceTableUpdates,
+	}, nil)
 	return
 }
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -353,9 +353,16 @@ func (c *Client) UpdateHostBlocklist(ctx context.Context, add, remove []string, 
 }
 
 // RecordHostInteraction records an interaction for the supplied host.
-func (c *Client) RecordInteractions(ctx context.Context, scans []hostdb.HostScan, priceTableUpdates []hostdb.PriceTableUpdate) (err error) {
-	err = c.c.WithContext(ctx).POST("/hosts/interactions", api.HostsInteractionRequest{
-		Scans:             scans,
+func (c *Client) RecordHostScans(ctx context.Context, scans []hostdb.HostScan) (err error) {
+	err = c.c.WithContext(ctx).POST("/hosts/interactions", api.HostsScanRequest{
+		Scans: scans,
+	}, nil)
+	return
+}
+
+// RecordHostInteraction records an interaction for the supplied host.
+func (c *Client) RecordPriceTableUpdates(ctx context.Context, priceTableUpdates []hostdb.PriceTableUpdate) (err error) {
+	err = c.c.WithContext(ctx).POST("/hosts/interactions", api.HostsPriceTableUpdateRequest{
 		PriceTableUpdates: priceTableUpdates,
 	}, nil)
 	return

--- a/hostdb/hostdb.go
+++ b/hostdb/hostdb.go
@@ -1,7 +1,6 @@
 package hostdb
 
 import (
-	"encoding/json"
 	"time"
 
 	"gitlab.com/NebulousLabs/encoding"
@@ -98,12 +97,19 @@ type Interactions struct {
 	FailedInteractions     float64
 }
 
-type Interaction struct {
-	Host      types.PublicKey `json:"host"`
-	Result    json.RawMessage `json:"result"`
-	Success   bool            `json:"success"`
-	Timestamp time.Time       `json:"timestamp"`
-	Type      string          `json:"type"`
+type HostScan struct {
+	HostKey    types.PublicKey `json:"hostKey"`
+	Success    bool
+	Timestamp  time.Time
+	Settings   rhpv2.HostSettings
+	PriceTable rhpv3.HostPriceTable
+}
+
+type PriceTableUpdate struct {
+	HostKey    types.PublicKey `json:"hostKey"`
+	Success    bool
+	Timestamp  time.Time
+	PriceTable HostPriceTable
 }
 
 // HostAddress contains the address of a specific host identified by a public

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -46,17 +46,16 @@ func TestHostPruning(t *testing.T) {
 	now := time.Now()
 	recordFailedInteractions := func(n int, hk types.PublicKey) {
 		t.Helper()
-		his := make([]hostdb.Interaction, n)
+		his := make([]hostdb.HostScan, n)
 		for i := 0; i < n; i++ {
 			now = now.Add(time.Hour).Add(time.Minute) // 1m leeway
-			his[i] = hostdb.Interaction{
-				Host:      hk,
+			his[i] = hostdb.HostScan{
+				HostKey:   hk,
 				Timestamp: now,
 				Success:   false,
-				Type:      hostdb.InteractionTypeScan,
 			}
 		}
-		if err = b.RecordInteractions(context.Background(), his); err != nil {
+		if err = b.RecordInteractions(context.Background(), his, nil); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -55,7 +55,7 @@ func TestHostPruning(t *testing.T) {
 				Success:   false,
 			}
 		}
-		if err = b.RecordInteractions(context.Background(), his, nil); err != nil {
+		if err = b.RecordHostScans(context.Background(), his); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -822,7 +822,7 @@ func (ss *SQLStore) RecordHostScans(ctx context.Context, scans []hostdb.HostScan
 	})
 }
 
-func (ss *SQLStore) RecordPriceTableUpdates(ctx context.Context, priceTableUpdate []hostdb.PriceTableUpdate) error {
+func (ss *SQLStore) RecordPriceTables(ctx context.Context, priceTableUpdate []hostdb.PriceTableUpdate) error {
 	if len(priceTableUpdate) == 0 {
 		return nil // nothing to do
 	}

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -738,11 +738,6 @@ func (ss *SQLStore) RecordInteractions(ctx context.Context, scans []hostdb.HostS
 				continue // host doesn't exist
 			}
 			lastScan := time.Unix(0, host.LastScan)
-			host.TotalScans++
-			host.Scanned = host.Scanned || scan.Success
-			host.SecondToLastScanSuccess = host.LastScanSuccess
-			host.LastScanSuccess = scan.Success
-			host.LastScan = scan.Timestamp.UnixNano()
 
 			if scan.Success {
 				// Handle successful scan.
@@ -779,6 +774,12 @@ func (ss *SQLStore) RecordInteractions(ctx context.Context, scans []hostdb.HostS
 					host.RecentDowntime += scan.Timestamp.Sub(lastScan)
 				}
 			}
+
+			host.TotalScans++
+			host.Scanned = host.Scanned || scan.Success
+			host.SecondToLastScanSuccess = host.LastScanSuccess
+			host.LastScanSuccess = scan.Success
+			host.LastScan = scan.Timestamp.UnixNano()
 
 			// Save to map again.
 			hostMap[host.PublicKey] = host

--- a/stores/hostdb_test.go
+++ b/stores/hostdb_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/alerts"
@@ -349,7 +350,7 @@ func TestRecordScan(t *testing.T) {
 		t.Fatal("wrong time")
 	}
 	host.Interactions.LastScan = time.Time{}
-	if host.Interactions != (hostdb.Interactions{
+	if expected := (hostdb.Interactions{
 		TotalScans:              1,
 		LastScan:                time.Time{},
 		LastScanSuccess:         true,
@@ -358,8 +359,8 @@ func TestRecordScan(t *testing.T) {
 		Downtime:                downtime,
 		SuccessfulInteractions:  1,
 		FailedInteractions:      0,
-	}) {
-		t.Fatal("mismatch")
+	}); host.Interactions != expected {
+		t.Fatal("mismatch", cmp.Diff(host.Interactions, expected))
 	}
 	if !reflect.DeepEqual(host.Settings, settings) {
 		t.Fatal("mismatch")

--- a/stores/hostdb_test.go
+++ b/stores/hostdb_test.go
@@ -165,14 +165,14 @@ func TestSQLHostDB(t *testing.T) {
 }
 
 func (s *SQLStore) addTestScan(hk types.PublicKey, t time.Time, err error, settings rhpv2.HostSettings) error {
-	return s.RecordInteractions(context.Background(), []hostdb.HostScan{
+	return s.RecordHostScans(context.Background(), []hostdb.HostScan{
 		{
 			HostKey:   hk,
 			Settings:  settings,
 			Success:   err == nil,
 			Timestamp: t,
 		},
-	}, nil)
+	})
 }
 
 // TestSQLHosts tests the Hosts method of the SQLHostDB type.
@@ -335,7 +335,7 @@ func TestRecordScan(t *testing.T) {
 	// Record a scan.
 	firstScanTime := time.Now().UTC()
 	settings := rhpv2.HostSettings{NetAddress: "host.com"}
-	if err := hdb.RecordInteractions(ctx, []hostdb.HostScan{newTestScan(hk, firstScanTime, settings, true)}, nil); err != nil {
+	if err := hdb.RecordHostScans(ctx, []hostdb.HostScan{newTestScan(hk, firstScanTime, settings, true)}); err != nil {
 		t.Fatal(err)
 	}
 	host, err = hdb.Host(ctx, hk)
@@ -368,7 +368,7 @@ func TestRecordScan(t *testing.T) {
 
 	// Record another scan 1 hour after the previous one.
 	secondScanTime := firstScanTime.Add(time.Hour)
-	if err := hdb.RecordInteractions(ctx, []hostdb.HostScan{newTestScan(hk, secondScanTime, settings, true)}, nil); err != nil {
+	if err := hdb.RecordHostScans(ctx, []hostdb.HostScan{newTestScan(hk, secondScanTime, settings, true)}); err != nil {
 		t.Fatal(err)
 	}
 	host, err = hdb.Host(ctx, hk)
@@ -395,7 +395,7 @@ func TestRecordScan(t *testing.T) {
 
 	// Record another scan 2 hours after the second one. This time it fails.
 	thirdScanTime := secondScanTime.Add(2 * time.Hour)
-	if err := hdb.RecordInteractions(ctx, []hostdb.HostScan{newTestScan(hk, thirdScanTime, settings, false)}, nil); err != nil {
+	if err := hdb.RecordHostScans(ctx, []hostdb.HostScan{newTestScan(hk, thirdScanTime, settings, false)}); err != nil {
 		t.Fatal(err)
 	}
 	host, err = hdb.Host(ctx, hk)
@@ -460,7 +460,7 @@ func TestRemoveHosts(t *testing.T) {
 	hi2 := newTestScan(hk, t2, rhpv2.HostSettings{NetAddress: "host.com"}, false)
 
 	// record interactions
-	if err := hdb.RecordInteractions(context.Background(), []hostdb.HostScan{hi1, hi2}, nil); err != nil {
+	if err := hdb.RecordHostScans(context.Background(), []hostdb.HostScan{hi1, hi2}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -488,7 +488,7 @@ func TestRemoveHosts(t *testing.T) {
 	// record interactions
 	t3 := now.Add(-time.Minute * 60) // 1 hour ago (60min downtime)
 	hi3 := newTestScan(hk, t3, rhpv2.HostSettings{NetAddress: "host.com"}, false)
-	if err := hdb.RecordInteractions(context.Background(), []hostdb.HostScan{hi3}, nil); err != nil {
+	if err := hdb.RecordHostScans(context.Background(), []hostdb.HostScan{hi3}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -25,7 +25,6 @@ var (
 		&dbAnnouncement{},
 		&dbConsensusInfo{},
 		&dbHost{},
-		&dbInteraction{},
 		&dbAllowlistEntry{},
 		&dbBlocklistEntry{},
 
@@ -180,6 +179,13 @@ func performMigrations(db *gorm.DB, logger glogger.Interface) error {
 			ID: "00007_contractspending",
 			Migrate: func(tx *gorm.DB) error {
 				return performMigration00007_archivedcontractspending(tx, logger)
+			},
+			Rollback: nil,
+		},
+		{
+			ID: "00008_dropInteractions",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration00008_dropInteractions(tx, logger)
 			},
 			Rollback: nil,
 		},
@@ -474,5 +480,16 @@ func performMigration00007_archivedcontractspending(txn *gorm.DB, logger glogger
 		}
 	}
 	logger.Info(context.Background(), "migration 00007_archivedcontractspending complete")
+	return nil
+}
+
+func performMigration00008_dropInteractions(txn *gorm.DB, logger glogger.Interface) error {
+	logger.Info(context.Background(), "performing migration 00008_dropInteractions")
+	if !txn.Migrator().HasTable("host_interactions") {
+		if err := txn.Migrator().DropTable("host_interactions"); err != nil {
+			return err
+		}
+	}
+	logger.Info(context.Background(), "migration 00008_dropInteractions complete")
 	return nil
 }

--- a/worker/interactions.go
+++ b/worker/interactions.go
@@ -45,13 +45,21 @@ func (w *worker) recordInteractions(scans []hostdb.HostScan, priceTableUpdates [
 
 // flushInteractions flushes the worker's interaction buffer to the bus.
 func (w *worker) flushInteractions() {
-	if len(w.interactionsScans)+len(w.interactionsPriceTableUpdates) > 0 {
-		ctx, span := tracing.Tracer.Start(context.Background(), "worker: flushInteractions")
+	if len(w.interactionsScans) > 0 {
+		ctx, span := tracing.Tracer.Start(context.Background(), "worker: recordHostScans")
 		defer span.End()
-		if err := w.bus.RecordInteractions(ctx, w.interactionsScans, w.interactionsPriceTableUpdates); err != nil {
-			w.logger.Errorw(fmt.Sprintf("failed to record interactions: %v", err))
+		if err := w.bus.RecordHostScans(ctx, w.interactionsScans); err != nil {
+			w.logger.Errorw(fmt.Sprintf("failed to record scans: %v", err))
 		} else {
 			w.interactionsScans = nil
+		}
+	}
+	if len(w.interactionsPriceTableUpdates) > 0 {
+		ctx, span := tracing.Tracer.Start(context.Background(), "worker: recordPriceTableUpdates")
+		defer span.End()
+		if err := w.bus.RecordPriceTableUpdates(ctx, w.interactionsPriceTableUpdates); err != nil {
+			w.logger.Errorw(fmt.Sprintf("failed to record price table updates: %v", err))
+		} else {
 			w.interactionsPriceTableUpdates = nil
 		}
 	}

--- a/worker/interactions.go
+++ b/worker/interactions.go
@@ -57,7 +57,7 @@ func (w *worker) flushInteractions() {
 	if len(w.interactionsPriceTableUpdates) > 0 {
 		ctx, span := tracing.Tracer.Start(context.Background(), "worker: recordPriceTableUpdates")
 		defer span.End()
-		if err := w.bus.RecordPriceTableUpdates(ctx, w.interactionsPriceTableUpdates); err != nil {
+		if err := w.bus.RecordPriceTables(ctx, w.interactionsPriceTableUpdates); err != nil {
 			w.logger.Errorw(fmt.Sprintf("failed to record price table updates: %v", err))
 		} else {
 			w.interactionsPriceTableUpdates = nil

--- a/worker/interactions.go
+++ b/worker/interactions.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -24,12 +23,13 @@ func errToStr(err error) string {
 
 // recordInteractions adds some interactions to the worker's interaction buffer
 // which is periodically flushed to the bus.
-func (w *worker) recordInteractions(interactions []hostdb.Interaction) {
+func (w *worker) recordInteractions(scans []hostdb.HostScan, priceTableUpdates []hostdb.PriceTableUpdate) {
 	w.interactionsMu.Lock()
 	defer w.interactionsMu.Unlock()
 
 	// Append interactions to buffer.
-	w.interactions = append(w.interactions, interactions...)
+	w.interactionsScans = append(w.interactionsScans, scans...)
+	w.interactionsPriceTableUpdates = append(w.interactionsPriceTableUpdates, priceTableUpdates...)
 
 	// If a thread was scheduled to flush the buffer we are done.
 	if w.interactionsFlushTimer != nil {
@@ -45,13 +45,14 @@ func (w *worker) recordInteractions(interactions []hostdb.Interaction) {
 
 // flushInteractions flushes the worker's interaction buffer to the bus.
 func (w *worker) flushInteractions() {
-	if len(w.interactions) > 0 {
+	if len(w.interactionsScans)+len(w.interactionsPriceTableUpdates) > 0 {
 		ctx, span := tracing.Tracer.Start(context.Background(), "worker: flushInteractions")
 		defer span.End()
-		if err := w.bus.RecordInteractions(ctx, w.interactions); err != nil {
+		if err := w.bus.RecordInteractions(ctx, w.interactionsScans, w.interactionsPriceTableUpdates); err != nil {
 			w.logger.Errorw(fmt.Sprintf("failed to record interactions: %v", err))
 		} else {
-			w.interactions = nil
+			w.interactionsScans = nil
+			w.interactionsPriceTableUpdates = nil
 		}
 	}
 	w.interactionsFlushTimer = nil
@@ -75,21 +76,6 @@ func recordPriceTableUpdate(ctx context.Context, siamuxAddr string, hostKey type
 	}
 }
 
-// recordScan records a scan metric.
-func recordScan(mr metrics.MetricsRecorder, elapsed time.Duration, hostIP string, hostKey types.PublicKey, pt rhpv3.HostPriceTable, settings rhpv2.HostSettings, err error) {
-	mr.RecordMetric(MetricHostScan{
-		metricCommon: metricCommon{
-			address:   hostIP,
-			hostKey:   hostKey,
-			timestamp: time.Now(),
-			elapsed:   elapsed,
-			err:       err,
-		},
-		pt:       pt,
-		settings: settings,
-	})
-}
-
 // ephemeralMetricsRecorder can be used to record metrics in memory.
 type ephemeralMetricsRecorder struct {
 	ms []metrics.Metric
@@ -102,9 +88,9 @@ func (mr *ephemeralMetricsRecorder) RecordMetric(m metrics.Metric) {
 	mr.ms = append(mr.ms, m)
 }
 
-func (mr *ephemeralMetricsRecorder) interactions() []hostdb.Interaction {
+func (mr *ephemeralMetricsRecorder) interactions() []any {
 	// TODO: merge/filter metrics?
-	var his []hostdb.Interaction
+	var his []any
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
 	for _, m := range mr.ms {
@@ -205,13 +191,6 @@ func isSuccessfulInteraction(err error) bool {
 	return false
 }
 
-func metricToInteraction(m metrics.Metric) hostdb.Interaction {
-	res, _ := json.Marshal(m.Result())
-	return hostdb.Interaction{
-		Host:      m.HostKey(),
-		Result:    res,
-		Success:   m.IsSuccess(),
-		Timestamp: m.Timestamp(),
-		Type:      m.Type(),
-	}
+func metricToInteraction(m metrics.Metric) any {
+	return nil
 }

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -165,16 +165,13 @@ func (t *transportV3) DialStream(ctx context.Context) (*streamV3, error) {
 
 // transportPoolV3 is a pool of rhpv3.Transports which allows for reusing them.
 type transportPoolV3 struct {
-	recordInteractions func([]hostdb.Interaction)
-
 	mu   sync.Mutex
 	pool map[string]*transportV3
 }
 
 func newTransportPoolV3(w *worker) *transportPoolV3 {
 	return &transportPoolV3{
-		recordInteractions: w.recordInteractions,
-		pool:               make(map[string]*transportV3),
+		pool: make(map[string]*transportV3),
 	}
 }
 
@@ -205,7 +202,7 @@ func dialTransport(ctx context.Context, siamuxAddr string, hostKey types.PublicK
 func (p *transportPoolV3) withTransportV3(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, fn func(context.Context, *transportV3) error) (err error) {
 	var mr ephemeralMetricsRecorder
 	defer func() {
-		p.recordInteractions(mr.interactions())
+		// TODO: record metrics
 	}()
 	ctx = metrics.WithRecorder(ctx, &mr)
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -146,7 +146,7 @@ type Bus interface {
 	ContractRoots(ctx context.Context, id types.FileContractID) ([]types.Hash256, []types.Hash256, error)
 	Contracts(ctx context.Context) ([]api.ContractMetadata, error)
 	ContractSetContracts(ctx context.Context, set string) ([]api.ContractMetadata, error)
-	RecordInteractions(ctx context.Context, interactions []hostdb.Interaction) error
+	RecordInteractions(ctx context.Context, scans []hostdb.HostScan, priceTableUpdate []hostdb.PriceTableUpdate) error
 	RecordContractSpending(ctx context.Context, records []api.ContractSpendingRecord) error
 	RenewedContract(ctx context.Context, renewedFrom types.FileContractID) (api.ContractMetadata, error)
 
@@ -248,9 +248,10 @@ type worker struct {
 
 	busFlushInterval time.Duration
 
-	interactionsMu         sync.Mutex
-	interactions           []hostdb.Interaction
-	interactionsFlushTimer *time.Timer
+	interactionsMu                sync.Mutex
+	interactionsScans             []hostdb.HostScan
+	interactionsPriceTableUpdates []hostdb.PriceTableUpdate
+	interactionsFlushTimer        *time.Timer
 
 	contractSpendingRecorder *contractSpendingRecorder
 	contractLockingDuration  time.Duration
@@ -267,7 +268,7 @@ func dial(ctx context.Context, hostIP string) (net.Conn, error) {
 func (w *worker) withTransportV2(ctx context.Context, hostKey types.PublicKey, hostIP string, fn func(*rhpv2.Transport) error) (err error) {
 	var mr ephemeralMetricsRecorder
 	defer func() {
-		w.recordInteractions(mr.interactions())
+		// TODO record metrics
 	}()
 	ctx = metrics.WithRecorder(ctx, &mr)
 	conn, err := dial(ctx, hostIP)
@@ -364,9 +365,18 @@ func (w *worker) rhpScanHandler(jc jape.Context) {
 	}
 
 	// record scan
-	var mr ephemeralMetricsRecorder
-	recordScan(&mr, elapsed, rsr.HostIP, rsr.HostKey, priceTable, settings, err)
-	w.recordInteractions(mr.interactions())
+	err = w.bus.RecordInteractions(jc.Request.Context(), []hostdb.HostScan{{
+		HostKey:    rsr.HostKey,
+		Success:    err == nil,
+		Timestamp:  time.Now(),
+		Settings:   settings,
+		PriceTable: priceTable,
+	}}, nil)
+	if jc.Check("failed to record scan", err) != nil {
+		return
+	}
+
+	// TODO: record metric
 
 	jc.Encode(api.RHPScanResponse{
 		Ping:      api.ParamDuration(elapsed),

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -146,7 +146,8 @@ type Bus interface {
 	ContractRoots(ctx context.Context, id types.FileContractID) ([]types.Hash256, []types.Hash256, error)
 	Contracts(ctx context.Context) ([]api.ContractMetadata, error)
 	ContractSetContracts(ctx context.Context, set string) ([]api.ContractMetadata, error)
-	RecordInteractions(ctx context.Context, scans []hostdb.HostScan, priceTableUpdate []hostdb.PriceTableUpdate) error
+	RecordHostScans(ctx context.Context, scans []hostdb.HostScan) error
+	RecordPriceTableUpdates(ctx context.Context, priceTableUpdate []hostdb.PriceTableUpdate) error
 	RecordContractSpending(ctx context.Context, records []api.ContractSpendingRecord) error
 	RenewedContract(ctx context.Context, renewedFrom types.FileContractID) (api.ContractMetadata, error)
 
@@ -365,13 +366,13 @@ func (w *worker) rhpScanHandler(jc jape.Context) {
 	}
 
 	// record scan
-	err = w.bus.RecordInteractions(jc.Request.Context(), []hostdb.HostScan{{
+	err = w.bus.RecordHostScans(jc.Request.Context(), []hostdb.HostScan{{
 		HostKey:    rsr.HostKey,
 		Success:    err == nil,
 		Timestamp:  time.Now(),
 		Settings:   settings,
 		PriceTable: priceTable,
-	}}, nil)
+	}})
 	if jc.Check("failed to record scan", err) != nil {
 		return
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -147,7 +147,7 @@ type Bus interface {
 	Contracts(ctx context.Context) ([]api.ContractMetadata, error)
 	ContractSetContracts(ctx context.Context, set string) ([]api.ContractMetadata, error)
 	RecordHostScans(ctx context.Context, scans []hostdb.HostScan) error
-	RecordPriceTableUpdates(ctx context.Context, priceTableUpdate []hostdb.PriceTableUpdate) error
+	RecordPriceTables(ctx context.Context, priceTableUpdate []hostdb.PriceTableUpdate) error
 	RecordContractSpending(ctx context.Context, records []api.ContractSpendingRecord) error
 	RenewedContract(ctx context.Context, renewedFrom types.FileContractID) (api.ContractMetadata, error)
 


### PR DESCRIPTION
Saving large amount of historic data harms. the performance of regular operations such as uploads and upload packing.
Especially using SQLite since tables of a database can't be locked independently for writing.

To avoid that, the goal is to create another database dedicated to historic data which doesn't interfere with the main database's operations. 