### PR TITLE
Shut down api last to avoid other modules getting stuck

### DIFF
--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -393,16 +393,22 @@ func main() {
 		SlowThreshold:             cfg.Database.Log.SlowThreshold,
 	}
 
-	var autopilotShutdownFn func(context.Context) error
-	var shutdownFns []func(context.Context) error
+	type shutdownFn struct {
+		name string
+		fn   func(context.Context) error
+	}
+	var shutdownFns []shutdownFn
 
 	// Init tracing.
 	if cfg.Tracing.Enabled {
-		shutdownFn, err := tracing.Init(cfg.Tracing.InstanceID)
+		fn, err := tracing.Init(cfg.Tracing.InstanceID)
 		if err != nil {
 			logger.Fatal("failed to init tracing: " + err.Error())
 		}
-		shutdownFns = append(shutdownFns, shutdownFn)
+		shutdownFns = append(shutdownFns, shutdownFn{
+			name: "Tracing",
+			fn:   fn,
+		})
 	}
 
 	if cfg.Bus.RemoteAddr != "" && len(cfg.Worker.Remotes) != 0 && !cfg.Autopilot.Enabled {
@@ -418,10 +424,11 @@ func main() {
 	if err != nil {
 		logger.Fatal("failed to create listener: " + err.Error())
 	}
-	shutdownFns = append(shutdownFns, func(_ context.Context) error {
-		_ = l.Close()
-		return nil
+	shutdownFns = append(shutdownFns, shutdownFn{
+		name: "Listener",
+		fn:   func(ctx context.Context) error { return l.Close() },
 	})
+
 	// override the address with the actual one
 	cfg.HTTP.Address = "http://" + l.Addr().String()
 
@@ -430,17 +437,27 @@ func main() {
 		sub: make(map[string]treeMux),
 	}
 
+	// Create the webserver.
+	srv := &http.Server{Handler: mux}
+	shutdownFns = append(shutdownFns, shutdownFn{
+		name: "HTTP Server",
+		fn:   srv.Shutdown,
+	})
+
 	if err := os.MkdirAll(cfg.Directory, 0700); err != nil {
 		logger.Fatal("failed to create directory: " + err.Error())
 	}
 
 	busAddr, busPassword := cfg.Bus.RemoteAddr, cfg.Bus.RemotePassword
 	if cfg.Bus.RemoteAddr == "" {
-		b, shutdownFn, err := node.NewBus(busCfg, cfg.Directory, getSeed(), logger)
+		b, fn, err := node.NewBus(busCfg, cfg.Directory, getSeed(), logger)
 		if err != nil {
 			logger.Fatal("failed to create bus, err: " + err.Error())
 		}
-		shutdownFns = append(shutdownFns, shutdownFn)
+		shutdownFns = append(shutdownFns, shutdownFn{
+			name: "Bus",
+			fn:   fn,
+		})
 
 		mux.sub["/api/bus"] = treeMux{h: auth(b)}
 		busAddr = cfg.HTTP.Address + "/api/bus"
@@ -456,11 +473,14 @@ func main() {
 	var workers []autopilot.Worker
 	if len(cfg.Worker.Remotes) == 0 {
 		if cfg.Worker.Enabled {
-			w, shutdownFn, err := node.NewWorker(cfg.Worker, bc, getSeed(), logger)
+			w, fn, err := node.NewWorker(cfg.Worker, bc, getSeed(), logger)
 			if err != nil {
 				logger.Fatal("failed to create worker: " + err.Error())
 			}
-			shutdownFns = append(shutdownFns, shutdownFn)
+			shutdownFns = append(shutdownFns, shutdownFn{
+				name: "Worker",
+				fn:   fn,
+			})
 
 			mux.sub["/api/worker"] = treeMux{h: workerAuth(cfg.HTTP.Password, cfg.Worker.AllowUnauthenticatedDownloads)(w)}
 			workerAddr := cfg.HTTP.Address + "/api/worker"
@@ -480,20 +500,22 @@ func main() {
 			ID:        api.DefaultAutopilotID,
 			Autopilot: cfg.Autopilot,
 		}
-		ap, runFn, shutdownFn, err := node.NewAutopilot(apCfg, bc, workers, logger)
+		ap, runFn, fn, err := node.NewAutopilot(apCfg, bc, workers, logger)
 		if err != nil {
 			logger.Fatal("failed to create autopilot: " + err.Error())
 		}
 
-		// NOTE: the autopilot shutdown function is not added to the shutdown
-		// functions array because it needs to be called first
-		autopilotShutdownFn = shutdownFn
+		// NOTE: the autopilot shutdown function needs to be called first.
+		shutdownFns = append(shutdownFns, shutdownFn{
+			name: "Autopilot",
+			fn:   fn,
+		})
 
 		go func() { autopilotErr <- runFn() }()
 		mux.sub["/api/autopilot"] = treeMux{h: auth(ap)}
 	}
 
-	srv := &http.Server{Handler: mux}
+	// Start server.
 	go srv.Serve(l)
 	logger.Info("api: Listening on " + l.Addr().String())
 
@@ -520,32 +542,22 @@ func main() {
 
 	// Give each service a fraction of the total shutdown timeout. One service
 	// timing out shouldn't prevent the others from attempting a shutdown.
-	timeout := cfg.ShutdownTimeout / time.Duration(len(shutdownFns)+2)
+	timeout := cfg.ShutdownTimeout / time.Duration(len(shutdownFns))
 	shutdown := func(fn func(ctx context.Context) error) error {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		return fn(ctx)
 	}
 
-	// Shut down the autopilot first, then the rest of the services in reverse order.
+	// Shut down the autopilot first, then the rest of the services in reverse order and then
 	exitCode := 0
-	if autopilotShutdownFn != nil {
-		if err := shutdown(autopilotShutdownFn); err != nil {
-			logger.Error("Failed to shut down autopilot: " + err.Error())
-			exitCode = 1
-		}
-	}
 	for i := len(shutdownFns) - 1; i >= 0; i-- {
-		if err := shutdown(shutdownFns[i]); err != nil {
-			logger.Sugar().Errorf("Shutdown function %v failed: %v", i+1, err)
+		if err := shutdown(shutdownFns[i].fn); err != nil {
+			logger.Sugar().Errorf("Failed to shut down %v: %v", shutdownFns[i].name, err)
 			exitCode = 1
+		} else {
+			logger.Sugar().Infof("%v shut down successfully", shutdownFns[i].name)
 		}
-	}
-	// Shut down the API last so that the other services can finish any pending
-	// requests as part of their shutdown procedures.
-	if err := shutdown(srv.Shutdown); err != nil {
-		logger.Error("Failed to shut down API server: " + err.Error())
-		exitCode = 1
 	}
 	logger.Info("Shutdown complete")
 	os.Exit(exitCode)

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -424,10 +424,6 @@ func main() {
 	if err != nil {
 		logger.Fatal("failed to create listener: " + err.Error())
 	}
-	shutdownFns = append(shutdownFns, shutdownFn{
-		name: "Listener",
-		fn:   func(ctx context.Context) error { return l.Close() },
-	})
 
 	// override the address with the actual one
 	cfg.HTTP.Address = "http://" + l.Addr().String()

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1374,7 +1374,7 @@ LIMIT ?
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
+		case <-time.After(time.Second):
 		}
 	}
 }


### PR DESCRIPTION
The PR also won't abort mid shutdown if any module fails to shut down. Instead renterd will print the error and eventually exit with exit code 1.