### PR TITLE
Fix SQL Performance: missing indices

### DIFF
--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -91,11 +91,23 @@ type (
 		Hosts []dbHost  `gorm:"many2many:host_allowlist_entry_hosts;constraint:OnDelete:CASCADE"`
 	}
 
+	// dbHostAllowlistEntryHost is a join table between dbAllowlistEntry and dbHost.
+	dbHostAllowlistEntryHost struct {
+		DBAllowlistEntryID uint8 `gorm:"primaryKey"`
+		DBHostID           uint8 `gorm:"primaryKey;index"`
+	}
+
 	// dbBlocklistEntry defines a table that stores the host blocklist.
 	dbBlocklistEntry struct {
 		Model
 		Entry string   `gorm:"unique;index;NOT NULL"`
 		Hosts []dbHost `gorm:"many2many:host_blocklist_entry_hosts;constraint:OnDelete:CASCADE"`
+	}
+
+	// dbHostBlocklistEntryHost is a join table between dbBlocklistEntry and dbHost.
+	dbHostBlocklistEntryHost struct {
+		DBBlocklistEntryID uint8 `gorm:"primaryKey"`
+		DBHostID           uint8 `gorm:"primaryKey;index"`
 	}
 
 	// dbConsensusInfo defines table which stores the latest consensus info
@@ -287,7 +299,13 @@ func (dbInteraction) TableName() string { return "host_interactions" }
 func (dbAllowlistEntry) TableName() string { return "host_allowlist_entries" }
 
 // TableName implements the gorm.Tabler interface.
+func (dbHostAllowlistEntryHost) TableName() string { return "host_allowlist_entry_hosts" }
+
+// TableName implements the gorm.Tabler interface.
 func (dbBlocklistEntry) TableName() string { return "host_blocklist_entries" }
