### PR TITLE
Migration Logs

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -44,6 +44,11 @@ type ContractsResponse struct {
 	Error     string     `json:"error,omitempty"`
 }
 
+// MigrateSlabResponse is the response type for the /slab/migrate endpoint.
+type MigrateSlabResponse struct {
+	NumShardsMigrated int `json:"numShardsMigrated"`
+}
+
 // RHPScanRequest is the request type for the /rhp/scan endpoint.
 type RHPScanRequest struct {
 	HostKey types.PublicKey `json:"hostKey"`

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -87,7 +87,7 @@ type Worker interface {
 	RHPBroadcast(ctx context.Context, fcid types.FileContractID) (err error)
 	Contracts(ctx context.Context, hostTimeout time.Duration) (api.ContractsResponse, error)
 	ID(ctx context.Context) (string, error)
-	MigrateSlab(ctx context.Context, s object.Slab, set string) error
+	MigrateSlab(ctx context.Context, s object.Slab, set string) (api.MigrateSlabResponse, error)
 	RHPForm(ctx context.Context, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds types.Currency, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP, siamuxAddr string, balance types.Currency) (err error)
 	RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (hostdb.HostPriceTable, error)

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -125,7 +125,7 @@ func (m *migrator) performMigrations(p *workerPool) {
 							m.logger.Errorf("%v: failed to fetch autopilot settings for migration %d/%d, health: %v, err: %v", id, j.slabIdx+1, j.batchSize, j.Health, err)
 							continue
 						}
-						err = w.MigrateSlab(ctx, slab, ap.Config.Contracts.Set)
+						res, err := w.MigrateSlab(ctx, slab, ap.Config.Contracts.Set)
 						if err != nil {
 							errMsg := fmt.Sprintf("%v: failed to migrate slab %d/%d, health: %v, err: %v", id, j.slabIdx+1, j.batchSize, j.Health, err)
 							rerr := m.ap.alerts.RegisterAlert(ctx, alerts.Alert{
@@ -143,7 +143,7 @@ func (m *migrator) performMigrations(p *workerPool) {
 							m.logger.Errorf(errMsg)
 							continue
 						}
-						m.logger.Debugf("%v: successfully migrated slab (health: %v) %d/%d", id, j.Health, j.slabIdx+1, j.batchSize)
+						m.logger.Debugf("%v: successfully migrated slab (health: %v migrated shards: %d) %d/%d", id, j.Health, res.NumShardsMigrated, j.slabIdx+1, j.batchSize)
 					}
 				}(w)
 			}

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1346,7 +1346,7 @@ func (ss *SQLStore) UpdateSlab(ctx context.Context, s object.Slab, contractSet s
 
 	// Update slab.
 	return ss.retryTransaction(func(tx *gorm.DB) (err error) {
-		// Fetch contract set.
+		// fetch contract set
 		var cs dbContractSet
 		if err := tx.Take(&cs, "name = ?", contractSet).Error; err != nil {
 			return err

--- a/worker/client.go
+++ b/worker/client.go
@@ -161,11 +161,11 @@ func (c *Client) State() (state api.WorkerStateResponse, err error) {
 }
 
 // MigrateSlab migrates the specified slab.
-func (c *Client) MigrateSlab(ctx context.Context, slab object.Slab, set string) error {
+func (c *Client) MigrateSlab(ctx context.Context, slab object.Slab, set string) (res api.MigrateSlabResponse, err error) {
 	values := make(url.Values)
 	values.Set("contractset", set)
-
-	return c.c.WithContext(ctx).POST("/slab/migrate?"+values.Encode(), slab, nil)
+	err = c.c.WithContext(ctx).POST("/slab/migrate?"+values.Encode(), slab, &res)
+	return
 }
 
 // DownloadStats returns the upload stats.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -908,13 +908,8 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 	}
 
 	// migrate the slab
-	used, err := migrateSlab(ctx, w.downloadManager, w.uploadManager, &slab, dlContracts, ulContracts, up.CurrentHeight, w.logger)
+	used, numShardsMigrated, err := migrateSlab(ctx, w.downloadManager, w.uploadManager, &slab, dlContracts, ulContracts, up.CurrentHeight, w.logger)
 	if jc.Check("couldn't migrate slabs", err) != nil {
-		return
-	}
-
-	// no migration took place, return early
-	if used == nil {
 		return
 	}
 
@@ -922,6 +917,8 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 	if jc.Check("couldn't update slab", w.bus.UpdateSlab(ctx, slab, up.ContractSet, used)) != nil {
 		return
 	}
+
+	jc.Encode(api.MigrateSlabResponse{NumShardsMigrated: numShardsMigrated})
 }
 
 func (w *worker) downloadsStatsHandlerGET(jc jape.Context) {


### PR DESCRIPTION
This PR logs the number of shards we migrated and it updates slabs that for whatever reason did not need to be migrated after all. This because we've seen some weird migration behaviour on arequipa where it blows through ~5k slabs with very poor health, only to skip migration and leave them in poor-health-status.