### PR TITLE
ModTime

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -206,9 +207,16 @@ type Object struct {
 
 // ObjectMetadata contains various metadata about an object.
 type ObjectMetadata struct {
-	Name   string  `json:"name"`
-	Size   int64   `json:"size"`
-	Health float64 `json:"health"`
+	Health  float64   `json:"health"`
+	ModTime time.Time `json:"modTime"`
+	Name    string    `json:"name"`
+	Size    int64     `json:"size"`
+}
+
+// LastModified returns the object's ModTime formatted for use in the
+// 'Last-Modified' header
+func (o *Object) LastModified() string {
+	return o.ModTime.UTC().Format(http.TimeFormat)
 }
 
 // ObjectAddRequest is the request type for the /object/*key endpoint.

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -114,7 +114,7 @@ type (
 		ObjectEntries(ctx context.Context, bucket, path, prefix, marker string, offset, limit int) ([]api.ObjectMetadata, bool, error)
 		ObjectsBySlabKey(ctx context.Context, bucket string, slabKey object.EncryptionKey) ([]api.ObjectMetadata, error)
 		SearchObjects(ctx context.Context, bucket, substring string, offset, limit int) ([]api.ObjectMetadata, error)
-		CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, dstPath string) error
+		CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, dstPath string) (api.ObjectMetadata, error)
 		UpdateObject(ctx context.Context, bucket, path, contractSet string, o object.Object, usedContracts map[types.PublicKey]types.FileContractID) error
 		RemoveObject(ctx context.Context, bucket, path string) error
 		RemoveObjects(ctx context.Context, bucket, prefix string) error
