### PR TITLE
docker: fix testnet image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ LABEL maintainer="The Sia Foundation <info@sia.tech>" \
 ENV PUID=0
 ENV PGID=0
 
-# Renterd env args..
+# Renterd env args
 ENV RENTERD_API_PASSWORD= 
 ENV RENTERD_SEED=
 ENV RENTERD_CONFIG_FILE=/data/renterd.yml
@@ -46,9 +46,6 @@ ENV RENTERD_CONFIG_FILE=/data/renterd.yml
 COPY --from=builder /renterd/renterd /usr/bin/renterd
 VOLUME [ "/data" ]
 
-EXPOSE 9980/tcp
-EXPOSE 9981/tcp
-
 USER ${PUID}:${PGID}
 
-ENTRYPOINT [ "renterd", "-dir", "./data", "-http", ":9980" ]
+ENTRYPOINT [ "renterd", "-dir", "./data"]


### PR DESCRIPTION
When deduping the dockerfiles I apparently messed up and forgot about the api port, which is 9880 instead of 9980 when building it for the testnet. This PR corrects that mistake by simply not passing the api port since we default to the appropriate ports anyway because of the environment files that have the correct build tags on them.

E.g. `env_default` and `env_testnet` have the `DefaultAPIAddress` which is set correctly.

I had to get rid of the `EXPOSE` instructions too since those don't really make sense any more. That's unfortunate, I considered some alternatives like exposing both testnet and default ports, or generating a dockerfile but those don't seem like the right way to go either... The `EXPOSE` instruction serves as mere documentation so functionality-wise we can remove them...