### PR TITLE
Update renterFundsToExpectedStorage to use rhpv3 pricing

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -72,9 +72,10 @@ type RHPPriceTableRequest struct {
 
 // RHPScanResponse is the response type for the /rhp/scan endpoint.
 type RHPScanResponse struct {
-	Ping      ParamDuration      `json:"ping"`
-	ScanError string             `json:"scanError,omitempty"`
-	Settings  rhpv2.HostSettings `json:"settings,omitempty"`
+	Ping       ParamDuration        `json:"ping"`
+	ScanError  string               `json:"scanError,omitempty"`
+	Settings   rhpv2.HostSettings   `json:"settings,omitempty"`
+	PriceTable rhpv3.HostPriceTable `json:"priceTable,omitempty"`
 }
 
 // RHPFormRequest is the request type for the /rhp/form endpoint.

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	rhpv2 "go.sia.tech/core/rhp/v2"
+	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/renterd/api"
@@ -111,6 +112,7 @@ type (
 	contractInfo struct {
 		contract    api.Contract
 		settings    rhpv2.HostSettings
+		priceTable  rhpv3.HostPriceTable
 		usable      bool
 		recoverable bool
 	}
@@ -728,7 +730,7 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 		}
 
 		// decide whether the contract is still good
-		ci := contractInfo{contract: contract, settings: host.Settings}
+		ci := contractInfo{contract: contract, priceTable: host.PriceTable.HostPriceTable, settings: host.Settings}
 		renterFunds, err := c.renewFundingEstimate(ctx, ci, state.fee, false)
 		if err != nil {
 			c.logger.Errorw(fmt.Sprintf("failed to compute renterFunds for contract: %v", err))
@@ -1359,7 +1361,7 @@ func (c *contractor) renewContract(ctx context.Context, w Worker, ci contractInf
 	}
 
 	// calculate the host collateral
-	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-cs.BlockHeight, settings)
+	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-cs.BlockHeight, ci.settings, ci.priceTable)
 	newCollateral := rhpv2.ContractRenewalCollateral(rev.FileContract, expectedStorage, settings, cs.BlockHeight, endHeight)
 
 	// renew the contract
@@ -1435,7 +1437,7 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 	}
 
 	// calculate the new collateral
-	expectedStorage := renterFundsToExpectedStorage(renterFunds, contract.EndHeight()-cs.BlockHeight, settings)
+	expectedStorage := renterFundsToExpectedStorage(renterFunds, contract.EndHeight()-cs.BlockHeight, ci.settings, ci.priceTable)
 	newCollateral := rhpv2.ContractRenewalCollateral(rev.FileContract, expectedStorage, settings, cs.BlockHeight, contract.EndHeight())
 
 	// do not refresh if the contract's updated collateral will fall below the threshold anyway
@@ -1518,7 +1520,7 @@ func (c *contractor) formContract(ctx context.Context, w Worker, host hostdb.Hos
 
 	// calculate the host collateral
 	endHeight := endHeight(state.cfg, state.period)
-	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-cs.BlockHeight, scan.Settings)
+	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-cs.BlockHeight, scan.Settings, scan.PriceTable)
 	hostCollateral := rhpv2.ContractFormationCollateral(state.cfg.Contracts.Period, expectedStorage, scan.Settings)
 
 	// form contract