@@ -1015,9 +1015,12 @@ func (b *bus) objectsCopyHandlerPOST(jc jape.Context) {
 	if jc.Decode(&orr) != nil {
 		return
 	}
-	if jc.Check("couldn't copy object", b.ms.CopyObject(jc.Request.Context(), orr.SourceBucket, orr.DestinationBucket, orr.SourcePath, orr.DestinationPath)) != nil {
+
+	om, err := b.ms.CopyObject(jc.Request.Context(), orr.SourceBucket, orr.DestinationBucket, orr.SourcePath, orr.DestinationPath)
+	if jc.Check("couldn't copy object", err) != nil {
 		return
 	}
+	jc.Encode(om)
 }
 
 func (b *bus) objectsRenameHandlerPOST(jc jape.Context) {

--- a/bus/client.go
+++ b/bus/client.go
@@ -664,13 +664,14 @@ func (c *Client) AddObject(ctx context.Context, bucket, path, contractSet string
 
 // CopyObject copies the object from the source bucket and path to the
 // destination bucket and path.
-func (c *Client) CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, dstPath string) error {
-	return c.c.WithContext(ctx).POST("/objects/copy", api.ObjectsCopyRequest{
+func (c *Client) CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, dstPath string) (om api.ObjectMetadata, err error) {
+	err = c.c.WithContext(ctx).POST("/objects/copy", api.ObjectsCopyRequest{
 		SourceBucket:      srcBucket,
 		DestinationBucket: dstBucket,
 		SourcePath:        srcPath,
 		DestinationPath:   dstPath,
-	}, nil)
+	}, &om)
+	return
 }
 
 // DeleteObject either deletes the object at the given path or if batch=true

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -381,6 +381,14 @@ func TestObjectEntries(t *testing.T) {
 			t.Fatal(err, test.path)
 		}
 
+		// assert mod time & clear it afterwards so we can compare
+		for i := range res.Entries {
+			if !strings.HasSuffix(res.Entries[i].Name, "/") && res.Entries[i].ModTime.IsZero() {
+				t.Fatal("mod time should be set")
+			}
+			res.Entries[i].ModTime = time.Time{}
+		}
+
 		if !(len(res.Entries) == 0 && len(test.want) == 0) && !reflect.DeepEqual(res.Entries, test.want) {
 			t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, res.Entries, test.want)
 		}
@@ -388,6 +396,14 @@ func TestObjectEntries(t *testing.T) {
 			res, err := b.Object(context.Background(), test.path, api.ObjectsWithPrefix(test.prefix), api.ObjectsWithOffset(offset), api.ObjectsWithLimit(1))
 			if err != nil {
 				t.Fatal(err)
+			}
+
+			// assert mod time & clear it afterwards so we can compare
+			for i := range res.Entries {
+				if !strings.HasSuffix(res.Entries[i].Name, "/") && res.Entries[i].ModTime.IsZero() {
+					t.Fatal("mod time should be set")
+				}
+				res.Entries[i].ModTime = time.Time{}
 			}
 
 			if len(res.Entries) != 1 || res.Entries[0] != test.want[offset] {
@@ -407,6 +423,15 @@ func TestObjectEntries(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			// assert mod time & clear it afterwards so we can compare
+			for i := range res.Entries {
+				if !strings.HasSuffix(res.Entries[i].Name, "/") && res.Entries[i].ModTime.IsZero() {
+					t.Fatal("mod time should be set")
+				}
+				res.Entries[i].ModTime = time.Time{}
+			}
+
 			if len(res.Entries) != 1 || res.Entries[0] != test.want[offset+1] {
 				t.Errorf("\nlist: %v\nprefix: %v\nmarker: %v\ngot: %v\nwant: %v", test.path, test.prefix, test.want[offset].Name, res.Entries, test.want[offset+1])
 			}
@@ -422,6 +447,15 @@ func TestObjectEntries(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// assert mod time & clear it afterwards so we can compare
+		for i := range got {
+			if !strings.HasSuffix(got[i].Name, "/") && got[i].ModTime.IsZero() {
+				t.Fatal("mod time should be set")
+			}
+			got[i].ModTime = time.Time{}
+		}
+
 		if !(len(got) == 0 && len(test.want) == 0) && !reflect.DeepEqual(got, test.want) {
 			t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want)
 		}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -301,9 +301,10 @@ func TestObjectEntries(t *testing.T) {
 	}
 
 	// assert mod time & clear it afterwards so we can compare
+	start := time.Now()
 	assertModTime := func(entries []api.ObjectMetadata) {
 		for i := range entries {
-			if !strings.HasSuffix(entries[i].Name, "/") && entries[i].ModTime.IsZero() {
+			if !strings.HasSuffix(entries[i].Name, "/") && !entries[i].ModTime.After(start.UTC()) {
 				t.Fatal("mod time should be set")
 			}
 			entries[i].ModTime = time.Time{}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -300,6 +300,16 @@ func TestObjectEntries(t *testing.T) {
 		t.SkipNow()
 	}
 
+	// assert mod time & clear it afterwards so we can compare
+	assertModTime := func(entries []api.ObjectMetadata) {
+		for i := range entries {
+			if !strings.HasSuffix(entries[i].Name, "/") && entries[i].ModTime.IsZero() {
+				t.Fatal("mod time should be set")
+			}
+			entries[i].ModTime = time.Time{}
+		}
+	}
+
 	// create a test cluster
 	cluster, err := newTestCluster(t.TempDir(), newTestLogger())
 	if err != nil {
@@ -382,12 +392,7 @@ func TestObjectEntries(t *testing.T) {
 		}
 
 		// assert mod time & clear it afterwards so we can compare
-		for i := range res.Entries {
-			if !strings.HasSuffix(res.Entries[i].Name, "/") && res.Entries[i].ModTime.IsZero() {
-				t.Fatal("mod time should be set")
-			}
-			res.Entries[i].ModTime = time.Time{}
-		}
+		assertModTime(res.Entries)
 
 		if !(len(res.Entries) == 0 && len(test.want) == 0) && !reflect.DeepEqual(res.Entries, test.want) {
 			t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, res.Entries, test.want)
@@ -399,12 +404,7 @@ func TestObjectEntries(t *testing.T) {
 			}
 
 			// assert mod time & clear it afterwards so we can compare
-			for i := range res.Entries {
-				if !strings.HasSuffix(res.Entries[i].Name, "/") && res.Entries[i].ModTime.IsZero() {
-					t.Fatal("mod time should be set")
-				}
-				res.Entries[i].ModTime = time.Time{}
-			}
+			assertModTime(res.Entries)
 
 			if len(res.Entries) != 1 || res.Entries[0] != test.want[offset] {
 				t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, res.Entries, test.want[offset])
@@ -425,12 +425,7 @@ func TestObjectEntries(t *testing.T) {
 			}
 
 			// assert mod time & clear it afterwards so we can compare
-			for i := range res.Entries {
-				if !strings.HasSuffix(res.Entries[i].Name, "/") && res.Entries[i].ModTime.IsZero() {
-					t.Fatal("mod time should be set")
-				}
-				res.Entries[i].ModTime = time.Time{}
-			}
+			assertModTime(res.Entries)
 
 			if len(res.Entries) != 1 || res.Entries[0] != test.want[offset+1] {
 				t.Errorf("\nlist: %v\nprefix: %v\nmarker: %v\ngot: %v\nwant: %v", test.path, test.prefix, test.want[offset].Name, res.Entries, test.want[offset+1])
@@ -449,12 +444,7 @@ func TestObjectEntries(t *testing.T) {
 		}
 
 		// assert mod time & clear it afterwards so we can compare
-		for i := range got {
-			if !strings.HasSuffix(got[i].Name, "/") && got[i].ModTime.IsZero() {
-				t.Fatal("mod time should be set")
-			}
-			got[i].ModTime = time.Time{}
-		}
+		assertModTime(got)
 
 		if !(len(got) == 0 && len(test.want) == 0) && !reflect.DeepEqual(got, test.want) {
 			t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want)

--- a/internal/testing/s3_test.go
+++ b/internal/testing/s3_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/SiaFoundation/gofakes3"
 	"github.com/google/go-cmp/cmp"
@@ -28,6 +29,7 @@ func TestS3Basic(t *testing.T) {
 		t.SkipNow()
 	}
 
+	start := time.Now()
 	cluster, err := newTestCluster(t.TempDir(), newTestLogger())
 	if err != nil {
 		t.Fatal(err)
@@ -131,6 +133,8 @@ func TestS3Basic(t *testing.T) {
 	}
 	if res.LastModified.IsZero() {
 		t.Fatal("expected LastModified to be non-zero")
+	} else if !res.LastModified.After(start.UTC()) {
+		t.Fatal("expected LastModified to be after the start of our test")
 	}
 
 	// get copied object

--- a/internal/testing/s3_test.go
+++ b/internal/testing/s3_test.go
@@ -111,7 +111,7 @@ func TestS3Basic(t *testing.T) {
 	}
 
 	// copy our object into the new bucket.
-	_, err = s3.CopyObject(context.Background(), minio.CopyDestOptions{
+	res, err := s3.CopyObject(context.Background(), minio.CopyDestOptions{
 		Bucket: bucket + "2",
 		Object: "object",
 	}, minio.CopySrcOptions{
@@ -120,6 +120,9 @@ func TestS3Basic(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if res.LastModified.IsZero() {
+		t.Fatal("expected LastModified to be non-zero")
 	}
 
 	// get copied object
@@ -285,6 +288,10 @@ func TestS3List(t *testing.T) {
 		for obj := range res {
 			if obj.Err != nil {
 				t.Fatal(err)
+			}
+
+			if !strings.HasSuffix(obj.Key, "/") && obj.LastModified.IsZero() {
+				t.Fatal("expected non-zero LastModified", obj.Key)
 			}
 			objs = append(objs, obj.Key)
 		}

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -10,7 +10,6 @@ import (
 	"mime"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/SiaFoundation/gofakes3"
 	"go.sia.tech/renterd/api"
@@ -138,8 +137,8 @@ func (s *s3) ListBucket(bucketName string, prefix *gofakes3.Prefix, page gofakes
 
 		item := &gofakes3.Content{
 			Key:          gofakes3.URLEncode(key),
-			LastModified: gofakes3.NewContentTime(time.Unix(0, 0).UTC()), // TODO: don't have that
-			ETag:         hex.EncodeToString(frand.Bytes(32)),            // TODO: don't have that
+			LastModified: gofakes3.NewContentTime(object.ModTime),
+			ETag:         hex.EncodeToString(frand.Bytes(32)), // TODO: don't have that
 			Size:         object.Size,
 			StorageClass: gofakes3.StorageStandard,
 		}
@@ -355,13 +354,13 @@ func (s *s3) DeleteMulti(bucketName string, objects ...string) (gofakes3.MultiDe
 
 // TODO: use metadata when we have support for it
 func (s *s3) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (gofakes3.CopyObjectResult, error) {
-	err := s.b.CopyObject(context.Background(), srcBucket, dstBucket, "/"+srcKey, "/"+dstKey)
+	obj, err := s.b.CopyObject(context.Background(), srcBucket, dstBucket, "/"+srcKey, "/"+dstKey)
 	if err != nil {
 		return gofakes3.CopyObjectResult{}, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 	}
 	return gofakes3.CopyObjectResult{
-		ETag:         "",                                             // TODO: don't have that
-		LastModified: gofakes3.NewContentTime(time.Unix(0, 0).UTC()), // TODO: don't have that
+		ETag:         "", // TODO: don't have that
+		LastModified: gofakes3.NewContentTime(obj.ModTime.UTC()),
 	}, nil
 }
 

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -252,7 +252,7 @@ func (s *s3) GetObject(bucketName, objectName string, rangeRequest *gofakes3.Obj
 	// TODO: When we support metadata we need to add it here.
 	metadata := map[string]string{
 		"Content-Type":  res.ContentType,
-		"Last-Modified": res.ModTime.Format(http.TimeFormat),
+		"Last-Modified": res.ModTime.UTC().Format(http.TimeFormat),
 	}
 
 	return &gofakes3.Object{

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -273,7 +273,7 @@ func (s *s3) HeadObject(bucketName, objectName string) (*gofakes3.Object, error)
 	// TODO: When we support metadata we need to add it here.
 	metadata := map[string]string{
 		"Content-Type":  mime.TypeByExtension(objectName),
-		"Last-Modified": time.Now().UTC().Format(http.TimeFormat), // TODO: update this when object has metadata
+		"Last-Modified": res.Object.LastModified(),
 	}
 	return &gofakes3.Object{
 		Name:     gofakes3.URLEncode(objectName),

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -30,7 +30,7 @@ type bus interface {
 	ListBuckets(ctx context.Context) (buckets []api.Bucket, err error)
 
 	AddObject(ctx context.Context, bucket, path, contractSet string, o object.Object, usedContract map[types.PublicKey]types.FileContractID) (err error)
-	CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, dstPath string) error
+	CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, dstPath string) (om api.ObjectMetadata, err error)
 	DeleteObject(ctx context.Context, bucket, path string, batch bool) (err error)
 	Object(ctx context.Context, path string, opts ...api.ObjectsOption) (res api.ObjectsResponse, err error)
 	SearchObjects(ctx context.Context, bucket, key string, offset, limit int) (entries []api.ObjectMetadata, err error)

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -154,6 +154,7 @@ type (
 	// rawObjectRow contains all necessary information to reconstruct the object.
 	rawObjectSector struct {
 		// object
+		ObjectID      uint
 		ObjectKey     []byte
 		ObjectName    string
 		ObjectSize    int64
@@ -1666,7 +1667,7 @@ func (s *SQLStore) object(ctx context.Context, txn *gorm.DB, bucket string, path
 	// accordingly
 	var rows rawObject
 	tx := s.db.
-		Select("o.key as ObjectKey, o.object_id as ObjectName, o.size as ObjectSize, o.created_at as ObjectModTime, sli.id as SliceID, sli.offset as SliceOffset, sli.length as SliceLength, sla.id as SlabID, sla.health as SlabHealth, sla.key as SlabKey, sla.min_shards as SlabMinShards, bs.id IS NOT NULL AS SlabBuffered, sec.id as SectorID, sec.root as SectorRoot, sec.latest_host as SectorHost").
+		Select("o.id as ObjectID, o.key as ObjectKey, o.object_id as ObjectName, o.size as ObjectSize, o.created_at as ObjectModTime, sli.id as SliceID, sli.offset as SliceOffset, sli.length as SliceLength, sla.id as SlabID, sla.health as SlabHealth, sla.key as SlabKey, sla.min_shards as SlabMinShards, bs.id IS NOT NULL AS SlabBuffered, sec.id as SectorID, sec.root as SectorRoot, sec.latest_host as SectorHost").
 		Model(&dbObject{}).
 		Table("objects o").
 		Joins("INNER JOIN buckets b ON o.db_bucket_id = b.id AND b.name = ?", bucket).

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -298,7 +298,7 @@ func (s dbSlab) convert() (slab object.Slab, err error) {
 func (raw rawObjectMetadata) convert() api.ObjectMetadata {
 	return api.ObjectMetadata{
 		Health:  raw.Health,
-		ModTime: time.Time(raw.ModTime),
+		ModTime: time.Time(raw.ModTime).UTC(),
 		Name:    raw.Name,
 		Size:    raw.Size,
 	}
@@ -386,7 +386,7 @@ func (raw rawObject) convert() (api.Object, error) {
 	return api.Object{
 		ObjectMetadata: api.ObjectMetadata{
 			Health:  minHealth,
-			ModTime: raw[0].ObjectModTime,
+			ModTime: raw[0].ObjectModTime.UTC(),
 			Name:    raw[0].ObjectName,
 			Size:    raw[0].ObjectSize,
 		},
@@ -1254,7 +1254,7 @@ func (s *SQLStore) CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath
 		om = api.ObjectMetadata{
 			Name:    dstObj.ObjectID,
 			Size:    dstObj.Size,
-			ModTime: dstObj.CreatedAt,
+			ModTime: dstObj.CreatedAt.UTC(),
 			Health:  minHealth,
 		}
 		return nil

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1054,10 +1054,7 @@ func (s *SQLStore) Object(ctx context.Context, bucket, path string) (api.Object,
 			return err
 		}
 		obj, err = o.convert()
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	})
 	return obj, err
 }

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3383,7 +3383,7 @@ func TestCopyObject(t *testing.T) {
 	}
 
 	// Copy it within the same bucket.
-	if err := os.CopyObject(ctx, "src", "src", "/foo", "/bar"); err != nil {
+	if _, err := os.CopyObject(ctx, "src", "src", "/foo", "/bar"); err != nil {
 		t.Fatal(err)
 	} else if entries, _, err := os.ObjectEntries(ctx, "src", "/", "", "", 0, -1); err != nil {
 		t.Fatal(err)
@@ -3394,7 +3394,7 @@ func TestCopyObject(t *testing.T) {
 	}
 
 	// Copy it cross buckets.
-	if err := os.CopyObject(ctx, "src", "dst", "/foo", "/bar"); err != nil {
+	if _, err := os.CopyObject(ctx, "src", "dst", "/foo", "/bar"); err != nil {
 		t.Fatal(err)
 	} else if entries, _, err := os.ObjectEntries(ctx, "dst", "/", "", "", 0, -1); err != nil {
 		t.Fatal(err)

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3383,7 +3383,7 @@ func TestCopyObject(t *testing.T) {
 	}
 
 	// Copy it within the same bucket.
-	if _, err := os.CopyObject(ctx, "src", "src", "/foo", "/bar"); err != nil {
+	if om, err := os.CopyObject(ctx, "src", "src", "/foo", "/bar"); err != nil {
 		t.Fatal(err)
 	} else if entries, _, err := os.ObjectEntries(ctx, "src", "/", "", "", 0, -1); err != nil {
 		t.Fatal(err)
@@ -3391,10 +3391,12 @@ func TestCopyObject(t *testing.T) {
 		t.Fatal("expected 2 entries", len(entries))
 	} else if entries[0].Name != "/bar" || entries[1].Name != "/foo" {
 		t.Fatal("unexpected names", entries[0].Name, entries[1].Name)
+	} else if om.ModTime.IsZero() {
+		t.Fatal("expected mod time to be set")
 	}
 
 	// Copy it cross buckets.
-	if _, err := os.CopyObject(ctx, "src", "dst", "/foo", "/bar"); err != nil {
+	if om, err := os.CopyObject(ctx, "src", "dst", "/foo", "/bar"); err != nil {
 		t.Fatal(err)
 	} else if entries, _, err := os.ObjectEntries(ctx, "dst", "/", "", "", 0, -1); err != nil {
 		t.Fatal(err)
@@ -3402,6 +3404,8 @@ func TestCopyObject(t *testing.T) {
 		t.Fatal("expected 1 entry", len(entries))
 	} else if entries[0].Name != "/bar" {
 		t.Fatal("unexpected names", entries[0].Name, entries[1].Name)
+	} else if om.ModTime.IsZero() {
+		t.Fatal("expected mod time to be set")
 	}
 }
 

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1331,6 +1331,20 @@ func TestObjectHealth(t *testing.T) {
 		t.Fatal("wrong health", obj.Health)
 	}
 
+	// assert (raw) object and object health methods
+	raw, err := db.object(context.Background(), db.db, api.DefaultBucketName, "/foo")
+	if err != nil {
+		t.Fatal(err)
+	} else if len(raw) == 0 {
+		t.Fatal("object not found")
+	}
+	health, err := db.objectHealth(context.Background(), db.db, raw[0].ObjectID)
+	if err != nil {
+		t.Fatal(err)
+	} else if health != expectedHealth {
+		t.Fatal("wrong health", health)
+	}
+
 	// assert health is returned correctly by ObjectEntries
 	entries, _, err := db.ObjectEntries(context.Background(), api.DefaultBucketName, "/", "", "", 0, -1)
 	if err != nil {

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1423,6 +1423,17 @@ func TestObjectEntries(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+
+	// assert mod time & clear it afterwards so we can compare
+	assertModTime := func(entries []api.ObjectMetadata) {
+		for i := range entries {
+			if !strings.HasSuffix(entries[i].Name, "/") && entries[i].ModTime.IsZero() {
+				t.Fatal("mod time should be set")
+			}
+			entries[i].ModTime = time.Time{}
+		}
+	}
+
 	tests := []struct {
 		path   string
 		prefix string
@@ -1447,12 +1458,7 @@ func TestObjectEntries(t *testing.T) {
 		}
 
 		// assert mod time & clear it afterwards so we can compare
-		for i := range got {
-			if !strings.HasSuffix(got[i].Name, "/") && got[i].ModTime.IsZero() {
-				t.Fatal("mod time should be set")
-			}
-			got[i].ModTime = time.Time{}
-		}
+		assertModTime(got)
 
 		if !(len(got) == 0 && len(test.want) == 0) && !reflect.DeepEqual(got, test.want) {
 			t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want)
@@ -1464,12 +1470,7 @@ func TestObjectEntries(t *testing.T) {
 			}
 
 			// assert mod time & clear it afterwards so we can compare
-			for i := range got {
-				if !strings.HasSuffix(got[i].Name, "/") && got[i].ModTime.IsZero() {
-					t.Fatal("mod time should be set")
-				}
-				got[i].ModTime = time.Time{}
-			}
+			assertModTime(got)
 
 			if len(got) != 1 || got[0] != test.want[offset] {
 				t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want[offset])
@@ -1491,12 +1492,7 @@ func TestObjectEntries(t *testing.T) {
 			}
 
 			// assert mod time & clear it afterwards so we can compare
-			for i := range got {
-				if !strings.HasSuffix(got[i].Name, "/") && got[i].ModTime.IsZero() {
-					t.Fatal("mod time should be set")
-				}
-				got[i].ModTime = time.Time{}
-			}
+			assertModTime(got)
 
 			if len(got) != 1 || got[0] != test.want[offset+1] {
 				t.Errorf("\nlist: %v\nprefix: %v\nmarker: %v\ngot: %v\nwant: %v", test.path, test.prefix, test.want[offset].Name, got, test.want[offset+1])
@@ -3535,6 +3531,17 @@ func TestListObjects(t *testing.T) {
 		{"/gab/guub", 5},
 		{"/FOO/bar", 6}, // test case sensitivity
 	}
+
+	// assert mod time & clear it afterwards so we can compare
+	assertModTime := func(entries []api.ObjectMetadata) {
+		for i := range entries {
+			if !strings.HasSuffix(entries[i].Name, "/") && entries[i].ModTime.IsZero() {
+				t.Fatal("mod time should be set")
+			}
+			entries[i].ModTime = time.Time{}
+		}
+	}
+
 	ctx := context.Background()
 	for _, o := range objects {
 		obj, ucs := newTestObject(frand.Intn(9) + 1)
@@ -3561,12 +3568,7 @@ func TestListObjects(t *testing.T) {
 		}
 
 		// assert mod time & clear it afterwards so we can compare
-		for i := range res.Objects {
-			if !strings.HasSuffix(res.Objects[i].Name, "/") && res.Objects[i].ModTime.IsZero() {
-				t.Fatal("mod time should be set")
-			}
-			res.Objects[i].ModTime = time.Time{}
-		}
+		assertModTime(res.Objects)
 
 		got := res.Objects
 		if !(len(got) == 0 && len(test.want) == 0) && !reflect.DeepEqual(got, test.want) {
@@ -3581,12 +3583,7 @@ func TestListObjects(t *testing.T) {
 				}
 
 				// assert mod time & clear it afterwards so we can compare
-				for i := range res.Objects {
-					if !strings.HasSuffix(res.Objects[i].Name, "/") && res.Objects[i].ModTime.IsZero() {
-						t.Fatal("mod time should be set")
-					}
-					res.Objects[i].ModTime = time.Time{}
-				}
+				assertModTime(res.Objects)
 
 				got := res.Objects
 				if len(got) != 1 {

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1445,6 +1445,15 @@ func TestObjectEntries(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// assert mod time & clear it afterwards so we can compare
+		for i := range got {
+			if !strings.HasSuffix(got[i].Name, "/") && got[i].ModTime.IsZero() {
+				t.Fatal("mod time should be set")
+			}
+			got[i].ModTime = time.Time{}
+		}
+
 		if !(len(got) == 0 && len(test.want) == 0) && !reflect.DeepEqual(got, test.want) {
 			t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want)
 		}
@@ -1453,6 +1462,15 @@ func TestObjectEntries(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			// assert mod time & clear it afterwards so we can compare
+			for i := range got {
+				if !strings.HasSuffix(got[i].Name, "/") && got[i].ModTime.IsZero() {
+					t.Fatal("mod time should be set")
+				}
+				got[i].ModTime = time.Time{}
+			}
+
 			if len(got) != 1 || got[0] != test.want[offset] {
 				t.Errorf("\nlist: %v\nprefix: %v\ngot: %v\nwant: %v", test.path, test.prefix, got, test.want[offset])
 			}
@@ -1471,6 +1489,15 @@ func TestObjectEntries(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			// assert mod time & clear it afterwards so we can compare
+			for i := range got {
+				if !strings.HasSuffix(got[i].Name, "/") && got[i].ModTime.IsZero() {
+					t.Fatal("mod time should be set")
+				}
+				got[i].ModTime = time.Time{}
+			}
+
 			if len(got) != 1 || got[0] != test.want[offset+1] {
 				t.Errorf("\nlist: %v\nprefix: %v\nmarker: %v\ngot: %v\nwant: %v", test.path, test.prefix, test.want[offset].Name, got, test.want[offset+1])
 			}

--- a/stores/types.go
+++ b/stores/types.go
@@ -210,8 +210,11 @@ func (dt *datetime) Scan(value interface{}) error {
 		s = value
 	case []byte:
 		s = string(value)
+	case time.Time:
+		*dt = datetime(value)
+		return nil
 	default:
-		return fmt.Errorf("failed to unmarshal time.Time value: %v %t", value, value)
+		return fmt.Errorf("failed to unmarshal time.Time value: %v %T", value, value)
 	}
 
 	var t time.Time

--- a/stores/types.go
+++ b/stores/types.go
@@ -180,6 +180,8 @@ func (hs *balance) Scan(value interface{}) error {
 	return nil
 }
 
+// SQLiteTimestampFormats were taken from github.com/mattn/go-sqlite3 and are
+// used when parsing a string to a date
 var SQLiteTimestampFormats = []string{
 	"2006-01-02 15:04:05.999999999-07:00",
 	"2006-01-02T15:04:05.999999999-07:00",
@@ -217,13 +219,18 @@ func (dt *datetime) Scan(value interface{}) error {
 		return fmt.Errorf("failed to unmarshal time.Time value: %v %T", value, value)
 	}
 
+	var ok bool
 	var t time.Time
 	s = strings.TrimSuffix(s, "Z")
 	for _, format := range SQLiteTimestampFormats {
 		if timeVal, err := time.ParseInLocation(format, s, time.UTC); err == nil {
+			ok = true
 			t = timeVal
 			break
 		}
+	}
+	if !ok {
+		return fmt.Errorf("failed to parse datetime value: %v", s)
 	}
 
 	*dt = datetime(t)

--- a/worker/client.go
+++ b/worker/client.go
@@ -346,7 +346,7 @@ func (c *Client) GetObject(ctx context.Context, bucket, path string, opts ...api
 	return api.GetObjectResponse{
 		Content:     body,
 		ContentType: header.Get("Content-Type"),
-		ModTime:     modTime,
+		ModTime:     modTime.UTC(),
 		Range:       r,
 		Size:        size,
 	}, nil

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1017,12 +1017,11 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 	} else if jc.Check("couldn't get object or entries", err) != nil {
 		return
 	}
-	jc.ResponseWriter.Header().Set("Last-Modified", res.Object.LastModified())
-
 	if path == "" || strings.HasSuffix(path, "/") {
 		jc.Encode(res.Entries)
 		return
 	}
+	jc.ResponseWriter.Header().Set("Last-Modified", res.Object.LastModified())
 	if len(res.Object.Slabs) == 0 && len(res.Object.PartialSlabs) == 0 {
 		return
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1017,7 +1017,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 	} else if jc.Check("couldn't get object or entries", err) != nil {
 		return
 	}
-	jc.ResponseWriter.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat)) // TODO: update this when object has a ModTime
+	jc.ResponseWriter.Header().Set("Last-Modified", res.Object.LastModified())
 
 	if path == "" || strings.HasSuffix(path, "/") {
 		jc.Encode(res.Entries)


### PR DESCRIPTION
This PR uses the object's `created_at` field as its `ModTime`.

Verified locally that it returns the objects created at timestamp in the `Last-Modified` header

```
➜  ~ curl -u ":test" localhost:9880/api/worker/objects/test -v -o /dev/null
...
< Content-Length: 302383
< Content-Type: application/octet-stream
< Last-Modified: Wed, 20 Sep 2023 09:34:39 GMT
< Date: Thu, 21 Sep 2023 12:17:26 GMT
...
* Connection #0 to host localhost left intact
```