+
+// TableName implements the gorm.Tabler interface.
+func (dbHostBlocklistEntryHost) TableName() string { return "host_blocklist_entry_hosts" }
 
 // convert converts a host into a hostdb.Host.
 func (h dbHost) convert() hostdb.Host {

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -93,8 +93,8 @@ type (
 
 	// dbHostAllowlistEntryHost is a join table between dbAllowlistEntry and dbHost.
 	dbHostAllowlistEntryHost struct {
-		DBAllowlistEntryID uint8 `gorm:"primaryKey"`
-		DBHostID           uint8 `gorm:"primaryKey;index"`
+		DBAllowlistEntryID uint `gorm:"primaryKey"`
+		DBHostID           uint `gorm:"primaryKey;index"`
 	}
 
 	// dbBlocklistEntry defines a table that stores the host blocklist.
@@ -106,8 +106,8 @@ type (
 
 	// dbHostBlocklistEntryHost is a join table between dbBlocklistEntry and dbHost.
 	dbHostBlocklistEntryHost struct {
-		DBBlocklistEntryID uint8 `gorm:"primaryKey"`
-		DBHostID           uint8 `gorm:"primaryKey;index"`
+		DBBlocklistEntryID uint `gorm:"primaryKey"`
+		DBHostID           uint `gorm:"primaryKey;index"`
 	}
 
 	// dbConsensusInfo defines table which stores the latest consensus info

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -126,8 +126,8 @@ type (
 
 	// dbContractSector is a join table between dbContract and dbSector.
 	dbContractSector struct {
-		DBContractID uint `gorm:"primaryKey"`
-		DBSectorID   uint `gorm:"primaryKey;index"`
+		DBSectorID   uint `gorm:"primaryKey"`
+		DBContractID uint `gorm:"primaryKey;index"`
 	}
 
 	// rawObject is used for hydration and is made up of one or many raw sectors.

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -69,6 +69,11 @@ type (
 		Contracts []dbContract `gorm:"many2many:contract_set_contracts;constraint:OnDelete:CASCADE"`
 	}
 
+	dbContractSetContract struct {
+		DBContractSetID uint `gorm:"primaryKey;"`
+		DBContractID    uint `gorm:"primaryKey;index"`
+	}
+
 	dbObject struct {
 		Model
 
@@ -126,7 +131,7 @@ type (
 
 	// dbContractSector is a join table between dbContract and dbSector.
 	dbContractSector struct {
-		DBSectorID   uint `gorm:"primaryKey"`
+		DBSectorID   uint `gorm:"primaryKey;"`
 		DBContractID uint `gorm:"primaryKey;index"`
 	}
 
@@ -163,6 +168,9 @@ func (dbArchivedContract) TableName() string { return "archived_contracts" }
 
 // TableName implements the gorm.Tabler interface.
 func (dbContract) TableName() string { return "contracts" }
+
+// TableName implements the gorm.Tabler interface.
+func (dbContractSetContract) TableName() string { return "contract_set_contracts" }
 
 // TableName implements the gorm.Tabler interface.
 func (dbContractSector) TableName() string { return "contract_sectors" }

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -127,7 +127,7 @@ type (
 	// dbContractSector is a join table between dbContract and dbSector.
 	dbContractSector struct {
 		DBContractID uint `gorm:"primaryKey"`
-		DBSectorID   uint `gorm:"primaryKey"`
+		DBSectorID   uint `gorm:"primaryKey;index"`
 	}
 
 	// rawObject is used for hydration and is made up of one or many raw sectors.

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -44,15 +44,6 @@ var (
 	}
 )
 
-type dbHostBlocklistEntryHost struct {
-	DBBlocklistEntryID uint8 `gorm:"primarykey;column:db_blocklist_entry_id"`
-	DBHostID           uint8 `gorm:"primarykey;index:idx_db_host_id;column:db_host_id"`
-}
-
-func (dbHostBlocklistEntryHost) TableName() string {
-	return "host_blocklist_entry_hosts"
-}
-
 // migrateShards performs the migrations necessary for removing the 'shards'
 // table.
 func migrateShards(ctx context.Context, db *gorm.DB, l glogger.Interface) error {
@@ -238,8 +229,23 @@ func setupJoinTables(tx *gorm.DB) error {
 		field     string
 	}{
 		{
+			&dbAllowlistEntry{},
+			&dbHostAllowlistEntryHost{},
+			"Hosts",
+		},
+		{
+			&dbBlocklistEntry{},
+			&dbHostBlocklistEntryHost{},
+			"Hosts",
+		},
+		{
 			&dbSector{},
 			&dbContractSector{},
+			"Contracts",
+		},
+		{
+			&dbContractSet{},
+			&dbContractSetContract{},
 			"Contracts",
 		},
 	}
@@ -519,7 +525,19 @@ func performMigration00008_jointableindices(txn *gorm.DB, logger glogger.Interfa
 		column    string
 	}{
 		{
+			&dbHostAllowlistEntryHost{},
+			"DBHostID",
+		},
+		{
+			&dbHostBlocklistEntryHost{},
+			"DBHostID",
+		},
+		{
 			&dbContractSector{},
+			"DBContractID",
+		},
+		{
+			&dbContractSetContract{},
 			"DBContractID",
 		},
 	}

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -127,10 +127,23 @@ func TestQueryPlan(t *testing.T) {
 	}
 
 	queries := []string{
+		// allow_list
+		"SELECT * FROM host_allowlist_entry_hosts WHERE db_host_id = 1",
+		"SELECT * FROM host_allowlist_entry_hosts WHERE db_allowlist_entry_id = 1",
+
+		// block_list
+		"SELECT * FROM host_blocklist_entry_hosts WHERE db_host_id = 1",
+		"SELECT * FROM host_blocklist_entry_hosts WHERE db_blocklist_entry_id = 1",
+
 		// contract_sectors
 		"SELECT * FROM contract_sectors WHERE db_contract_id = 1",
 		"SELECT * FROM contract_sectors WHERE db_sector_id = 1",
+
+		// contract_set_contracts
+		"SELECT * FROM contract_set_contracts WHERE db_contract_id = 1",
+		"SELECT * FROM contract_set_contracts WHERE db_contract_set_id = 1",
 	}
+
 	for _, query := range queries {
 		var explain queryPlanExplain
 		err = db.db.Raw(fmt.Sprintf("EXPLAIN QUERY PLAN %s;", query)).Scan(&explain).Error


### PR DESCRIPTION
I found out we were missing indices on the 2nd field of our composite primary keys in all of our join tables.

- contract_set_contracts (db_contract_id)
- contract_sectors (db_contract_id)
- host_blocklist_entry_hosts (db_host_id)
- host_allowlist_entry_hosts (db_host_id)

I decided to use `SetupJoinTable` as mentioned in the `gorm` docs and add a migration to handle existing setups. I tested this extensively on SQLite databases, haven't tested it on MySQL yet but seems like this is something that would work on MySQL if it passes SQLite validations.

Will validate it on my MySQL node when approved/green.