### PR TITLE
Improve performance of refreshing cached slab health

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1397,6 +1397,11 @@ func (ss *SQLStore) UpdateSlab(ctx context.Context, s object.Slab, contractSet s
 			return err
 		}
 
+		// invalidate health
+		if err := tx.Model(&slab).Where(&slab).Update("health_valid", false).Error; err != nil {
+			return err
+		}
+
 		// loop updated shards
 		for _, shard := range s.Shards {
 			// ensure the sector exists

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1881,12 +1881,15 @@ func archiveContracts(tx *gorm.DB, contracts []dbContract, toArchive map[types.F
 func invalidateSlabHealthByFCID(tx *gorm.DB, fcids []fileContractID) error {
 	return tx.Exec(`
 UPDATE slabs SET health_valid = 0 WHERE id in (
-	SELECT slabs.id
-	FROM slabs
-	LEFT JOIN sectors se ON se.db_slab_id = slabs.id
-	LEFT JOIN contract_sectors cs ON cs.db_sector_id = se.id
-	LEFT JOIN contracts c ON c.id = cs.db_contract_id
-	WHERE health_valid = 1 AND c.fcid IN (?)
+	SELECT *
+	FROM (
+		SELECT slabs.id
+		FROM slabs
+		LEFT JOIN sectors se ON se.db_slab_id = slabs.id
+		LEFT JOIN contract_sectors cs ON cs.db_sector_id = se.id
+		LEFT JOIN contracts c ON c.id = cs.db_contract_id
+		WHERE health_valid = 1 AND c.fcid IN (?)
+	)
 )
 		`, fcids).Error
 }

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1855,7 +1855,12 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 		t.Fatalf("unexpected amount of slabs to migrate, %v!=0", len(slabs))
 	}
 
-	// delete the sector
+	// delete the sector - we manually invalidate the slabs for the contract
+	// before deletion.
+	err = invalidateSlabHealthByFCID(db.db, []fileContractID{fileContractID(fcid1)})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := db.db.Table("contract_sectors").Where("TRUE").Delete(&dbContractSector{}).Error; err != nil {
 		t.Fatal(err)
 	}

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -186,6 +186,12 @@ func performMigrations(db *gorm.DB, logger glogger.Interface) error {
 				return performMigration00009_dropInteractions(tx, logger)
 			},
 		},
+		{
+			ID: "00010_healthValidColumn",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration00010_healthValidColumn(tx, logger)
+			},
+		},
 	}
 
 	// Create migrator.
@@ -568,5 +574,16 @@ func performMigration00009_dropInteractions(txn *gorm.DB, logger glogger.Interfa
 		}
 	}
 	logger.Info(context.Background(), "migration 00009_dropInteractions complete")
+	return nil
+}
+
+func performMigration00010_healthValidColumn(txn *gorm.DB, logger glogger.Interface) error {
+	logger.Info(context.Background(), "performing migration 00010_healthValidColumn")
+	if !txn.Migrator().HasColumn(&dbSlab{}, "HealthValid") {
+		if err := txn.Migrator().AddColumn(&dbSlab{}, "HealthValid"); err != nil {
+			return err
+		}
+	}
+	logger.Info(context.Background(), "migration 00010_healthValidColumn complete")
 	return nil
 }


### PR DESCRIPTION
Updating the health currently locks SQLite on a large node for more than a minute. To prevent that this PR changes 2 things.

1. slabs get a new "health_invalid" column and we only invalidate the health on slabs when some event happens that might have triggered a change. e.g. archiving a contract, adding a slab to the db, updating the contract set etc.
2. we don't compute the health for all slabs at once. Instead we do so in batches of 10k slabs at once which equals around 1.2TiB of uploaded sectors