### PR TITLE
ui: v0.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	go.sia.tech/jape v0.9.1-0.20230525021720-ecf031ecbffb
 	go.sia.tech/mux v1.2.0
 	go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca
-	go.sia.tech/web/renterd v0.26.0
+	go.sia.tech/web/renterd v0.27.0
 	go.uber.org/zap v1.25.0
 	golang.org/x/crypto v0.12.0
 	golang.org/x/term v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca h1:aZMg2AKevn7jKx+wlusWQf
 go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca/go.mod h1:h/1afFwpxzff6/gG5i1XdAgPK7dEY6FaibhK7N5F86Y=
 go.sia.tech/web v0.0.0-20230817201630-c3d9328334b1 h1:qzS1HFVPuQlOyh17zqO4Qkz63Q0YwADGMt9YAiL9mrk=
 go.sia.tech/web v0.0.0-20230817201630-c3d9328334b1/go.mod h1:RKODSdOmR3VtObPAcGwQqm4qnqntDVFylbvOBbWYYBU=
-go.sia.tech/web/renterd v0.26.0 h1:KhgyvdFdUfBd2PqbBe1JUVUyZateM46iTFBM0cv2x8g=
-go.sia.tech/web/renterd v0.26.0/go.mod h1:FgXrdmAnu591a3h96RB/15pMZ74xO9457g902uE06BM=
+go.sia.tech/web/renterd v0.27.0 h1:paaR3J5rtEG/ZxG3FMoOG2fMcQNgyUKtAda/ChpTRsk=
+go.sia.tech/web/renterd v0.27.0/go.mod h1:FgXrdmAnu591a3h96RB/15pMZ74xO9457g902uE06BM=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=


### PR DESCRIPTION
- The failed to migrate slab alert now lists the associated objects/files.
- The host explorer now has an interactive map. Filtered hosts can be selected via the list or map, and hosts on the map are colored based on whether renterd is actively contracting with the host. For hosts with active contracts the size of the hosts on the map is based on renterd's used storage, for hosts without active contracts the size is based on the hosts remaining storage.
- New users are now more clearly instructed to configure autopilot and to wait for enough contracts before files can be uploaded.
- File upload and directory creation are now disabled until enough contracts are formed.
- Node profile information now includes the build version.
- The connectivity and login check no longer depends on consensus APIs which in some rare cases can be unresponsive.
- Alerts now show contract additions and removals, formatted address, balance, and more.
- Health percentage values are now clamped to a range of 0-100%.
- File health tooltip now includes redundancy info and supports partial slabs.