@@ -1612,16 +1614,16 @@ func endHeight(cfg api.AutopilotConfig, currentPeriod uint64) uint64 {
 
 // renterFundsToExpectedStorage returns how much storage a renter is expected to
 // be able to afford given the provided 'renterFunds'.
-func renterFundsToExpectedStorage(renterFunds types.Currency, duration uint64, host rhpv2.HostSettings) uint64 {
-	costPerByte := host.UploadBandwidthPrice.Add(host.StoragePrice.Mul64(duration)).Add(host.DownloadBandwidthPrice)
-	// If storage is free, we can afford 'unlimited' data.
-	if costPerByte.IsZero() {
-		return math.MaxUint64
+func renterFundsToExpectedStorage(renterFunds types.Currency, duration uint64, settings rhpv2.HostSettings, pt rhpv3.HostPriceTable) uint64 {
+	costPerSector := sectorUploadCost(pt, duration)
+	// Handle free storage.
+	if costPerSector.IsZero() {
+		costPerSector = types.NewCurrency64(1)
 	}
 	// Catch overflow.
-	expectedStorage := renterFunds.Div(costPerByte)
+	expectedStorage := renterFunds.Div(costPerSector).Mul64(rhpv2.SectorSize)
 	if expectedStorage.Cmp(types.NewCurrency64(math.MaxUint64)) > 0 {
-		return math.MaxUint64
+		expectedStorage = types.NewCurrency64(math.MaxUint64)
 	}
 	return expectedStorage.Big().Uint64()
 }

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -239,7 +239,7 @@ func isUsableContract(cfg api.AutopilotConfig, ci contractInfo, bh uint64, rente
 		refresh = false
 		renew = false
 	} else {
-		if isOutOfCollateral(c, s, pt, renterFunds, bh) {
+		if isOutOfCollateral(c, s, pt, renterFunds, cfg.Contracts.Period, bh) {
 			reasons = append(reasons, errContractOutOfCollateral.Error())
 			usable = false
 			recoverable = true
@@ -288,28 +288,39 @@ func isOutOfFunds(cfg api.AutopilotConfig, s rhpv2.HostSettings, c api.Contract)
 // isOutOfCollateral returns 'true' if the remaining/unallocated collateral in
 // the contract is below a certain threshold of the collateral we would try to
 // put into a contract upon renew.
-func isOutOfCollateral(c api.Contract, s rhpv2.HostSettings, pt rhpv3.HostPriceTable, renterFunds types.Currency, blockHeight uint64) bool {
-	expectedStorage := renterFundsToExpectedStorage(renterFunds, c.EndHeight()-blockHeight, s, pt)
+func isOutOfCollateral(c api.Contract, s rhpv2.HostSettings, pt rhpv3.HostPriceTable, renterFunds types.Currency, period, blockHeight uint64) bool {
+	// Compute the expected storage for the contract given the funds we are
+	// willing to put into it.
+	// Note: we use the full period here even though we are checking whether to
+	// do a refresh. Otherwise, the 'expectedStorage' would would become
+	// ridiculously large the closer the contract is to its end height.
+	expectedStorage := renterFundsToExpectedStorage(renterFunds, period, pt)
 	// Cap the expected storage at the remaining storage of the host. If the
 	// host doesn't have any storage left, there is no point in adding
 	// collateral.
 	if expectedStorage > s.RemainingStorage {
 		expectedStorage = s.RemainingStorage
 	}
-	expectedCollateral := rhpv2.ContractRenewalCollateral(c.Revision.FileContract, expectedStorage, s, blockHeight, c.EndHeight())
-	return isBelowCollateralThreshold(expectedCollateral, c.RemainingCollateral(s))
+	newCollateral := rhpv2.ContractRenewalCollateral(c.Revision.FileContract, expectedStorage, s, blockHeight, c.EndHeight())
+	return isBelowCollateralThreshold(newCollateral, c.RemainingCollateral(s))
 }
 
 // isBelowCollateralThreshold returns true if the actualCollateral is below a
-// certain percentage of expectedCollateral. The expectedCollateral is the
-// amount of new collateral we intend to put into a contract when refreshing it
-// and the actualCollateral is the amount we can actually put in after adjusting
-// our expectation using the host settings.
-func isBelowCollateralThreshold(expectedCollateral, actualCollateral types.Currency) bool {
-	if expectedCollateral.IsZero() {
-		return false // protect against division-by-zero
+// certain percentage of newCollateral. The newCollateral is the amount of
+// unallocated collateral in a contract after refreshing it and the
+// actualCollateral is the current amount of unallocated collateral in the
+// contract.
+func isBelowCollateralThreshold(newCollateral, actualCollateral types.Currency) bool {
+	if newCollateral.IsZero() {
+		// Protect against division-by-zero. This can happen for 2 reasons.
+		// 1. the collateral is already at the host's max collateral so a
+		// refresh wouldn't result in any new unallocated collateral.
+		// 2. the host has no more remaining storage so a refresh would only
+		// lead to unallocated collateral that we can't use.
+		// In both cases we don't want to refresh the contract.
+		return false
 	}
-	collateral := big.NewRat(0, 1).SetFrac(actualCollateral.Big(), expectedCollateral.Big())
+	collateral := big.NewRat(0, 1).SetFrac(actualCollateral.Big(), newCollateral.Big())
 	threshold := big.NewRat(minContractCollateralThresholdNumerator, minContractCollateralThresholdDenominator)
 	return collateral.Cmp(threshold) < 0
 }

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -317,7 +317,11 @@ func isBelowCollateralThreshold(newCollateral, actualCollateral types.Currency) 
 		// refresh wouldn't result in any new unallocated collateral.
 		// 2. the host has no more remaining storage so a refresh would only
 		// lead to unallocated collateral that we can't use.
-		// In both cases we don't want to refresh the contract.
+		// In both cases we don't gain anything from refreshing the contract.
+		// NOTE: This causes us to not immediately consider contracts as bad
+		// even though we can't upload to them anymore. This is fine since the
+		// collateral score or remaining storage score should filter these
+		// contracts out eventually.
 		return false
 	}
 	collateral := big.NewRat(0, 1).SetFrac(actualCollateral.Big(), newCollateral.Big())

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -307,7 +307,7 @@ func isOutOfCollateral(c api.Contract, s rhpv2.HostSettings, pt rhpv3.HostPriceT
 // our expectation using the host settings.
 func isBelowCollateralThreshold(expectedCollateral, actualCollateral types.Currency) bool {
 	if expectedCollateral.IsZero() {
-		return true // protect against division-by-zero
+		return false // protect against division-by-zero
 	}
 	collateral := big.NewRat(0, 1).SetFrac(actualCollateral.Big(), expectedCollateral.Big())
 	threshold := big.NewRat(minContractCollateralThresholdNumerator, minContractCollateralThresholdDenominator)

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -293,6 +293,11 @@ func bytesToSectors(bytes uint64) uint64 {
 	return numSectors
 }
 
+func sectorStorageCost(pt rhpv3.HostPriceTable, duration uint64) types.Currency {
+	asc := pt.BaseCost().Add(pt.AppendSectorCost(duration))
+	return asc.Storage
+}
+
 func sectorUploadCost(pt rhpv3.HostPriceTable, duration uint64) types.Currency {
 	asc := pt.BaseCost().Add(pt.AppendSectorCost(duration))
 	uploadSectorCostRHPv3, _ := asc.Total()
@@ -313,8 +318,7 @@ func downloadCostForScore(cfg api.AutopilotConfig, h hostdb.Host, bytes uint64) 
 }
 
 func storageCostForScore(cfg api.AutopilotConfig, h hostdb.Host, bytes uint64) types.Currency {
-	asc := h.PriceTable.BaseCost().Add(h.PriceTable.AppendSectorCost(cfg.Contracts.Period))
-	storeSectorCostRHPv3 := asc.Storage
+	storeSectorCostRHPv3 := sectorStorageCost(h.PriceTable.HostPriceTable, cfg.Contracts.Period)
 	numSectors := bytesToSectors(bytes)
 	return storeSectorCostRHPv3.Mul64(numSectors)
 }

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
+	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/hostdb"
@@ -292,9 +293,14 @@ func bytesToSectors(bytes uint64) uint64 {
 	return numSectors
 }
 
-func uploadCostForScore(cfg api.AutopilotConfig, h hostdb.Host, bytes uint64) types.Currency {
-	asc := h.PriceTable.BaseCost().Add(h.PriceTable.AppendSectorCost(cfg.Contracts.Period))
+func sectorUploadCost(pt rhpv3.HostPriceTable, duration uint64) types.Currency {
+	asc := pt.BaseCost().Add(pt.AppendSectorCost(duration))
 	uploadSectorCostRHPv3, _ := asc.Total()
+	return uploadSectorCostRHPv3
+}
+
+func uploadCostForScore(cfg api.AutopilotConfig, h hostdb.Host, bytes uint64) types.Currency {
+	uploadSectorCostRHPv3 := sectorUploadCost(h.PriceTable.HostPriceTable, cfg.Contracts.Period)
 	numSectors := bytesToSectors(bytes)
 	return uploadSectorCostRHPv3.Mul64(numSectors)
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -396,9 +396,10 @@ func (w *worker) rhpScanHandler(jc jape.Context) {
 	// TODO: record metric
 
 	jc.Encode(api.RHPScanResponse{
-		Ping:      api.ParamDuration(elapsed),
-		ScanError: errStr,
-		Settings:  settings,
+		Ping:       api.ParamDuration(elapsed),
+		PriceTable: priceTable,
+		ScanError:  errStr,
+		Settings:   settings,
 	})
 }
 


### PR DESCRIPTION
Also cap the amount of expected storage in `isOutOfCollateral` using the host's remaining storage.