### PR TITLE
Fix SQLite Slow DISTINCT

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -131,7 +131,7 @@ type (
 
 	// dbContractSector is a join table between dbContract and dbSector.
 	dbContractSector struct {
-		DBSectorID   uint `gorm:"primaryKey;"`
+		DBSectorID   uint `gorm:"primaryKey;index"`
 		DBContractID uint `gorm:"primaryKey;index"`
 	}
 

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -181,6 +181,13 @@ func performMigrations(db *gorm.DB, logger glogger.Interface) error {
 			},
 			Rollback: nil,
 		},
+		{
+			ID: "00009_distinctcontractsector",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration00009_distinctcontractsector(tx, logger)
+			},
+			Rollback: nil,
+		},
 	}
 
 	// Create migrator.
@@ -552,5 +559,18 @@ func performMigration00008_jointableindices(txn *gorm.DB, logger glogger.Interfa
 	}
 
 	logger.Info(context.Background(), "migration 00008_jointableindices complete")
+	return nil
+}
+
+func performMigration00009_distinctcontractsector(txn *gorm.DB, logger glogger.Interface) error {
+	logger.Info(context.Background(), "performing migration 00009_distinctcontractsector")
+
+	if !txn.Migrator().HasIndex(&dbContractSector{}, "DBSectorID") {
+		if err := txn.Migrator().CreateIndex(&dbContractSector{}, "DBSectorID"); err != nil {
+			return fmt.Errorf("failed to create index on column 'DBSectorID' of table 'contract_sectors': %w", err)
+		}
+	}
+
+	logger.Info(context.Background(), "migration 00009_distinctcontractsector complete")
 	return nil
 }

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -140,6 +140,7 @@ func TestQueryPlan(t *testing.T) {
 		// contract_sectors
 		"SELECT * FROM contract_sectors WHERE db_contract_id = 1",
 		"SELECT * FROM contract_sectors WHERE db_sector_id = 1",
+		"SELECT COUNT(DISTINCT db_sector_id) FROM contract_sectors",
 
 		// contract_set_contracts
 		"SELECT * FROM contract_set_contracts WHERE db_contract_id = 1",


### PR DESCRIPTION
```
{"level":"warn","date":"2023-08-18T18:13:14Z","component":"db","msg":"SLOW SQL >= 500ms","elapsed":"19005.002ms","rows":1,"sql":"SELECT COUNT(DISTINCT db_sector_id) * 4194304 as sectors_size, COUNT(*) * 4194304 as uploaded_size FROM `contract_sectors`"}
```

I found that performing a distinct count on `db_sector_id` is super slow on arequipa. The UI performs that action quite a lot (essentially with every on_focus). The problem is only for SQLite but since we add the `index` annotation regardless of the dialector I figured we can just add it on both SQLite and MySQL databases. An extra index on such an important table/column won't hurt us.