### PR TITLE
Run S3 api on different port

### DIFF
--- a/build/env_default.go
+++ b/build/env_default.go
@@ -14,6 +14,7 @@ const (
 
 	DefaultAPIAddress     = "localhost:9980"
 	DefaultGatewayAddress = ":9981"
+	DefaultS3Address      = "localhost:8080"
 )
 
 var (

--- a/build/env_testnet.go
+++ b/build/env_testnet.go
@@ -14,6 +14,7 @@ const (
 
 	DefaultAPIAddress     = "localhost:9880"
 	DefaultGatewayAddress = ":9881"
+	DefaultS3Address      = "localhost:7070"
 )
 
 var (

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -309,7 +309,7 @@ func main() {
 	// s3
 	flag.StringVar(&cfg.S3.Address, "s3.address", cfg.S3.Address, "address to serve S3 API on - can be overwritten using the RENTERD_S3_ADDRESS environment variable")
 	flag.BoolVar(&cfg.S3.DisableAuth, "s3.disableAuth", cfg.S3.DisableAuth, "disables authentication for the S3 API - can be overwritten using the RENTERD_S3_DISABLE_AUTH environment variable")
-	flag.BoolVar(&cfg.S3.Enabled, "s3.enabled", cfg.S3.Enabled, "enable/disable the S3 API (only works if worker.enabled is also 'true') - can be overwritten using the RENTERD_S3_ENABLED environment variable (WARNING: S3 is currently not protected by any form of authentication by default)")
+	flag.BoolVar(&cfg.S3.Enabled, "s3.enabled", cfg.S3.Enabled, "enable/disable the S3 API (only works if worker.enabled is also 'true') - can be overwritten using the RENTERD_S3_ENABLED environment variable")
 
 	flag.Parse()
 

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,7 @@ type (
 	}
 
 	S3 struct {
+		Address     string            `yaml:"address"`
 		DisableAuth bool              `yaml:"disableAuth"`
 		Enabled     bool              `yaml:"enabled"`
 		KeypairsV4  map[string]string `yaml:"keypairsV4"`

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ "$BUILD_TAGS" == *'testnet'* ]]; then
-    exec renterd -http=':9880' "$@"
+    exec renterd -http=':9880' -s3.address=':7070' "$@"
 else
-    exec renterd -http=':9980' "$@"
+    exec renterd -http=':9980' -s3.address=':8080' "$@"
 fi


### PR DESCRIPTION
So after some research it turns out That the S3 specs are not meant to support running the API on an endpoint + path. 
e.g. `/api/s3`. So to avoid that `renterd` will spin up a new web server on a different port if `S3` is enabled.

This fixes issues people have reported regarding the authentication failing.