### PR TITLE
TestNewTestCluster NDF 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/testing/..."
-          args: "-race;-tags='testing';-timeout=30m"
+          args: "-race;-tags='testing';-timeout=30m;-count=100;-run='TestNewTestCluster'"
       - name: Test Integration - MySQL
         if: matrix.os == 'ubuntu-latest'
         uses: n8maninger/action-golang-test@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,33 +30,33 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-      # - name: Lint
-      #   uses: golangci/golangci-lint-action@v3
-      #   with:
-      #     args: --timeout=30m
-      # - name: Test
-      #   uses: n8maninger/action-golang-test@v1
-      #   with:
-      #     args: "-race;-short"
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          args: --timeout=30m
+      - name: Test
+        uses: n8maninger/action-golang-test@v1
+        with:
+          args: "-race;-short"
       - name: Test Integration
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/testing/..."
-          args: "-race;-tags='testing';-timeout=30m;-count=100;-run=TestNewTestCluster"
-      # - name: Test Integration - MySQL
-      #   if: matrix.os == 'ubuntu-latest'
-      #   uses: n8maninger/action-golang-test@v1
-      #   env:
-      #     RENTERD_DB_URI: 127.0.0.1:3800
-      #     RENTERD_DB_USER: root
-      #     RENTERD_DB_PASSWORD: test
-      #   with:
-      #     package: "./internal/testing/..."
-      #     args: "-race;-tags='testing';-timeout=30m"
-      # - name: Check Endpoints
-      #   uses: SiaFoundation/action-golang-analysis@HEAD
-      #   with:
-      #     analyzers: |
-      #       go.sia.tech/jape.Analyzer
-      # - name: Build
-      #   run: go build -o bin/ ./cmd/renterd
+          args: "-race;-tags='testing';-timeout=30m"
+      - name: Test Integration - MySQL
+        if: matrix.os == 'ubuntu-latest'
+        uses: n8maninger/action-golang-test@v1
+        env:
+          RENTERD_DB_URI: 127.0.0.1:3800
+          RENTERD_DB_USER: root
+          RENTERD_DB_PASSWORD: test
+        with:
+          package: "./internal/testing/..."
+          args: "-race;-tags='testing';-timeout=30m"
+      - name: Check Endpoints
+        uses: SiaFoundation/action-golang-analysis@HEAD
+        with:
+          analyzers: |
+            go.sia.tech/jape.Analyzer
+      - name: Build
+        run: go build -o bin/ ./cmd/renterd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,33 +30,33 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          args: --timeout=30m
-      - name: Test
-        uses: n8maninger/action-golang-test@v1
-        with:
-          args: "-race;-short"
+      # - name: Lint
+      #   uses: golangci/golangci-lint-action@v3
+      #   with:
+      #     args: --timeout=30m
+      # - name: Test
+      #   uses: n8maninger/action-golang-test@v1
+      #   with:
+      #     args: "-race;-short"
       - name: Test Integration
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/testing/..."
-          args: "-race;-tags='testing';-timeout=30m;-count=100;-run='TestNewTestCluster'"
-      - name: Test Integration - MySQL
-        if: matrix.os == 'ubuntu-latest'
-        uses: n8maninger/action-golang-test@v1
-        env:
-          RENTERD_DB_URI: 127.0.0.1:3800
-          RENTERD_DB_USER: root
-          RENTERD_DB_PASSWORD: test
-        with:
-          package: "./internal/testing/..."
-          args: "-race;-tags='testing';-timeout=30m"
-      - name: Check Endpoints
-        uses: SiaFoundation/action-golang-analysis@HEAD
-        with:
-          analyzers: |
-            go.sia.tech/jape.Analyzer
-      - name: Build
-        run: go build -o bin/ ./cmd/renterd
+          args: "-race;-tags='testing';-timeout=30m;-count=100;-run=TestNewTestCluster"
+      # - name: Test Integration - MySQL
+      #   if: matrix.os == 'ubuntu-latest'
+      #   uses: n8maninger/action-golang-test@v1
+      #   env:
+      #     RENTERD_DB_URI: 127.0.0.1:3800
+      #     RENTERD_DB_USER: root
+      #     RENTERD_DB_PASSWORD: test
+      #   with:
+      #     package: "./internal/testing/..."
+      #     args: "-race;-tags='testing';-timeout=30m"
+      # - name: Check Endpoints
+      #   uses: SiaFoundation/action-golang-analysis@HEAD
+      #   with:
+      #     analyzers: |
+      #       go.sia.tech/jape.Analyzer
+      # - name: Build
+      #   run: go build -o bin/ ./cmd/renterd

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -259,7 +259,7 @@ func TestNewTestCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(hostInfos, hostInfosUsable) {
-		t.Fatal("result for 'usable' should match the result for 'all'")
+		t.Fatalf("result for 'usable' should match the result for 'all', \n\nall: %+v \n\nusable: %+v", hostInfos, hostInfosUsable)
 	}
 
 	// Fetch the autopilot status

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -246,19 +246,20 @@ func TestNewTestCluster(t *testing.T) {
 			t.Fatal("host wasn't set")
 		}
 	}
