### PR TITLE
Don't fail markPackedSlabUploaded when a contract is missing

### DIFF
--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3449,4 +3449,11 @@ func TestMarkSlabUploadedAfterRenew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var count int64
+	if err := db.db.Model(&dbContractSector{}).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	} else if count != 1 {
+		t.Fatal("expected 1 sector", count)
+	}
 }

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -411,6 +411,7 @@ func (s *SQLStore) retryTransaction(fc func(tx *gorm.DB) error, opts ...*sql.TxO
 	abortRetry := func(err error) bool {
 		if err == nil ||
 			errors.Is(err, gorm.ErrRecordNotFound) ||
+			errors.Is(err, api.ErrContractNotFound) ||
 			errors.Is(err, api.ErrObjectNotFound) ||
 			errors.Is(err, api.ErrObjectCorrupted) ||
 			errors.Is(err, api.ErrBucketExists) ||


### PR DESCRIPTION
This PR prevents an upload from failing just because a contract couldn't be found. Instead a warning is logged.

It also updates the `CreatedAt` timestamp in `AddRenewedContract` to make it easier to see when a contract has been renewed. In combination with the timestamp from the logging it should allow us to tell whether a contract that can't be found was renewed at that moment.