### PR TITLE
Update versionScore weights

### DIFF
--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -236,10 +236,8 @@ func versionScore(settings rhpv2.HostSettings) float64 {
 		version string
 		penalty float64
 	}{
-		{"1.5.10", 1.0},
-		{"1.5.9", 0.99},
-		{"1.5.8", 0.99},
-		{"1.5.6", 0.90},
+		{"1.6.0", 0.99},
+		{"1.5.9", 0.00},
 	}
 	weight := 1.0
 	for _, v := range versions {


### PR DESCRIPTION
While going through the logs I noticed we have contracts with hosts as old as 1.5.4 that we fail to interact with. 
This PR updates the scoring to not form contracts with versions below 1.5.9 which is about 3% of hosts on the network.