### PR TITLE
Deprecate `autopilot/status` route

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -88,21 +88,15 @@ type (
 		Triggered bool `json:"triggered"`
 	}
 
-	// AutopilotStatusResponse is the response type for the /autopilot/status
+	// AutopilotStateResponse is the response type for the /autopilot/state
 	// endpoint.
-	AutopilotStatusResponse struct {
+	AutopilotStateResponse struct {
 		Configured         bool          `json:"configured"`
 		Migrating          bool          `json:"migrating"`
 		MigratingLastStart ParamTime     `json:"migratingLastStart"`
 		Scanning           bool          `json:"scanning"`
 		ScanningLastStart  ParamTime     `json:"scanningLastStart"`
 		UptimeMS           ParamDuration `json:"uptimeMS"`
-	}
-
-	// AutopilotStateResponse is the response type for the /autopilot/state
-	// endpoint.
-	AutopilotStateResponse struct {
-		AutopilotStatusResponse // TODO: deprecate /autopilot/status
 
 		StartTime time.Time `json:"startTime"`
 		BuildState

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -173,7 +173,6 @@ func (ap *Autopilot) Handler() http.Handler {
 		"POST   /debug/trigger": ap.triggerHandlerPOST,
 		"POST   /hosts":         ap.hostsHandlerPOST,
 		"GET    /host/:hostKey": ap.hostHandlerGET,
-		"GET    /status":        ap.statusHandlerGET,
 		"GET    /state":         ap.stateHandlerGET,
 	}))
 }
@@ -584,24 +583,6 @@ func (ap *Autopilot) hostHandlerGET(jc jape.Context) {
 	jc.Encode(host)
 }
 
-func (ap *Autopilot) statusHandlerGET(jc jape.Context) {
-	migrating, mLastStart := ap.m.Status()
-	scanning, sLastStart := ap.s.Status()
-	_, err := ap.bus.Autopilot(jc.Request.Context(), ap.id)
-	if err != nil && !strings.Contains(err.Error(), api.ErrAutopilotNotFound.Error()) {
-		jc.Error(err, http.StatusInternalServerError)
-		return
-	}
-	jc.Encode(api.AutopilotStatusResponse{
-		Configured:         err == nil,
-		Migrating:          migrating,
-		MigratingLastStart: api.ParamTime(mLastStart),
-		Scanning:           scanning,
-		ScanningLastStart:  api.ParamTime(sLastStart),
-		UptimeMS:           api.ParamDuration(ap.Uptime()),
-	})
-}
-
 func (ap *Autopilot) stateHandlerGET(jc jape.Context) {
 	migrating, mLastStart := ap.m.Status()
 	scanning, sLastStart := ap.s.Status()
@@ -612,14 +593,13 @@ func (ap *Autopilot) stateHandlerGET(jc jape.Context) {
 	}
 
 	jc.Encode(api.AutopilotStateResponse{
-		AutopilotStatusResponse: api.AutopilotStatusResponse{
-			Configured:         err == nil,
-			Migrating:          migrating,
-			MigratingLastStart: api.ParamTime(mLastStart),
-			Scanning:           scanning,
-			ScanningLastStart:  api.ParamTime(sLastStart),
-			UptimeMS:           api.ParamDuration(ap.Uptime()),
-		},
+		Configured:         err == nil,
+		Migrating:          migrating,
+		MigratingLastStart: api.ParamTime(mLastStart),
+		Scanning:           scanning,
+		ScanningLastStart:  api.ParamTime(sLastStart),
+		UptimeMS:           api.ParamDuration(ap.Uptime()),
+
 		StartTime: ap.StartTime(),
 		BuildState: api.BuildState{
 			Network:   build.NetworkName(),

--- a/autopilot/client.go
+++ b/autopilot/client.go
@@ -55,11 +55,6 @@ func (c *Client) State() (state api.AutopilotStateResponse, err error) {
 	return
 }
 
-func (c *Client) Status() (resp api.AutopilotStatusResponse, err error) {
-	err = c.c.GET("/status", &resp)
-	return
-}
-
 func (c *Client) Trigger(forceScan bool) (_ bool, err error) {
 	var resp api.AutopilotTriggerResponse
 	err = c.c.POST("/debug/trigger", api.AutopilotTriggerRequest{ForceScan: forceScan}, &resp)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -269,21 +269,24 @@ func TestNewTestCluster(t *testing.T) {
 		t.Fatalf("result for 'usable' should match the result for 'all', \n\nall: %+v \n\nusable: %+v", hostInfos, hostInfosUsable)
 	}
 
-	// Fetch the autopilot status
-	status, err := cluster.Autopilot.Status()
+	// Fetch the autopilot state
+	state, err := cluster.Autopilot.State()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if time.Time(status.MigratingLastStart).IsZero() {
+	if time.Time(state.StartTime).IsZero() {
+		t.Fatal("autopilot should have start time")
+	}
+	if time.Time(state.MigratingLastStart).IsZero() {
 		t.Fatal("autopilot should have completed a migration")
 	}
-	if time.Time(status.ScanningLastStart).IsZero() {
+	if time.Time(state.ScanningLastStart).IsZero() {
 		t.Fatal("autopilot should have completed a scan")
 	}
-	if status.UptimeMS == 0 {
+	if state.UptimeMS == 0 {
 		t.Fatal("uptime should be set")
 	}
-	if !status.Configured {
+	if !state.Configured {
 		t.Fatal("autopilot should be configured")
 	}
 }


### PR DESCRIPTION
The UI moved to use `autopilot/state` (which we added to be consistent with `hostd`), now that the UI stopped using it we can fully deprecate the status route.