### PR TITLE
Support YAML config

### DIFF
--- a/bus/client_test.go
+++ b/bus/client_test.go
@@ -14,6 +14,7 @@ import (
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/build"
 	"go.sia.tech/renterd/bus"
+	"go.sia.tech/renterd/config"
 	"go.sia.tech/renterd/internal/node"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -70,10 +71,12 @@ func newTestClient(dir string) (*bus.Client, func() error, func(context.Context)
 	// create client
 	client := bus.NewClient("http://"+l.Addr().String(), "test")
 	b, cleanup, err := node.NewBus(node.BusConfig{
-		Bootstrap:      false,
-		GatewayAddr:    "127.0.0.1:0",
-		Miner:          node.NewMiner(client),
-		UsedUTXOExpiry: time.Minute,
+		Bus: config.Bus{
+			Bootstrap:      false,
+			GatewayAddr:    "127.0.0.1:0",
+			UsedUTXOExpiry: time.Minute,
+		},
+		Miner: node.NewMiner(client),
 	}, filepath.Join(dir, "bus"), types.GeneratePrivateKey(), zap.New(zapcore.NewNopCore()))
 	if err != nil {
 		return nil, nil, nil, err

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -21,6 +21,7 @@ import (
 	"go.sia.tech/renterd/autopilot"
 	"go.sia.tech/renterd/build"
 	"go.sia.tech/renterd/bus"
+	"go.sia.tech/renterd/config"
 	"go.sia.tech/renterd/internal/node"
 	"go.sia.tech/renterd/stores"
 	"go.sia.tech/renterd/tracing"
@@ -28,6 +29,8 @@ import (
 	"go.sia.tech/renterd/worker"
 	"go.sia.tech/web/renterd"
 	"golang.org/x/term"
+	"gopkg.in/yaml.v3"
+	"gorm.io/gorm/logger"
 )
 
 const (
@@ -47,9 +50,61 @@ var (
 	githash   = "?"
 	builddate = "?"
 
-	// fetched once, then cached
-	apiPassword *string
-	seed        *types.PrivateKey
+	cfg = config.Config{
+		Directory: ".",
+		Seed:      os.Getenv("RENTERD_SEED"),
+		HTTP: config.HTTP{
+			Address:  build.DefaultAPIAddress,
+			Password: os.Getenv("RENTERD_API_PASSWORD"),
+		},
+		ShutdownTimeout: 5 * time.Minute,
+		Tracing: config.Tracing{
+			InstanceID: "cluster",
+		},
+		Database: config.Database{
+			Log: config.DatabaseLog{
+				IgnoreRecordNotFoundError: true,
+				SlowThreshold:             100 * time.Millisecond,
+			},
+		},
+		Log: config.Log{
+			Level: "warn",
+		},
+		Bus: config.Bus{
+			Bootstrap:                     true,
+			GatewayAddr:                   build.DefaultGatewayAddress,
+			PersistInterval:               time.Minute,
+			UsedUTXOExpiry:                24 * time.Hour,
+			SlabBufferCompletionThreshold: 1 << 12,
+		},
+		Worker: config.Worker{
+			Enabled: true,
+
+			ID:                  "worker",
+			ContractLockTimeout: 30 * time.Second,
+			BusFlushInterval:    5 * time.Second,
+
+			DownloadMaxOverdrive:     5,
+			DownloadOverdriveTimeout: 3 * time.Second,
+
+			UploadMaxOverdrive:     5,
+			UploadOverdriveTimeout: 3 * time.Second,
+		},
+		Autopilot: config.Autopilot{
+			Enabled:                        true,
+			RevisionSubmissionBuffer:       144,
+			AccountsRefillInterval:         defaultAccountRefillInterval,
+			Heartbeat:                      30 * time.Minute,
+			MigrationHealthCutoff:          0.75,
+			RevisionBroadcastInterval:      24 * time.Hour,
+			ScannerBatchSize:               1000,
+			ScannerInterval:                24 * time.Hour,
+			ScannerMinRecentFailures:       10,
+			ScannerNumThreads:              100,
+			MigratorParallelSlabsPerWorker: 1,
+		},
+	}
+	seed types.PrivateKey
 )
 
 func check(context string, err error) {
@@ -58,45 +113,76 @@ func check(context string, err error) {
 	}
 }
 
-func getAPIPassword() string {
-	if apiPassword == nil {
-		pw := os.Getenv("RENTERD_API_PASSWORD")
-		if pw != "" {
-			fmt.Println("Using RENTERD_API_PASSWORD environment variable.")
-			apiPassword = &pw
-		} else {
-			fmt.Print("Enter API password: ")
-			pw, err := term.ReadPassword(int(os.Stdin.Fd()))
-			fmt.Println()
-			if err != nil {
-				log.Fatal(err)
-			}
-			s := string(pw)
-			apiPassword = &s
-		}
+func mustLoadAPIPassword() {
+	if len(cfg.HTTP.Password) != 0 {
+		return
 	}
-	return *apiPassword
+
+	fmt.Print("Enter API password: ")
+	pw, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println()
+	if err != nil {
+		log.Fatal(err)
+	}
+	cfg.HTTP.Password = string(pw)
 }
 
-func getSeed() types.PrivateKey {
-	if seed == nil {
-		phrase := os.Getenv("RENTERD_SEED")
-		if phrase != "" {
-			fmt.Println("Using RENTERD_SEED environment variable")
-		} else {
-			fmt.Print("Enter seed: ")
-			pw, err := term.ReadPassword(int(os.Stdin.Fd()))
-			check("Could not read seed phrase:", err)
-			fmt.Println()
-			phrase = string(pw)
-		}
-		key, err := wallet.KeyFromPhrase(phrase)
-		if err != nil {
-			log.Fatal(err)
-		}
-		seed = &key
+func mustLoadRecoveryPhrase() {
+	phrase := cfg.Seed
+	if len(phrase) == 0 {
+		fmt.Print("Enter seed: ")
+		pw, err := term.ReadPassword(int(os.Stdin.Fd()))
+		check("Could not read seed phrase:", err)
+		fmt.Println()
+		phrase = string(pw)
 	}
-	return *seed
+	key, err := wallet.KeyFromPhrase(phrase)
+	if err != nil {
+		log.Fatal(err)
+	}
+	seed = key
+}
+
+func mustParseWorkers(workers, password string) {
+	if workers == "" {
+		return
+	}
+	// if the CLI flag/environment variable is set, overwrite the config file
+	cfg.Worker.Remotes = cfg.Worker.Remotes[:0]
+	for _, addr := range strings.Split(workers, ";") {
+		cfg.Worker.Remotes = append(cfg.Worker.Remotes, config.RemoteWorker{
+			Address:  addr,
+			Password: password,
+		})
+	}
+}
+
+// mustLoadConfig loads the config file specified by the RENTERD_CONFIG_FILE
+// environment variable. If the config file does not exist, it will not be
+// loaded.
+func mustLoadConfig() {
+	configPath := "renterd.yml"
+	if str := os.Getenv("RENTERD_CONFIG_FILE"); len(str) != 0 {
+		configPath = str
+	}
+
+	// If the config file doesn't exist, don't try to load it.
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return
+	}
+
+	f, err := os.Open(configPath)
+	if err != nil {
+		log.Fatal("failed to open config file:", err)
+	}
+	defer f.Close()
+
+	dec := yaml.NewDecoder(f)
+	dec.KnownFields(true)
+
+	if err := dec.Decode(&cfg); err != nil {
+		log.Fatal("failed to decode config file:", err)
+	}
 }
 
 func parseEnvVar(s string, v interface{}) {
@@ -111,52 +197,25 @@ func parseEnvVar(s string, v interface{}) {
 func main() {
 	log.SetFlags(0)
 
-	var nodeCfg struct {
-		shutdownTimeout time.Duration
-	}
-
-	var busCfg struct {
-		remoteAddr  string
-		apiPassword string
-		node.BusConfig
-	}
-	busCfg.Network, _ = build.Network()
-
-	var dbCfg struct {
-		uri      string
-		user     string
-		password string
-		database string
-	}
-
-	var dbLoggerCfg struct {
-		ignoreNotFoundError string
-		logLevel            string
-		slowThreshold       string
-	}
-
-	var workerCfg struct {
-		enabled     bool
-		remoteAddrs string
-		apiPassword string
-		node.WorkerConfig
-	}
-	workerCfg.ContractLockTimeout = 30 * time.Second
-
-	var autopilotCfg struct {
-		enabled bool
-		node.AutopilotConfig
-	}
-	autopilotCfg.RevisionSubmissionBuffer = api.BlocksPerDay
+	// load the YAML config first. CLI flags and environment variables will
+	// overwrite anything set in the config file.
+	mustLoadConfig()
 
 	// TODO: the following flags will be deprecated in v1.0.0 in favor of
 	// environment variables to ensure we do not ask the user to pass sensitive
 	// information via CLI parameters.
-	flag.StringVar(&dbCfg.password, "db.password", "", "[DEPRECATED] password for the database to use for the bus - can be overwritten using RENTERD_DB_PASSWORD environment variable")
-	flag.StringVar(&busCfg.apiPassword, "bus.apiPassword", "", "[DEPRECATED] API password for remote bus service - can be overwritten using RENTERD_BUS_API_PASSWORD environment variable")
-	flag.StringVar(&busCfg.remoteAddr, "bus.remoteAddr", "", "[DEPRECATED] URL of remote bus service - can be overwritten using RENTERD_BUS_REMOTE_ADDR environment variable")
-	flag.StringVar(&workerCfg.apiPassword, "worker.apiPassword", "", "[DEPRECATED] API password for remote worker service")
-	flag.StringVar(&workerCfg.remoteAddrs, "worker.remoteAddrs", "", "[DEPRECATED] URL of remote worker service(s). Multiple addresses can be provided by separating them with a semicolon. Can be overwritten using the RENTERD_WORKER_REMOTE_ADDRS environment variable")
+	var workerRemoteAddrsStr string
+	var workerRemotePassStr string
+	if len(cfg.Worker.Remotes) > 0 {
+		// note: duplicates the old behavior of all CLI workers sharing the same
+		// password
+		workerRemotePassStr = cfg.Worker.Remotes[0].Password
+	}
+	flag.StringVar(&cfg.Database.MySQL.Password, "db.password", cfg.Database.MySQL.Password, "[DEPRECATED] password for the database to use for the bus - can be overwritten using RENTERD_DB_PASSWORD environment variable")
+	flag.StringVar(&cfg.Bus.RemotePassword, "bus.apiPassword", cfg.Bus.RemotePassword, "[DEPRECATED] API password for remote bus service - can be overwritten using RENTERD_BUS_API_PASSWORD environment variable")
+	flag.StringVar(&cfg.Bus.RemoteAddr, "bus.remoteAddr", cfg.Bus.RemoteAddr, "[DEPRECATED] URL of remote bus service - can be overwritten using RENTERD_BUS_REMOTE_ADDR environment variable")
+	flag.StringVar(&workerRemotePassStr, "worker.apiPassword", workerRemotePassStr, "[DEPRECATED] API password for remote worker service")
+	flag.StringVar(&workerRemoteAddrsStr, "worker.remoteAddrs", "", "[DEPRECATED] URL of remote worker service(s). Multiple addresses can be provided by separating them with a semicolon. Can be overwritten using the RENTERD_WORKER_REMOTE_ADDRS environment variable")
 
 	for _, flag := range []struct {
 		input    string
@@ -164,11 +223,11 @@ func main() {
 		env      string
 		insecure bool
 	}{
-		{dbCfg.password, "db.password", "RENTERD_DB_PASSWORD", true},
-		{busCfg.apiPassword, "bus.apiPassword", "RENTERD_BUS_API_PASSWORD", true},
-		{busCfg.remoteAddr, "bus.remoteAddr", "RENTERD_BUS_REMOTE_ADDR", false},
-		{workerCfg.apiPassword, "worker.apiPassword", "RENTERD_WORKER_API_PASSWORDS", true},
-		{workerCfg.remoteAddrs, "worker.remoteAddrs", "RENTERD_WORKER_REMOTE_ADDRS", false},
+		{cfg.Database.MySQL.Password, "db.password", "RENTERD_DB_PASSWORD", true},
+		{cfg.Bus.RemotePassword, "bus.apiPassword", "RENTERD_BUS_API_PASSWORD", true},
+		{cfg.Bus.RemoteAddr, "bus.remoteAddr", "RENTERD_BUS_REMOTE_ADDR", false},
+		{workerRemotePassStr, "worker.apiPassword", "RENTERD_WORKER_API_PASSWORDS", true},
+		{workerRemoteAddrsStr, "worker.remoteAddrs", "RENTERD_WORKER_REMOTE_ADDRS", false},
 	} {
 		if flag.input != "" {
 			if flag.insecure {
@@ -180,54 +239,52 @@ func main() {
 	}
 
 	// node
-	var customLogPath string
-	apiAddr := flag.String("http", build.DefaultAPIAddress, "address to serve API on")
-	dir := flag.String("dir", ".", "directory to store node state in")
-	tracingEnabled := flag.Bool("tracing-enabled", false, "Enables tracing through OpenTelemetry. If RENTERD_TRACING_ENABLED is set, it overwrites the CLI flag's value. Tracing can be configured using the standard OpenTelemetry environment variables. https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md")
-	tracingServiceInstanceId := flag.String("tracing-service-instance-id", "cluster", "ID of the service instance used for tracing. If RENTERD_TRACING_SERVICE_INSTANCE_ID is set, it overwrites the CLI flag's value.")
-	flag.StringVar(&customLogPath, "log-path", "", "Overwrites the default log location on disk. Alternatively RENTERD_LOG_PATH can be used")
+	flag.StringVar(&cfg.HTTP.Address, "http", cfg.HTTP.Address, "address to serve API on")
+	flag.StringVar(&cfg.Directory, "dir", cfg.Directory, "directory to store node state in")
+	flag.BoolVar(&cfg.Tracing.Enabled, "tracing-enabled", cfg.Tracing.Enabled, "Enables tracing through OpenTelemetry. If RENTERD_TRACING_ENABLED is set, it overwrites the CLI flag's value. Tracing can be configured using the standard OpenTelemetry environment variables. https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md")
+	flag.StringVar(&cfg.Tracing.InstanceID, "tracing-service-instance-id", cfg.Tracing.InstanceID, "ID of the service instance used for tracing. If RENTERD_TRACING_SERVICE_INSTANCE_ID is set, it overwrites the CLI flag's value.")
+	flag.StringVar(&cfg.Log.Path, "log-path", cfg.Log.Path, "Overwrites the default log location on disk. Alternatively RENTERD_LOG_PATH can be used")
 
 	// db
-	flag.StringVar(&dbCfg.uri, "db.uri", "", "URI of the database to use for the bus - can be overwritten using RENTERD_DB_URI environment variable")
-	flag.StringVar(&dbCfg.user, "db.user", "", "username for the database to use for the bus - can be overwritten using RENTERD_DB_USER environment variable")
-	flag.StringVar(&dbCfg.database, "db.name", "", "name of the database to use for the bus - can be overwritten using RENTERD_DB_NAME environment variable")
+	flag.StringVar(&cfg.Database.MySQL.URI, "db.uri", cfg.Database.MySQL.URI, "URI of the database to use for the bus - can be overwritten using RENTERD_DB_URI environment variable")
+	flag.StringVar(&cfg.Database.MySQL.User, "db.user", cfg.Database.MySQL.User, "username for the database to use for the bus - can be overwritten using RENTERD_DB_USER environment variable")
+	flag.StringVar(&cfg.Database.MySQL.Database, "db.name", cfg.Database.MySQL.Database, "name of the database to use for the bus - can be overwritten using RENTERD_DB_NAME environment variable")
 
 	// db logger
-	flag.StringVar(&dbLoggerCfg.ignoreNotFoundError, "db.logger.ignoreNotFoundError", "true", "ignore not found error for logger - can be overwritten using RENTERD_DB_LOGGER_IGNORE_NOT_FOUND_ERROR environment variable")
-	flag.StringVar(&dbLoggerCfg.logLevel, "db.logger.logLevel", "warn", "log level for logger - can be overwritten using RENTERD_DB_LOGGER_LOG_LEVEL environment variable")
-	flag.StringVar(&dbLoggerCfg.slowThreshold, "db.logger.slowThreshold", "500ms", "slow threshold for logger - can be overwritten using RENTERD_DB_LOGGER_SLOW_THRESHOLD environment variable")
+	flag.BoolVar(&cfg.Database.Log.IgnoreRecordNotFoundError, "db.logger.ignoreNotFoundError", cfg.Database.Log.IgnoreRecordNotFoundError, "ignore not found error for logger - can be overwritten using RENTERD_DB_LOGGER_IGNORE_NOT_FOUND_ERROR environment variable")
+	flag.StringVar(&cfg.Log.Level, "db.logger.logLevel", cfg.Log.Level, "log level for logger - can be overwritten using RENTERD_DB_LOGGER_LOG_LEVEL environment variable")
+	flag.DurationVar(&cfg.Database.Log.SlowThreshold, "db.logger.slowThreshold", cfg.Database.Log.SlowThreshold, "slow threshold for logger - can be overwritten using RENTERD_DB_LOGGER_SLOW_THRESHOLD environment variable")
 
 	// bus
-	flag.BoolVar(&busCfg.Bootstrap, "bus.bootstrap", true, "bootstrap the gateway and consensus modules")
-	flag.StringVar(&busCfg.GatewayAddr, "bus.gatewayAddr", build.DefaultGatewayAddress, "address to listen on for Sia peer connections - can be overwritten using RENTERD_BUS_GATEWAY_ADDR environment variable")
-	flag.DurationVar(&busCfg.PersistInterval, "bus.persistInterval", busCfg.PersistInterval, "interval at which to persist the consensus updates")
-	flag.DurationVar(&busCfg.UsedUTXOExpiry, "bus.usedUTXOExpiry", 24*time.Hour, "time after which a used UTXO that hasn't been included in a transaction becomes spendable again")
-	flag.Int64Var(&busCfg.SlabBufferCompletionThreshold, "bus.slabBufferCompletionThreshold", 1<<12, "number of remaining bytes in a slab buffer before it is uploaded - can be overwritten using the RENTERD_BUS_SLAB_BUFFER_COMPLETION_THRESHOLD environment variable")
+	flag.BoolVar(&cfg.Bus.Bootstrap, "bus.bootstrap", cfg.Bus.Bootstrap, "bootstrap the gateway and consensus modules")
+	flag.StringVar(&cfg.Bus.GatewayAddr, "bus.gatewayAddr", cfg.Bus.GatewayAddr, "address to listen on for Sia peer connections - can be overwritten using RENTERD_BUS_GATEWAY_ADDR environment variable")
+	flag.DurationVar(&cfg.Bus.PersistInterval, "bus.persistInterval", cfg.Bus.PersistInterval, "interval at which to persist the consensus updates")
+	flag.DurationVar(&cfg.Bus.UsedUTXOExpiry, "bus.usedUTXOExpiry", cfg.Bus.UsedUTXOExpiry, "time after which a used UTXO that hasn't been included in a transaction becomes spendable again")
+	flag.Int64Var(&cfg.Bus.SlabBufferCompletionThreshold, "bus.slabBufferCompletionThreshold", cfg.Bus.SlabBufferCompletionThreshold, "number of remaining bytes in a slab buffer before it is uploaded - can be overwritten using the RENTERD_BUS_SLAB_BUFFER_COMPLETION_THRESHOLD environment variable")
 
 	// worker
-	var unauthenticatedDownloads bool
-	flag.BoolVar(&workerCfg.AllowPrivateIPs, "worker.allowPrivateIPs", false, "allow hosts with private IPs")
-	flag.DurationVar(&workerCfg.BusFlushInterval, "worker.busFlushInterval", 5*time.Second, "time after which the worker flushes buffered data to bus for persisting")
-	flag.Uint64Var(&workerCfg.DownloadMaxOverdrive, "worker.downloadMaxOverdrive", 5, "maximum number of active overdrive workers when downloading a slab")
-	flag.StringVar(&workerCfg.WorkerConfig.ID, "worker.id", "worker", "unique identifier of worker used internally - can be overwritten using the RENTERD_WORKER_ID environment variable")
-	flag.DurationVar(&workerCfg.DownloadOverdriveTimeout, "worker.downloadOverdriveTimeout", 3*time.Second, "timeout applied to slab downloads that decides when we start overdriving")
-	flag.Uint64Var(&workerCfg.UploadMaxOverdrive, "worker.uploadMaxOverdrive", 5, "maximum number of active overdrive workers when uploading a slab")
-	flag.DurationVar(&workerCfg.UploadOverdriveTimeout, "worker.uploadOverdriveTimeout", 3*time.Second, "timeout applied to slab uploads that decides when we start overdriving")
-	flag.BoolVar(&workerCfg.enabled, "worker.enabled", true, "enable/disable creating a worker - can be overwritten using the RENTERD_WORKER_ENABLED environment variable")
-	flag.BoolVar(&unauthenticatedDownloads, "worker.unauthenticatedDownloads", false, "if set to 'true', the worker will allow for downloading from the /objects endpoint without basic authentication. Can be overwritten using the RENTERD_WORKER_UNAUTHENTICATED_DOWNLOADS environment variable")
+	flag.BoolVar(&cfg.Worker.AllowPrivateIPs, "worker.allowPrivateIPs", cfg.Worker.AllowPrivateIPs, "allow hosts with private IPs")
+	flag.DurationVar(&cfg.Worker.BusFlushInterval, "worker.busFlushInterval", cfg.Worker.BusFlushInterval, "time after which the worker flushes buffered data to bus for persisting")
+	flag.Uint64Var(&cfg.Worker.DownloadMaxOverdrive, "worker.downloadMaxOverdrive", cfg.Worker.DownloadMaxOverdrive, "maximum number of active overdrive workers when downloading a slab")
+	flag.StringVar(&cfg.Worker.ID, "worker.id", cfg.Worker.ID, "unique identifier of worker used internally - can be overwritten using the RENTERD_WORKER_ID environment variable")
+	flag.DurationVar(&cfg.Worker.DownloadOverdriveTimeout, "worker.downloadOverdriveTimeout", cfg.Worker.DownloadOverdriveTimeout, "timeout applied to slab downloads that decides when we start overdriving")
+	flag.Uint64Var(&cfg.Worker.UploadMaxOverdrive, "worker.uploadMaxOverdrive", cfg.Worker.UploadMaxOverdrive, "maximum number of active overdrive workers when uploading a slab")
+	flag.DurationVar(&cfg.Worker.UploadOverdriveTimeout, "worker.uploadOverdriveTimeout", cfg.Worker.UploadOverdriveTimeout, "timeout applied to slab uploads that decides when we start overdriving")
+	flag.BoolVar(&cfg.Worker.Enabled, "worker.enabled", cfg.Worker.Enabled, "enable/disable creating a worker - can be overwritten using the RENTERD_WORKER_ENABLED environment variable")
+	flag.BoolVar(&cfg.Worker.AllowUnauthenticatedDownloads, "worker.unauthenticatedDownloads", cfg.Worker.AllowUnauthenticatedDownloads, "if set to 'true', the worker will allow for downloading from the /objects endpoint without basic authentication. Can be overwritten using the RENTERD_WORKER_UNAUTHENTICATED_DOWNLOADS environment variable")
 
 	// autopilot
-	flag.DurationVar(&autopilotCfg.AccountsRefillInterval, "autopilot.accountRefillInterval", defaultAccountRefillInterval, "interval at which the autopilot checks the workers' accounts balance and refills them if necessary")
-	flag.DurationVar(&autopilotCfg.Heartbeat, "autopilot.heartbeat", 30*time.Minute, "interval at which autopilot loop runs")
-	flag.Float64Var(&autopilotCfg.MigrationHealthCutoff, "autopilot.migrationHealthCutoff", 0.75, "health threshold below which slabs are migrated to new hosts")
-	flag.DurationVar(&autopilotCfg.RevisionBroadcastInterval, "autopilot.revisionBroadcastInterval", 24*time.Hour, "interval at which the autopilot broadcasts contract revisions to be mined - can be overwritten using the RENTERD_AUTOPILOT_REVISION_BROADCAST_INTERVAL environment variable - setting it to 0 will disable this feature")
-	flag.Uint64Var(&autopilotCfg.ScannerBatchSize, "autopilot.scannerBatchSize", 1000, "size of the batch with which hosts are scanned")
-	flag.DurationVar(&autopilotCfg.ScannerInterval, "autopilot.scannerInterval", 24*time.Hour, "interval at which hosts are scanned")
-	flag.Uint64Var(&autopilotCfg.ScannerMinRecentFailures, "autopilot.scannerMinRecentFailures", 10, "minimum amount of consesutive failed scans a host must have before it is removed for exceeding the max downtime")
-	flag.Uint64Var(&autopilotCfg.ScannerNumThreads, "autopilot.scannerNumThreads", 100, "number of threads that scan hosts")
-	flag.Uint64Var(&autopilotCfg.MigratorParallelSlabsPerWorker, "autopilot.migratorParallelSlabsPerWorker", 1, "number of slabs that the autopilot migrates in parallel per worker. Can be overwritten using the RENTERD_MIGRATOR_PARALLEL_SLABS_PER_WORKER environment variable")
-	flag.BoolVar(&autopilotCfg.enabled, "autopilot.enabled", true, "enable/disable the autopilot - can be overwritten using the RENTERD_AUTOPILOT_ENABLED environment variable")
-	flag.DurationVar(&nodeCfg.shutdownTimeout, "node.shutdownTimeout", 5*time.Minute, "the timeout applied to the node shutdown")
+	flag.DurationVar(&cfg.Autopilot.AccountsRefillInterval, "autopilot.accountRefillInterval", cfg.Autopilot.AccountsRefillInterval, "interval at which the autopilot checks the workers' accounts balance and refills them if necessary")
+	flag.DurationVar(&cfg.Autopilot.Heartbeat, "autopilot.heartbeat", cfg.Autopilot.Heartbeat, "interval at which autopilot loop runs")
+	flag.Float64Var(&cfg.Autopilot.MigrationHealthCutoff, "autopilot.migrationHealthCutoff", cfg.Autopilot.MigrationHealthCutoff, "health threshold below which slabs are migrated to new hosts")
+	flag.DurationVar(&cfg.Autopilot.RevisionBroadcastInterval, "autopilot.revisionBroadcastInterval", cfg.Autopilot.RevisionBroadcastInterval, "interval at which the autopilot broadcasts contract revisions to be mined - can be overwritten using the RENTERD_AUTOPILOT_REVISION_BROADCAST_INTERVAL environment variable - setting it to 0 will disable this feature")
+	flag.Uint64Var(&cfg.Autopilot.ScannerBatchSize, "autopilot.scannerBatchSize", cfg.Autopilot.ScannerBatchSize, "size of the batch with which hosts are scanned")
+	flag.DurationVar(&cfg.Autopilot.ScannerInterval, "autopilot.scannerInterval", cfg.Autopilot.ScannerInterval, "interval at which hosts are scanned")
+	flag.Uint64Var(&cfg.Autopilot.ScannerMinRecentFailures, "autopilot.scannerMinRecentFailures", cfg.Autopilot.ScannerMinRecentFailures, "minimum amount of consesutive failed scans a host must have before it is removed for exceeding the max downtime")
+	flag.Uint64Var(&cfg.Autopilot.ScannerNumThreads, "autopilot.scannerNumThreads", cfg.Autopilot.ScannerNumThreads, "number of threads that scan hosts")
+	flag.Uint64Var(&cfg.Autopilot.MigratorParallelSlabsPerWorker, "autopilot.migratorParallelSlabsPerWorker", cfg.Autopilot.MigratorParallelSlabsPerWorker, "number of slabs that the autopilot migrates in parallel per worker. Can be overwritten using the RENTERD_MIGRATOR_PARALLEL_SLABS_PER_WORKER environment variable")
+	flag.BoolVar(&cfg.Autopilot.Enabled, "autopilot.enabled", cfg.Autopilot.Enabled, "enable/disable the autopilot - can be overwritten using the RENTERD_AUTOPILOT_ENABLED environment variable")
+	flag.DurationVar(&cfg.ShutdownTimeout, "node.shutdownTimeout", cfg.ShutdownTimeout, "the timeout applied to the node shutdown")
 	flag.Parse()
 
 	log.Println("renterd v0.4.0-beta")
@@ -243,74 +300,96 @@ func main() {
 	}
 
 	// Overwrite flags from environment if set.
-	parseEnvVar("RENTERD_LOG_PATH", &customLogPath)
+	parseEnvVar("RENTERD_LOG_PATH", &cfg.Log.Path)
 
-	parseEnvVar("RENTERD_TRACING_ENABLED", tracingEnabled)
-	parseEnvVar("RENTERD_TRACING_SERVICE_INSTANCE_ID", tracingServiceInstanceId)
+	parseEnvVar("RENTERD_TRACING_ENABLED", &cfg.Tracing.Enabled)
+	parseEnvVar("RENTERD_TRACING_SERVICE_INSTANCE_ID", &cfg.Tracing.InstanceID)
 
-	parseEnvVar("RENTERD_BUS_REMOTE_ADDR", &busCfg.remoteAddr)
-	parseEnvVar("RENTERD_BUS_API_PASSWORD", &busCfg.apiPassword)
-	parseEnvVar("RENTERD_BUS_GATEWAY_ADDR", &busCfg.GatewayAddr)
-	parseEnvVar("RENTERD_BUS_SLAB_BUFFER_COMPLETION_THRESHOLD", &busCfg.SlabBufferCompletionThreshold)
+	parseEnvVar("RENTERD_BUS_REMOTE_ADDR", &cfg.Bus.RemoteAddr)
+	parseEnvVar("RENTERD_BUS_API_PASSWORD", &cfg.Bus.RemotePassword)
+	parseEnvVar("RENTERD_BUS_GATEWAY_ADDR", &cfg.Bus.GatewayAddr)
+	parseEnvVar("RENTERD_BUS_SLAB_BUFFER_COMPLETION_THRESHOLD", &cfg.Bus.SlabBufferCompletionThreshold)
 
-	parseEnvVar("RENTERD_DB_URI", &dbCfg.uri)
-	parseEnvVar("RENTERD_DB_USER", &dbCfg.user)
-	parseEnvVar("RENTERD_DB_PASSWORD", &dbCfg.password)
-	parseEnvVar("RENTERD_DB_NAME", &dbCfg.database)
+	parseEnvVar("RENTERD_DB_URI", &cfg.Database.MySQL.URI)
+	parseEnvVar("RENTERD_DB_USER", &cfg.Database.MySQL.User)
+	parseEnvVar("RENTERD_DB_PASSWORD", &cfg.Database.MySQL.Password)
+	parseEnvVar("RENTERD_DB_NAME", &cfg.Database.MySQL.Database)
 
-	parseEnvVar("RENTERD_DB_LOGGER_IGNORE_NOT_FOUND_ERROR", &dbLoggerCfg.ignoreNotFoundError)
-	parseEnvVar("RENTERD_DB_LOGGER_LOG_LEVEL", &dbLoggerCfg.logLevel)
-	parseEnvVar("RENTERD_DB_LOGGER_SLOW_THRESHOLD", &dbLoggerCfg.slowThreshold)
+	parseEnvVar("RENTERD_DB_LOGGER_IGNORE_NOT_FOUND_ERROR", &cfg.Database.Log.IgnoreRecordNotFoundError)
+	parseEnvVar("RENTERD_DB_LOGGER_LOG_LEVEL", &cfg.Log.Level)
+	parseEnvVar("RENTERD_DB_LOGGER_SLOW_THRESHOLD", &cfg.Database.Log.SlowThreshold)
 
-	parseEnvVar("RENTERD_WORKER_REMOTE_ADDRS", &workerCfg.remoteAddrs)
-	parseEnvVar("RENTERD_WORKER_API_PASSWORD", &workerCfg.apiPassword)
-	parseEnvVar("RENTERD_WORKER_ENABLED", &workerCfg.enabled)
-	parseEnvVar("RENTERD_WORKER_ID", &workerCfg.ID)
-	parseEnvVar("RENTERD_WORKER_UNAUTHENTICATED_DOWNLOADS", &unauthenticatedDownloads)
+	parseEnvVar("RENTERD_WORKER_REMOTE_ADDRS", &workerRemoteAddrsStr)
+	parseEnvVar("RENTERD_WORKER_API_PASSWORD", &workerRemotePassStr)
+	parseEnvVar("RENTERD_WORKER_ENABLED", &cfg.Worker.Enabled)
+	parseEnvVar("RENTERD_WORKER_ID", &cfg.Worker.ID)
+	parseEnvVar("RENTERD_WORKER_UNAUTHENTICATED_DOWNLOADS", &cfg.Worker.AllowUnauthenticatedDownloads)
 
-	parseEnvVar("RENTERD_AUTOPILOT_ENABLED", &autopilotCfg.enabled)
-	parseEnvVar("RENTERD_AUTOPILOT_REVISION_BROADCAST_INTERVAL", &autopilotCfg.RevisionBroadcastInterval)
-	parseEnvVar("RENTERD_MIGRATOR_PARALLEL_SLABS_PER_WORKER", &autopilotCfg.MigratorParallelSlabsPerWorker)
+	parseEnvVar("RENTERD_AUTOPILOT_ENABLED", &cfg.Autopilot.Enabled)
+	parseEnvVar("RENTERD_AUTOPILOT_REVISION_BROADCAST_INTERVAL", &cfg.Autopilot.RevisionBroadcastInterval)
+	parseEnvVar("RENTERD_MIGRATOR_PARALLEL_SLABS_PER_WORKER", &cfg.Autopilot.MigratorParallelSlabsPerWorker)
 
+	mustLoadAPIPassword()
+	mustLoadRecoveryPhrase()
+	mustParseWorkers(workerRemoteAddrsStr, workerRemotePassStr)
+
+	network, _ := build.Network()
+	busCfg := node.BusConfig{
+		Bus:     cfg.Bus,
+		Network: network,
+	}
 	// Init db dialector
-	if dbCfg.uri != "" {
+	if cfg.Database.MySQL.URI != "" {
 		busCfg.DBDialector = stores.NewMySQLConnection(
-			dbCfg.user,
-			dbCfg.password,
-			dbCfg.uri,
-			dbCfg.database,
+			cfg.Database.MySQL.User,
+			cfg.Database.MySQL.Password,
+			cfg.Database.MySQL.URI,
+			cfg.Database.MySQL.Database,
 		)
 	}
 
-	// Init db logger config
-	if cfg, err := stores.ParseLoggerConfig(dbLoggerCfg.logLevel, dbLoggerCfg.ignoreNotFoundError, dbLoggerCfg.slowThreshold); err != nil {
-		log.Fatalf("failed to parse logger config, err: %v", err)
-	} else {
-		busCfg.DBLoggerConfig = cfg
+	var level logger.LogLevel
+	switch strings.ToLower(cfg.Log.Level) {
+	case "silent":
+		level = logger.Silent
+	case "error":
+		level = logger.Error
+	case "warn":
+		level = logger.Warn
+	case "info":
+		level = logger.Info
+	default:
+		log.Fatalf("invalid log level %q, options are: silent, error, warn, info", cfg.Log.Level)
+	}
+
+	busCfg.DBLoggerConfig = stores.LoggerConfig{
+		LogLevel:                  level,
+		IgnoreRecordNotFoundError: cfg.Database.Log.IgnoreRecordNotFoundError,
+		SlowThreshold:             cfg.Database.Log.SlowThreshold,
 	}
 
 	var autopilotShutdownFn func(context.Context) error
 	var shutdownFns []func(context.Context) error
 
 	// Init tracing.
-	if *tracingEnabled {
-		shutdownFn, err := tracing.Init(*tracingServiceInstanceId)
+	if cfg.Tracing.Enabled {
+		shutdownFn, err := tracing.Init(cfg.Tracing.InstanceID)
 		if err != nil {
 			log.Fatal("failed to init tracing", err)
 		}
 		shutdownFns = append(shutdownFns, shutdownFn)
 	}
 
-	if busCfg.remoteAddr != "" && workerCfg.remoteAddrs != "" && !autopilotCfg.enabled {
+	if cfg.Bus.RemoteAddr != "" && len(cfg.Worker.Remotes) == 0 && !cfg.Autopilot.Enabled {
 		log.Fatal("remote bus, remote worker, and no autopilot -- nothing to do!")
 	}
-	if workerCfg.remoteAddrs == "" && !workerCfg.enabled && autopilotCfg.enabled {
+	if len(cfg.Worker.Remotes) == 0 && !cfg.Worker.Enabled && cfg.Autopilot.Enabled {
 		log.Fatal("can't enable autopilot without providing either workers to connect to or creating a worker")
 	}
 
 	// create listener first, so that we know the actual apiAddr if the user
 	// specifies port :0
-	l, err := net.Listen("tcp", *apiAddr)
+	l, err := net.Listen("tcp", cfg.HTTP.Address)
 	if err != nil {
 		log.Fatal("failed to create listener", err)
 	}
@@ -318,35 +397,40 @@ func main() {
 		_ = l.Close()
 		return nil
 	})
-	*apiAddr = "http://" + l.Addr().String()
+	// override the address with the actual one
+	cfg.HTTP.Address = "http://" + l.Addr().String()
 
-	auth := jape.BasicAuth(getAPIPassword())
+	auth := jape.BasicAuth(cfg.HTTP.Password)
 	mux := treeMux{
 		sub: make(map[string]treeMux),
 	}
 
+	if err := os.MkdirAll(cfg.Directory, 0700); err != nil {
+		log.Fatal("failed to create directory:", err)
+	}
+
 	// Create logger.
-	renterdLog := filepath.Join(*dir, "renterd.log")
-	if customLogPath != "" {
-		renterdLog = customLogPath
+	renterdLog := filepath.Join(cfg.Directory, "renterd.log")
+	if cfg.Log.Path != "" {
+		renterdLog = cfg.Log.Path
 	}
 	logger, closeFn, err := node.NewLogger(renterdLog)
 	if err != nil {
-		log.Fatal("failed to create logger", err)
+		log.Fatalln("failed to create logger:", err)
 	}
 	shutdownFns = append(shutdownFns, closeFn)
 
-	busAddr, busPassword := busCfg.remoteAddr, busCfg.apiPassword
-	if busAddr == "" {
-		b, shutdownFn, err := node.NewBus(busCfg.BusConfig, *dir, getSeed(), logger)
+	busAddr, busPassword := cfg.Bus.RemoteAddr, cfg.Bus.RemotePassword
+	if cfg.Bus.RemoteAddr == "" {
+		b, shutdownFn, err := node.NewBus(busCfg, cfg.Directory, seed, logger)
 		if err != nil {
 			log.Fatal("failed to create bus, err: ", err)
 		}
 		shutdownFns = append(shutdownFns, shutdownFn)
 
 		mux.sub["/api/bus"] = treeMux{h: auth(b)}
-		busAddr = *apiAddr + "/api/bus"
-		busPassword = getAPIPassword()
+		busAddr = cfg.HTTP.Address + "/api/bus"
+		busPassword = cfg.HTTP.Password
 
 		// only serve the UI if a bus is created
 		mux.h = renterd.Handler()
@@ -356,35 +440,33 @@ func main() {
 	bc := bus.NewClient(busAddr, busPassword)
 
 	var workers []autopilot.Worker
-	workerAddrs, workerPassword := workerCfg.remoteAddrs, workerCfg.apiPassword
-	if workerAddrs == "" {
-		if workerCfg.enabled {
-			w, shutdownFn, err := node.NewWorker(workerCfg.WorkerConfig, bc, getSeed(), logger)
+	if len(cfg.Worker.Remotes) == 0 {
+		if cfg.Worker.Enabled {
+			w, shutdownFn, err := node.NewWorker(cfg.Worker, bc, seed, logger)
 			if err != nil {
 				log.Fatal("failed to create worker", err)
 			}
 			shutdownFns = append(shutdownFns, shutdownFn)
 
-			mux.sub["/api/worker"] = treeMux{h: workerAuth(getAPIPassword(), unauthenticatedDownloads)(w)}
-			workerAddr := *apiAddr + "/api/worker"
-			workerPassword = getAPIPassword()
-			workers = append(workers, worker.NewClient(workerAddr, workerPassword))
+			mux.sub["/api/worker"] = treeMux{h: workerAuth(cfg.HTTP.Password, cfg.Worker.AllowUnauthenticatedDownloads)(w)}
+			workerAddr := cfg.HTTP.Address + "/api/worker"
+			workers = append(workers, worker.NewClient(workerAddr, cfg.HTTP.Password))
 		}
 	} else {
-		// TODO: all workers use the same password. Figure out a nice way to
-		// have individual passwords.
-		workerAddrsSplit := strings.Split(workerAddrs, ";")
-		for _, workerAddr := range workerAddrsSplit {
-			workers = append(workers, worker.NewClient(workerAddr, workerPassword))
-			fmt.Println("connecting to remote worker at", workerAddr)
+		for _, remote := range cfg.Worker.Remotes {
+			workers = append(workers, worker.NewClient(remote.Address, remote.Password))
+			fmt.Println("connecting to remote worker at", remote.Address)
 		}
 	}
 
 	autopilotErr := make(chan error, 1)
-	autopilotDir := filepath.Join(*dir, "autopilot")
-	if autopilotCfg.enabled {
-		autopilotCfg.AutopilotConfig.ID = api.DefaultAutopilotID // hardcoded
-		ap, runFn, shutdownFn, err := node.NewAutopilot(autopilotCfg.AutopilotConfig, bc, workers, logger)
+	autopilotDir := filepath.Join(cfg.Directory, api.DefaultAutopilotID)
+	if cfg.Autopilot.Enabled {
+		apCfg := node.AutopilotConfig{
+			ID:        api.DefaultAutopilotID,
+			Autopilot: cfg.Autopilot,
+		}
+		ap, runFn, shutdownFn, err := node.NewAutopilot(apCfg, bc, workers, logger)
 		if err != nil {
 			log.Fatal("failed to create autopilot", err)
 		}
@@ -407,8 +489,8 @@ func main() {
 	}
 	log.Println("bus: Listening on", syncerAddress)
 
-	if autopilotCfg.enabled {
-		if err := runCompatMigrateAutopilotJSONToStore(bc, autopilotCfg.ID, autopilotDir); err != nil {
+	if cfg.Autopilot.Enabled {
+		if err := runCompatMigrateAutopilotJSONToStore(bc, "autopilot", autopilotDir); err != nil {
 			log.Fatal("failed to migrate autopilot JSON", err)
 		}
 	}
@@ -424,7 +506,7 @@ func main() {
 	}
 
 	// Shut down the autopilot first, then the rest of the services in reverse order.
-	ctx, cancel := context.WithTimeout(context.Background(), nodeCfg.shutdownTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
 	defer cancel()
 	if autopilotShutdownFn != nil {
 		if err := autopilotShutdownFn(ctx); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"time"
+)
+
+type (
+	// Config contains the configuration for a renterd node
+	Config struct {
+		Seed      string `yaml:"seed"`
+		Directory string `yaml:"directory"`
+
+		ShutdownTimeout time.Duration `yaml:"shutdownTimeout"`
+
+		Log Log `yaml:"log"`
+
+		HTTP      HTTP      `yaml:"http"`
+		Bus       Bus       `yaml:"bus"`
+		Worker    Worker    `yaml:"worker"`
+		Autopilot Autopilot `yaml:"autopilot"`
+
+		Database Database `yaml:"database"`
+		Tracing  Tracing  `yaml:"tracing"`
+	}
+
+	// HTTP contains the configuration for the HTTP server.
+	HTTP struct {
+		Address  string `yaml:"address"`
+		Password string `yaml:"password"`
+	}
+
+	DatabaseLog struct {
+		IgnoreRecordNotFoundError bool          `yaml:"ignoreRecordNotFoundError"`
+		SlowThreshold             time.Duration `yaml:"slowThreshold"`
+	}
+
+	Database struct {
+		Log DatabaseLog `yaml:"log"`
+		// optional fields depending on backend
+		MySQL MySQL `yaml:"mysql"`
+	}
+
+	// Tracing contains the configuration for tracing.
+	Tracing struct {
+		Enabled    bool   `yaml:"enabled"`
+		InstanceID string `yaml:"instanceID"`
+	}
+
+	// Bus contains the configuration for a bus.
+	Bus struct {
+		Bootstrap                     bool          `yaml:"bootstrap"`
+		GatewayAddr                   string        `yaml:"gatewayAddr"`
+		RemoteAddr                    string        `yaml:"remoteAddr"`
+		RemotePassword                string        `yaml:"remotePassword"`
+		PersistInterval               time.Duration `yaml:"persistInterval"`
+		UsedUTXOExpiry                time.Duration `yaml:"usedUTXOExpiry"`
+		SlabBufferCompletionThreshold int64         `yaml:"slabBufferCompleionThreshold"`
+	}
+
+	// Log contains the configuration for the logger.
+	Log struct {
+		Path  string `yaml:"path"`
+		Level string `yaml:"level"`
+	}
+
+	// MySQL contains the configuration for an optional MySQL database.
+	MySQL struct {
+		URI      string `yaml:"URI"`
+		User     string `yaml:"user"`
+		Password string `yaml:"password"`
+		Database string `yaml:"database"`
+	}
+
+	RemoteWorker struct {
+		Address  string `yaml:"address"`
+		Password string `yaml:"password"`
+	}
+
+	// Worker contains the configuration for a worker.
+	Worker struct {
+		Enabled                       bool           `yaml:"enabled"`
+		ID                            string         `yaml:"ID"`
+		Remotes                       []RemoteWorker `yaml:"remotes"`
+		AllowPrivateIPs               bool           `yaml:"allowPrivateIPs"`
+		BusFlushInterval              time.Duration  `yaml:"busFlushInterval"`
+		ContractLockTimeout           time.Duration  `yaml:"contractLockTimeout"`
+		DownloadOverdriveTimeout      time.Duration  `yaml:"downloadOverdriveTimeout"`
+		UploadOverdriveTimeout        time.Duration  `yaml:"uploadOverdriveTimeout"`
+		DownloadMaxOverdrive          uint64         `yaml:"downloadMaxOverdrive"`
+		UploadMaxOverdrive            uint64         `yaml:"uploadMaxOverdrive"`
+		AllowUnauthenticatedDownloads bool           `yaml:"allowUnauthenticatedDownloads"`
+	}
+
+	// Autopilot contains the configuration for an autopilot.
+	Autopilot struct {
+		Enabled                        bool          `yaml:"enabled"`
+		AccountsRefillInterval         time.Duration `yaml:"accountsRefillInterval"`
+		Heartbeat                      time.Duration `yaml:"heartbeat"`
+		MigrationHealthCutoff          float64       `yaml:"migrationHealthCutoff"`
+		RevisionBroadcastInterval      time.Duration `yaml:"revisionBroadcastInterval"`
+		RevisionSubmissionBuffer       uint64        `yaml:"revisionSubmissionBuffer"`
+		ScannerInterval                time.Duration `yaml:"scannerInterval"`
+		ScannerBatchSize               uint64        `yaml:"scannerBatchSize"`
+		ScannerMinRecentFailures       uint64        `yaml:"scannerMinRecentFailures"`
+		ScannerNumThreads              uint64        `yaml:"scannerNumThreads"`
+		MigratorParallelSlabsPerWorker uint64        `yaml:"migratorParallelSlabsPerWorker"`
+	}
+)

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.uber.org/zap v1.25.0
 	golang.org/x/crypto v0.12.0
 	golang.org/x/term v0.11.0
+	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.5.1
 	gorm.io/driver/sqlite v1.5.3
 	gorm.io/gorm v1.25.3

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,10 @@ github.com/klauspost/reedsolomon v1.11.8/go.mod h1:4bXRN+cVzMdml6ti7qLouuYi32KHJ
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -192,6 +194,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -405,6 +408,7 @@ google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
@@ -412,6 +416,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/mysql v1.5.1 h1:WUEH5VF9obL/lTtzjmML/5e6VfFR/788coz2uaVCAZw=
 gorm.io/driver/mysql v1.5.1/go.mod h1:Jo3Xu7mMhCyj8dlrb3WoCaRd1FhsVh+yMXb1jUInf5o=
 gorm.io/driver/postgres v1.5.2 h1:ytTDxxEv+MplXOfFe3Lzm7SjG09fcdb3Z/c056DTBx0=

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -18,6 +18,7 @@ import (
 	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/renterd/autopilot"
 	"go.sia.tech/renterd/bus"
+	"go.sia.tech/renterd/config"
 	"go.sia.tech/renterd/stores"
 	"go.sia.tech/renterd/wallet"
 	"go.sia.tech/renterd/webhooks"
@@ -59,17 +60,8 @@ type BusConfig struct {
 }
 
 type AutopilotConfig struct {
-	ID                             string
-	AccountsRefillInterval         time.Duration
-	Heartbeat                      time.Duration
-	MigrationHealthCutoff          float64
-	RevisionBroadcastInterval      time.Duration
-	RevisionSubmissionBuffer       uint64
-	ScannerInterval                time.Duration
-	ScannerBatchSize               uint64
-	ScannerMinRecentFailures       uint64
-	ScannerNumThreads              uint64
-	MigratorParallelSlabsPerWorker uint64
+	config.Autopilot
+	ID string
 }
 
 type (

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -35,26 +35,10 @@ import (
 	"gorm.io/gorm"
 )
 
-type WorkerConfig struct {
-	ID                       string
-	AllowPrivateIPs          bool
-	BusFlushInterval         time.Duration
-	ContractLockTimeout      time.Duration
-	DownloadOverdriveTimeout time.Duration
-	UploadOverdriveTimeout   time.Duration
-	DownloadMaxOverdrive     uint64
-	UploadMaxOverdrive       uint64
-}
-
 type BusConfig struct {
-	Bootstrap                     bool
-	GatewayAddr                   string
-	Network                       *consensus.Network
-	Miner                         *Miner
-	PersistInterval               time.Duration
-	UsedUTXOExpiry                time.Duration
-	SlabBufferCompletionThreshold int64
-
+	config.Bus
+	Network        *consensus.Network
+	Miner          *Miner
 	DBLoggerConfig stores.LoggerConfig
 	DBDialector    gorm.Dialector
 }
@@ -304,7 +288,7 @@ func NewBus(cfg BusConfig, dir string, seed types.PrivateKey, l *zap.Logger) (ht
 	return b.Handler(), shutdownFn, nil
 }
 
-func NewWorker(cfg WorkerConfig, b worker.Bus, seed types.PrivateKey, l *zap.Logger) (http.Handler, ShutdownFn, error) {
+func NewWorker(cfg config.Worker, b worker.Bus, seed types.PrivateKey, l *zap.Logger) (http.Handler, ShutdownFn, error) {
 	workerKey := blake2b.Sum256(append([]byte("worker"), seed...))
 	w, err := worker.New(workerKey, cfg.ID, b, cfg.ContractLockTimeout, cfg.BusFlushInterval, cfg.DownloadOverdriveTimeout, cfg.UploadOverdriveTimeout, cfg.DownloadMaxOverdrive, cfg.UploadMaxOverdrive, cfg.AllowPrivateIPs, l)
 	if err != nil {

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -19,6 +19,7 @@ import (
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/autopilot"
 	"go.sia.tech/renterd/bus"
+	"go.sia.tech/renterd/config"
 	"go.sia.tech/renterd/internal/node"
 	"go.sia.tech/renterd/stores"
 	"go.uber.org/zap"
@@ -822,15 +823,17 @@ func testWorkerCfg() node.WorkerConfig {
 
 func testApCfg() node.AutopilotConfig {
 	return node.AutopilotConfig{
-		ID:                             api.DefaultAutopilotID,
-		AccountsRefillInterval:         time.Second,
-		Heartbeat:                      time.Second,
-		MigrationHealthCutoff:          0.99,
-		MigratorParallelSlabsPerWorker: 1,
-		RevisionSubmissionBuffer:       0,
-		ScannerInterval:                time.Second,
-		ScannerBatchSize:               10,
-		ScannerNumThreads:              1,
-		ScannerMinRecentFailures:       5,
+		ID: api.DefaultAutopilotID,
+		Autopilot: config.Autopilot{
+			AccountsRefillInterval:         time.Second,
+			Heartbeat:                      time.Second,
+			MigrationHealthCutoff:          0.99,
+			MigratorParallelSlabsPerWorker: 1,
+			RevisionSubmissionBuffer:       0,
+			ScannerInterval:                time.Second,
+			ScannerBatchSize:               10,
+			ScannerNumThreads:              1,
+			ScannerMinRecentFailures:       5,
+		},
 	}
 }

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -204,7 +204,7 @@ func newTestClusterWithFunding(dir, dbName string, funding bool, wk types.Privat
 }
 
 // newTestClusterCustom creates a customisable cluster.
-func newTestClusterCustom(dir, dbName string, funding bool, wk types.PrivateKey, busCfg node.BusConfig, workerCfg node.WorkerConfig, apCfg node.AutopilotConfig, logger *zap.Logger) (*TestCluster, error) {
+func newTestClusterCustom(dir, dbName string, funding bool, wk types.PrivateKey, busCfg node.BusConfig, workerCfg config.Worker, apCfg node.AutopilotConfig, logger *zap.Logger) (*TestCluster, error) {
 	// Check if we are testing against an external database. If so, we create a
 	// database with a random name first.
 	uri, user, password, _ := stores.DBConfigFromEnv()
@@ -801,16 +801,18 @@ func testNetwork() *consensus.Network {
 
 func testBusCfg() node.BusConfig {
 	return node.BusConfig{
-		Bootstrap:       false,
-		GatewayAddr:     "127.0.0.1:0",
-		Network:         testNetwork(),
-		PersistInterval: testPersistInterval,
-		UsedUTXOExpiry:  time.Minute,
+		Bus: config.Bus{
+			Bootstrap:       false,
+			GatewayAddr:     "127.0.0.1:0",
+			PersistInterval: testPersistInterval,
+			UsedUTXOExpiry:  time.Minute,
+		},
+		Network: testNetwork(),
 	}
 }
 
-func testWorkerCfg() node.WorkerConfig {
-	return node.WorkerConfig{
+func testWorkerCfg() config.Worker {
+	return config.Worker{
 		AllowPrivateIPs:          true,
 		ContractLockTimeout:      5 * time.Second,
 		ID:                       "worker",

--- a/stores/logger.go
+++ b/stores/logger.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -30,42 +29,6 @@ func NewSQLLogger(l *zap.Logger, config LoggerConfig) logger.Interface {
 		LoggerConfig: config,
 		l:            l.Sugar(),
 	}
-}
-
-// ParseLoggerConfig parses the given variables into a logger config.
-func ParseLoggerConfig(logLevel, ignoreRecordNotFoundError, slowThreshold string) (config LoggerConfig, err error) {
-	// try parse log level
-	if logLevel != "" {
-		switch strings.ToLower(logLevel) {
-		case "silent":
-			config.LogLevel = logger.Silent
-		case "error":
-			config.LogLevel = logger.Error
-		case "warn":
-			config.LogLevel = logger.Warn
-		case "info":
-			config.LogLevel = logger.Info
-		default:
-			return LoggerConfig{}, errors.New("invalid log level, options are: silent, error, warn, info")
-		}
-	}
-
-	// try parse ignore record not found error
-	if ignoreRecordNotFoundError != "" {
-		config.IgnoreRecordNotFoundError, err = strconv.ParseBool(ignoreRecordNotFoundError)
-		if err != nil {
-			return LoggerConfig{}, err
-		}
-	}
-
-	// try parse slow threshold
-	if slowThreshold != "" {
-		config.SlowThreshold, err = time.ParseDuration(slowThreshold)
-		if err != nil {
-			return LoggerConfig{}, err
-		}
-	}
-	return
 }
 
 func (l *gormLogger) LogMode(level logger.LogLevel) logger.Interface {


### PR DESCRIPTION
Adds support for YAML configuration files for all CLI flags and environment variables. Checks for `renterd.yml` in the current directory. If the file doesn't exist, the startup should continue as it does today. The path can be overloaded by setting the `RENTERD_CONFIG_FILE` environment variable.

Having support for a config file will make renterd easier to package.

Example:
```yml
seed: clutch cook castle mistake slush arrange horse nothing forest potato oil wash
http:
  address: 127.0.0.1:10080
  password: sia is cool
```

The priority for settings is currently:
1. default values
2. yaml
3. flags
4. environment variables