### PR TITLE
Upload Refactor 

### DIFF
--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1932,16 +1932,23 @@ func TestUploadPacking(t *testing.T) {
 	uploadDownload("file5", data5)
 	download("file4", data4, 0, int64(len(data4)))
 
-	// check the object stats, we use a retry loop since packed slabs are upload
-	// in a separate goroutine so stats might lag a bit
+	// assert number of objects
+	os, err := b.ObjectsStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.NumObjects != 5 {
+		t.Fatalf("expected 5 objects, got %v", os.NumObjects)
+	}
+
+	// check the object size stats, we use a retry loop since packed slabs are
+	// uploaded in a separate goroutine, so the object stats might lag a bit
 	err = Retry(60, time.Second, func() error {
 		os, err := b.ObjectsStats()
 		if err != nil {
 			t.Fatal(err)
 		}
-		if os.NumObjects != 5 {
-			return fmt.Errorf("expected 5 objects, got %v", os.NumObjects)
-		}
+
 		totalObjectSize := uint64(3 * slabSize)
 		totalRedundantSize := totalObjectSize * uint64(rs.TotalShards) / uint64(rs.MinShards)
 		if os.TotalObjectsSize != totalObjectSize {
@@ -2133,15 +2140,21 @@ func TestSlabBufferStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// check the object stats, we use a retry loop since packed slabs are upload
-	// in a separate goroutine so stats might lag a bit
+	// assert number of objects
+	os, err := b.ObjectsStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.NumObjects != 1 {
+		t.Fatalf("expected 1 object, got %d", os.NumObjects)
+	}
+
+	// check the object size stats, we use a retry loop since packed slabs are
+	// uploaded in a separate goroutine, so the object stats might lag a bit
 	err = Retry(60, time.Second, func() error {
 		os, err := b.ObjectsStats()
 		if err != nil {
 			t.Fatal(err)
-		}
-		if os.NumObjects != 1 {
-			return fmt.Errorf("expected 1 object, got %d", os.NumObjects)
 		}
 		if os.TotalObjectsSize != uint64(len(data1)) {
 			return fmt.Errorf("expected totalObjectSize of %d, got %d", len(data1), os.TotalObjectsSize)
@@ -2190,15 +2203,21 @@ func TestSlabBufferStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// check the object stats again, we use a retry loop since packed slabs are upload
-	// in a separate goroutine so stats might lag a bit
+	// assert number of objects
+	os, err = b.ObjectsStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.NumObjects != 2 {
+		t.Fatalf("expected 1 object, got %d", os.NumObjects)
+	}
+
+	// check the object size stats, we use a retry loop since packed slabs are
+	// uploaded in a separate goroutine, so the object stats might lag a bit
 	err = Retry(60, time.Second, func() error {
 		os, err := b.ObjectsStats()
 		if err != nil {
 			t.Fatal(err)
-		}
-		if os.NumObjects != 2 {
-			return fmt.Errorf("expected 1 object, got %d", os.NumObjects)
 		}
 		if os.TotalObjectsSize != uint64(len(data1)+len(data2)) {
 			return fmt.Errorf("expected totalObjectSize of %d, got %d", len(data1)+len(data2), os.TotalObjectsSize)

--- a/object/object.go
+++ b/object/object.go
@@ -5,7 +5,6 @@ import (
 	"crypto/cipher"
 	"encoding/binary"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -52,7 +51,7 @@ func (k *EncryptionKey) UnmarshalText(b []byte) error {
 // given offset.
 func (k EncryptionKey) Encrypt(r io.Reader, offset uint64) (cipher.StreamReader, error) {
 	if offset%64 != 0 {
-		return cipher.StreamReader{}, errors.New("offset must be a multiple of 64")
+		return cipher.StreamReader{}, fmt.Errorf("offset must be a multiple of 64, got %v", offset)
 	}
 	if k.IsNoopKey() {
 		return cipher.StreamReader{S: &noOpStream{}, R: r}, nil

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -74,7 +74,7 @@ func WithCustomEncryptionOffset(offset uint64) UploadOption {
 func WithUploadParams(up api.UploadParams) UploadOption {
 	return func(cfg *uploadConfig) {
 		cfg.rs = up.RedundancySettings
-		cfg.bh = up.ConsensusState.BlockHeight
+		cfg.bh = up.CurrentHeight
 		cfg.contractSet = up.ContractSet
 		cfg.pack = up.UploadPacking
 	}

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -372,14 +372,12 @@ func (w *worker) uploadPackedSlab(ps api.PackedSlab, rs api.RedundancySettings, 
 	}
 
 	// mark packed slab as uploaded
-	if err = w.bus.MarkPackedSlabsUploaded(ctx, []api.UploadedPackedSlab{
-		{
-			BufferID: ps.BufferID,
-			Shards:   sectors,
-		},
-	}, used); err != nil {
+	slab := api.UploadedPackedSlab{BufferID: ps.BufferID, Shards: sectors}
+	err = w.bus.MarkPackedSlabsUploaded(ctx, []api.UploadedPackedSlab{slab}, used)
+	if err != nil {
 		return fmt.Errorf("couldn't mark packed slabs uploaded, err: %v", err)
 	}
+
 	return nil
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1139,13 +1139,10 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	ctx = WithGougingChecker(ctx, w.bus, up.GougingParams)
 
 	// upload the object
-	etag, err := w.upload(ctx, jc.Request.Body, bucket, jc.PathParam("path"), opts...)
+	_, err = w.upload(ctx, jc.Request.Body, bucket, jc.PathParam("path"), opts...)
 	if jc.Check("couldn't upload object", err) != nil {
 		return
 	}
-
-	// set etag in header response.
-	jc.ResponseWriter.Header().Set("ETag", api.FormatEtag(etag))
 }
 
 func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1132,11 +1132,14 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 		return
 	}
 
+	// built options
+	opts := []UploadOption{WithUploadParams(up)}
+
 	// attach gouging checker to the context
 	ctx = WithGougingChecker(ctx, w.bus, up.GougingParams)
 
 	// upload the object
-	etag, err := w.upload(ctx, jc.Request.Body, rs, bucket, jc.PathParam("path"), up.ContractSet, up.CurrentHeight, up.UploadPacking)
+	etag, err := w.upload(ctx, jc.Request.Body, bucket, jc.PathParam("path"), opts...)
 	if jc.Check("couldn't upload object", err) != nil {
 		return
 	}
@@ -1209,8 +1212,6 @@ func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {
 		return
 	}
 
-	var opts []UploadOption
-
 	// make sure only one of the following is set
 	var disablePreshardingEncryption bool
 	if jc.DecodeForm("disablepreshardingencryption", &disablePreshardingEncryption) != nil {
@@ -1228,6 +1229,9 @@ func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {
 	if jc.DecodeForm("offset", &offset) != nil {
 		return
 	}
+
+	// built options
+	opts := []UploadOption{WithUploadParams(up)}
 	if disablePreshardingEncryption {
 		opts = append(opts, WithCustomKey(object.NoOpKey))
 	} else {
@@ -1238,7 +1242,7 @@ func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {
 	ctx = WithGougingChecker(ctx, w.bus, up.GougingParams)
 
 	// upload the multipart
-	etag, err := w.uploadMultiPart(ctx, jc.Request.Body, rs, bucket, jc.PathParam("path"), up.ContractSet, uploadID, partNumber, up.CurrentHeight, up.UploadPacking, opts...)
+	etag, err := w.uploadMultiPart(ctx, jc.Request.Body, bucket, jc.PathParam("path"), uploadID, partNumber, opts...)
 	if jc.Check("couldn't upload object", err) != nil {
 		return
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1133,7 +1133,12 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	}
 
 	// built options
-	opts := []UploadOption{WithUploadParams(up)}
+	opts := []UploadOption{
+		WithBlockHeight(up.CurrentHeight),
+		WithContractSet(up.ContractSet),
+		WithPacking(up.UploadPacking),
+		WithRedundancySettings(up.RedundancySettings),
+	}
 
 	// attach gouging checker to the context
 	ctx = WithGougingChecker(ctx, w.bus, up.GougingParams)
@@ -1228,7 +1233,12 @@ func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {
 	}
 
 	// built options
-	opts := []UploadOption{WithUploadParams(up)}
+	opts := []UploadOption{
+		WithBlockHeight(up.CurrentHeight),
+		WithContractSet(up.ContractSet),
+		WithPacking(up.UploadPacking),
+		WithRedundancySettings(up.RedundancySettings),
+	}
 	if disablePreshardingEncryption {
 		opts = append(opts, WithCustomKey(object.NoOpKey))
 	} else {


### PR DESCRIPTION
I was seeing how to implement etags and got side-tracked on a mini-refactor. It's a bit hard to see in the diff but it does deduplicate a bunch of code we had. I went back and forth on it a bit so definitely don't mind to discuss it further.

I extended the worker with two methods:
`func (w *worker) upload`
`func (w *worker) uploadMultiPart`

that each wrap an upload and then handle the object and (potential) partial slab data with the bus. I moved this in and out of the upload manager but eventually figured that it should not be handled by the upload manager, at the cost of duplicating persisting the partial slabs and setting it on the object.

Most importantly we now spin a goroutine to persist packed slabs, so the request that pushes it over the limit isn't blocked by the upload. I think this is better and it gets rid of duplicate logic we had in regular upload vs multi-part uploads. (This is the thing you did initially and then ran into an error, so I hope the error you ran into is in a test we still have so it flags if I made the same mistake).

It also extends the `uploadConfig` with everything we can gather from the upload parameters and greatly simplifies the interface of the upload manager. Now we return the etag and a potential error but eventually I'll return the `object.Object` that has the etag.