### PR TITLE
Fix prune slab edge case

### DIFF
--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -98,6 +98,7 @@ type TestCluster struct {
 	Bus       *bus.Client
 	Worker    *worker.Client
 	S3        *minio.Client
+	S3Core    *minio.Core
 
 	workerShutdownFns    []func(context.Context) error
 	busShutdownFns       []func(context.Context) error
@@ -280,6 +281,13 @@ func newTestClusterCustom(dir, dbName string, funding bool, wk types.PrivateKey,
 	if err != nil {
 		return nil, err
 	}
+	url := s3Client.EndpointURL()
+	s3Core, err := minio.NewCore(url.Host+url.Path, &minio.Options{
+		Creds: testS3Credentials,
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	// Create miner.
 	busCfg.Miner = node.NewMiner(busClient)
@@ -352,6 +360,7 @@ func newTestClusterCustom(dir, dbName string, funding bool, wk types.PrivateKey,
 		Bus:       busClient,
 		Worker:    workerClient,
 		S3:        s3Client,
+		S3Core:    s3Core,
 
 		workerShutdownFns:    workerShutdownFns,
 		busShutdownFns:       busShutdownFns,

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1102,7 +1102,7 @@ func (s *SQLStore) isKnownContract(fcid types.FileContractID) bool {
 func pruneSlabs(tx *gorm.DB) error {
 	return tx.Exec(`DELETE FROM slabs WHERE slabs.id IN (SELECT * FROM (SELECT sla.id FROM slabs sla
 		LEFT JOIN slices sli ON sli.db_slab_id  = sla.id
-		WHERE db_object_id IS NULL AND sla.db_buffered_slab_id IS NULL) toDelete)`).Error
+		WHERE db_object_id IS NULL AND db_multipart_part_id IS NULL AND sla.db_buffered_slab_id IS NULL) toDelete)`).Error
 }
 
 func fetchUsedContracts(tx *gorm.DB, usedContracts map[types.PublicKey]types.FileContractID) (map[types.PublicKey]dbContract, error) {

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
@@ -274,7 +275,7 @@ func (s *SQLStore) CompleteMultipartUpload(ctx context.Context, bucket, path str
 				} else if mu.Parts[j].PartNumber > part.PartNumber {
 					// missing part
 					return api.ErrPartNotFound
-				} else if mu.Parts[j].PartNumber == part.PartNumber && mu.Parts[j].Etag == part.ETag {
+				} else if mu.Parts[j].PartNumber == part.PartNumber && mu.Parts[j].Etag == strings.Trim(part.ETag, "\"") {
 					// found a match
 					dbParts = append(dbParts, mu.Parts[j])
 					size += mu.Parts[j].Size

--- a/worker/client.go
+++ b/worker/client.go
@@ -243,7 +243,7 @@ func (c *Client) UploadMultipartUploadPart(ctx context.Context, r io.Reader, pat
 		err, _ := io.ReadAll(resp.Body)
 		return "", errors.New(string(err))
 	}
-	return resp.Header.Get("ETag"), nil
+	return strings.Trim(resp.Header.Get("ETag"), "\""), nil
 }
 
 func (c *Client) object(ctx context.Context, bucket, path, prefix string, offset, limit int, opts ...api.DownloadObjectOption) (_ io.ReadCloser, _ http.Header, err error) {


### PR DESCRIPTION
f/u to 610 which adds a regression test

Also fixes a bug related to the official amazon client and multipart uploads. Reason for that bug was that different clients seem to behave differently around passing etags to `CompleteMultipartUpload`. So sometimes the etag would reach the backend with quotes surrounding it and sometimes not.