### PR TITLE
Add support for buckets

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -43,7 +43,11 @@ var (
 	// yet because it has been set too recently.
 	ErrRequiresSyncSetRecently = errors.New("account had 'requiresSync' flag set recently")
 
-	// ErrOBjectNotFound is returned when an object can't be retrieved from the
+	// ErrBucketNotFound is returned when an bucket can't be retrieved from the
+	// database.
+	ErrBucketNotFound = errors.New("bucket not found")
+
+	// ErrObjectNotFound is returned when an object can't be retrieved from the
 	// database.
 	ErrObjectNotFound = errors.New("object not found")
 

--- a/api/bus.go
+++ b/api/bus.go
@@ -497,6 +497,10 @@ func (gs GougingSettings) Validate() error {
 	return nil
 }
 
+type Bucket struct {
+	Name string `json:"name"`
+}
+
 type SearchHostsRequest struct {
 	Offset          int               `json:"offset"`
 	Limit           int               `json:"limit"`

--- a/api/bus.go
+++ b/api/bus.go
@@ -498,8 +498,8 @@ func (gs GougingSettings) Validate() error {
 }
 
 type Bucket struct {
-	CreationDate time.Time `json:"creationDate"`
-	Name         string    `json:"name"`
+	CreatedAt time.Time `json:"creationDate"`
+	Name      string    `json:"name"`
 }
 
 type SearchHostsRequest struct {

--- a/api/bus.go
+++ b/api/bus.go
@@ -39,13 +39,21 @@ const (
 )
 
 var (
-	// ErrRequiresSyncSetRecently indicates that an account can't be set to sync
-	// yet because it has been set too recently.
-	ErrRequiresSyncSetRecently = errors.New("account had 'requiresSync' flag set recently")
+	// ErrBucketExists is returned when trying to create a bucket that already
+	// exists.
+	ErrBucketExists = errors.New("bucket already exists")
+
+	// ErrBucketNotEmpty is returned when trying to delete a bucket that is not
+	// empty.
+	ErrBucketNotEmpty = errors.New("bucket not empty")
 
 	// ErrBucketNotFound is returned when an bucket can't be retrieved from the
 	// database.
 	ErrBucketNotFound = errors.New("bucket not found")
+
+	// ErrRequiresSyncSetRecently indicates that an account can't be set to sync
+	// yet because it has been set too recently.
+	ErrRequiresSyncSetRecently = errors.New("account had 'requiresSync' flag set recently")
 
 	// ErrObjectNotFound is returned when an object can't be retrieved from the
 	// database.

--- a/api/bus.go
+++ b/api/bus.go
@@ -498,7 +498,8 @@ func (gs GougingSettings) Validate() error {
 }
 
 type Bucket struct {
-	Name string `json:"name"`
+	CreationDate time.Time `json:"creationDate"`
+	Name         string    `json:"name"`
 }
 
 type SearchHostsRequest struct {

--- a/api/bus.go
+++ b/api/bus.go
@@ -205,6 +205,7 @@ type ObjectMetadata struct {
 
 // ObjectAddRequest is the request type for the /object/*key endpoint.
 type ObjectAddRequest struct {
+	Bucket        string                                   `json:"bucket"`
 	ContractSet   string                                   `json:"contractSet"`
 	Object        object.Object                            `json:"object"`
 	UsedContracts map[types.PublicKey]types.FileContractID `json:"usedContracts"`
@@ -218,9 +219,10 @@ type ObjectsResponse struct {
 
 // ObjectsRenameRequest is the request type for the /objects/rename endpoint.
 type ObjectsRenameRequest struct {
-	From string `json:"from"`
-	To   string `json:"to"`
-	Mode string `json:"mode"`
+	Bucket string `json:"bucket"`
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Mode   string `json:"mode"`
 }
 
 // ObjectsStatsResponse is the response type for the /stats/objects endpoint.

--- a/api/bus.go
+++ b/api/bus.go
@@ -29,9 +29,9 @@ const (
 	UsabilityFilterModeAll      = "all"
 	UsabilityFilterModeUsable   = "usable"
 	UsabilityFilterModeUnusable = "unusable"
-)
 
-const (
+	DefaultBucketName = "default"
+
 	SettingContractSet   = "contractset"
 	SettingGouging       = "gouging"
 	SettingRedundancy    = "redundancy"

--- a/api/worker.go
+++ b/api/worker.go
@@ -199,6 +199,13 @@ func UploadWithContractSet(set string) UploadOption {
 	}
 }
 
+// UploadWithBucket sets the bucket that should be used for an upload
+func UploadWithBucket(bucket string) UploadOption {
+	return func(v url.Values) {
+		v.Set("bucket", bucket)
+	}
+}
+
 type DownloadObjectOption func(http.Header)
 
 func DownloadWithRange(offset, length uint64) DownloadObjectOption {
@@ -224,5 +231,11 @@ func ObjectsWithOffset(offset int) ObjectsOption {
 func ObjectsWithLimit(limit int) ObjectsOption {
 	return func(v url.Values) {
 		v.Set("limit", fmt.Sprint(limit))
+	}
+}
+
+func ObjectsWithBucket(bucket string) ObjectsOption {
+	return func(v url.Values) {
+		v.Set("bucket", bucket)
 	}
 }

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -71,7 +71,7 @@ type Bus interface {
 	ConsensusState(ctx context.Context) (api.ConsensusState, error)
 
 	// objects
-	ObjectsBySlabKey(ctx context.Context, key object.EncryptionKey) (objects []api.ObjectMetadata, err error)
+	ObjectsBySlabKey(ctx context.Context, key object.EncryptionKey, bucket string) (objects []api.ObjectMetadata, err error)
 	RefreshHealth(ctx context.Context) error
 	Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
 	SlabsForMigration(ctx context.Context, healthCutoff float64, set string, limit int) ([]api.UnhealthySlab, error)

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -71,7 +71,7 @@ type Bus interface {
 	ConsensusState(ctx context.Context) (api.ConsensusState, error)
 
 	// objects
-	ObjectsBySlabKey(ctx context.Context, key object.EncryptionKey, bucket string) (objects []api.ObjectMetadata, err error)
+	ObjectsBySlabKey(ctx context.Context, bucket string, key object.EncryptionKey) (objects []api.ObjectMetadata, err error)
 	RefreshHealth(ctx context.Context) error
 	Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
 	SlabsForMigration(ctx context.Context, healthCutoff float64, set string, limit int) ([]api.UnhealthySlab, error)

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -248,7 +248,7 @@ func (b *bus) bucketsHandlerGET(jc jape.Context) {
 	jc.Encode(resp)
 }
 
-func (b *bus) bucketHandlerPUT(jc jape.Context) {
+func (b *bus) bucketsHandlerPUT(jc jape.Context) {
 	var bucket api.Bucket
 	if jc.Decode(&bucket) != nil {
 		return
@@ -1828,7 +1828,7 @@ func (b *bus) Handler() http.Handler {
 		"DELETE /contract/:id":           b.contractIDHandlerDELETE,
 
 		"GET    /buckets":       b.bucketsHandlerGET,
-		"PUT    /buckets":       b.bucketHandlerPUT,
+		"PUT    /buckets":       b.bucketsHandlerPUT,
 		"DELETE /buckets/:name": b.bucketHandlerDELETE,
 
 		"GET    /objects/*path":  b.objectsHandlerGET,

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -105,9 +105,9 @@ type (
 		ContractSize(ctx context.Context, id types.FileContractID) (api.ContractSize, error)
 
 		Object(ctx context.Context, path string) (api.Object, error)
-		ObjectEntries(ctx context.Context, path, prefix string, offset, limit int) ([]api.ObjectMetadata, error)
+		ObjectEntries(ctx context.Context, path, prefix string, offset, limit int, bucket *string) ([]api.ObjectMetadata, error)
 		ObjectsBySlabKey(ctx context.Context, slabKey object.EncryptionKey) ([]api.ObjectMetadata, error)
-		SearchObjects(ctx context.Context, substring string, offset, limit int) ([]api.ObjectMetadata, error)
+		SearchObjects(ctx context.Context, substring string, offset, limit int, bucket *string) ([]api.ObjectMetadata, error)
 		UpdateObject(ctx context.Context, path, contractSet string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
 		RemoveObject(ctx context.Context, path string) error
 		RemoveObjects(ctx context.Context, prefix string) error
@@ -844,7 +844,8 @@ func (b *bus) searchObjectsHandlerGET(jc jape.Context) {
 	if jc.DecodeForm("offset", &offset) != nil || jc.DecodeForm("limit", &limit) != nil || jc.DecodeForm("key", &key) != nil {
 		return
 	}
-	keys, err := b.ms.SearchObjects(jc.Request.Context(), key, offset, limit)
+	// TODO
+	keys, err := b.ms.SearchObjects(jc.Request.Context(), key, offset, limit, nil)
 	if jc.Check("couldn't list objects", err) != nil {
 		return
 	}
@@ -884,7 +885,8 @@ func (b *bus) objectEntriesHandlerGET(jc jape.Context, path string) {
 	}
 
 	// look for object entries
-	entries, err := b.ms.ObjectEntries(jc.Request.Context(), path, prefix, offset, limit)
+	// TODO
+	entries, err := b.ms.ObjectEntries(jc.Request.Context(), path, prefix, offset, limit, nil)
 	if jc.Check("couldn't list object entries", err) != nil {
 		return
 	}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -106,7 +106,7 @@ type (
 
 		CreateBucket(_ context.Context, bucket string) error
 		DeleteBucket(_ context.Context, bucket string) error
-		ListBuckets(_ context.Context) ([]string, error)
+		ListBuckets(_ context.Context) ([]api.Bucket, error)
 
 		Object(ctx context.Context, path string, bucket string) (api.Object, error)
 		ObjectEntries(ctx context.Context, path, prefix string, offset, limit int, bucket string) ([]api.ObjectMetadata, error)
@@ -235,15 +235,9 @@ func (b *bus) txpoolBroadcastHandler(jc jape.Context) {
 }
 
 func (b *bus) bucketsHandlerGET(jc jape.Context) {
-	buckets, err := b.ms.ListBuckets(jc.Request.Context())
+	resp, err := b.ms.ListBuckets(jc.Request.Context())
 	if jc.Check("couldn't list buckets", err) != nil {
 		return
-	}
-	var resp []api.Bucket
-	for _, bucket := range buckets {
-		resp = append(resp, api.Bucket{
-			Name: bucket,
-		})
 	}
 	jc.Encode(resp)
 }

--- a/bus/client.go
+++ b/bus/client.go
@@ -58,6 +58,12 @@ func (c *Client) DeleteBucket(ctx context.Context, name string) error {
 	return c.c.WithContext(ctx).DELETE(fmt.Sprintf("/buckets/%s", name))
 }
 
+// ExistsBucket returns whether a bucket exists.
+func (c *Client) Bucket(ctx context.Context, name string) (resp api.Bucket, err error) {
+	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/buckets/%s", name), &resp)
+	return
+}
+
 // ListBuckets lists all available buckets.
 func (c *Client) ListBuckets(ctx context.Context) (buckets []api.Bucket, err error) {
 	err = c.c.WithContext(ctx).GET("/buckets", &buckets)

--- a/bus/client.go
+++ b/bus/client.go
@@ -48,9 +48,9 @@ func (c *Client) RegisterAlert(ctx context.Context, alert alerts.Alert) error {
 
 // CreateBucket creates a new bucket.
 func (c *Client) CreateBucket(ctx context.Context, name string) error {
-	return c.c.WithContext(ctx).PUT("/buckets", api.Bucket{
+	return c.c.WithContext(ctx).POST("/buckets", api.Bucket{
 		Name: name,
-	})
+	}, nil)
 }
 
 // DeleteBucket deletes an existing bucket. Fails if the bucket isn't empty.
@@ -58,7 +58,7 @@ func (c *Client) DeleteBucket(ctx context.Context, name string) error {
 	return c.c.WithContext(ctx).DELETE(fmt.Sprintf("/buckets/%s", name))
 }
 
-// ExistsBucket returns whether a bucket exists.
+// Bucket returns information about a specific bucket.
 func (c *Client) Bucket(ctx context.Context, name string) (resp api.Bucket, err error) {
 	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/buckets/%s", name), &resp)
 	return

--- a/bus/client.go
+++ b/bus/client.go
@@ -46,6 +46,24 @@ func (c *Client) RegisterAlert(ctx context.Context, alert alerts.Alert) error {
 	return c.c.WithContext(ctx).POST("/alerts/register", alert, nil)
 }
 
+// CreateBucket creates a new bucket.
+func (c *Client) CreateBucket(ctx context.Context, name string) error {
+	return c.c.WithContext(ctx).PUT("/buckets", api.Bucket{
+		Name: name,
+	})
+}
+
+// DeleteBucket deletes an existing bucket. Fails if the bucket isn't empty.
+func (c *Client) DeleteBucket(ctx context.Context, name string) error {
+	return c.c.WithContext(ctx).DELETE(fmt.Sprintf("/buckets/%s", name))
+}
+
+// ListBuckets lists all available buckets.
+func (c *Client) ListBuckets(ctx context.Context) (buckets []api.Bucket, err error) {
+	err = c.c.WithContext(ctx).GET("/buckets", &buckets)
+	return
+}
+
 // RegisterWebhook registers a new webhook for the given URL.
 func (c *Client) RegisterWebhook(ctx context.Context, url, module, event string) error {
 	err := c.c.WithContext(ctx).POST("/webhooks", webhooks.Webhook{

--- a/bus/client.go
+++ b/bus/client.go
@@ -917,12 +917,12 @@ func (c *Client) State() (state api.BusStateResponse, err error) {
 
 // RenameObject renames a single object.
 func (c *Client) RenameObject(ctx context.Context, bucket, from, to string) (err error) {
-	return c.renameObjects(ctx, from, to, bucket, api.ObjectsRenameModeSingle)
+	return c.renameObjects(ctx, bucket, from, to, api.ObjectsRenameModeSingle)
 }
 
 // RenameObjects renames all objects with the prefix 'from' to the prefix 'to'.
 func (c *Client) RenameObjects(ctx context.Context, bucket, from, to string) (err error) {
-	return c.renameObjects(ctx, from, to, bucket, api.ObjectsRenameModeMulti)
+	return c.renameObjects(ctx, bucket, from, to, api.ObjectsRenameModeMulti)
 }
 
 func (c *Client) renameObjects(ctx context.Context, bucket, from, to, mode string) (err error) {

--- a/bus/client.go
+++ b/bus/client.go
@@ -620,7 +620,7 @@ func (c *Client) SearchHosts(ctx context.Context, filterMode string, addressCont
 }
 
 // ObjectsBySlabKey returns all objects that reference a given slab.
-func (c *Client) ObjectsBySlabKey(ctx context.Context, key object.EncryptionKey, bucket string) (objects []api.ObjectMetadata, err error) {
+func (c *Client) ObjectsBySlabKey(ctx context.Context, bucket string, key object.EncryptionKey) (objects []api.ObjectMetadata, err error) {
 	values := url.Values{}
 	values.Set("bucket", bucket)
 	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/slab/%v/objects?"+values.Encode(), key), &objects)
@@ -628,7 +628,7 @@ func (c *Client) ObjectsBySlabKey(ctx context.Context, key object.EncryptionKey,
 }
 
 // SearchObjects returns all objects that contains a sub-string in their key.
-func (c *Client) SearchObjects(ctx context.Context, key, bucket string, offset, limit int) (entries []api.ObjectMetadata, err error) {
+func (c *Client) SearchObjects(ctx context.Context, bucket, key string, offset, limit int) (entries []api.ObjectMetadata, err error) {
 	values := url.Values{}
 	values.Set("offset", fmt.Sprint(offset))
 	values.Set("limit", fmt.Sprint(limit))
@@ -656,7 +656,7 @@ func (c *Client) Object(ctx context.Context, path string, opts ...api.ObjectsOpt
 }
 
 // AddObject stores the provided object under the given path.
-func (c *Client) AddObject(ctx context.Context, path, bucket, contractSet string, o object.Object, usedContract map[types.PublicKey]types.FileContractID) (err error) {
+func (c *Client) AddObject(ctx context.Context, bucket, path, contractSet string, o object.Object, usedContract map[types.PublicKey]types.FileContractID) (err error) {
 	path = strings.TrimPrefix(path, "/")
 	err = c.c.WithContext(ctx).PUT(fmt.Sprintf("/objects/%s", path), api.ObjectAddRequest{
 		Bucket:        bucket,
@@ -669,7 +669,7 @@ func (c *Client) AddObject(ctx context.Context, path, bucket, contractSet string
 
 // DeleteObject either deletes the object at the given path or if batch=true
 // deletes all objects that start with the given path.
-func (c *Client) DeleteObject(ctx context.Context, path, bucket string, batch bool) (err error) {
+func (c *Client) DeleteObject(ctx context.Context, bucket, path string, batch bool) (err error) {
 	path = strings.TrimPrefix(path, "/")
 	values := url.Values{}
 	values.Set("batch", fmt.Sprint(batch))
@@ -916,16 +916,16 @@ func (c *Client) State() (state api.BusStateResponse, err error) {
 }
 
 // RenameObject renames a single object.
-func (c *Client) RenameObject(ctx context.Context, from, to, bucket string) (err error) {
+func (c *Client) RenameObject(ctx context.Context, bucket, from, to string) (err error) {
 	return c.renameObjects(ctx, from, to, bucket, api.ObjectsRenameModeSingle)
 }
 
 // RenameObjects renames all objects with the prefix 'from' to the prefix 'to'.
-func (c *Client) RenameObjects(ctx context.Context, from, to, bucket string) (err error) {
+func (c *Client) RenameObjects(ctx context.Context, bucket, from, to string) (err error) {
 	return c.renameObjects(ctx, from, to, bucket, api.ObjectsRenameModeMulti)
 }
 
-func (c *Client) renameObjects(ctx context.Context, from, to, bucket, mode string) (err error) {
+func (c *Client) renameObjects(ctx context.Context, bucket, from, to, mode string) (err error) {
 	err = c.c.POST("/objects/rename", api.ObjectsRenameRequest{
 		Bucket: bucket,
 		From:   from,

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -429,7 +429,7 @@ func main() {
 	cfg.HTTP.Address = "http://" + l.Addr().String()
 
 	auth := jape.BasicAuth(cfg.HTTP.Password)
-	mux := treeMux{
+	mux := &treeMux{
 		sub: make(map[string]treeMux),
 	}
 

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -394,7 +394,7 @@ func TestObjectEntries(t *testing.T) {
 		}
 
 		// use the worker client
-		got, err = w.ObjectEntries(context.Background(), test.path, api.DefaultBucketName, test.prefix, 0, -1)
+		got, err = w.ObjectEntries(context.Background(), api.DefaultBucketName, test.path, test.prefix, 0, -1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -419,7 +419,7 @@ func TestObjectEntries(t *testing.T) {
 	}
 
 	// assert root dir is empty
-	if entries, err := w.ObjectEntries(context.Background(), "/", api.DefaultBucketName, "", 0, -1); err != nil {
+	if entries, err := w.ObjectEntries(context.Background(), api.DefaultBucketName, "/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 0 {
 		t.Fatal("there should be no entries left", entries)
@@ -471,10 +471,10 @@ func TestObjectsRename(t *testing.T) {
 	}
 
 	// rename
-	if err := b.RenameObjects(context.Background(), "/foo/", "/", api.DefaultBucketName); err != nil {
+	if err := b.RenameObjects(context.Background(), api.DefaultBucketName, "/foo/", "/"); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.RenameObject(context.Background(), "/baz/quuz", "/quuz", api.DefaultBucketName); err != nil {
+	if err := b.RenameObject(context.Background(), api.DefaultBucketName, "/baz/quuz", "/quuz"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -60,7 +60,7 @@ func TestNewTestCluster(t *testing.T) {
 	}
 
 	// Try talking to the bus API by adding an object.
-	err = b.AddObject(context.Background(), "foo", testAutopilotConfig.Contracts.Set, object.Object{
+	err = b.AddObject(context.Background(), "foo", api.DefaultBucketName, testAutopilotConfig.Contracts.Set, object.Object{
 		Key: object.GenerateEncryptionKey(),
 		Slabs: []object.SlabSlice{
 			{
@@ -471,10 +471,10 @@ func TestObjectsRename(t *testing.T) {
 	}
 
 	// rename
-	if err := b.RenameObjects(context.Background(), "/foo/", "/"); err != nil {
+	if err := b.RenameObjects(context.Background(), "/foo/", "/", api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.RenameObject(context.Background(), "/baz/quuz", "/quuz"); err != nil {
+	if err := b.RenameObject(context.Background(), "/baz/quuz", "/quuz", api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -958,21 +958,21 @@ func TestUploadDownloadSpending(t *testing.T) {
 	uploadDownload()
 
 	// Fuzzy search for uploaded data in various ways.
-	objects, err := cluster.Bus.SearchObjects(context.Background(), "", 0, -1)
+	objects, err := cluster.Bus.SearchObjects(context.Background(), "", api.DefaultBucketName, 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(objects) != 2 {
 		t.Fatalf("should have 2 objects but got %v", len(objects))
 	}
-	objects, err = cluster.Bus.SearchObjects(context.Background(), "ata", 0, -1)
+	objects, err = cluster.Bus.SearchObjects(context.Background(), "ata", api.DefaultBucketName, 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(objects) != 2 {
 		t.Fatalf("should have 2 objects but got %v", len(objects))
 	}
-	objects, err = cluster.Bus.SearchObjects(context.Background(), "1258", 0, -1)
+	objects, err = cluster.Bus.SearchObjects(context.Background(), "1258", api.DefaultBucketName, 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1278,7 +1278,7 @@ func TestParallelUpload(t *testing.T) {
 	wg.Wait()
 
 	// Check if objects exist.
-	objects, err := cluster.Bus.SearchObjects(context.Background(), "/dir/", 0, 100)
+	objects, err := cluster.Bus.SearchObjects(context.Background(), "/dir/", api.DefaultBucketName, 0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1291,7 +1291,7 @@ func TestParallelUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	objects, err = cluster.Bus.SearchObjects(context.Background(), "/", 0, 100)
+	objects, err = cluster.Bus.SearchObjects(context.Background(), "/", api.DefaultBucketName, 0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1300,10 +1300,10 @@ func TestParallelUpload(t *testing.T) {
 	}
 
 	// Delete all objects under /dir/.
-	if err := cluster.Bus.DeleteObject(context.Background(), "/dir/", true); err != nil {
+	if err := cluster.Bus.DeleteObject(context.Background(), "/dir/", api.DefaultBucketName, true); err != nil {
 		t.Fatal(err)
 	}
-	objects, err = cluster.Bus.SearchObjects(context.Background(), "/", 0, 100)
+	objects, err = cluster.Bus.SearchObjects(context.Background(), "/", api.DefaultBucketName, 0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1312,10 +1312,10 @@ func TestParallelUpload(t *testing.T) {
 	}
 
 	// Delete all objects under /.
-	if err := cluster.Bus.DeleteObject(context.Background(), "/", true); err != nil {
+	if err := cluster.Bus.DeleteObject(context.Background(), "/", api.DefaultBucketName, true); err != nil {
 		t.Fatal(err)
 	}
-	objects, err = cluster.Bus.SearchObjects(context.Background(), "/", 0, 100)
+	objects, err = cluster.Bus.SearchObjects(context.Background(), "/", api.DefaultBucketName, 0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1934,7 +1934,7 @@ func TestUploadPacking(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	objs, err := b.ObjectsBySlabKey(context.Background(), file1.Slabs[0].Key)
+	objs, err := b.ObjectsBySlabKey(context.Background(), file1.Slabs[0].Key, api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -705,7 +705,7 @@ func TestUploadDownloadExtended(t *testing.T) {
 	}
 
 	// fetch all entries from the worker
-	entries, err := cluster.Worker.ObjectEntries(context.Background(), "", api.DefaultBucketName, "", 0, -1)
+	entries, err := cluster.Worker.ObjectEntries(context.Background(), api.DefaultBucketName, "", "", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -732,7 +732,7 @@ func TestUploadDownloadExtended(t *testing.T) {
 	}
 
 	// fetch entries from the worker for unexisting path
-	entries, err = cluster.Worker.ObjectEntries(context.Background(), "bar/", api.DefaultBucketName, "", 0, -1)
+	entries, err = cluster.Worker.ObjectEntries(context.Background(), api.DefaultBucketName, "bar/", "", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -958,21 +958,21 @@ func TestUploadDownloadSpending(t *testing.T) {
 	uploadDownload()
 
 	// Fuzzy search for uploaded data in various ways.
-	objects, err := cluster.Bus.SearchObjects(context.Background(), "", api.DefaultBucketName, 0, -1)
+	objects, err := cluster.Bus.SearchObjects(context.Background(), api.DefaultBucketName, "", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(objects) != 2 {
 		t.Fatalf("should have 2 objects but got %v", len(objects))
 	}
-	objects, err = cluster.Bus.SearchObjects(context.Background(), "ata", api.DefaultBucketName, 0, -1)
+	objects, err = cluster.Bus.SearchObjects(context.Background(), api.DefaultBucketName, "ata", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(objects) != 2 {
 		t.Fatalf("should have 2 objects but got %v", len(objects))
 	}
-	objects, err = cluster.Bus.SearchObjects(context.Background(), "1258", api.DefaultBucketName, 0, -1)
+	objects, err = cluster.Bus.SearchObjects(context.Background(), api.DefaultBucketName, "1258", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1278,7 +1278,7 @@ func TestParallelUpload(t *testing.T) {
 	wg.Wait()
 
 	// Check if objects exist.
-	objects, err := cluster.Bus.SearchObjects(context.Background(), "/dir/", api.DefaultBucketName, 0, 100)
+	objects, err := cluster.Bus.SearchObjects(context.Background(), api.DefaultBucketName, "/dir/", 0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1291,7 +1291,7 @@ func TestParallelUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	objects, err = cluster.Bus.SearchObjects(context.Background(), "/", api.DefaultBucketName, 0, 100)
+	objects, err = cluster.Bus.SearchObjects(context.Background(), api.DefaultBucketName, "/", 0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1300,10 +1300,10 @@ func TestParallelUpload(t *testing.T) {
 	}
 
 	// Delete all objects under /dir/.
-	if err := cluster.Bus.DeleteObject(context.Background(), "/dir/", api.DefaultBucketName, true); err != nil {
+	if err := cluster.Bus.DeleteObject(context.Background(), api.DefaultBucketName, "/dir/", true); err != nil {
 		t.Fatal(err)
 	}
-	objects, err = cluster.Bus.SearchObjects(context.Background(), "/", api.DefaultBucketName, 0, 100)
+	objects, err = cluster.Bus.SearchObjects(context.Background(), api.DefaultBucketName, "/", 0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1312,10 +1312,10 @@ func TestParallelUpload(t *testing.T) {
 	}
 
 	// Delete all objects under /.
-	if err := cluster.Bus.DeleteObject(context.Background(), "/", api.DefaultBucketName, true); err != nil {
+	if err := cluster.Bus.DeleteObject(context.Background(), api.DefaultBucketName, "/", true); err != nil {
 		t.Fatal(err)
 	}
-	objects, err = cluster.Bus.SearchObjects(context.Background(), "/", api.DefaultBucketName, 0, 100)
+	objects, err = cluster.Bus.SearchObjects(context.Background(), api.DefaultBucketName, "/", 0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1847,7 +1847,7 @@ func TestUploadPacking(t *testing.T) {
 		if obj.Size != int64(len(data)) {
 			t.Fatal("unexpected size after upload", obj.Size, len(data))
 		}
-		entries, err := w.ObjectEntries(context.Background(), "/", api.DefaultBucketName, "", 0, -1)
+		entries, err := w.ObjectEntries(context.Background(), api.DefaultBucketName, "/", "", 0, -1)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -394,7 +394,7 @@ func TestObjectEntries(t *testing.T) {
 		}
 
 		// use the worker client
-		got, err = w.ObjectEntries(context.Background(), test.path, test.prefix, 0, -1)
+		got, err = w.ObjectEntries(context.Background(), test.path, api.DefaultBucketName, test.prefix, 0, -1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -419,7 +419,7 @@ func TestObjectEntries(t *testing.T) {
 	}
 
 	// assert root dir is empty
-	if entries, err := w.ObjectEntries(context.Background(), "/", "", 0, -1); err != nil {
+	if entries, err := w.ObjectEntries(context.Background(), "/", api.DefaultBucketName, "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 0 {
 		t.Fatal("there should be no entries left", entries)
@@ -705,7 +705,7 @@ func TestUploadDownloadExtended(t *testing.T) {
 	}
 
 	// fetch all entries from the worker
-	entries, err := cluster.Worker.ObjectEntries(context.Background(), "", "", 0, -1)
+	entries, err := cluster.Worker.ObjectEntries(context.Background(), "", api.DefaultBucketName, "", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -732,7 +732,7 @@ func TestUploadDownloadExtended(t *testing.T) {
 	}
 
 	// fetch entries from the worker for unexisting path
-	entries, err = cluster.Worker.ObjectEntries(context.Background(), "bar/", "", 0, -1)
+	entries, err = cluster.Worker.ObjectEntries(context.Background(), "bar/", api.DefaultBucketName, "", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1847,7 +1847,7 @@ func TestUploadPacking(t *testing.T) {
 		if obj.Size != int64(len(data)) {
 			t.Fatal("unexpected size after upload", obj.Size, len(data))
 		}
-		entries, err := w.ObjectEntries(context.Background(), "/", "", 0, -1)
+		entries, err := w.ObjectEntries(context.Background(), "/", api.DefaultBucketName, "", 0, -1)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -60,7 +60,7 @@ func TestNewTestCluster(t *testing.T) {
 	}
 
 	// Try talking to the bus API by adding an object.
-	err = b.AddObject(context.Background(), "foo", api.DefaultBucketName, testAutopilotConfig.Contracts.Set, object.Object{
+	err = b.AddObject(context.Background(), api.DefaultBucketName, "foo", testAutopilotConfig.Contracts.Set, object.Object{
 		Key: object.GenerateEncryptionKey(),
 		Slabs: []object.SlabSlice{
 			{

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1934,7 +1934,7 @@ func TestUploadPacking(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	objs, err := b.ObjectsBySlabKey(context.Background(), file1.Slabs[0].Key, api.DefaultBucketName)
+	objs, err := b.ObjectsBySlabKey(context.Background(), api.DefaultBucketName, file1.Slabs[0].Key)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -265,7 +265,7 @@ func TestSectorPruning(t *testing.T) {
 	// delete a random number of objects
 	for i := 0; i < 10; i += 2 {
 		filename := fmt.Sprintf("obj_%d", i)
-		if err := b.DeleteObject(context.Background(), filename, api.DefaultBucketName, false); err != nil {
+		if err := b.DeleteObject(context.Background(), api.DefaultBucketName, filename, false); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -265,7 +265,7 @@ func TestSectorPruning(t *testing.T) {
 	// delete a random number of objects
 	for i := 0; i < 10; i += 2 {
 		filename := fmt.Sprintf("obj_%d", i)
-		if err := b.DeleteObject(context.Background(), filename, false); err != nil {
+		if err := b.DeleteObject(context.Background(), filename, api.DefaultBucketName, false); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -3,7 +3,6 @@ package stores
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -1001,14 +1000,6 @@ func (ss *SQLStore) isBlocked(h dbHost) (blocked bool) {
 		blocked = true
 	}
 	return
-}
-
-func extractCommonMetric(result json.RawMessage) (json.RawMessage, error) {
-	var mrc hostdb.MetricResultCommon
-	if err := json.Unmarshal(result, &mrc); err != nil {
-		return nil, err
-	}
-	return json.Marshal(mrc)
 }
 
 func updateCCID(tx *gorm.DB, newCCID modules.ConsensusChangeID, newTip types.ChainIndex) error {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1280,7 +1280,7 @@ func (s *SQLStore) RemoveObject(ctx context.Context, bucket, key string) error {
 	var rowsAffected int64
 	var err error
 	err = s.retryTransaction(func(tx *gorm.DB) error {
-		rowsAffected, err = deleteObject(tx, key, bucket)
+		rowsAffected, err = deleteObject(tx, bucket, key)
 		return err
 	})
 	if err != nil {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -455,7 +455,7 @@ func (s *SQLStore) DeleteBucket(_ context.Context, bucket string) error {
 	})
 }
 
-func (s *SQLStore) ListBuckets(_ context.Context) ([]string, error) {
+func (s *SQLStore) ListBuckets(_ context.Context) ([]api.Bucket, error) {
 	var buckets []dbBucket
 	err := s.db.
 		Model(&dbBucket{}).
@@ -465,11 +465,14 @@ func (s *SQLStore) ListBuckets(_ context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	names := make([]string, len(buckets))
+	resp := make([]api.Bucket, len(buckets))
 	for i, b := range buckets {
-		names[i] = b.Name
+		resp[i] = api.Bucket{
+			CreationDate: b.CreatedAt.UTC(),
+			Name:         b.Name,
+		}
 	}
-	return names, nil
+	return resp, nil
 }
 
 // ObjectsStats returns some info related to the objects stored in the store. To

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1090,7 +1090,7 @@ func fetchUsedContracts(tx *gorm.DB, usedContracts map[types.PublicKey]types.Fil
 	return fetchedContracts, nil
 }
 
-func (s *SQLStore) RenameObject(ctx context.Context, keyOld, keyNew string, bucket string) error {
+func (s *SQLStore) RenameObject(ctx context.Context, bucket, keyOld, keyNew string) error {
 	tx := s.db.Exec(`UPDATE objects SET object_id = ? WHERE object_id = ? AND ?`, keyNew, keyOld, sqlWhereBucket("objects", bucket))
 	if tx.Error != nil {
 		return tx.Error
@@ -1101,7 +1101,7 @@ func (s *SQLStore) RenameObject(ctx context.Context, keyOld, keyNew string, buck
 	return nil
 }
 
-func (s *SQLStore) RenameObjects(ctx context.Context, prefixOld, prefixNew string, bucket string) error {
+func (s *SQLStore) RenameObjects(ctx context.Context, bucket, prefixOld, prefixNew string) error {
 	tx := s.db.Exec("UPDATE objects SET object_id = "+sqlConcat(s.db, "?", "SUBSTR(object_id, ?)")+" WHERE SUBSTR(object_id, 1, ?) = ?",
 		prefixNew, utf8.RuneCountInString(prefixOld)+1, utf8.RuneCountInString(prefixOld), prefixOld)
 	if tx.Error != nil {
@@ -1296,7 +1296,7 @@ func (s *SQLStore) RemoveObjects(ctx context.Context, bucket, prefix string) err
 	var rowsAffected int64
 	var err error
 	err = s.retryTransaction(func(tx *gorm.DB) error {
-		rowsAffected, err = deleteObjects(tx, prefix, bucket)
+		rowsAffected, err = deleteObjects(tx, bucket, prefix)
 		return err
 	})
 	if err != nil {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -980,7 +980,7 @@ LIMIT ? OFFSET ?`,
 	return metadata, nil
 }
 
-func (s *SQLStore) Object(ctx context.Context, path string, bucket string) (api.Object, error) {
+func (s *SQLStore) Object(ctx context.Context, bucket, path string) (api.Object, error) {
 	var obj api.Object
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		o, err := s.object(ctx, tx, bucket, path)

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -891,9 +891,9 @@ func (s *SQLStore) SearchObjects(ctx context.Context, substring string, offset, 
 		Select("o.object_id as name, MAX(o.size) as size, MIN(sla.health) as health").
 		Model(&dbObject{}).
 		Table("objects o").
-		Joins("LEFT JOIN slices sli ON o.id = sli.`db_object_id` AND ?", sqlWhereBucket("o", bucket)).
+		Joins("LEFT JOIN slices sli ON o.id = sli.`db_object_id`").
 		Joins("LEFT JOIN slabs sla ON sli.db_slab_id = sla.`id`").
-		Where("INSTR(o.object_id, ?) > 0", substring).
+		Where("INSTR(o.object_id, ?) > 0 AND ?", substring, sqlWhereBucket("o", bucket)).
 		Group("o.object_id").
 		Offset(offset).
 		Limit(limit).
@@ -928,9 +928,9 @@ FROM (
 	FROM (
 		SELECT MAX(size) AS size, MIN(slabs.health) as health, SUBSTR(object_id, ?) AS trimmed
 		FROM objects
-		LEFT JOIN slices ON objects.id = slices.db_object_id AND ?
+		LEFT JOIN slices ON objects.id = slices.db_object_id 
 		LEFT JOIN slabs ON slices.db_slab_id = slabs.id
-		WHERE SUBSTR(object_id, 1, ?) = ?
+		WHERE SUBSTR(object_id, 1, ?) = ? AND ?
 		GROUP BY object_id
 	) AS i
 ) AS m
@@ -943,9 +943,9 @@ LIMIT ? OFFSET ?`,
 		path,
 		path,
 		utf8.RuneCountInString(path)+1,
-		sqlWhereBucket("objects", bucket),
 		utf8.RuneCountInString(path),
 		path,
+		sqlWhereBucket("objects", bucket),
 		utf8.RuneCountInString(path+prefix),
 		path+prefix,
 		path,
@@ -1511,7 +1511,7 @@ func (s *SQLStore) object(ctx context.Context, txn *gorm.DB, path string, bucket
 		Joins("LEFT JOIN slabs sla ON sli.db_slab_id = sla.`id`").
 		Joins("LEFT JOIN sectors sec ON sla.id = sec.`db_slab_id`").
 		Joins("LEFT JOIN buffered_slabs bs ON sla.db_buffered_slab_id = bs.`id`").
-		Where("o.object_id = ? AND o.db_bucket_id = ?", path, sqlWhereBucket("o", bucket)).
+		Where("o.object_id = ? AND ?", path, sqlWhereBucket("o", bucket)).
 		Order("sli.id ASC").
 		Order("sec.id ASC").
 		Scan(&rows)

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -68,7 +68,7 @@ type (
 	dbContractSet struct {
 		Model
 
-		Name      string       `gorm:"unique;index:,length:255;"`
+		Name      string       `gorm:"unique;index;"`
 		Contracts []dbContract `gorm:"many2many:contract_set_contracts;constraint:OnDelete:CASCADE"`
 	}
 
@@ -91,7 +91,7 @@ type (
 	dbBucket struct {
 		Model
 
-		Name string `gorm:"unique;index:,length:255;"`
+		Name string `gorm:"unique;index;"`
 	}
 
 	dbSlice struct {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -410,7 +410,7 @@ func (raw rawObject) toSlabSlice() (slice object.SlabSlice, _ error) {
 	return slice, nil
 }
 
-func (s *SQLStore) Bucket(_ context.Context, bucket string) (api.Bucket, error) {
+func (s *SQLStore) Bucket(ctx context.Context, bucket string) (api.Bucket, error) {
 	var b dbBucket
 	err := s.db.
 		Model(&dbBucket{}).
@@ -423,12 +423,12 @@ func (s *SQLStore) Bucket(_ context.Context, bucket string) (api.Bucket, error) 
 		return api.Bucket{}, err
 	}
 	return api.Bucket{
-		CreationDate: b.CreatedAt.UTC(),
-		Name:         b.Name,
+		CreatedAt: b.CreatedAt.UTC(),
+		Name:      b.Name,
 	}, nil
 }
 
-func (s *SQLStore) CreateBucket(_ context.Context, bucket string) error {
+func (s *SQLStore) CreateBucket(ctx context.Context, bucket string) error {
 	// Create bucket.
 	return s.retryTransaction(func(tx *gorm.DB) error {
 		res := tx.Clauses(clause.OnConflict{
@@ -444,7 +444,7 @@ func (s *SQLStore) CreateBucket(_ context.Context, bucket string) error {
 	})
 }
 
-func (s *SQLStore) DeleteBucket(_ context.Context, bucket string) error {
+func (s *SQLStore) DeleteBucket(ctx context.Context, bucket string) error {
 	// Delete bucket.
 	return s.retryTransaction(func(tx *gorm.DB) error {
 		var b dbBucket
@@ -462,18 +462,15 @@ func (s *SQLStore) DeleteBucket(_ context.Context, bucket string) error {
 		if count > 0 {
 			return api.ErrBucketNotEmpty
 		}
-		res := tx.Where("buckets.id = ?", b.ID).
-			Delete(&dbBucket{})
+		res := tx.Delete(&b)
 		if res.Error != nil {
 			return res.Error
-		} else if res.RowsAffected == 0 {
-			return api.ErrBucketNotFound
 		}
 		return nil
 	})
 }
 
-func (s *SQLStore) ListBuckets(_ context.Context) ([]api.Bucket, error) {
+func (s *SQLStore) ListBuckets(ctx context.Context) ([]api.Bucket, error) {
 	var buckets []dbBucket
 	err := s.db.
 		Model(&dbBucket{}).
@@ -486,8 +483,8 @@ func (s *SQLStore) ListBuckets(_ context.Context) ([]api.Bucket, error) {
 	resp := make([]api.Bucket, len(buckets))
 	for i, b := range buckets {
 		resp[i] = api.Bucket{
-			CreationDate: b.CreatedAt.UTC(),
-			Name:         b.Name,
+			CreatedAt: b.CreatedAt.UTC(),
+			Name:      b.Name,
 		}
 	}
 	return resp, nil
@@ -902,7 +899,7 @@ func (s *SQLStore) RenewedContract(ctx context.Context, renewedFrom types.FileCo
 	return contract.convert(), nil
 }
 
-func (s *SQLStore) SearchObjects(ctx context.Context, substring string, offset, limit int, bucket string) ([]api.ObjectMetadata, error) {
+func (s *SQLStore) SearchObjects(ctx context.Context, bucket, substring string, offset, limit int) ([]api.ObjectMetadata, error) {
 	if limit <= -1 {
 		limit = math.MaxInt
 	}
@@ -912,9 +909,10 @@ func (s *SQLStore) SearchObjects(ctx context.Context, substring string, offset, 
 		Select("o.object_id as name, MAX(o.size) as size, MIN(sla.health) as health").
 		Model(&dbObject{}).
 		Table("objects o").
+		Joins("INNER JOIN buckets b ON o.db_bucket_id = b.id AND b.name = ?", bucket).
 		Joins("LEFT JOIN slices sli ON o.id = sli.`db_object_id`").
 		Joins("LEFT JOIN slabs sla ON sli.db_slab_id = sla.`id`").
-		Where("INSTR(o.object_id, ?) > 0 AND ?", substring, sqlWhereBucket("o", bucket)).
+		Where("INSTR(o.object_id, ?) > 0", substring).
 		Group("o.object_id").
 		Offset(offset).
 		Limit(limit).
@@ -926,7 +924,7 @@ func (s *SQLStore) SearchObjects(ctx context.Context, substring string, offset, 
 	return objects, nil
 }
 
-func (s *SQLStore) ObjectEntries(ctx context.Context, path, prefix string, offset, limit int, bucket string) ([]api.ObjectMetadata, error) {
+func (s *SQLStore) ObjectEntries(ctx context.Context, bucket, path, prefix string, offset, limit int) ([]api.ObjectMetadata, error) {
 	// sanity check we are passing a directory
 	if !strings.HasSuffix(path, "/") {
 		panic("path must end in /")
@@ -949,9 +947,10 @@ FROM (
 	FROM (
 		SELECT MAX(size) AS size, MIN(slabs.health) as health, SUBSTR(object_id, ?) AS trimmed
 		FROM objects
+		INNER JOIN buckets b ON objects.db_bucket_id = b.id AND b.name = ?
 		LEFT JOIN slices ON objects.id = slices.db_object_id 
 		LEFT JOIN slabs ON slices.db_slab_id = slabs.id
-		WHERE SUBSTR(object_id, 1, ?) = ? AND ?
+		WHERE SUBSTR(object_id, 1, ?) = ?
 		GROUP BY object_id
 	) AS i
 ) AS m
@@ -964,9 +963,9 @@ LIMIT ? OFFSET ?`,
 		path,
 		path,
 		utf8.RuneCountInString(path)+1,
+		bucket,
 		utf8.RuneCountInString(path),
 		path,
-		sqlWhereBucket("objects", bucket),
 		utf8.RuneCountInString(path+prefix),
 		path+prefix,
 		path,
@@ -984,7 +983,7 @@ LIMIT ? OFFSET ?`,
 func (s *SQLStore) Object(ctx context.Context, path string, bucket string) (api.Object, error) {
 	var obj api.Object
 	err := s.db.Transaction(func(tx *gorm.DB) error {
-		o, err := s.object(ctx, tx, path, bucket)
+		o, err := s.object(ctx, tx, bucket, path)
 		if err != nil {
 			return err
 		}
@@ -1126,7 +1125,7 @@ func (s *SQLStore) AddPartialSlab(ctx context.Context, data []byte, minShards, t
 	return s.slabBufferMgr.AddPartialSlab(ctx, data, minShards, totalShards, contractSetID)
 }
 
-func (s *SQLStore) UpdateObject(ctx context.Context, path, contractSet string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID, bucket string) error {
+func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error {
 	s.objectsMu.Lock()
 	defer s.objectsMu.Unlock()
 
@@ -1151,7 +1150,7 @@ func (s *SQLStore) UpdateObject(ctx context.Context, path, contractSet string, o
 
 		// Try to delete. We want to get rid of the object and its
 		// slices if it exists.
-		_, err := deleteObject(tx, path, bucket)
+		_, err := deleteObject(tx, bucket, path)
 		if err != nil {
 			return fmt.Errorf("failed to delete object: %w", err)
 		}
@@ -1277,7 +1276,7 @@ func (s *SQLStore) UpdateObject(ctx context.Context, path, contractSet string, o
 	})
 }
 
-func (s *SQLStore) RemoveObject(ctx context.Context, key string, bucket string) error {
+func (s *SQLStore) RemoveObject(ctx context.Context, bucket, key string) error {
 	var rowsAffected int64
 	var err error
 	err = s.retryTransaction(func(tx *gorm.DB) error {
@@ -1293,7 +1292,7 @@ func (s *SQLStore) RemoveObject(ctx context.Context, key string, bucket string) 
 	return nil
 }
 
-func (s *SQLStore) RemoveObjects(ctx context.Context, prefix string, bucket string) error {
+func (s *SQLStore) RemoveObjects(ctx context.Context, bucket, prefix string) error {
 	var rowsAffected int64
 	var err error
 	err = s.retryTransaction(func(tx *gorm.DB) error {
@@ -1518,7 +1517,7 @@ func (s *SQLStore) UnhealthySlabs(ctx context.Context, healthCutoff float64, set
 }
 
 // object retrieves a raw object from the store.
-func (s *SQLStore) object(ctx context.Context, txn *gorm.DB, path string, bucket string) (rawObject, error) {
+func (s *SQLStore) object(ctx context.Context, txn *gorm.DB, bucket string, path string) (rawObject, error) {
 	// NOTE: we LEFT JOIN here because empty objects are valid and need to be
 	// included in the result set, when we convert the rawObject before
 	// returning it we'll check for SlabID and/or SectorID being 0 and act
@@ -1528,11 +1527,12 @@ func (s *SQLStore) object(ctx context.Context, txn *gorm.DB, path string, bucket
 		Select("o.key as ObjectKey, o.object_id as ObjectName, o.size as ObjectSize, sli.id as SliceID, sli.offset as SliceOffset, sli.length as SliceLength, sla.id as SlabID, sla.health as SlabHealth, sla.key as SlabKey, sla.min_shards as SlabMinShards, bs.id IS NOT NULL AS SlabBuffered, sec.id as SectorID, sec.root as SectorRoot, sec.latest_host as SectorHost").
 		Model(&dbObject{}).
 		Table("objects o").
+		Joins("INNER JOIN buckets b ON o.db_bucket_id = b.id AND b.name = ?", bucket).
 		Joins("LEFT JOIN slices sli ON o.id = sli.`db_object_id`").
 		Joins("LEFT JOIN slabs sla ON sli.db_slab_id = sla.`id`").
 		Joins("LEFT JOIN sectors sec ON sla.id = sec.`db_slab_id`").
 		Joins("LEFT JOIN buffered_slabs bs ON sla.db_buffered_slab_id = bs.`id`").
-		Where("o.object_id = ? AND ?", path, sqlWhereBucket("o", bucket)).
+		Where("o.object_id = ?", path).
 		Order("sli.id ASC").
 		Order("sec.id ASC").
 		Scan(&rows)
@@ -1578,7 +1578,7 @@ func (s *SQLStore) PackedSlabsForUpload(ctx context.Context, lockingDuration tim
 	return s.slabBufferMgr.SlabsForUpload(ctx, lockingDuration, minShards, totalShards, contractSetID, limit)
 }
 
-func (s *SQLStore) ObjectsBySlabKey(ctx context.Context, slabKey object.EncryptionKey, bucket string) ([]api.ObjectMetadata, error) {
+func (s *SQLStore) ObjectsBySlabKey(ctx context.Context, bucket string, slabKey object.EncryptionKey) ([]api.ObjectMetadata, error) {
 	var objs []struct {
 		Name   string
 		Size   int64
@@ -1592,9 +1592,10 @@ func (s *SQLStore) ObjectsBySlabKey(ctx context.Context, slabKey object.Encrypti
 SELECT DISTINCT obj.object_id as Name, obj.size as Size, sla.health as Health
 FROM slabs sla
 INNER JOIN slices sli ON sli.db_slab_id = sla.id
-INNER JOIN objects obj ON sli.db_object_id = obj.id AND ?
+INNER JOIN objects obj ON sli.db_object_id = obj.id
+INNER JOIN buckets b ON obj.db_bucket_id = b.id AND b.name = ?
 WHERE sla.key = ?
-	`, sqlWhereBucket("obj", bucket), key).
+	`, bucket, key).
 		Scan(&objs).
 		Error
 	if err != nil {
@@ -1830,7 +1831,7 @@ func archiveContracts(tx *gorm.DB, contracts []dbContract, toArchive map[types.F
 // deleteObject deletes an object from the store and prunes all slabs which are
 // without an obect after the deletion. That means in case of packed uploads,
 // the slab is only deleted when no more objects point to it.
-func deleteObject(tx *gorm.DB, path string, bucket string) (numDeleted int64, _ error) {
+func deleteObject(tx *gorm.DB, bucket string, path string) (numDeleted int64, _ error) {
 	tx = tx.Where("object_id = ? AND ?", path, sqlWhereBucket("objects", bucket)).
 		Delete(&dbObject{})
 	if tx.Error != nil {
@@ -1846,7 +1847,7 @@ func deleteObject(tx *gorm.DB, path string, bucket string) (numDeleted int64, _ 
 	return
 }
 
-func deleteObjects(tx *gorm.DB, path string, bucket string) (numDeleted int64, _ error) {
+func deleteObjects(tx *gorm.DB, bucket string, path string) (numDeleted int64, _ error) {
 	tx = tx.Exec("DELETE FROM objects WHERE SUBSTR(object_id, 1, ?) = ? AND ?",
 		utf8.RuneCountInString(path), path, sqlWhereBucket("objects", bucket))
 	if tx.Error != nil {

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -99,12 +99,12 @@ func TestObjectBasic(t *testing.T) {
 	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
-	}, nil); err != nil {
+	}, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
 	// fetch the object
-	got, err := db.Object(context.Background(), t.Name(), nil)
+	got, err := db.Object(context.Background(), t.Name(), api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestObjectBasic(t *testing.T) {
 	}
 
 	// fetch the object again and assert we receive an indication it was corrupted
-	_, err = db.Object(context.Background(), t.Name(), nil)
+	_, err = db.Object(context.Background(), t.Name(), api.DefaultBucketName)
 	if !errors.Is(err, api.ErrObjectCorrupted) {
 		t.Fatal("unexpected err", err)
 	}
@@ -135,12 +135,12 @@ func TestObjectBasic(t *testing.T) {
 	}
 
 	// add the object
-	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want2, make(map[types.PublicKey]types.FileContractID), nil); err != nil {
+	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want2, make(map[types.PublicKey]types.FileContractID), api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
 	// fetch the object
-	got2, err := db.Object(context.Background(), t.Name(), nil)
+	got2, err := db.Object(context.Background(), t.Name(), api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +433,7 @@ func TestContractRoots(t *testing.T) {
 	}
 
 	// add the object.
-	if err := cs.UpdateObject(context.Background(), t.Name(), testContractSet, obj, map[types.PublicKey]types.FileContractID{hks[0]: fcids[0]}, nil); err != nil {
+	if err := cs.UpdateObject(context.Background(), t.Name(), testContractSet, obj, map[types.PublicKey]types.FileContractID{hks[0]: fcids[0]}, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -548,7 +548,7 @@ func TestRenewedContract(t *testing.T) {
 	if err := cs.UpdateObject(context.Background(), "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk:  fcid1,
 		hk2: fcid2,
-	}, nil); err != nil {
+	}, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -985,12 +985,12 @@ func TestSQLMetadataStore(t *testing.T) {
 	// Store it.
 	ctx := context.Background()
 	objID := "key1"
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, nil); err != nil {
+	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to store it again. Should work.
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, nil); err != nil {
+	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1045,7 +1045,7 @@ func TestSQLMetadataStore(t *testing.T) {
 	}
 
 	// Fetch it and verify again.
-	fullObj, err := db.Object(ctx, objID, nil)
+	fullObj, err := db.Object(ctx, objID, api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1153,10 +1153,10 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	// Remove the first slab of the object.
 	obj1.Slabs = obj1.Slabs[1:]
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, nil); err != nil {
+	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
-	fullObj, err = db.Object(ctx, objID, nil)
+	fullObj, err = db.Object(ctx, objID, api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1201,7 +1201,7 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	// Delete the object. Due to the cascade this should delete everything
 	// but the sectors.
-	if err := db.RemoveObject(ctx, objID, nil); err != nil {
+	if err := db.RemoveObject(ctx, objID, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 	if err := countCheck(0, 0, 0, 0); err != nil {
@@ -1294,7 +1294,7 @@ func TestObjectHealth(t *testing.T) {
 		hks[2]: fcids[2],
 		hks[3]: fcids[3],
 		hks[4]: fcids[4],
-	}, nil); err != nil {
+	}, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1304,7 +1304,7 @@ func TestObjectHealth(t *testing.T) {
 	}
 
 	// assert health
-	obj, err := db.Object(context.Background(), "/foo", nil)
+	obj, err := db.Object(context.Background(), "/foo", api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != 1 {
@@ -1321,7 +1321,7 @@ func TestObjectHealth(t *testing.T) {
 	expectedHealth := float64(2) / float64(3)
 
 	// assert health
-	obj, err = db.Object(context.Background(), "/foo", nil)
+	obj, err = db.Object(context.Background(), "/foo", api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != expectedHealth {
@@ -1329,7 +1329,7 @@ func TestObjectHealth(t *testing.T) {
 	}
 
 	// assert health is returned correctly by ObjectEntries
-	entries, err := db.ObjectEntries(context.Background(), "/", "", 0, -1, nil)
+	entries, err := db.ObjectEntries(context.Background(), "/", "", 0, -1, api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
@@ -1339,7 +1339,7 @@ func TestObjectHealth(t *testing.T) {
 	}
 
 	// assert health is returned correctly by SearchObject
-	entries, err = db.SearchObjects(context.Background(), "foo", 0, -1, nil)
+	entries, err = db.SearchObjects(context.Background(), "foo", 0, -1, api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
@@ -1358,7 +1358,7 @@ func TestObjectHealth(t *testing.T) {
 	expectedHealth = float64(1) / float64(3)
 
 	// assert health is the min. health of the slabs
-	obj, err = db.Object(context.Background(), "/foo", nil)
+	obj, err = db.Object(context.Background(), "/foo", api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != expectedHealth {
@@ -1374,12 +1374,12 @@ func TestObjectHealth(t *testing.T) {
 		Key:   object.GenerateEncryptionKey(),
 		Slabs: nil,
 	}
-	if err := db.UpdateObject(context.Background(), "/bar", testContractSet, add, nil, nil); err != nil {
+	if err := db.UpdateObject(context.Background(), "/bar", testContractSet, add, nil, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
 	// assert the health is 1
-	obj, err = db.Object(context.Background(), "/bar", nil)
+	obj, err = db.Object(context.Background(), "/bar", api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != 1 {
@@ -1410,7 +1410,7 @@ func TestObjectEntries(t *testing.T) {
 		obj, ucs := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		err := os.UpdateObject(ctx, o.path, testContractSet, obj, ucs, nil)
+		err := os.UpdateObject(ctx, o.path, testContractSet, obj, ucs, api.DefaultBucketName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1433,7 +1433,7 @@ func TestObjectEntries(t *testing.T) {
 		{"/gab/", "/guub", []api.ObjectMetadata{}},
 	}
 	for _, test := range tests {
-		got, err := os.ObjectEntries(ctx, test.path, test.prefix, 0, -1, nil)
+		got, err := os.ObjectEntries(ctx, test.path, test.prefix, 0, -1, api.DefaultBucketName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1441,7 +1441,7 @@ func TestObjectEntries(t *testing.T) {
 			t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want)
 		}
 		for offset := 0; offset < len(test.want); offset++ {
-			got, err := os.ObjectEntries(ctx, test.path, test.prefix, offset, 1, nil)
+			got, err := os.ObjectEntries(ctx, test.path, test.prefix, offset, 1, api.DefaultBucketName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1474,7 +1474,7 @@ func TestSearchObjects(t *testing.T) {
 		obj, ucs := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		os.UpdateObject(ctx, o.path, testContractSet, obj, ucs, nil)
+		os.UpdateObject(ctx, o.path, testContractSet, obj, ucs, api.DefaultBucketName)
 	}
 	tests := []struct {
 		path string
@@ -1486,7 +1486,7 @@ func TestSearchObjects(t *testing.T) {
 		{"uu", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3, Health: 1}, {Name: "/foo/baz/quuz", Size: 4, Health: 1}, {Name: "/gab/guub", Size: 5, Health: 1}}},
 	}
 	for _, test := range tests {
-		got, err := os.SearchObjects(ctx, test.path, 0, -1, nil)
+		got, err := os.SearchObjects(ctx, test.path, 0, -1, api.DefaultBucketName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1494,7 +1494,7 @@ func TestSearchObjects(t *testing.T) {
 			t.Errorf("\nkey: %v\ngot: %v\nwant: %v", test.path, got, test.want)
 		}
 		for offset := 0; offset < len(test.want); offset++ {
-			got, err := os.SearchObjects(ctx, test.path, offset, 1, nil)
+			got, err := os.SearchObjects(ctx, test.path, offset, 1, api.DefaultBucketName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1673,7 +1673,7 @@ func TestUnhealthySlabs(t *testing.T) {
 		hk3: fcid3,
 		hk4: fcid4,
 		{5}: {5}, // deleted host and contract
-	}, nil); err != nil {
+	}, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1781,7 +1781,7 @@ func TestUnhealthySlabsNegHealth(t *testing.T) {
 
 	// add the object
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}, nil); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1845,7 +1845,7 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 
 	// add the object
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}, nil); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1954,7 +1954,7 @@ func TestUnhealthySlabsNoRedundancy(t *testing.T) {
 		hk1: fcid1,
 		hk2: fcid2,
 		hk3: fcid3,
-	}, nil); err != nil {
+	}, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2023,7 +2023,7 @@ func TestContractSectors(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts, nil); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2049,12 +2049,12 @@ func TestContractSectors(t *testing.T) {
 	}
 
 	// Add the object again.
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts, nil); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
 	// Delete the object.
-	if err := db.RemoveObject(ctx, "foo", nil); err != nil {
+	if err := db.RemoveObject(ctx, "foo", api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2117,7 +2117,7 @@ func TestPutSlab(t *testing.T) {
 	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
-	}, nil); err != nil {
+	}, api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2379,34 +2379,34 @@ func TestRenameObjects(t *testing.T) {
 	ctx := context.Background()
 	for _, path := range objects {
 		obj, ucs := newTestObject(1)
-		cs.UpdateObject(ctx, path, testContractSet, obj, ucs, nil)
+		cs.UpdateObject(ctx, path, testContractSet, obj, ucs, api.DefaultBucketName)
 	}
 
 	// Try renaming objects that don't exist.
-	if err := cs.RenameObject(ctx, "/fileś", "/fileś2", nil); !errors.Is(err, api.ErrObjectNotFound) {
+	if err := cs.RenameObject(ctx, "/fileś", "/fileś2", api.DefaultBucketName); !errors.Is(err, api.ErrObjectNotFound) {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObjects(ctx, "/fileś1", "/fileś2", nil); !errors.Is(err, api.ErrObjectNotFound) {
+	if err := cs.RenameObjects(ctx, "/fileś1", "/fileś2", api.DefaultBucketName); !errors.Is(err, api.ErrObjectNotFound) {
 		t.Fatal(err)
 	}
 
 	// Perform some renames.
-	if err := cs.RenameObjects(ctx, "/fileś/dir/", "/fileś/", nil); err != nil {
+	if err := cs.RenameObjects(ctx, "/fileś/dir/", "/fileś/", api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObject(ctx, "/foo", "/fileś/foo", nil); err != nil {
+	if err := cs.RenameObject(ctx, "/foo", "/fileś/foo", api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObject(ctx, "/bar", "/fileś/bar", nil); err != nil {
+	if err := cs.RenameObject(ctx, "/bar", "/fileś/bar", api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObject(ctx, "/baz", "/fileś/baz", nil); err != nil {
+	if err := cs.RenameObject(ctx, "/baz", "/fileś/baz", api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObjects(ctx, "/fileś/case", "/fileś/case1", nil); err != nil {
+	if err := cs.RenameObjects(ctx, "/fileś/case", "/fileś/case1", api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObjects(ctx, "/fileś/CASE", "/fileś/case2", nil); err != nil {
+	if err := cs.RenameObjects(ctx, "/fileś/CASE", "/fileś/case2", api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2430,7 +2430,7 @@ func TestRenameObjects(t *testing.T) {
 	}
 
 	// Assert that number of objects matches.
-	objs, err := cs.SearchObjects(ctx, "/", 0, 100, nil)
+	objs, err := cs.SearchObjects(ctx, "/", 0, 100, api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2483,7 +2483,7 @@ func TestObjectsStats(t *testing.T) {
 		}
 
 		key := hex.EncodeToString(frand.Bytes(32))
-		err := cs.UpdateObject(context.Background(), key, testContractSet, obj, contracts, nil)
+		err := cs.UpdateObject(context.Background(), key, testContractSet, obj, contracts, api.DefaultBucketName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2664,11 +2664,11 @@ func TestPartialSlab(t *testing.T) {
 		}
 	}
 	obj := testObject(slabs)
-	err = db.UpdateObject(context.Background(), "key", testContractSet, obj, usedContracts, nil)
+	err = db.UpdateObject(context.Background(), "key", testContractSet, obj, usedContracts, api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fetched, err := db.Object(context.Background(), "key", nil)
+	fetched, err := db.Object(context.Background(), "key", api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2701,11 +2701,11 @@ func TestPartialSlab(t *testing.T) {
 
 	// Create an object again.
 	obj2 := testObject(slabs)
-	err = db.UpdateObject(context.Background(), "key2", testContractSet, obj2, usedContracts, nil)
+	err = db.UpdateObject(context.Background(), "key2", testContractSet, obj2, usedContracts, api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fetched, err = db.Object(context.Background(), "key2", nil)
+	fetched, err = db.Object(context.Background(), "key2", api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2748,11 +2748,11 @@ func TestPartialSlab(t *testing.T) {
 
 	// Create an object again.
 	obj3 := testObject(slabs)
-	err = db.UpdateObject(context.Background(), "key3", testContractSet, obj3, usedContracts, nil)
+	err = db.UpdateObject(context.Background(), "key3", testContractSet, obj3, usedContracts, api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fetched, err = db.Object(context.Background(), "key3", nil)
+	fetched, err = db.Object(context.Background(), "key3", api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2930,7 +2930,7 @@ func TestContractSizes(t *testing.T) {
 			},
 		}, map[types.PublicKey]types.FileContractID{
 			hks[i]: fcids[i],
-		}, nil); err != nil {
+		}, api.DefaultBucketName); err != nil {
 			t.Fatal(err)
 		}
 		if err := db.RecordContractSpending(context.Background(), []api.ContractSpendingRecord{
@@ -2959,7 +2959,7 @@ func TestContractSizes(t *testing.T) {
 	}
 
 	// remove the first object
-	if err := db.RemoveObject(context.Background(), "obj_1", nil); err != nil {
+	if err := db.RemoveObject(context.Background(), "obj_1", api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2972,7 +2972,7 @@ func TestContractSizes(t *testing.T) {
 	}
 
 	// remove the second object
-	if err := db.RemoveObject(context.Background(), "obj_2", nil); err != nil {
+	if err := db.RemoveObject(context.Background(), "obj_2", api.DefaultBucketName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3087,14 +3087,14 @@ func TestObjectsBySlabKey(t *testing.T) {
 	}
 	for _, name := range []string{"obj1", "obj2", "obj3"} {
 		obj.Slabs[0].Length++
-		err = db.UpdateObject(context.Background(), name, testContractSet, obj, usedContracts, nil)
+		err = db.UpdateObject(context.Background(), name, testContractSet, obj, usedContracts, api.DefaultBucketName)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// Fetch the objects by slab.
-	objs, err := db.ObjectsBySlabKey(context.Background(), slab.Key, nil)
+	objs, err := db.ObjectsBySlabKey(context.Background(), slab.Key, api.DefaultBucketName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -99,12 +99,12 @@ func TestObjectBasic(t *testing.T) {
 	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// fetch the object
-	got, err := db.Object(context.Background(), t.Name())
+	got, err := db.Object(context.Background(), t.Name(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestObjectBasic(t *testing.T) {
 	}
 
 	// fetch the object again and assert we receive an indication it was corrupted
-	_, err = db.Object(context.Background(), t.Name())
+	_, err = db.Object(context.Background(), t.Name(), nil)
 	if !errors.Is(err, api.ErrObjectCorrupted) {
 		t.Fatal("unexpected err", err)
 	}
@@ -135,12 +135,12 @@ func TestObjectBasic(t *testing.T) {
 	}
 
 	// add the object
-	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want2, make(map[types.PublicKey]types.FileContractID)); err != nil {
+	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want2, make(map[types.PublicKey]types.FileContractID), nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// fetch the object
-	got2, err := db.Object(context.Background(), t.Name())
+	got2, err := db.Object(context.Background(), t.Name(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +433,7 @@ func TestContractRoots(t *testing.T) {
 	}
 
 	// add the object.
-	if err := cs.UpdateObject(context.Background(), t.Name(), testContractSet, obj, map[types.PublicKey]types.FileContractID{hks[0]: fcids[0]}); err != nil {
+	if err := cs.UpdateObject(context.Background(), t.Name(), testContractSet, obj, map[types.PublicKey]types.FileContractID{hks[0]: fcids[0]}, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -548,7 +548,7 @@ func TestRenewedContract(t *testing.T) {
 	if err := cs.UpdateObject(context.Background(), "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk:  fcid1,
 		hk2: fcid2,
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -985,12 +985,12 @@ func TestSQLMetadataStore(t *testing.T) {
 	// Store it.
 	ctx := context.Background()
 	objID := "key1"
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts); err != nil {
+	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to store it again. Should work.
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts); err != nil {
+	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1045,7 +1045,7 @@ func TestSQLMetadataStore(t *testing.T) {
 	}
 
 	// Fetch it and verify again.
-	fullObj, err := db.Object(ctx, objID)
+	fullObj, err := db.Object(ctx, objID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1153,10 +1153,10 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	// Remove the first slab of the object.
 	obj1.Slabs = obj1.Slabs[1:]
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts); err != nil {
+	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, nil); err != nil {
 		t.Fatal(err)
 	}
-	fullObj, err = db.Object(ctx, objID)
+	fullObj, err = db.Object(ctx, objID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1201,7 +1201,7 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	// Delete the object. Due to the cascade this should delete everything
 	// but the sectors.
-	if err := db.RemoveObject(ctx, objID); err != nil {
+	if err := db.RemoveObject(ctx, objID, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := countCheck(0, 0, 0, 0); err != nil {
@@ -1294,7 +1294,7 @@ func TestObjectHealth(t *testing.T) {
 		hks[2]: fcids[2],
 		hks[3]: fcids[3],
 		hks[4]: fcids[4],
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1304,7 +1304,7 @@ func TestObjectHealth(t *testing.T) {
 	}
 
 	// assert health
-	obj, err := db.Object(context.Background(), "/foo")
+	obj, err := db.Object(context.Background(), "/foo", nil)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != 1 {
@@ -1321,7 +1321,7 @@ func TestObjectHealth(t *testing.T) {
 	expectedHealth := float64(2) / float64(3)
 
 	// assert health
-	obj, err = db.Object(context.Background(), "/foo")
+	obj, err = db.Object(context.Background(), "/foo", nil)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != expectedHealth {
@@ -1358,7 +1358,7 @@ func TestObjectHealth(t *testing.T) {
 	expectedHealth = float64(1) / float64(3)
 
 	// assert health is the min. health of the slabs
-	obj, err = db.Object(context.Background(), "/foo")
+	obj, err = db.Object(context.Background(), "/foo", nil)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != expectedHealth {
@@ -1374,12 +1374,12 @@ func TestObjectHealth(t *testing.T) {
 		Key:   object.GenerateEncryptionKey(),
 		Slabs: nil,
 	}
-	if err := db.UpdateObject(context.Background(), "/bar", testContractSet, add, nil); err != nil {
+	if err := db.UpdateObject(context.Background(), "/bar", testContractSet, add, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// assert the health is 1
-	obj, err = db.Object(context.Background(), "/bar")
+	obj, err = db.Object(context.Background(), "/bar", nil)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != 1 {
@@ -1410,7 +1410,7 @@ func TestObjectEntries(t *testing.T) {
 		obj, ucs := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		err := os.UpdateObject(ctx, o.path, testContractSet, obj, ucs)
+		err := os.UpdateObject(ctx, o.path, testContractSet, obj, ucs, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1474,7 +1474,7 @@ func TestSearchObjects(t *testing.T) {
 		obj, ucs := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		os.UpdateObject(ctx, o.path, testContractSet, obj, ucs)
+		os.UpdateObject(ctx, o.path, testContractSet, obj, ucs, nil)
 	}
 	tests := []struct {
 		path string
@@ -1673,7 +1673,7 @@ func TestUnhealthySlabs(t *testing.T) {
 		hk3: fcid3,
 		hk4: fcid4,
 		{5}: {5}, // deleted host and contract
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1781,7 +1781,7 @@ func TestUnhealthySlabsNegHealth(t *testing.T) {
 
 	// add the object
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1845,7 +1845,7 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 
 	// add the object
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1954,7 +1954,7 @@ func TestUnhealthySlabsNoRedundancy(t *testing.T) {
 		hk1: fcid1,
 		hk2: fcid2,
 		hk3: fcid3,
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2023,7 +2023,7 @@ func TestContractSectors(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2049,12 +2049,12 @@ func TestContractSectors(t *testing.T) {
 	}
 
 	// Add the object again.
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts); err != nil {
+	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// Delete the object.
-	if err := db.RemoveObject(ctx, "foo"); err != nil {
+	if err := db.RemoveObject(ctx, "foo", nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2117,7 +2117,7 @@ func TestPutSlab(t *testing.T) {
 	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2379,34 +2379,34 @@ func TestRenameObjects(t *testing.T) {
 	ctx := context.Background()
 	for _, path := range objects {
 		obj, ucs := newTestObject(1)
-		cs.UpdateObject(ctx, path, testContractSet, obj, ucs)
+		cs.UpdateObject(ctx, path, testContractSet, obj, ucs, nil)
 	}
 
 	// Try renaming objects that don't exist.
-	if err := cs.RenameObject(ctx, "/fileś", "/fileś2"); !errors.Is(err, api.ErrObjectNotFound) {
+	if err := cs.RenameObject(ctx, "/fileś", "/fileś2", nil); !errors.Is(err, api.ErrObjectNotFound) {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObjects(ctx, "/fileś1", "/fileś2"); !errors.Is(err, api.ErrObjectNotFound) {
+	if err := cs.RenameObjects(ctx, "/fileś1", "/fileś2", nil); !errors.Is(err, api.ErrObjectNotFound) {
 		t.Fatal(err)
 	}
 
 	// Perform some renames.
-	if err := cs.RenameObjects(ctx, "/fileś/dir/", "/fileś/"); err != nil {
+	if err := cs.RenameObjects(ctx, "/fileś/dir/", "/fileś/", nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObject(ctx, "/foo", "/fileś/foo"); err != nil {
+	if err := cs.RenameObject(ctx, "/foo", "/fileś/foo", nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObject(ctx, "/bar", "/fileś/bar"); err != nil {
+	if err := cs.RenameObject(ctx, "/bar", "/fileś/bar", nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObject(ctx, "/baz", "/fileś/baz"); err != nil {
+	if err := cs.RenameObject(ctx, "/baz", "/fileś/baz", nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObjects(ctx, "/fileś/case", "/fileś/case1"); err != nil {
+	if err := cs.RenameObjects(ctx, "/fileś/case", "/fileś/case1", nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObjects(ctx, "/fileś/CASE", "/fileś/case2"); err != nil {
+	if err := cs.RenameObjects(ctx, "/fileś/CASE", "/fileś/case2", nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2483,7 +2483,7 @@ func TestObjectsStats(t *testing.T) {
 		}
 
 		key := hex.EncodeToString(frand.Bytes(32))
-		err := cs.UpdateObject(context.Background(), key, testContractSet, obj, contracts)
+		err := cs.UpdateObject(context.Background(), key, testContractSet, obj, contracts, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2664,11 +2664,11 @@ func TestPartialSlab(t *testing.T) {
 		}
 	}
 	obj := testObject(slabs)
-	err = db.UpdateObject(context.Background(), "key", testContractSet, obj, usedContracts)
+	err = db.UpdateObject(context.Background(), "key", testContractSet, obj, usedContracts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fetched, err := db.Object(context.Background(), "key")
+	fetched, err := db.Object(context.Background(), "key", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2701,11 +2701,11 @@ func TestPartialSlab(t *testing.T) {
 
 	// Create an object again.
 	obj2 := testObject(slabs)
-	err = db.UpdateObject(context.Background(), "key2", testContractSet, obj2, usedContracts)
+	err = db.UpdateObject(context.Background(), "key2", testContractSet, obj2, usedContracts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fetched, err = db.Object(context.Background(), "key2")
+	fetched, err = db.Object(context.Background(), "key2", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2748,11 +2748,11 @@ func TestPartialSlab(t *testing.T) {
 
 	// Create an object again.
 	obj3 := testObject(slabs)
-	err = db.UpdateObject(context.Background(), "key3", testContractSet, obj3, usedContracts)
+	err = db.UpdateObject(context.Background(), "key3", testContractSet, obj3, usedContracts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fetched, err = db.Object(context.Background(), "key3")
+	fetched, err = db.Object(context.Background(), "key3", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2930,7 +2930,7 @@ func TestContractSizes(t *testing.T) {
 			},
 		}, map[types.PublicKey]types.FileContractID{
 			hks[i]: fcids[i],
-		}); err != nil {
+		}, nil); err != nil {
 			t.Fatal(err)
 		}
 		if err := db.RecordContractSpending(context.Background(), []api.ContractSpendingRecord{
@@ -2959,7 +2959,7 @@ func TestContractSizes(t *testing.T) {
 	}
 
 	// remove the first object
-	if err := db.RemoveObject(context.Background(), "obj_1"); err != nil {
+	if err := db.RemoveObject(context.Background(), "obj_1", nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2972,7 +2972,7 @@ func TestContractSizes(t *testing.T) {
 	}
 
 	// remove the second object
-	if err := db.RemoveObject(context.Background(), "obj_2"); err != nil {
+	if err := db.RemoveObject(context.Background(), "obj_2", nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3087,14 +3087,14 @@ func TestObjectsBySlabKey(t *testing.T) {
 	}
 	for _, name := range []string{"obj1", "obj2", "obj3"} {
 		obj.Slabs[0].Length++
-		err = db.UpdateObject(context.Background(), name, testContractSet, obj, usedContracts)
+		err = db.UpdateObject(context.Background(), name, testContractSet, obj, usedContracts, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// Fetch the objects by slab.
-	objs, err := db.ObjectsBySlabKey(context.Background(), slab.Key)
+	objs, err := db.ObjectsBySlabKey(context.Background(), slab.Key, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3245,7 +3245,7 @@ func TestBucketObjects(t *testing.T) {
 	}
 
 	// Rename object foo/bar in bucket 1 to foo/baz but not in bucket 2.
-	if err := os.RenameObject(context.Background(), "/foo/bar", "/foo/baz", b1); err != nil {
+	if err := os.RenameObject(context.Background(), b1, "/foo/bar", "/foo/baz"); err != nil {
 		t.Fatal(err)
 	} else if entries, err := os.ObjectEntries(context.Background(), b1, "/foo/", "", 0, -1); err != nil {
 		t.Fatal(err)
@@ -3262,7 +3262,7 @@ func TestBucketObjects(t *testing.T) {
 	}
 
 	// Rename foo/bar in bucket 2 using the batch rename.
-	if err := os.RenameObjects(context.Background(), "/foo/bar", "/foo/bam", b2); err != nil {
+	if err := os.RenameObjects(context.Background(), b2, "/foo/bar", "/foo/bam"); err != nil {
 		t.Fatal(err)
 	} else if entries, err := os.ObjectEntries(context.Background(), b1, "/foo/", "", 0, -1); err != nil {
 		t.Fatal(err)
@@ -3279,9 +3279,9 @@ func TestBucketObjects(t *testing.T) {
 	}
 
 	// Delete foo/baz in bucket 1 but first try bucket 2 since that should fail.
-	if err := os.RemoveObject(context.Background(), "/foo/baz", b2); !errors.Is(err, api.ErrObjectNotFound) {
+	if err := os.RemoveObject(context.Background(), b2, "/foo/baz"); !errors.Is(err, api.ErrObjectNotFound) {
 		t.Fatal(err)
-	} else if err := os.RemoveObject(context.Background(), "/foo/baz", b1); err != nil {
+	} else if err := os.RemoveObject(context.Background(), b1, "/foo/baz"); err != nil {
 		t.Fatal(err)
 	} else if entries, err := os.ObjectEntries(context.Background(), b1, "/foo/", "", 0, -1); err != nil {
 		t.Fatal(err)
@@ -3298,30 +3298,30 @@ func TestBucketObjects(t *testing.T) {
 		t.Fatal(err)
 	} else if len(entries) != 2 {
 		t.Fatal("expected 2 entries", len(entries))
-	} else if err := os.RemoveObjects(context.Background(), "/", b2); err != nil {
+	} else if err := os.RemoveObjects(context.Background(), b2, "/"); err != nil {
 		t.Fatal(err)
-	} else if entries, err := os.ObjectEntries(context.Background(), "/", b2, "", 0, -1); err != nil {
+	} else if entries, err := os.ObjectEntries(context.Background(), b2, "/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 0 {
 		t.Fatal("expected 0 entries", len(entries))
-	} else if entries, err := os.ObjectEntries(context.Background(), "/", b1, "", 0, -1); err != nil {
+	} else if entries, err := os.ObjectEntries(context.Background(), b1, "/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
 		t.Fatal("expected 1 entry", len(entries))
 	}
 
 	// Fetch /bar from bucket 1.
-	if obj, err := os.Object(context.Background(), "/bar", b1); err != nil {
+	if obj, err := os.Object(context.Background(), b1, "/bar"); err != nil {
 		t.Fatal(err)
 	} else if obj.Size != 3 {
 		t.Fatal("unexpected size", obj.Size)
-	} else if _, err := os.Object(context.Background(), "/bar", b2); !errors.Is(err, api.ErrObjectNotFound) {
+	} else if _, err := os.Object(context.Background(), b2, "/bar"); !errors.Is(err, api.ErrObjectNotFound) {
 		t.Fatal(err)
 	}
 
 	// See if we can fetch the object by slab.
 	var ec object.EncryptionKey
-	if obj, err := os.object(context.Background(), os.db, "/bar", b1); err != nil {
+	if obj, err := os.object(context.Background(), os.db, b1, "/bar"); err != nil {
 		t.Fatal(err)
 	} else if err := ec.UnmarshalText(obj[0].SlabKey); err != nil {
 		t.Fatal(err)

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3124,7 +3124,7 @@ func TestBuckets(t *testing.T) {
 		t.Fatal(err)
 	} else if len(buckets) != 1 {
 		t.Fatal("expected 1 bucket", len(buckets))
-	} else if buckets[0] != api.DefaultBucketName {
+	} else if buckets[0].Name != api.DefaultBucketName {
 		t.Fatal("expected default bucket")
 	}
 
@@ -3141,9 +3141,9 @@ func TestBuckets(t *testing.T) {
 		t.Fatal(err)
 	} else if len(buckets) != 2 {
 		t.Fatal("expected 2 buckets", len(buckets))
-	} else if buckets[0] != b1 {
+	} else if buckets[0].Name != b1 {
 		t.Fatal("unexpected bucket", buckets[0])
-	} else if buckets[1] != b2 {
+	} else if buckets[1].Name != b2 {
 		t.Fatal("unexpected bucket", buckets[1])
 	}
 

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -96,15 +96,15 @@ func TestObjectBasic(t *testing.T) {
 	}
 
 	// add the object
-	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want, map[types.PublicKey]types.FileContractID{
+	if err := db.UpdateObject(context.Background(), api.DefaultBucketName, t.Name(), testContractSet, want, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
-	}, api.DefaultBucketName); err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
 	// fetch the object
-	got, err := db.Object(context.Background(), t.Name(), api.DefaultBucketName)
+	got, err := db.Object(context.Background(), api.DefaultBucketName, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestObjectBasic(t *testing.T) {
 	}
 
 	// fetch the object again and assert we receive an indication it was corrupted
-	_, err = db.Object(context.Background(), t.Name(), api.DefaultBucketName)
+	_, err = db.Object(context.Background(), api.DefaultBucketName, t.Name())
 	if !errors.Is(err, api.ErrObjectCorrupted) {
 		t.Fatal("unexpected err", err)
 	}
@@ -135,12 +135,12 @@ func TestObjectBasic(t *testing.T) {
 	}
 
 	// add the object
-	if err := db.UpdateObject(context.Background(), t.Name(), testContractSet, want2, make(map[types.PublicKey]types.FileContractID), api.DefaultBucketName); err != nil {
+	if err := db.UpdateObject(context.Background(), api.DefaultBucketName, t.Name(), testContractSet, want2, make(map[types.PublicKey]types.FileContractID)); err != nil {
 		t.Fatal(err)
 	}
 
 	// fetch the object
-	got2, err := db.Object(context.Background(), t.Name(), api.DefaultBucketName)
+	got2, err := db.Object(context.Background(), api.DefaultBucketName, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +433,7 @@ func TestContractRoots(t *testing.T) {
 	}
 
 	// add the object.
-	if err := cs.UpdateObject(context.Background(), t.Name(), testContractSet, obj, map[types.PublicKey]types.FileContractID{hks[0]: fcids[0]}, api.DefaultBucketName); err != nil {
+	if err := cs.UpdateObject(context.Background(), api.DefaultBucketName, t.Name(), testContractSet, obj, map[types.PublicKey]types.FileContractID{hks[0]: fcids[0]}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -545,10 +545,10 @@ func TestRenewedContract(t *testing.T) {
 	}
 
 	// add the object.
-	if err := cs.UpdateObject(context.Background(), "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
+	if err := cs.UpdateObject(context.Background(), api.DefaultBucketName, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk:  fcid1,
 		hk2: fcid2,
-	}, api.DefaultBucketName); err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -985,12 +985,12 @@ func TestSQLMetadataStore(t *testing.T) {
 	// Store it.
 	ctx := context.Background()
 	objID := "key1"
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, api.DefaultBucketName); err != nil {
+	if err := db.UpdateObject(ctx, api.DefaultBucketName, objID, testContractSet, obj1, usedHosts); err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to store it again. Should work.
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, api.DefaultBucketName); err != nil {
+	if err := db.UpdateObject(ctx, api.DefaultBucketName, objID, testContractSet, obj1, usedHosts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1046,7 +1046,7 @@ func TestSQLMetadataStore(t *testing.T) {
 	}
 
 	// Fetch it and verify again.
-	fullObj, err := db.Object(ctx, objID, api.DefaultBucketName)
+	fullObj, err := db.Object(ctx, api.DefaultBucketName, objID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1154,10 +1154,10 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	// Remove the first slab of the object.
 	obj1.Slabs = obj1.Slabs[1:]
-	if err := db.UpdateObject(ctx, objID, testContractSet, obj1, usedHosts, api.DefaultBucketName); err != nil {
+	if err := db.UpdateObject(ctx, api.DefaultBucketName, objID, testContractSet, obj1, usedHosts); err != nil {
 		t.Fatal(err)
 	}
-	fullObj, err = db.Object(ctx, objID, api.DefaultBucketName)
+	fullObj, err = db.Object(ctx, api.DefaultBucketName, objID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1202,7 +1202,7 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	// Delete the object. Due to the cascade this should delete everything
 	// but the sectors.
-	if err := db.RemoveObject(ctx, objID, api.DefaultBucketName); err != nil {
+	if err := db.RemoveObject(ctx, api.DefaultBucketName, objID); err != nil {
 		t.Fatal(err)
 	}
 	if err := countCheck(0, 0, 0, 0); err != nil {
@@ -1289,13 +1289,13 @@ func TestObjectHealth(t *testing.T) {
 		},
 	}
 
-	if err := db.UpdateObject(context.Background(), "/foo", testContractSet, add, map[types.PublicKey]types.FileContractID{
+	if err := db.UpdateObject(context.Background(), api.DefaultBucketName, "/foo", testContractSet, add, map[types.PublicKey]types.FileContractID{
 		hks[0]: fcids[0],
 		hks[1]: fcids[1],
 		hks[2]: fcids[2],
 		hks[3]: fcids[3],
 		hks[4]: fcids[4],
-	}, api.DefaultBucketName); err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1305,7 +1305,7 @@ func TestObjectHealth(t *testing.T) {
 	}
 
 	// assert health
-	obj, err := db.Object(context.Background(), "/foo", api.DefaultBucketName)
+	obj, err := db.Object(context.Background(), api.DefaultBucketName, "/foo")
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != 1 {
@@ -1322,7 +1322,7 @@ func TestObjectHealth(t *testing.T) {
 	expectedHealth := float64(2) / float64(3)
 
 	// assert health
-	obj, err = db.Object(context.Background(), "/foo", api.DefaultBucketName)
+	obj, err = db.Object(context.Background(), api.DefaultBucketName, "/foo")
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != expectedHealth {
@@ -1330,7 +1330,7 @@ func TestObjectHealth(t *testing.T) {
 	}
 
 	// assert health is returned correctly by ObjectEntries
-	entries, err := db.ObjectEntries(context.Background(), "/", "", 0, -1, api.DefaultBucketName)
+	entries, err := db.ObjectEntries(context.Background(), api.DefaultBucketName, "/", "", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
@@ -1340,7 +1340,7 @@ func TestObjectHealth(t *testing.T) {
 	}
 
 	// assert health is returned correctly by SearchObject
-	entries, err = db.SearchObjects(context.Background(), "foo", 0, -1, api.DefaultBucketName)
+	entries, err = db.SearchObjects(context.Background(), api.DefaultBucketName, "foo", 0, -1)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
@@ -1359,7 +1359,7 @@ func TestObjectHealth(t *testing.T) {
 	expectedHealth = float64(1) / float64(3)
 
 	// assert health is the min. health of the slabs
-	obj, err = db.Object(context.Background(), "/foo", api.DefaultBucketName)
+	obj, err = db.Object(context.Background(), api.DefaultBucketName, "/foo")
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != expectedHealth {
@@ -1375,12 +1375,12 @@ func TestObjectHealth(t *testing.T) {
 		Key:   object.GenerateEncryptionKey(),
 		Slabs: nil,
 	}
-	if err := db.UpdateObject(context.Background(), "/bar", testContractSet, add, nil, api.DefaultBucketName); err != nil {
+	if err := db.UpdateObject(context.Background(), api.DefaultBucketName, "/bar", testContractSet, add, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// assert the health is 1
-	obj, err = db.Object(context.Background(), "/bar", api.DefaultBucketName)
+	obj, err = db.Object(context.Background(), api.DefaultBucketName, "/bar")
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.Health != 1 {
@@ -1411,7 +1411,7 @@ func TestObjectEntries(t *testing.T) {
 		obj, ucs := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		err := os.UpdateObject(ctx, o.path, testContractSet, obj, ucs, api.DefaultBucketName)
+		err := os.UpdateObject(ctx, api.DefaultBucketName, o.path, testContractSet, obj, ucs)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1434,7 +1434,7 @@ func TestObjectEntries(t *testing.T) {
 		{"/gab/", "/guub", []api.ObjectMetadata{}},
 	}
 	for _, test := range tests {
-		got, err := os.ObjectEntries(ctx, test.path, test.prefix, 0, -1, api.DefaultBucketName)
+		got, err := os.ObjectEntries(ctx, api.DefaultBucketName, test.path, test.prefix, 0, -1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1442,7 +1442,7 @@ func TestObjectEntries(t *testing.T) {
 			t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want)
 		}
 		for offset := 0; offset < len(test.want); offset++ {
-			got, err := os.ObjectEntries(ctx, test.path, test.prefix, offset, 1, api.DefaultBucketName)
+			got, err := os.ObjectEntries(ctx, api.DefaultBucketName, test.path, test.prefix, offset, 1)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1475,7 +1475,9 @@ func TestSearchObjects(t *testing.T) {
 		obj, ucs := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		os.UpdateObject(ctx, o.path, testContractSet, obj, ucs, api.DefaultBucketName)
+		if err := os.UpdateObject(ctx, api.DefaultBucketName, o.path, testContractSet, obj, ucs); err != nil {
+			t.Fatal(err)
+		}
 	}
 	tests := []struct {
 		path string
@@ -1487,7 +1489,7 @@ func TestSearchObjects(t *testing.T) {
 		{"uu", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3, Health: 1}, {Name: "/foo/baz/quuz", Size: 4, Health: 1}, {Name: "/gab/guub", Size: 5, Health: 1}}},
 	}
 	for _, test := range tests {
-		got, err := os.SearchObjects(ctx, test.path, 0, -1, api.DefaultBucketName)
+		got, err := os.SearchObjects(ctx, api.DefaultBucketName, test.path, 0, -1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1495,7 +1497,7 @@ func TestSearchObjects(t *testing.T) {
 			t.Errorf("\nkey: %v\ngot: %v\nwant: %v", test.path, got, test.want)
 		}
 		for offset := 0; offset < len(test.want); offset++ {
-			got, err := os.SearchObjects(ctx, test.path, offset, 1, api.DefaultBucketName)
+			got, err := os.SearchObjects(ctx, api.DefaultBucketName, test.path, offset, 1)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1668,13 +1670,13 @@ func TestUnhealthySlabs(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
+	if err := db.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
 		hk3: fcid3,
 		hk4: fcid4,
 		{5}: {5}, // deleted host and contract
-	}, api.DefaultBucketName); err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1782,7 +1784,7 @@ func TestUnhealthySlabsNegHealth(t *testing.T) {
 
 	// add the object
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}, api.DefaultBucketName); err != nil {
+	if err := db.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1846,7 +1848,7 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 
 	// add the object
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}, api.DefaultBucketName); err != nil {
+	if err := db.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{hk1: fcid1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1951,11 +1953,11 @@ func TestUnhealthySlabsNoRedundancy(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
+	if err := db.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
 		hk3: fcid3,
-	}, api.DefaultBucketName); err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2024,7 +2026,7 @@ func TestContractSectors(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts, api.DefaultBucketName); err != nil {
+	if err := db.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, obj, usedContracts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2050,12 +2052,12 @@ func TestContractSectors(t *testing.T) {
 	}
 
 	// Add the object again.
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, usedContracts, api.DefaultBucketName); err != nil {
+	if err := db.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, obj, usedContracts); err != nil {
 		t.Fatal(err)
 	}
 
 	// Delete the object.
-	if err := db.RemoveObject(ctx, "foo", api.DefaultBucketName); err != nil {
+	if err := db.RemoveObject(ctx, api.DefaultBucketName, "foo"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2115,10 +2117,10 @@ func TestPutSlab(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	if err := db.UpdateObject(ctx, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
+	if err := db.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, obj, map[types.PublicKey]types.FileContractID{
 		hk1: fcid1,
 		hk2: fcid2,
-	}, api.DefaultBucketName); err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2380,34 +2382,36 @@ func TestRenameObjects(t *testing.T) {
 	ctx := context.Background()
 	for _, path := range objects {
 		obj, ucs := newTestObject(1)
-		cs.UpdateObject(ctx, path, testContractSet, obj, ucs, api.DefaultBucketName)
+		if err := cs.UpdateObject(ctx, api.DefaultBucketName, path, testContractSet, obj, ucs); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// Try renaming objects that don't exist.
-	if err := cs.RenameObject(ctx, "/fileś", "/fileś2", api.DefaultBucketName); !errors.Is(err, api.ErrObjectNotFound) {
+	if err := cs.RenameObject(ctx, api.DefaultBucketName, "/fileś", "/fileś2"); !errors.Is(err, api.ErrObjectNotFound) {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObjects(ctx, "/fileś1", "/fileś2", api.DefaultBucketName); !errors.Is(err, api.ErrObjectNotFound) {
+	if err := cs.RenameObjects(ctx, api.DefaultBucketName, "/fileś1", "/fileś2"); !errors.Is(err, api.ErrObjectNotFound) {
 		t.Fatal(err)
 	}
 
 	// Perform some renames.
-	if err := cs.RenameObjects(ctx, "/fileś/dir/", "/fileś/", api.DefaultBucketName); err != nil {
+	if err := cs.RenameObjects(ctx, api.DefaultBucketName, "/fileś/dir/", "/fileś/"); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObject(ctx, "/foo", "/fileś/foo", api.DefaultBucketName); err != nil {
+	if err := cs.RenameObject(ctx, api.DefaultBucketName, "/foo", "/fileś/foo"); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObject(ctx, "/bar", "/fileś/bar", api.DefaultBucketName); err != nil {
+	if err := cs.RenameObject(ctx, api.DefaultBucketName, "/bar", "/fileś/bar"); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObject(ctx, "/baz", "/fileś/baz", api.DefaultBucketName); err != nil {
+	if err := cs.RenameObject(ctx, api.DefaultBucketName, "/baz", "/fileś/baz"); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObjects(ctx, "/fileś/case", "/fileś/case1", api.DefaultBucketName); err != nil {
+	if err := cs.RenameObjects(ctx, api.DefaultBucketName, "/fileś/case", "/fileś/case1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := cs.RenameObjects(ctx, "/fileś/CASE", "/fileś/case2", api.DefaultBucketName); err != nil {
+	if err := cs.RenameObjects(ctx, api.DefaultBucketName, "/fileś/CASE", "/fileś/case2"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2431,7 +2435,7 @@ func TestRenameObjects(t *testing.T) {
 	}
 
 	// Assert that number of objects matches.
-	objs, err := cs.SearchObjects(ctx, "/", 0, 100, api.DefaultBucketName)
+	objs, err := cs.SearchObjects(ctx, api.DefaultBucketName, "/", 0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2484,7 +2488,7 @@ func TestObjectsStats(t *testing.T) {
 		}
 
 		key := hex.EncodeToString(frand.Bytes(32))
-		err := cs.UpdateObject(context.Background(), key, testContractSet, obj, contracts, api.DefaultBucketName)
+		err := cs.UpdateObject(context.Background(), api.DefaultBucketName, key, testContractSet, obj, contracts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2665,11 +2669,11 @@ func TestPartialSlab(t *testing.T) {
 		}
 	}
 	obj := testObject(slabs)
-	err = db.UpdateObject(context.Background(), "key", testContractSet, obj, usedContracts, api.DefaultBucketName)
+	err = db.UpdateObject(context.Background(), api.DefaultBucketName, "key", testContractSet, obj, usedContracts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fetched, err := db.Object(context.Background(), "key", api.DefaultBucketName)
+	fetched, err := db.Object(context.Background(), api.DefaultBucketName, "key")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2702,11 +2706,11 @@ func TestPartialSlab(t *testing.T) {
 
 	// Create an object again.
 	obj2 := testObject(slabs)
-	err = db.UpdateObject(context.Background(), "key2", testContractSet, obj2, usedContracts, api.DefaultBucketName)
+	err = db.UpdateObject(context.Background(), api.DefaultBucketName, "key2", testContractSet, obj2, usedContracts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fetched, err = db.Object(context.Background(), "key2", api.DefaultBucketName)
+	fetched, err = db.Object(context.Background(), api.DefaultBucketName, "key2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2749,11 +2753,11 @@ func TestPartialSlab(t *testing.T) {
 
 	// Create an object again.
 	obj3 := testObject(slabs)
-	err = db.UpdateObject(context.Background(), "key3", testContractSet, obj3, usedContracts, api.DefaultBucketName)
+	err = db.UpdateObject(context.Background(), api.DefaultBucketName, "key3", testContractSet, obj3, usedContracts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fetched, err = db.Object(context.Background(), "key3", api.DefaultBucketName)
+	fetched, err = db.Object(context.Background(), api.DefaultBucketName, "key3")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2913,7 +2917,7 @@ func TestContractSizes(t *testing.T) {
 
 	// add an object to both contracts
 	for i := 0; i < 2; i++ {
-		if err := db.UpdateObject(context.Background(), fmt.Sprintf("obj_%d", i+1), testContractSet, object.Object{
+		if err := db.UpdateObject(context.Background(), api.DefaultBucketName, fmt.Sprintf("obj_%d", i+1), testContractSet, object.Object{
 			Key: object.GenerateEncryptionKey(),
 			Slabs: []object.SlabSlice{
 				{
@@ -2931,7 +2935,7 @@ func TestContractSizes(t *testing.T) {
 			},
 		}, map[types.PublicKey]types.FileContractID{
 			hks[i]: fcids[i],
-		}, api.DefaultBucketName); err != nil {
+		}); err != nil {
 			t.Fatal(err)
 		}
 		if err := db.RecordContractSpending(context.Background(), []api.ContractSpendingRecord{
@@ -2960,7 +2964,7 @@ func TestContractSizes(t *testing.T) {
 	}
 
 	// remove the first object
-	if err := db.RemoveObject(context.Background(), "obj_1", api.DefaultBucketName); err != nil {
+	if err := db.RemoveObject(context.Background(), api.DefaultBucketName, "obj_1"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2973,7 +2977,7 @@ func TestContractSizes(t *testing.T) {
 	}
 
 	// remove the second object
-	if err := db.RemoveObject(context.Background(), "obj_2", api.DefaultBucketName); err != nil {
+	if err := db.RemoveObject(context.Background(), api.DefaultBucketName, "obj_2"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3088,14 +3092,14 @@ func TestObjectsBySlabKey(t *testing.T) {
 	}
 	for _, name := range []string{"obj1", "obj2", "obj3"} {
 		obj.Slabs[0].Length++
-		err = db.UpdateObject(context.Background(), name, testContractSet, obj, usedContracts, api.DefaultBucketName)
+		err = db.UpdateObject(context.Background(), api.DefaultBucketName, name, testContractSet, obj, usedContracts)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// Fetch the objects by slab.
-	objs, err := db.ObjectsBySlabKey(context.Background(), slab.Key, api.DefaultBucketName)
+	objs, err := db.ObjectsBySlabKey(context.Background(), api.DefaultBucketName, slab.Key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3164,7 +3168,7 @@ func TestBucketObjects(t *testing.T) {
 
 	// Adding an object to a bucket that doesn't exist shouldn't work.
 	obj, ucs := newTestObject(1)
-	err = os.UpdateObject(context.Background(), "foo", testContractSet, obj, ucs, "unknown-bucket")
+	err = os.UpdateObject(context.Background(), "unknown-bucket", "foo", testContractSet, obj, ucs)
 	if !errors.Is(err, api.ErrBucketNotFound) {
 		t.Fatal("expected ErrBucketNotFound", err)
 	}
@@ -3174,6 +3178,8 @@ func TestBucketObjects(t *testing.T) {
 	if err := os.CreateBucket(context.Background(), b1); err != nil {
 		t.Fatal(err)
 	} else if err := os.CreateBucket(context.Background(), b2); err != nil {
+		t.Fatal(err)
+	} else if err := os.CreateBucket(context.Background(), b2); !errors.Is(err, api.ErrBucketExists) {
 		t.Fatal(err)
 	}
 
@@ -3193,10 +3199,15 @@ func TestBucketObjects(t *testing.T) {
 		obj, ucs := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		err := os.UpdateObject(ctx, o.path, testContractSet, obj, ucs, o.bucket)
+		err := os.UpdateObject(ctx, o.bucket, o.path, testContractSet, obj, ucs)
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+
+	var boing []dbObject
+	if err := os.db.Find(&boing).Error; err != nil {
+		t.Fatal(err)
 	}
 	// Deleting a bucket with objects shouldn't work.
 	if err := os.DeleteBucket(ctx, b1); !errors.Is(err, api.ErrBucketNotEmpty) {
@@ -3204,13 +3215,13 @@ func TestBucketObjects(t *testing.T) {
 	}
 
 	// List the objects in the buckets.
-	if entries, err := os.ObjectEntries(context.Background(), "/foo/", "", 0, -1, b1); err != nil {
+	if entries, err := os.ObjectEntries(context.Background(), b1, "/foo/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
 		t.Fatal("expected 1 entry", len(entries))
 	} else if entries[0].Size != 1 {
 		t.Fatal("unexpected size", entries[0].Size)
-	} else if entries, err := os.ObjectEntries(context.Background(), "/foo/", "", 0, -1, b2); err != nil {
+	} else if entries, err := os.ObjectEntries(context.Background(), b2, "/foo/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
 		t.Fatal("expected 1 entry", len(entries))
@@ -3219,13 +3230,13 @@ func TestBucketObjects(t *testing.T) {
 	}
 
 	// Search the objects in the buckets.
-	if objects, err := os.SearchObjects(context.Background(), "", 0, -1, b1); err != nil {
+	if objects, err := os.SearchObjects(context.Background(), b1, "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(objects) != 2 {
 		t.Fatal("expected 2 objects", len(objects))
 	} else if objects[0].Size != 3 || objects[1].Size != 1 {
 		t.Fatal("unexpected size", objects[0].Size, objects[1].Size)
-	} else if objects, err := os.SearchObjects(context.Background(), "", 0, -1, b2); err != nil {
+	} else if objects, err := os.SearchObjects(context.Background(), b2, "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(objects) != 2 {
 		t.Fatal("expected 2 objects", len(objects))
@@ -3236,13 +3247,13 @@ func TestBucketObjects(t *testing.T) {
 	// Rename object foo/bar in bucket 1 to foo/baz but not in bucket 2.
 	if err := os.RenameObject(context.Background(), "/foo/bar", "/foo/baz", b1); err != nil {
 		t.Fatal(err)
-	} else if entries, err := os.ObjectEntries(context.Background(), "/foo/", "", 0, -1, b1); err != nil {
+	} else if entries, err := os.ObjectEntries(context.Background(), b1, "/foo/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
 		t.Fatal("expected 2 entries", len(entries))
 	} else if entries[0].Name != "/foo/baz" {
 		t.Fatal("unexpected name", entries[0].Name)
-	} else if entries, err := os.ObjectEntries(context.Background(), "/foo/", "", 0, -1, b2); err != nil {
+	} else if entries, err := os.ObjectEntries(context.Background(), b2, "/foo/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
 		t.Fatal("expected 2 entries", len(entries))
@@ -3253,13 +3264,13 @@ func TestBucketObjects(t *testing.T) {
 	// Rename foo/bar in bucket 2 using the batch rename.
 	if err := os.RenameObjects(context.Background(), "/foo/bar", "/foo/bam", b2); err != nil {
 		t.Fatal(err)
-	} else if entries, err := os.ObjectEntries(context.Background(), "/foo/", "", 0, -1, b1); err != nil {
+	} else if entries, err := os.ObjectEntries(context.Background(), b1, "/foo/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
 		t.Fatal("expected 2 entries", len(entries))
 	} else if entries[0].Name != "/foo/baz" {
 		t.Fatal("unexpected name", entries[0].Name)
-	} else if entries, err := os.ObjectEntries(context.Background(), "/foo/", "", 0, -1, b2); err != nil {
+	} else if entries, err := os.ObjectEntries(context.Background(), b2, "/foo/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
 		t.Fatal("expected 2 entries", len(entries))
@@ -3272,28 +3283,28 @@ func TestBucketObjects(t *testing.T) {
 		t.Fatal(err)
 	} else if err := os.RemoveObject(context.Background(), "/foo/baz", b1); err != nil {
 		t.Fatal(err)
-	} else if entries, err := os.ObjectEntries(context.Background(), "/foo/", "", 0, -1, b1); err != nil {
+	} else if entries, err := os.ObjectEntries(context.Background(), b1, "/foo/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) > 0 {
 		t.Fatal("expected 0 entries", len(entries))
-	} else if entries, err := os.ObjectEntries(context.Background(), "/foo/", "", 0, -1, b2); err != nil {
+	} else if entries, err := os.ObjectEntries(context.Background(), b2, "/foo/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
 		t.Fatal("expected 1 entry", len(entries))
 	}
 
 	// Delete all files in bucket 2.
-	if entries, err := os.ObjectEntries(context.Background(), "/", "", 0, -1, b2); err != nil {
+	if entries, err := os.ObjectEntries(context.Background(), b2, "/", "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 2 {
 		t.Fatal("expected 2 entries", len(entries))
 	} else if err := os.RemoveObjects(context.Background(), "/", b2); err != nil {
 		t.Fatal(err)
-	} else if entries, err := os.ObjectEntries(context.Background(), "/", "", 0, -1, b2); err != nil {
+	} else if entries, err := os.ObjectEntries(context.Background(), "/", b2, "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 0 {
 		t.Fatal("expected 0 entries", len(entries))
-	} else if entries, err := os.ObjectEntries(context.Background(), "/", "", 0, -1, b1); err != nil {
+	} else if entries, err := os.ObjectEntries(context.Background(), "/", b1, "", 0, -1); err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
 		t.Fatal("expected 1 entry", len(entries))
@@ -3314,11 +3325,11 @@ func TestBucketObjects(t *testing.T) {
 		t.Fatal(err)
 	} else if err := ec.UnmarshalText(obj[0].SlabKey); err != nil {
 		t.Fatal(err)
-	} else if objects, err := os.ObjectsBySlabKey(context.Background(), ec, b1); err != nil {
+	} else if objects, err := os.ObjectsBySlabKey(context.Background(), b1, ec); err != nil {
 		t.Fatal(err)
 	} else if len(objects) != 1 {
 		t.Fatal("expected 1 object", len(objects))
-	} else if objects, err := os.ObjectsBySlabKey(context.Background(), ec, b2); err != nil {
+	} else if objects, err := os.ObjectsBySlabKey(context.Background(), b2, ec); err != nil {
 		t.Fatal(err)
 	} else if len(objects) != 0 {
 		t.Fatal("expected 0 objects", len(objects))

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1022,9 +1022,10 @@ func TestSQLMetadataStore(t *testing.T) {
 	}
 
 	expectedObj := dbObject{
-		ObjectID: objID,
-		Key:      obj1Key,
-		Size:     obj1.TotalSize(),
+		DBBucketID: 1,
+		ObjectID:   objID,
+		Key:        obj1Key,
+		Size:       obj1.TotalSize(),
 		Slabs: []dbSlice{
 			{
 				DBObjectID: 1,

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1329,7 +1329,7 @@ func TestObjectHealth(t *testing.T) {
 	}
 
 	// assert health is returned correctly by ObjectEntries
-	entries, err := db.ObjectEntries(context.Background(), "/", "", 0, -1)
+	entries, err := db.ObjectEntries(context.Background(), "/", "", 0, -1, nil)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
@@ -1339,7 +1339,7 @@ func TestObjectHealth(t *testing.T) {
 	}
 
 	// assert health is returned correctly by SearchObject
-	entries, err = db.SearchObjects(context.Background(), "foo", 0, -1)
+	entries, err = db.SearchObjects(context.Background(), "foo", 0, -1, nil)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(entries) != 1 {
@@ -1410,7 +1410,10 @@ func TestObjectEntries(t *testing.T) {
 		obj, ucs := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		os.UpdateObject(ctx, o.path, testContractSet, obj, ucs)
+		err := os.UpdateObject(ctx, o.path, testContractSet, obj, ucs)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	tests := []struct {
 		path   string
@@ -1430,7 +1433,7 @@ func TestObjectEntries(t *testing.T) {
 		{"/gab/", "/guub", []api.ObjectMetadata{}},
 	}
 	for _, test := range tests {
-		got, err := os.ObjectEntries(ctx, test.path, test.prefix, 0, -1)
+		got, err := os.ObjectEntries(ctx, test.path, test.prefix, 0, -1, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1438,7 +1441,7 @@ func TestObjectEntries(t *testing.T) {
 			t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want)
 		}
 		for offset := 0; offset < len(test.want); offset++ {
-			got, err := os.ObjectEntries(ctx, test.path, test.prefix, offset, 1)
+			got, err := os.ObjectEntries(ctx, test.path, test.prefix, offset, 1, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1483,7 +1486,7 @@ func TestSearchObjects(t *testing.T) {
 		{"uu", []api.ObjectMetadata{{Name: "/foo/baz/quux", Size: 3, Health: 1}, {Name: "/foo/baz/quuz", Size: 4, Health: 1}, {Name: "/gab/guub", Size: 5, Health: 1}}},
 	}
 	for _, test := range tests {
-		got, err := os.SearchObjects(ctx, test.path, 0, -1)
+		got, err := os.SearchObjects(ctx, test.path, 0, -1, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1491,7 +1494,7 @@ func TestSearchObjects(t *testing.T) {
 			t.Errorf("\nkey: %v\ngot: %v\nwant: %v", test.path, got, test.want)
 		}
 		for offset := 0; offset < len(test.want); offset++ {
-			got, err := os.SearchObjects(ctx, test.path, offset, 1)
+			got, err := os.SearchObjects(ctx, test.path, offset, 1, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2427,7 +2430,7 @@ func TestRenameObjects(t *testing.T) {
 	}
 
 	// Assert that number of objects matches.
-	objs, err := cs.SearchObjects(ctx, "/", 0, 100)
+	objs, err := cs.SearchObjects(ctx, "/", 0, 100, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -16,6 +16,7 @@ var (
 		&dbContract{},
 		&dbContractSet{},
 		&dbObject{},
+		&dbBucket{},
 		&dbBufferedSlab{},
 		&dbSlab{},
 		&dbSector{},
@@ -247,9 +248,17 @@ func initSchema(tx *gorm.DB) error {
 	if err != nil {
 		return fmt.Errorf("failed to init schema: %w", err)
 	}
-	// Change the object_id colum to use case sensitive collation.
+
+	// Change the collation of columns that we need to be case sensitive.
 	if !isSQLite(tx) {
-		return tx.Exec("ALTER TABLE objects MODIFY COLUMN object_id VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;").Error
+		err = tx.Exec("ALTER TABLE objects MODIFY COLUMN object_id VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;").Error
+		if err != nil {
+			return fmt.Errorf("failed to change object_id collation: %w", err)
+		}
+		err = tx.Exec("ALTER TABLE buckets MODIFY COLUMN name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;").Error
+		if err != nil {
+			return fmt.Errorf("failed to change buckets_name collation: %w", err)
+		}
 	}
 	return nil
 }

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -216,6 +216,12 @@ func performMigrations(db *gorm.DB, logger *zap.SugaredLogger) error {
 				return performMigration00013_uploadPackingOptimisations(tx, logger)
 			},
 		},
+		{
+			ID: "00014_buckets",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration00014_buckets(tx, logger)
+			},
+		},
 	}
 	// Create migrator.
 	m := gormigrate.New(db, gormigrate.DefaultOptions, migrations)
@@ -451,30 +457,30 @@ func performMigration00002_dropconstraintslabcsid(txn *gorm.DB, logger *zap.Suga
 }
 
 func performMigration00003_healthcache(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info(context.Background(), "performing migration 00003_healthcache")
+	logger.Info("performing migration 00003_healthcache")
 	if !txn.Migrator().HasColumn(&dbSlab{}, "health") {
 		if err := txn.Migrator().AddColumn(&dbSlab{}, "health"); err != nil {
 			return err
 		}
 	}
-	logger.Info(context.Background(), "migration 00003_healthcheck complete")
+	logger.Info("migration 00003_healthcheck complete")
 	return nil
 }
 
 func performMigration00004_objectID_collation(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info(context.Background(), "performing migration 00004_objectID_collation")
+	logger.Info("performing migration 00004_objectID_collation")
 	if !isSQLite(txn) {
 		err := txn.Exec("ALTER TABLE objects MODIFY COLUMN object_id VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;").Error
 		if err != nil {
 			return err
 		}
 	}
-	logger.Info(context.Background(), "migration 00004_objectID_collation complete")
+	logger.Info("migration 00004_objectID_collation complete")
 	return nil
 }
 
 func performMigration00005_uploadPacking(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info(context.Background(), "performing migration performMigration00005_uploadPacking")
+	logger.Info("performing migration performMigration00005_uploadPacking")
 	m := txn.Migrator()
 
 	// Disable foreign keys in SQLite to avoid issues with updating constraints.
@@ -527,12 +533,12 @@ func performMigration00005_uploadPacking(txn *gorm.DB, logger *zap.SugaredLogger
 			return err
 		}
 	}
-	logger.Info(context.Background(), "migration performMigration00005_uploadPacking complete")
+	logger.Info("migration performMigration00005_uploadPacking complete")
 	return nil
 }
 
 func performMigration00006_contractspending(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info(context.Background(), "performing migration 00006_contractspending")
+	logger.Info("performing migration 00006_contractspending")
 	if !txn.Migrator().HasColumn(&dbContract{}, "delete_spending") {
 		if err := txn.Migrator().AddColumn(&dbContract{}, "delete_spending"); err != nil {
 			return err
@@ -543,12 +549,12 @@ func performMigration00006_contractspending(txn *gorm.DB, logger *zap.SugaredLog
 			return err
 		}
 	}
-	logger.Info(context.Background(), "migration 00006_contractspending complete")
+	logger.Info("migration 00006_contractspending complete")
 	return nil
 }
 
 func performMigration00007_archivedcontractspending(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info(context.Background(), "performing migration 00007_archivedcontractspending")
+	logger.Info("performing migration 00007_archivedcontractspending")
 	if !txn.Migrator().HasColumn(&dbArchivedContract{}, "delete_spending") {
 		if err := txn.Migrator().AddColumn(&dbArchivedContract{}, "delete_spending"); err != nil {
 			return err
@@ -559,12 +565,12 @@ func performMigration00007_archivedcontractspending(txn *gorm.DB, logger *zap.Su
 			return err
 		}
 	}
-	logger.Info(context.Background(), "migration 00007_archivedcontractspending complete")
+	logger.Info("migration 00007_archivedcontractspending complete")
 	return nil
 }
 
 func performMigration00008_jointableindices(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info(context.Background(), "performing migration 00008_jointableindices")
+	logger.Info("performing migration 00008_jointableindices")
 
 	indices := []struct {
 		joinTable interface{ TableName() string }
@@ -597,23 +603,23 @@ func performMigration00008_jointableindices(txn *gorm.DB, logger *zap.SugaredLog
 		}
 	}
 
-	logger.Info(context.Background(), "migration 00008_jointableindices complete")
+	logger.Info("migration 00008_jointableindices complete")
 	return nil
 }
 
 func performMigration00009_dropInteractions(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info(context.Background(), "performing migration 00009_dropInteractions")
+	logger.Info("performing migration 00009_dropInteractions")
 	if !txn.Migrator().HasTable("host_interactions") {
 		if err := txn.Migrator().DropTable("host_interactions"); err != nil {
 			return err
 		}
 	}
-	logger.Info(context.Background(), "migration 00009_dropInteractions complete")
+	logger.Info("migration 00009_dropInteractions complete")
 	return nil
 }
 
 func performMigration00010_distinctcontractsector(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info(context.Background(), "performing migration 00010_distinctcontractsector")
+	logger.Info("performing migration 00010_distinctcontractsector")
 
 	if !txn.Migrator().HasIndex(&dbContractSector{}, "DBSectorID") {
 		if err := txn.Migrator().CreateIndex(&dbContractSector{}, "DBSectorID"); err != nil {
@@ -621,34 +627,34 @@ func performMigration00010_distinctcontractsector(txn *gorm.DB, logger *zap.Suga
 		}
 	}
 
-	logger.Info(context.Background(), "migration 00010_distinctcontractsector complete")
+	logger.Info("migration 00010_distinctcontractsector complete")
 	return nil
 }
 
 func performMigration00011_healthValidColumn(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info(context.Background(), "performing migration 00011_healthValidColumn")
+	logger.Info("performing migration 00011_healthValidColumn")
 	if !txn.Migrator().HasColumn(&dbSlab{}, "health_valid") {
 		if err := txn.Migrator().AddColumn(&dbSlab{}, "health_valid"); err != nil {
 			return err
 		}
 	}
-	logger.Info(context.Background(), "migration 00011_healthValidColumn complete")
+	logger.Info("migration 00011_healthValidColumn complete")
 	return nil
 }
 
 func performMigration00012_webhooks(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info(context.Background(), "performing migration 00012_webhooks")
+	logger.Info("performing migration 00012_webhooks")
 	if !txn.Migrator().HasTable(&dbWebhook{}) {
 		if err := txn.Migrator().CreateTable(&dbWebhook{}); err != nil {
 			return err
 		}
 	}
-	logger.Info(context.Background(), "migration 00012_webhooks complete")
+	logger.Info("migration 00012_webhooks complete")
 	return nil
 }
 
 func performMigration00013_uploadPackingOptimisations(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info(context.Background(), "performing migration 00013_uploadPackingOptimisations")
+	logger.Info("performing migration 00013_uploadPackingOptimisations")
 	if txn.Migrator().HasColumn(&dbBufferedSlab{}, "lock_id") {
 		if err := txn.Migrator().DropColumn(&dbBufferedSlab{}, "lock_id"); err != nil {
 			return err
@@ -659,6 +665,71 @@ func performMigration00013_uploadPackingOptimisations(txn *gorm.DB, logger *zap.
 			return err
 		}
 	}
-	logger.Info(context.Background(), "migration 00013_uploadPackingOptimisations complete")
+	logger.Info("migration 00013_uploadPackingOptimisations complete")
+	return nil
+}
+
+func performMigration00014_buckets(txn *gorm.DB, logger *zap.SugaredLogger) error {
+	logger.Info("performing migration 00014_buckets")
+	// Disable foreign keys in SQLite to avoid issues with updating constraints.
+	if isSQLite(txn) {
+		if err := txn.Exec(`PRAGMA foreign_keys = 0`).Error; err != nil {
+			return err
+		}
+	}
+
+	// Create buckets table
+	if !txn.Migrator().HasTable(&dbBucket{}) {
+		if err := txn.Migrator().CreateTable(&dbBucket{}); err != nil {
+			return err
+		}
+	}
+
+	// Add default bucket.
+	bucket := &dbBucket{
+		Name: api.DefaultBucketName,
+	}
+	if err := txn.FirstOrCreate(&bucket).Error; err != nil {
+		return err
+	}
+
+	// Add bucket id column to objects table.
+	if !txn.Migrator().HasColumn(&dbObject{}, "db_bucket_id") {
+		if err := txn.Migrator().AddColumn(&dbObject{}, "db_bucket_id"); err != nil {
+			return err
+		}
+	}
+
+	// Create missing composite index.
+	if !txn.Migrator().HasIndex(&dbObject{}, "idx_object_bucket") {
+		if err := txn.Migrator().CreateIndex(&dbObject{}, "idx_object_bucket"); err != nil {
+			return err
+		}
+	}
+
+	// Update objects to belong to default bucket
+	if err := txn.Model(&dbObject{}).
+		Where("db_bucket_id", 0).
+		Update("db_bucket_id", bucket.ID).Error; err != nil {
+		return err
+	}
+
+	// Add foreign key constraint between dbObject's db_bucket_id and dbBucket's id.
+	if !txn.Migrator().HasConstraint(&dbObject{}, "DBBucket") {
+		if err := txn.Migrator().CreateConstraint(&dbObject{}, "DBBucket"); err != nil {
+			return err
+		}
+	}
+
+	// Enable foreign keys again.
+	if isSQLite(txn) {
+		if err := txn.Exec(`PRAGMA foreign_keys = 1`).Error; err != nil {
+			return err
+		}
+		if err := txn.Exec(`PRAGMA foreign_key_check(slabs)`).Error; err != nil {
+			return err
+		}
+	}
+	logger.Info("migration 00014_buckets complete")
 	return nil
 }

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-gormigrate/gormigrate/v2"
+	"go.sia.tech/renterd/api"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
@@ -260,7 +261,11 @@ func initSchema(tx *gorm.DB) error {
 			return fmt.Errorf("failed to change buckets_name collation: %w", err)
 		}
 	}
-	return nil
+
+	// Add default bucket.
+	return tx.Create(&dbBucket{
+		Name: api.DefaultBucketName,
+	}).Error
 }
 
 func setupJoinTables(tx *gorm.DB) error {

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -683,6 +683,10 @@ func performMigration00014_buckets(txn *gorm.DB, logger *zap.SugaredLogger) erro
 		if err := txn.Migrator().CreateTable(&dbBucket{}); err != nil {
 			return err
 		}
+		err := txn.Exec("ALTER TABLE buckets MODIFY COLUMN name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;").Error
+		if err != nil {
+			return fmt.Errorf("failed to change buckets_name collation: %w", err)
+		}
 	}
 
 	// Add default bucket.
@@ -726,7 +730,7 @@ func performMigration00014_buckets(txn *gorm.DB, logger *zap.SugaredLogger) erro
 		if err := txn.Exec(`PRAGMA foreign_keys = 1`).Error; err != nil {
 			return err
 		}
-		if err := txn.Exec(`PRAGMA foreign_key_check(slabs)`).Error; err != nil {
+		if err := txn.Exec(`PRAGMA foreign_key_check(objects)`).Error; err != nil {
 			return err
 		}
 	}

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -413,6 +413,9 @@ func (s *SQLStore) retryTransaction(fc func(tx *gorm.DB) error, opts ...*sql.TxO
 			errors.Is(err, gorm.ErrRecordNotFound) ||
 			errors.Is(err, api.ErrObjectNotFound) ||
 			errors.Is(err, api.ErrObjectCorrupted) ||
+			errors.Is(err, api.ErrBucketExists) ||
+			errors.Is(err, api.ErrBucketNotFound) ||
+			errors.Is(err, api.ErrBucketNotEmpty) ||
 			errors.Is(err, api.ErrContractNotFound) {
 			return true
 		}

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -425,7 +425,7 @@ func (s *SQLStore) retryTransaction(fc func(tx *gorm.DB) error, opts ...*sql.TxO
 		if abortRetry(err) {
 			return err
 		}
-		s.logger.Warn(context.Background(), fmt.Sprintf("transaction attempt %d/%d failed, retry in %v,  err: %v", i+1, len(timeoutIntervals), timeoutIntervals[i], err))
+		s.logger.Warn(fmt.Sprintf("transaction attempt %d/%d failed, retry in %v,  err: %v", i+1, len(timeoutIntervals), timeoutIntervals[i], err))
 		time.Sleep(timeoutIntervals[i])
 	}
 	return fmt.Errorf("retryTransaction failed: %w", err)

--- a/worker/client.go
+++ b/worker/client.go
@@ -251,7 +251,7 @@ func (c *Client) DownloadObject(ctx context.Context, w io.Writer, path string, o
 	}
 
 	path = strings.TrimPrefix(path, "/")
-	err = c.object(ctx, path, api.DefaultBucketName, "", 0, -1, w, nil, opts...)
+	err = c.object(ctx, api.DefaultBucketName, path, "", 0, -1, w, nil, opts...)
 	return
 }
 

--- a/worker/client.go
+++ b/worker/client.go
@@ -201,7 +201,7 @@ func (c *Client) UploadObject(ctx context.Context, r io.Reader, path string, opt
 	return
 }
 
-func (c *Client) object(ctx context.Context, path, bucket, prefix string, offset, limit int, w io.Writer, entries *[]api.ObjectMetadata, opts ...api.DownloadObjectOption) (err error) {
+func (c *Client) object(ctx context.Context, bucket, path, prefix string, offset, limit int, w io.Writer, entries *[]api.ObjectMetadata, opts ...api.DownloadObjectOption) (err error) {
 	values := url.Values{}
 	values.Set("bucket", url.QueryEscape(bucket))
 	values.Set("prefix", url.QueryEscape(prefix))
@@ -237,9 +237,9 @@ func (c *Client) object(ctx context.Context, path, bucket, prefix string, offset
 }
 
 // ObjectEntries returns the entries at the given path, which must end in /.
-func (c *Client) ObjectEntries(ctx context.Context, path, bucket, prefix string, offset, limit int) (entries []api.ObjectMetadata, err error) {
+func (c *Client) ObjectEntries(ctx context.Context, bucket, path, prefix string, offset, limit int) (entries []api.ObjectMetadata, err error) {
 	path = strings.TrimPrefix(path, "/")
-	err = c.object(ctx, path, bucket, prefix, offset, limit, nil, &entries)
+	err = c.object(ctx, bucket, path, prefix, offset, limit, nil, &entries)
 	return
 }
 

--- a/worker/client.go
+++ b/worker/client.go
@@ -201,8 +201,9 @@ func (c *Client) UploadObject(ctx context.Context, r io.Reader, path string, opt
 	return
 }
 
-func (c *Client) object(ctx context.Context, path, prefix string, offset, limit int, w io.Writer, entries *[]api.ObjectMetadata, opts ...api.DownloadObjectOption) (err error) {
+func (c *Client) object(ctx context.Context, path, bucket, prefix string, offset, limit int, w io.Writer, entries *[]api.ObjectMetadata, opts ...api.DownloadObjectOption) (err error) {
 	values := url.Values{}
+	values.Set("bucket", url.QueryEscape(bucket))
 	values.Set("prefix", url.QueryEscape(prefix))
 	values.Set("offset", fmt.Sprint(offset))
 	values.Set("limit", fmt.Sprint(limit))
@@ -236,9 +237,9 @@ func (c *Client) object(ctx context.Context, path, prefix string, offset, limit 
 }
 
 // ObjectEntries returns the entries at the given path, which must end in /.
-func (c *Client) ObjectEntries(ctx context.Context, path, prefix string, offset, limit int) (entries []api.ObjectMetadata, err error) {
+func (c *Client) ObjectEntries(ctx context.Context, path, bucket, prefix string, offset, limit int) (entries []api.ObjectMetadata, err error) {
 	path = strings.TrimPrefix(path, "/")
-	err = c.object(ctx, path, prefix, offset, limit, nil, &entries)
+	err = c.object(ctx, path, bucket, prefix, offset, limit, nil, &entries)
 	return
 }
 
@@ -250,7 +251,7 @@ func (c *Client) DownloadObject(ctx context.Context, w io.Writer, path string, o
 	}
 
 	path = strings.TrimPrefix(path, "/")
-	err = c.object(ctx, path, "", 0, -1, w, nil, opts...)
+	err = c.object(ctx, path, api.DefaultBucketName, "", 0, -1, w, nil, opts...)
 	return
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -925,7 +925,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 	if jc.DecodeForm("prefix", &prefix) != nil {
 		return
 	}
-	var bucket string
+	bucket := api.DefaultBucketName
 	if jc.DecodeForm("bucket", &bucket) != nil {
 		return
 	}
@@ -1019,7 +1019,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	}
 
 	// decode the bucket from the query string
-	var bucket string
+	bucket := api.DefaultBucketName
 	if jc.DecodeForm("bucket", &bucket) != nil {
 		return
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -157,8 +157,8 @@ type Bus interface {
 	UploadParams(ctx context.Context) (api.UploadParams, error)
 
 	Object(ctx context.Context, path string, opts ...api.ObjectsOption) (api.Object, []api.ObjectMetadata, error)
-	AddObject(ctx context.Context, path, contractSet, bucket string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
-	DeleteObject(ctx context.Context, path, bucket string, batch bool) error
+	AddObject(ctx context.Context, bucket string, path, contractSet string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
+	DeleteObject(ctx context.Context, bucket, path string, batch bool) error
 
 	AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.PartialSlab, err error)
 	FetchPartialSlab(ctx context.Context, key object.EncryptionKey, offset, length uint32) ([]byte, error)
@@ -1085,7 +1085,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	}
 
 	// persist the object
-	if jc.Check("couldn't add object", w.bus.AddObject(ctx, jc.PathParam("path"), bucket, up.ContractSet, obj, used)) != nil {
+	if jc.Check("couldn't add object", w.bus.AddObject(ctx, bucket, jc.PathParam("path"), up.ContractSet, obj, used)) != nil {
 		return
 	}
 
@@ -1152,7 +1152,7 @@ func (w *worker) objectsHandlerDELETE(jc jape.Context) {
 	if jc.DecodeForm("bucket", &bucket) != nil {
 		return
 	}
-	err := w.bus.DeleteObject(jc.Request.Context(), jc.PathParam("path"), bucket, batch)
+	err := w.bus.DeleteObject(jc.Request.Context(), bucket, jc.PathParam("path"), batch)
 	if err != nil && strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
 		jc.Error(err, http.StatusNotFound)
 		return

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -926,7 +926,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 		return
 	}
 	var bucket string
-	if jc.DecodeForm("bucket", &prefix) != nil {
+	if jc.DecodeForm("bucket", &bucket) != nil {
 		return
 	}
 


### PR DESCRIPTION
This PR adds supports for buckets to `renterd`. A bucket is a collection of objects that have been uploaded to `renterd` with some unique properties

- Two objects can have the same key if they are within different buckets
- A bucket can only be deleted if it is empty
- A bucket is not created implicitly, instead it has to be created manually before adding objects
- Operations can only be performed on a single bucket at a time with a few potential exceptions

In a sense a buckets are like folders but with stronger isolation. e.g. it's not possible to rename objects from one bucket to another or batch delete from multiple buckets at once. There is also a lot of room to extend buckets in the future by attaching metadata to them and assigning them specific properties such as different default values for uploads but for now they merely serve as a means to categorise objects.