### PR TITLE
Various S3 fixes

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -423,6 +423,19 @@ type PackedSlabsRequestGET struct {
 	Limit           int           `json:"limit"`
 }
 
+type ObjectsListRequest struct {
+	Bucket string `json:"bucket"`
+	Limit  int    `json:"limit"`
+	Prefix string `json:"prefix"`
+	Marker string `json:"marker"`
+}
+
+type ObjectsListResponse struct {
+	HasMore    bool             `json:"hasMore"`
+	NextMarker string           `json:"nextMarker"`
+	Objects    []ObjectMetadata `json:"objects"`
+}
+
 type PackedSlabsRequestPOST struct {
 	Slabs         []UploadedPackedSlab                     `json:"slabs"`
 	UsedContracts map[types.PublicKey]types.FileContractID `json:"usedContracts"`
@@ -551,9 +564,9 @@ type (
 		Limit            int64  `json:"limit"`
 	}
 	MultipartListPartsResponse struct {
-		IsTruncated bool                    `json:"isTruncated"`
-		NextMarker  int                     `json:"nextMarker"`
-		Parts       []MultipartListPartItem `json:"parts"`
+		HasMore    bool                    `json:"hasMore"`
+		NextMarker int                     `json:"nextMarker"`
+		Parts      []MultipartListPartItem `json:"parts"`
 	}
 	MultipartListPartItem struct {
 		PartNumber   int       `json:"partNumber"`

--- a/api/worker.go
+++ b/api/worker.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
@@ -296,4 +297,32 @@ func ObjectsWithMarker(marker string) ObjectsOption {
 	return func(v url.Values) {
 		v.Set("marker", marker)
 	}
+}
+
+func ParseDownloadRange(contentRange string) (DownloadRange, error) {
+	parts := strings.Split(contentRange, " ")
+	if len(parts) != 2 || parts[0] != "bytes" {
+		return DownloadRange{}, errors.New("missing 'bytes' prefix in range header")
+	}
+	parts = strings.Split(parts[1], "/")
+	if len(parts) != 2 {
+		return DownloadRange{}, fmt.Errorf("invalid Content-Range header: %s", contentRange)
+	}
+	rangeStr := parts[0]
+	rangeParts := strings.Split(rangeStr, "-")
+	if len(rangeParts) != 2 {
+		return DownloadRange{}, errors.New("invalid Content-Range header")
+	}
+	start, err := strconv.ParseInt(rangeParts[0], 10, 64)
+	if err != nil {
+		return DownloadRange{}, err
+	}
+	end, err := strconv.ParseInt(rangeParts[1], 10, 64)
+	if err != nil {
+		return DownloadRange{}, err
+	}
+	return DownloadRange{
+		Start:  start,
+		Length: end - start + 1,
+	}, nil
 }

--- a/api/worker.go
+++ b/api/worker.go
@@ -246,7 +246,12 @@ type DownloadObjectOption func(http.Header)
 
 func DownloadWithRange(offset, length int64) DownloadObjectOption {
 	return func(h http.Header) {
-		h.Set("Range", fmt.Sprintf("bytes=%v-%v", offset, offset+length-1))
+		fmt.Println("rangeWith", offset, length)
+		if length == -1 {
+			h.Set("Range", fmt.Sprintf("bytes=%v-", offset))
+		} else {
+			h.Set("Range", fmt.Sprintf("bytes=%v-%v", offset, offset+length-1))
+		}
 	}
 }
 
@@ -279,6 +284,12 @@ func ObjectsWithLimit(limit int) ObjectsOption {
 func ObjectsWithBucket(bucket string) ObjectsOption {
 	return func(v url.Values) {
 		v.Set("bucket", bucket)
+	}
+}
+
+func ObjectsWithIgnoreDelim(ignore bool) ObjectsOption {
+	return func(v url.Values) {
+		v.Set("ignoreDelim", fmt.Sprint(ignore))
 	}
 }
 

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -945,8 +945,12 @@ func (b *bus) searchObjectsHandlerGET(jc jape.Context) {
 }
 
 func (b *bus) objectsHandlerGET(jc jape.Context) {
+	var ignoreDelim bool
+	if jc.DecodeForm("ignoreDelim", &ignoreDelim) != nil {
+		return
+	}
 	path := jc.PathParam("path")
-	if strings.HasSuffix(path, "/") {
+	if strings.HasSuffix(path, "/") && !ignoreDelim {
 		b.objectEntriesHandlerGET(jc, path)
 		return
 	}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -110,6 +110,7 @@ type (
 		DeleteBucket(_ context.Context, bucket string) error
 		ListBuckets(_ context.Context) ([]api.Bucket, error)
 
+		ListObjects(ctx context.Context, bucket, prefix, marker string, limit int) (api.ObjectsListResponse, error)
 		Object(ctx context.Context, bucket, path string) (api.Object, error)
 		ObjectEntries(ctx context.Context, bucket, path, prefix, marker string, offset, limit int) ([]api.ObjectMetadata, bool, error)
 		ObjectsBySlabKey(ctx context.Context, bucket string, slabKey object.EncryptionKey) ([]api.ObjectMetadata, error)
@@ -1022,6 +1023,20 @@ func (b *bus) objectsCopyHandlerPOST(jc jape.Context) {
 	if jc.Check("couldn't copy object", b.ms.CopyObject(jc.Request.Context(), orr.SourceBucket, orr.DestinationBucket, orr.SourcePath, orr.DestinationPath)) != nil {
 		return
 	}
+}
+
+func (b *bus) objectsListHandlerPOST(jc jape.Context) {
+	var req api.ObjectsListRequest
+	if jc.Decode(&req) != nil {
+		return
+	} else if req.Bucket == "" {
+		req.Bucket = api.DefaultBucketName
+	}
+	resp, err := b.ms.ListObjects(jc.Request.Context(), req.Bucket, req.Prefix, req.Marker, req.Limit)
+	if jc.Check("couldn't list objects", err) != nil {
+		return
+	}
+	jc.Encode(resp)
 }
 
 func (b *bus) objectsRenameHandlerPOST(jc jape.Context) {
@@ -1980,6 +1995,7 @@ func (b *bus) Handler() http.Handler {
 		"DELETE /objects/*path":  b.objectsHandlerDELETE,
 		"POST   /objects/copy":   b.objectsCopyHandlerPOST,
 		"POST   /objects/rename": b.objectsRenameHandlerPOST,
+		"POST   /objects/list":   b.objectsListHandlerPOST,
 
 		"GET    /params/upload":  b.paramsHandlerUploadGET,
 		"GET    /params/gouging": b.paramsHandlerGougingGET,

--- a/bus/client.go
+++ b/bus/client.go
@@ -627,6 +627,17 @@ func (c *Client) ObjectsBySlabKey(ctx context.Context, bucket string, key object
 	return
 }
 
+// ListOBjects lists objects in the given bucket.
+func (c *Client) ListObjects(ctx context.Context, bucket, prefix, marker string, limit int) (resp api.ObjectsListResponse, err error) {
+	err = c.c.WithContext(ctx).POST("/objects/list", api.ObjectsListRequest{
+		Bucket: bucket,
+		Limit:  limit,
+		Prefix: prefix,
+		Marker: marker,
+	}, &resp)
+	return
+}
+
 // SearchObjects returns all objects that contains a sub-string in their key.
 func (c *Client) SearchObjects(ctx context.Context, bucket, key string, offset, limit int) (entries []api.ObjectMetadata, err error) {
 	values := url.Values{}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module go.sia.tech/renterd
 go 1.20
 
 require (
-	github.com/SiaFoundation/gofakes3 v0.0.0-20230918145812-698366c1fd56
+	github.com/SiaFoundation/gofakes3 v0.0.0-20230919075754-db4f3d79eb50
 	github.com/go-gormigrate/gormigrate/v2 v2.1.0
 	github.com/google/go-cmp v0.5.9
 	github.com/gotd/contrib v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/SiaFoundation/gofakes3 v0.0.0-20230919115219-af470842bcfa h1:CMKw/7lpPrLLZaT+sFQysXEE7Zgj8Iqz+dUuaYrh0wg=
 github.com/SiaFoundation/gofakes3 v0.0.0-20230919115219-af470842bcfa/go.mod h1:pm3DyXGoeF7/gka6OYDqAW4E5hkcnXm/GfUagzztlxk=
+github.com/SiaFoundation/gofakes3 v0.0.0-20230920080442-785341635c3a h1:upsVYvk3Wg6+bOjduZpc4Fmf7nVgCR+F7oUH9GNkPE4=
+github.com/SiaFoundation/gofakes3 v0.0.0-20230920080442-785341635c3a/go.mod h1:pm3DyXGoeF7/gka6OYDqAW4E5hkcnXm/GfUagzztlxk=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/SiaFoundation/gofakes3 v0.0.0-20230918145812-698366c1fd56 h1:Wx1Xp4d5jb2lYgHfPRPeA4PhY9/hwXO3H7557AZB6j8=
 github.com/SiaFoundation/gofakes3 v0.0.0-20230918145812-698366c1fd56/go.mod h1:pm3DyXGoeF7/gka6OYDqAW4E5hkcnXm/GfUagzztlxk=
+github.com/SiaFoundation/gofakes3 v0.0.0-20230919075754-db4f3d79eb50 h1:Z+AQLQgrIlOWihTUP/HIvOSQ0slMsDfAhzaVGydFe5Y=
+github.com/SiaFoundation/gofakes3 v0.0.0-20230919075754-db4f3d79eb50/go.mod h1:pm3DyXGoeF7/gka6OYDqAW4E5hkcnXm/GfUagzztlxk=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=

--- a/internal/testing/s3_test.go
+++ b/internal/testing/s3_test.go
@@ -355,13 +355,13 @@ func TestS3List(t *testing.T) {
 			delimiter: "/",
 			prefix:    "",
 			marker:    "",
-			want:      []string{"a/", "ab", "b", "c/", "d", "y/"},
+			want:      []string{"ab", "b", "d", "a/", "c/", "y/"},
 		},
 		{
 			delimiter: "/",
 			prefix:    "a",
 			marker:    "",
-			want:      []string{"a/", "ab"},
+			want:      []string{"ab", "a/"},
 		},
 		{
 			delimiter: "/",
@@ -373,7 +373,7 @@ func TestS3List(t *testing.T) {
 			delimiter: "/",
 			prefix:    "",
 			marker:    "b",
-			want:      []string{"c/", "d", "y/"},
+			want:      []string{"d", "c/", "y/"},
 		},
 		{
 			delimiter: "/",

--- a/internal/testing/s3_test.go
+++ b/internal/testing/s3_test.go
@@ -104,6 +104,14 @@ func TestS3Basic(t *testing.T) {
 		t.Fatal("data mismatch")
 	}
 
+	// stat object
+	info, err := s3.StatObject(context.Background(), bucket, "object", minio.StatObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	} else if info.Size != int64(len(data)) {
+		t.Fatal("size mismatch")
+	}
+
 	// add another bucket
 	err = s3.MakeBucket(context.Background(), bucket+"2", minio.MakeBucketOptions{})
 	if err != nil {
@@ -334,20 +342,25 @@ func TestS3List(t *testing.T) {
 		{
 			prefix: "",
 			marker: "",
-			want:   []string{"ab", "b", "d", "a/", "c/"},
+			want:   []string{"a/", "ab", "b", "c/", "d"},
 		},
 		{
 			prefix: "a",
 			marker: "",
-			want:   []string{"ab", "a/"},
+			want:   []string{"a/", "ab"},
+		},
+		{
+			prefix: "a/a",
+			marker: "",
+			want:   []string{"a/a/"},
 		},
 		{
 			prefix: "",
 			marker: "b",
-			want:   []string{"d", "c/"},
+			want:   []string{"c/", "d"},
 		},
 		{
-			prefix: "e",
+			prefix: "z",
 			marker: "",
 			want:   nil,
 		},

--- a/internal/testing/s3_test.go
+++ b/internal/testing/s3_test.go
@@ -264,6 +264,19 @@ func TestS3List(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// manually create the 'a/' object as a directory. It should also be
+	// possible to call StatObject on it without errors.
+	_, err = s3.PutObject(context.Background(), "bucket", "a/", bytes.NewReader(nil), 0, minio.PutObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	so, err := s3.StatObject(context.Background(), "bucket", "a/", minio.StatObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	} else if so.Key != "a/" {
+		t.Fatal("unexpected key:", so.Key)
+	}
+
 	objects := []string{
 		"a/a/a",
 		"a/b",

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -141,20 +141,18 @@ func (s *s3) ListBucket(bucketName string, prefix *gofakes3.Prefix, page gofakes
 	}
 
 	// Loop over the entries and add them to the response.
-	for i, object := range objects {
+	for _, object := range objects {
 		key := strings.TrimPrefix(object.Name, "/")
 		var match gofakes3.PrefixMatch
 		if !prefix.Match(key, &match) {
 			continue
 		} else if match.CommonPrefix {
-			fmt.Println(i, "commonPrefix", key)
-			response.AddPrefix(gofakes3.URLEncode(key))
+			response.AddPrefix(key)
 			continue
 		}
-		fmt.Println(i, "object", key)
 
 		item := &gofakes3.Content{
-			Key:          gofakes3.URLEncode(key),
+			Key:          key,
 			LastModified: gofakes3.NewContentTime(time.Unix(0, 0).UTC()), // TODO: don't have that
 			ETag:         hex.EncodeToString(frand.Bytes(32)),            // TODO: don't have that
 			Size:         object.Size,

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -284,7 +284,7 @@ func (s *s3) HeadObject(bucketName, objectName string) (*gofakes3.Object, error)
 	// TODO: When we support metadata we need to add it here.
 	metadata := map[string]string{
 		"Content-Type":  mime.TypeByExtension(objectName),
-		"Last-Modified": time.Now().UTC().Format(http.TimeFormat), // TODO: update this when object has metadata
+		"Last-Modified": time.Unix(0, 0).UTC().Format(http.TimeFormat), // TODO: update this when object has metadata
 	}
 	return &gofakes3.Object{
 		Name:     gofakes3.URLEncode(objectName),

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -333,7 +333,6 @@ func (s *s3) DeleteObject(bucketName, objectName string) (gofakes3.ObjectDeleteR
 // TODO: Metadata is currently ignored. The backend requires an update to
 // support it.
 func (s *s3) PutObject(bucketName, key string, meta map[string]string, input io.Reader, size int64) (gofakes3.PutObjectResult, error) {
-	fmt.Println("put", key)
 	err := s.w.UploadObject(context.Background(), input, key, api.UploadWithBucket(bucketName))
 	if err != nil {
 		return gofakes3.PutObjectResult{}, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -262,10 +261,7 @@ func (s *s3) GetObject(bucketName, objectName string, rangeRequest *gofakes3.Obj
 // HeadObject should return a NotFound() error if the object does not
 // exist.
 func (s *s3) HeadObject(bucketName, objectName string) (*gofakes3.Object, error) {
-	if strings.HasSuffix(objectName, "/") {
-		return nil, errors.New("object name must not end with '/'")
-	}
-	res, err := s.b.Object(context.Background(), objectName, api.ObjectsWithBucket(bucketName))
+	res, err := s.b.Object(context.Background(), objectName, api.ObjectsWithBucket(bucketName), api.ObjectsWithIgnoreDelim(true))
 	if err != nil && strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
 		return nil, gofakes3.KeyNotFound(objectName)
 	}

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -108,7 +108,7 @@ func (s *s3) ListBucket(bucketName string, prefix *gofakes3.Prefix, page gofakes
 		}
 		var path string // root of bucket
 		adjustedPrefix := prefix.Prefix
-		if idx := strings.LastIndex(adjustedPrefix, "/"); idx != -1 {
+		if idx := strings.LastIndex(adjustedPrefix, prefix.Delimiter); idx != -1 {
 			path = adjustedPrefix[:idx+1]
 			adjustedPrefix = adjustedPrefix[idx+1:]
 		}
@@ -143,10 +143,7 @@ func (s *s3) ListBucket(bucketName string, prefix *gofakes3.Prefix, page gofakes
 	// Loop over the entries and add them to the response.
 	for _, object := range objects {
 		key := strings.TrimPrefix(object.Name, "/")
-		var match gofakes3.PrefixMatch
-		if !prefix.Match(key, &match) {
-			continue
-		} else if match.CommonPrefix {
+		if prefix.HasDelimiter && strings.HasSuffix(key, prefix.Delimiter) {
 			response.AddPrefix(key)
 			continue
 		}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -33,7 +33,7 @@ type bus interface {
 	CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, dstPath string) error
 	DeleteObject(ctx context.Context, bucket, path string, batch bool) (err error)
 	Object(ctx context.Context, path string, opts ...api.ObjectsOption) (res api.ObjectsResponse, err error)
-	SearchObjects(ctx context.Context, bucket, key string, offset, limit int) (entries []api.ObjectMetadata, err error)
+	ListObjects(ctx context.Context, bucket, prefix, marker string, limit int) (resp api.ObjectsListResponse, err error)
 
 	AbortMultipartUpload(ctx context.Context, bucket, path string, uploadID string) (err error)
 	CompleteMultipartUpload(ctx context.Context, bucket, path string, uploadID string, parts []api.MultipartCompletedPart) (_ api.MultipartCompleteResponse, err error)

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1984,8 +1984,9 @@ func sqlWhereBucket(objTable string, bucket string) clause.Expr {
 	return gorm.Expr(fmt.Sprintf("%s.db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?)", objTable), bucket)
 }
 
-// TODO: we can use ObjectEntries for now but it would be interesting to have
-// 'delim' support in ListObjects.
+// TODO: we can use ObjectEntries instead of ListObject if we want to use '/' as
+// a delimiter for now (see backend.go) but it would be interesting to have
+// arbitrary 'delim' support in ListObjects.
 func (s *SQLStore) ListObjects(ctx context.Context, bucket, prefix, marker string, limit int) (api.ObjectsListResponse, error) {
 	// fetch one more to see if there are more entries
 	if limit <= -1 {
@@ -2013,6 +2014,7 @@ func (s *SQLStore) ListObjects(ctx context.Context, bucket, prefix, marker strin
 		Joins("LEFT JOIN slabs sla ON sli.db_slab_id = sla.`id`").
 		Where("? AND ? AND ?", sqlWhereBucket("o", bucket), prefixExpr, markerExpr).
 		Group("o.object_id").
+		Order("o.object_id").
 		Limit(int(limit)).
 		Scan(&objects).Error
 	if err != nil {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -900,6 +900,7 @@ func (s *SQLStore) RenewedContract(ctx context.Context, renewedFrom types.FileCo
 }
 
 func (s *SQLStore) SearchObjects(ctx context.Context, bucket, substring string, offset, limit int) ([]api.ObjectMetadata, error) {
+	// fetch one more to see if there are more entries
 	if limit <= -1 {
 		limit = math.MaxInt
 	}
@@ -1981,4 +1982,55 @@ func sqlConcat(db *gorm.DB, a, b string) string {
 
 func sqlWhereBucket(objTable string, bucket string) clause.Expr {
 	return gorm.Expr(fmt.Sprintf("%s.db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?)", objTable), bucket)
+}
+
+// TODO: we can use ObjectEntries for now but it would be interesting to have
+// 'delim' support in ListObjects.
+func (s *SQLStore) ListObjects(ctx context.Context, bucket, prefix, marker string, limit int) (api.ObjectsListResponse, error) {
+	// fetch one more to see if there are more entries
+	if limit <= -1 {
+		limit = math.MaxInt
+	} else {
+		limit++
+	}
+
+	prefixExpr := gorm.Expr("TRUE")
+	if prefix != "" {
+		prefixExpr = gorm.Expr("SUBSTR(o.object_id, 1, ?) = ?", utf8.RuneCountInString(prefix), prefix)
+	}
+	markerExpr := gorm.Expr("TRUE")
+	if marker != "" {
+		markerExpr = gorm.Expr("o.object_id > ?", marker)
+	}
+
+	var objects []api.ObjectMetadata
+	err := s.db.
+		Select("o.object_id as name, MAX(o.size) as size, MIN(sla.health) as health").
+		Model(&dbObject{}).
+		Table("objects o").
+		Joins("INNER JOIN buckets b ON o.db_bucket_id = b.id AND b.name = ?", bucket).
+		Joins("LEFT JOIN slices sli ON o.id = sli.`db_object_id`").
+		Joins("LEFT JOIN slabs sla ON sli.db_slab_id = sla.`id`").
+		Where("? AND ? AND ?", sqlWhereBucket("o", bucket), prefixExpr, markerExpr).
+		Group("o.object_id").
+		Limit(int(limit)).
+		Scan(&objects).Error
+	if err != nil {
+		return api.ObjectsListResponse{}, err
+	}
+
+	hasMore := len(objects) == limit
+	nextMarker := ""
+	if hasMore {
+		nextMarker = objects[len(objects)-2].Name
+	}
+	if len(objects) == limit {
+		objects = objects[:len(objects)-1]
+	}
+
+	return api.ObjectsListResponse{
+		HasMore:    hasMore,
+		NextMarker: nextMarker,
+		Objects:    objects,
+	}, nil
 }

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3487,7 +3487,7 @@ func TestMarkSlabUploadedAfterRenew(t *testing.T) {
 	}
 }
 
-func TestListBucket(t *testing.T) {
+func TestListObjects(t *testing.T) {
 	os, _, _, err := newTestSQLStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -182,8 +182,8 @@ func (s *SQLStore) MultipartUploadParts(ctx context.Context, bucket, object stri
 		// Check if there are more parts beyond 'limit'.
 		if limitUsed && len(dbParts) == int(limit) {
 			resp.HasMore = true
-			resp.NextMarker = dbParts[len(dbParts)-2].PartNumber
 			dbParts = dbParts[:len(dbParts)-1]
+			resp.NextMarker = dbParts[len(dbParts)-1].PartNumber
 		}
 		for _, part := range dbParts {
 			resp.Parts = append(resp.Parts, api.MultipartListPartItem{

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -181,8 +181,8 @@ func (s *SQLStore) MultipartUploadParts(ctx context.Context, bucket, object stri
 		}
 		// Check if there are more parts beyond 'limit'.
 		if limitUsed && len(dbParts) == int(limit) {
-			resp.IsTruncated = true
-			resp.NextMarker = dbParts[len(dbParts)-1].PartNumber
+			resp.HasMore = true
+			resp.NextMarker = dbParts[len(dbParts)-2].PartNumber
 			dbParts = dbParts[:len(dbParts)-1]
 		}
 		for _, part := range dbParts {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1017,7 +1017,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 	} else if jc.Check("couldn't get object or entries", err) != nil {
 		return
 	}
-	jc.ResponseWriter.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat)) // TODO: update this when object has a ModTime
+	jc.ResponseWriter.Header().Set("Last-Modified", time.Unix(0, 0).UTC().Format(http.TimeFormat)) // TODO: update this when object has a ModTime
 
 	if path == "" || strings.HasSuffix(path, "/") {
 		jc.Encode(res.Entries)


### PR DESCRIPTION
This PR contains a number of changes I had to make to get Nextcloud working with my renterd node.

The most notable change is the introduction of a new endpoint for listing objects within a bucket that reflects the `ListObjects` functionality of S3 more. That was necessary for 2 reasons.

1. the current ObjectEntries endpoint doesn't support querying without delimiter. The query has also grown a bit out of hand so updating it with yet another flag might have been possible but also been a nightmare.
2. the current SearchObjects endpoint does support searching without delimiter and could've been extended but it returns a slice so we can't update the response without breaking compatibility

Maybe in the future we will be able to deprecate the ObjectEntries endpoint and use the ListObjects endpoint in the UI as well since it is quite a bit simpler.