-	hostInfosUsable, err := cluster.Autopilot.HostInfos(context.Background(), api.HostFilterModeAll, api.UsabilityFilterModeUsable, "", nil, 0, -1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(hostInfos, hostInfosUsable) {
-		t.Fatal("result for 'usable' should match the result for ''")
-	}
 	hostInfosUnusable, err := cluster.Autopilot.HostInfos(context.Background(), api.HostFilterModeAll, api.UsabilityFilterModeUnusable, "", nil, 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(hostInfosUnusable) != 0 {
 		t.Fatal("there should be no unusable hosts", len(hostInfosUnusable))
+	}
+
+	hostInfosUsable, err := cluster.Autopilot.HostInfos(context.Background(), api.HostFilterModeAll, api.UsabilityFilterModeUsable, "", nil, 0, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(hostInfos, hostInfosUsable) {
+		t.Fatal("result for 'usable' should match the result for 'all'")
 	}
 
 	// Fetch the autopilot status


### PR DESCRIPTION
We've had this NDF for a while in TestNewTestCluster. Turns out the host's price table may have been updated which caused the `DeepEqual` to fail. I reversed the order of the assertions so we are notified should the host be `unusable` and I've replaced the deep equal with a length check as well as a check to see if all hosts are in the result.

Could consistently reproduce in a loop, verified that the NDF was gone too, then reverted CI changes.

```
cluster_test.go:254: result for 'usable' should match the result for ''
```

```
[{Host:{KnownSince:2023-08-23 07:36:46.138355825 +0000 UTC LastAnnouncement:2023-08-23 07:36:46 +0000 UTC PublicKey:ed25519:913a0a12468c972156f4e642becc81fc3d8764b90bde8c892b3e577995a5dbc6 NetAddress:127.0.0.1:46731 PriceTable:{HostPriceTable:{UID:e783be9db8f230399cf84f1688d9ce38 Validity:10s HostBlockHeight:214 UpdatePriceTableCost:1 H AccountBalanceCost:1 H FundAccountCost:1 H LatestRevisionCost:~204.8 nS SubscriptionMemoryCost:1 H SubscriptionNotificationCost:1 H InitBaseCost:100 H MemoryTimeCost:1 H DownloadBandwidthCost:100 pS UploadBandwidthCost:100 pS DropSectorsBaseCost:1 H DropSectorsUnitCost:1 H HasSectorBaseCost:1 H ReadBaseCost:100 H ReadLengthCost:1 H RenewContractCost:100 nS RevisionBaseCost:0 H SwapSectorBaseCost:1 H WriteBaseCost:100 H WriteLengthCost:1 H WriteStoreCost:23148148148 H TxnFeeMinRecommended:10 uS TxnFeeMaxRecommended:30 uS ContractPrice:250 mS CollateralCost:46296296296 H MaxCollateral:5 KS MaxDuration:12960 WindowSize:5 RegistryEntriesLeft:262144 RegistryEntriesTotal:262144} Expiry:2023-08-23 07:37:02.447020112 +0000 UTC} Settings:{AcceptingContracts:true MaxDownloadBatchSize:20971520 MaxDuration:12960 MaxReviseBatchSize:20971520 NetAddress:127.0.0.1:46731 RemainingStorage:41943040 SectorSize:4194304 TotalStorage:41943040 Address:addr:93a73f0902a6e5520d810dd27ea9faa37b31447910e15c1aad8e9ac7a5d60f9ab2aef3e581ff WindowSize:5 Collateral:46296296296 H MaxCollateral:5 KS BaseRPCPrice:100 H ContractPrice:250 mS DownloadBandwidthPrice:100 pS SectorAccessPrice:100 H StoragePrice:23148148148 H UploadBandwidthPrice:100 pS EphemeralAccountExpiry:720h0m0s MaxEphemeralAccountBalance:10 SC RevisionNumber:0 Version:1.6.0 SiaMuxPort:35271} Interactions:{TotalScans:4 LastScan:2023-08-23 07:36:51.303355947 +0000 UTC LastScanSuccess:true SecondToLastScanSuccess:true Uptime:5.008781832s Downtime:0s SuccessfulInteractions:14 FailedInteractions:0} Scanned:true} Checks:0xc0007bca50}]
```
```
[{Host:{KnownSince:2023-08-23 07:36:46.138355825 +0000 UTC LastAnnouncement:2023-08-23 07:36:46 +0000 UTC PublicKey:ed25519:913a0a12468c972156f4e642becc81fc3d8764b90bde8c892b3e577995a5dbc6 NetAddress:127.0.0.1:46731 PriceTable:{HostPriceTable:{UID:d0b7183828b374045ad1e82e0db78f62 Validity:10s HostBlockHeight:177 UpdatePriceTableCost:1 H AccountBalanceCost:1 H FundAccountCost:1 H LatestRevisionCost:~204.8 nS SubscriptionMemoryCost:1 H SubscriptionNotificationCost:1 H InitBaseCost:100 H MemoryTimeCost:1 H DownloadBandwidthCost:100 pS UploadBandwidthCost:100 pS DropSectorsBaseCost:1 H DropSectorsUnitCost:1 H HasSectorBaseCost:1 H ReadBaseCost:100 H ReadLengthCost:1 H RenewContractCost:100 nS RevisionBaseCost:0 H SwapSectorBaseCost:1 H WriteBaseCost:100 H WriteLengthCost:1 H WriteStoreCost:23148148148 H TxnFeeMinRecommended:10 uS TxnFeeMaxRecommended:30 uS ContractPrice:250 mS CollateralCost:46296296296 H MaxCollateral:5 KS MaxDuration:12960 WindowSize:5 RegistryEntriesLeft:262144 RegistryEntriesTotal:262144} Expiry:2023-08-23 07:37:01.387460733 +0000 UTC} Settings:{AcceptingContracts:true MaxDownloadBatchSize:20971520 MaxDuration:12960 MaxReviseBatchSize:20971520 NetAddress:127.0.0.1:46731 RemainingStorage:41943040 SectorSize:4194304 TotalStorage:41943040 Address:addr:93a73f0902a6e5520d810dd27ea9faa37b31447910e15c1aad8e9ac7a5d60f9ab2aef3e581ff WindowSize:5 Collateral:46296296296 H MaxCollateral:5 KS BaseRPCPrice:100 H ContractPrice:250 mS DownloadBandwidthPrice:100 pS SectorAccessPrice:100 H StoragePrice:23148148148 H UploadBandwidthPrice:100 pS EphemeralAccountExpiry:720h0m0s MaxEphemeralAccountBalance:10 SC RevisionNumber:0 Version:1.6.0 SiaMuxPort:35271} Interactions:{TotalScans:4 LastScan:2023-08-23 07:36:51.303355947 +0000 UTC LastScanSuccess:true SecondToLastScanSuccess:true Uptime:5.008781832s Downtime:0s SuccessfulInteractions:13 FailedInteractions:0} Scanned:true} Checks:0xc0009223c0}]
```