### PR TITLE
SlabBufferMaxSizeSoft Setting

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -616,7 +616,8 @@ type SearchHostsRequest struct {
 }
 
 type UploadPackingSettings struct {
-	Enabled bool `json:"enabled"`
+	Enabled               bool  `json:"enabled"`
+	SlabBufferMaxSizeSoft int64 `json:"slabBufferMaxSizeSoft"`
 }
 
 // RedundancySettings contain settings that dictate an object's redundancy.
@@ -647,7 +648,8 @@ func (rs RedundancySettings) Validate() error {
 }
 
 type AddPartialSlabResponse struct {
-	Slabs []object.PartialSlab `json:"slabs"`
+	SlabBufferMaxSizeSoftReached bool                 `json:"slabBufferMaxSizeSoftReached"`
+	Slabs                        []object.PartialSlab `json:"slabs"`
 }
 
 func FormatEtag(etag string) string {

--- a/build/env_default.go
+++ b/build/env_default.go
@@ -37,7 +37,8 @@ var (
 	// DefaultUploadPackingSettings define the default upload packing settings
 	// the bus is configured with on startup.
 	DefaultUploadPackingSettings = api.UploadPackingSettings{
-		Enabled: false,
+		Enabled:               false,
+		SlabBufferMaxSizeSoft: 1 << 32, // 4 GiB
 	}
 
 	// DefaultRedundancySettings define the default redundancy settings the bus

--- a/build/env_testnet.go
+++ b/build/env_testnet.go
@@ -39,7 +39,8 @@ var (
 	// DefaultUploadPackingSettings define the default upload packing settings
 	// the bus is configured with on startup.
 	DefaultUploadPackingSettings = api.UploadPackingSettings{
-		Enabled: false,
+		Enabled:                    false,
+		MaxDiskBufferSizeSoftLimit: 1 << 32, // 4 GiB
 	}
 
 	// DefaultRedundancySettings define the default redundancy settings the bus

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -135,7 +135,7 @@ type (
 
 		ObjectsStats(ctx context.Context) (api.ObjectsStatsResponse, error)
 
-		AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.PartialSlab, err error)
+		AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.PartialSlab, bufferSize int64, err error)
 		FetchPartialSlab(ctx context.Context, key object.EncryptionKey, offset, length uint32) ([]byte, error)
 		Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
 		RefreshHealth(ctx context.Context) error
@@ -1252,12 +1252,18 @@ func (b *bus) slabsPartialHandlerPOST(jc jape.Context) {
 	if jc.Check("failed to read request body", err) != nil {
 		return
 	}
-	slabs, err := b.ms.AddPartialSlab(jc.Request.Context(), data, uint8(minShards), uint8(totalShards), contractSet)
+	slabs, bufferSize, err := b.ms.AddPartialSlab(jc.Request.Context(), data, uint8(minShards), uint8(totalShards), contractSet)
 	if jc.Check("failed to add partial slab", err) != nil {
 		return
 	}
+	var pus api.UploadPackingSettings
+	if err := b.fetchSetting(jc.Request.Context(), api.SettingUploadPacking, &pus); err != nil && !errors.Is(err, api.ErrSettingNotFound) {
+		jc.Error(fmt.Errorf("could not get upload packing settings: %w", err), http.StatusInternalServerError)
+		return
+	}
 	jc.Encode(api.AddPartialSlabResponse{
-		Slabs: slabs,
+		Slabs:                        slabs,
+		SlabBufferMaxSizeSoftReached: bufferSize >= pus.SlabBufferMaxSizeSoft,
 	})
 }
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -596,6 +596,7 @@ func (c *Client) GougingSettings(ctx context.Context) (gs api.GougingSettings, e
 	return
 }
 
+// UploadPackingSettings returns the upload packing settings.
 func (c *Client) UploadPackingSettings(ctx context.Context) (ups api.UploadPackingSettings, err error) {
 	err = c.Setting(ctx, api.SettingUploadPacking, &ups)
 	return

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1152,10 +1152,10 @@ func (s *SQLStore) FetchPartialSlab(ctx context.Context, ec object.EncryptionKey
 	return s.slabBufferMgr.FetchPartialSlab(ctx, ec, offset, length)
 }
 
-func (s *SQLStore) AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) ([]object.PartialSlab, error) {
+func (s *SQLStore) AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) ([]object.PartialSlab, int64, error) {
 	var contractSetID uint
 	if err := s.db.Raw("SELECT id FROM contract_sets WHERE name = ?", contractSet).Scan(&contractSetID).Error; err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	return s.slabBufferMgr.AddPartialSlab(ctx, data, minShards, totalShards, contractSetID)
 }

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2642,7 +2642,7 @@ func TestPartialSlab(t *testing.T) {
 
 	// Add the first slab.
 	ctx := context.Background()
-	slabs, err := db.AddPartialSlab(ctx, slab1Data, 1, 2, testContractSet)
+	slabs, bufferSize, err := db.AddPartialSlab(ctx, slab1Data, 1, 2, testContractSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2651,6 +2651,8 @@ func TestPartialSlab(t *testing.T) {
 	}
 	if slabs[0].Length != uint32(len(slab1Data)) || slabs[0].Offset != 0 {
 		t.Fatal("wrong offset/length", slabs[0].Offset, slabs[0].Length)
+	} else if bufferSize != int64(len(slab1Data)) {
+		t.Fatal("unexpected buffer size", bufferSize)
 	}
 	data, err := db.FetchPartialSlab(ctx, slabs[0].Key, slabs[0].Offset, slabs[0].Length)
 	if err != nil {
@@ -2711,7 +2713,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 
 	// Add the second slab.
-	slabs, err = db.AddPartialSlab(ctx, slab2Data, 1, 2, testContractSet)
+	slabs, bufferSize, err = db.AddPartialSlab(ctx, slab2Data, 1, 2, testContractSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2720,6 +2722,8 @@ func TestPartialSlab(t *testing.T) {
 	}
 	if slabs[0].Length != uint32(len(slab2Data)) || slabs[0].Offset != uint32(len(slab1Data)) {
 		t.Fatal("wrong offset/length", slabs[0].Offset, slabs[0].Length)
+	} else if bufferSize != int64(len(slab1Data)+len(slab2Data)) {
+		t.Fatal("unexpected buffer size", bufferSize)
 	}
 	data, err = db.FetchPartialSlab(ctx, slabs[0].Key, slabs[0].Offset, slabs[0].Length)
 	if err != nil {
@@ -2748,7 +2752,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 
 	// Add third slab.
-	slabs, err = db.AddPartialSlab(ctx, slab3Data, 1, 2, testContractSet)
+	slabs, bufferSize, err = db.AddPartialSlab(ctx, slab3Data, 1, 2, testContractSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2760,6 +2764,9 @@ func TestPartialSlab(t *testing.T) {
 	}
 	if slabs[1].Length != uint32(len(slab3Data)-1) || slabs[1].Offset != 0 {
 		t.Fatal("wrong offset/length", slabs[0].Offset, slabs[0].Length)
+	}
+	if bufferSize != rhpv2.SectorSize+1 {
+		t.Fatal("unexpected buffer size", bufferSize)
 	}
 	if data1, err := db.FetchPartialSlab(ctx, slabs[0].Key, slabs[0].Offset, slabs[0].Length); err != nil {
 		t.Fatal(err)
@@ -2860,11 +2867,11 @@ func TestPartialSlab(t *testing.T) {
 	}
 
 	// Add 2 more partial slabs.
-	_, err = db.AddPartialSlab(ctx, frand.Bytes(rhpv2.SectorSize/2), 1, 2, testContractSet)
+	_, _, err = db.AddPartialSlab(ctx, frand.Bytes(rhpv2.SectorSize/2), 1, 2, testContractSet)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = db.AddPartialSlab(ctx, frand.Bytes(rhpv2.SectorSize/2), 1, 2, testContractSet)
+	_, bufferSize, err = db.AddPartialSlab(ctx, frand.Bytes(rhpv2.SectorSize/2), 1, 2, testContractSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2881,6 +2888,9 @@ func TestPartialSlab(t *testing.T) {
 		t.Fatal("expected buffer to be complete")
 	} else if buffersBefore[1].Complete {
 		t.Fatal("expected buffer to be incomplete")
+	}
+	if bufferSize != rhpv2.SectorSize+buffersBefore[1].Size {
+		t.Fatal("unexpected buffer size", bufferSize)
 	}
 
 	// Close manager to make sure we can restart the database without
@@ -3431,7 +3441,7 @@ func TestMarkSlabUploadedAfterRenew(t *testing.T) {
 
 	// create a full buffered slab.
 	completeSize := bufferedSlabSize(1)
-	_, err = db.AddPartialSlab(context.Background(), frand.Bytes(completeSize), 1, 1, testContractSet)
+	_, _, err = db.AddPartialSlab(context.Background(), frand.Bytes(completeSize), 1, 1, testContractSet)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2651,7 +2651,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 	if slabs[0].Length != uint32(len(slab1Data)) || slabs[0].Offset != 0 {
 		t.Fatal("wrong offset/length", slabs[0].Offset, slabs[0].Length)
-	} else if bufferSize != int64(len(slab1Data)) {
+	} else if bufferSize != rhpv2.SectorSize {
 		t.Fatal("unexpected buffer size", bufferSize)
 	}
 	data, err := db.FetchPartialSlab(ctx, slabs[0].Key, slabs[0].Offset, slabs[0].Length)
@@ -2722,7 +2722,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 	if slabs[0].Length != uint32(len(slab2Data)) || slabs[0].Offset != uint32(len(slab1Data)) {
 		t.Fatal("wrong offset/length", slabs[0].Offset, slabs[0].Length)
-	} else if bufferSize != int64(len(slab1Data)+len(slab2Data)) {
+	} else if bufferSize != rhpv2.SectorSize {
 		t.Fatal("unexpected buffer size", bufferSize)
 	}
 	data, err = db.FetchPartialSlab(ctx, slabs[0].Key, slabs[0].Offset, slabs[0].Length)
@@ -2765,7 +2765,7 @@ func TestPartialSlab(t *testing.T) {
 	if slabs[1].Length != uint32(len(slab3Data)-1) || slabs[1].Offset != 0 {
 		t.Fatal("wrong offset/length", slabs[0].Offset, slabs[0].Length)
 	}
-	if bufferSize != rhpv2.SectorSize+1 {
+	if bufferSize != 2*rhpv2.SectorSize {
 		t.Fatal("unexpected buffer size", bufferSize)
 	}
 	if data1, err := db.FetchPartialSlab(ctx, slabs[0].Key, slabs[0].Offset, slabs[0].Length); err != nil {
@@ -2889,7 +2889,7 @@ func TestPartialSlab(t *testing.T) {
 	} else if buffersBefore[1].Complete {
 		t.Fatal("expected buffer to be incomplete")
 	}
-	if bufferSize != rhpv2.SectorSize+buffersBefore[1].Size {
+	if bufferSize != 2*rhpv2.SectorSize {
 		t.Fatal("unexpected buffer size", bufferSize)
 	}
 

--- a/stores/slabbuffer.go
+++ b/stores/slabbuffer.go
@@ -288,10 +288,11 @@ func (mgr *SlabBufferManager) AddPartialSlab(ctx context.Context, data []byte, m
 func (mgr *SlabBufferManager) BufferSize(gid bufferGroupID) (total int64) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
-	for _, buffer := range append(mgr.completeBuffers[gid], mgr.incompleteBuffers[gid]...) {
-		buffer.mu.Lock()
-		total += buffer.size
-		buffer.mu.Unlock()
+	for _, buffer := range mgr.completeBuffers[gid] {
+		total += buffer.maxSize
+	}
+	for _, buffer := range mgr.incompleteBuffers[gid] {
+		total += buffer.maxSize
 	}
 	return
 }

--- a/stores/slabbuffer.go
+++ b/stores/slabbuffer.go
@@ -149,17 +149,17 @@ func (mgr *SlabBufferManager) Close() error {
 	return errors.Join(errs...)
 }
 
-func (mgr *SlabBufferManager) AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet uint) ([]object.PartialSlab, error) {
+func (mgr *SlabBufferManager) AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet uint) ([]object.PartialSlab, int64, error) {
 	gid := bufferGID(minShards, totalShards, uint32(contractSet))
 
 	// Sanity check input.
 	slabSize := bufferedSlabSize(minShards)
 	if minShards == 0 || totalShards == 0 || minShards > totalShards {
-		return nil, fmt.Errorf("invalid shard configuration: minShards=%v, totalShards=%v", minShards, totalShards)
+		return nil, 0, fmt.Errorf("invalid shard configuration: minShards=%v, totalShards=%v", minShards, totalShards)
 	} else if contractSet == 0 {
-		return nil, fmt.Errorf("contract set must be set")
+		return nil, 0, fmt.Errorf("contract set must be set")
 	} else if len(data) > slabSize {
-		return nil, fmt.Errorf("data size %v exceeds size of a slab %v", len(data), slabSize)
+		return nil, 0, fmt.Errorf("data size %v exceeds size of a slab %v", len(data), slabSize)
 	}
 
 	// Deep copy available buffers. We don't want to block the manager while we
@@ -178,7 +178,7 @@ func (mgr *SlabBufferManager) AddPartialSlab(ctx context.Context, data []byte, m
 		var used bool
 		slab, data, used, err = buffer.recordAppend(data)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if used {
 			usedBuffers = append(usedBuffers, buffer)
@@ -195,11 +195,11 @@ func (mgr *SlabBufferManager) AddPartialSlab(ctx context.Context, data []byte, m
 			return err
 		})
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		slab, data, _, err = sb.recordAppend(data)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if len(data) > 0 {
 			panic("remaining data after creating new buffer")
@@ -222,9 +222,9 @@ func (mgr *SlabBufferManager) AddPartialSlab(ctx context.Context, data []byte, m
 	}
 	var dbUpdates []dbUpdate
 	for _, buffer := range usedBuffers {
-		syncSize, complete, err := buffer.commitAppend(data, mgr.bufferedSlabCompletionThreshold)
+		syncSize, complete, err := buffer.commitAppend(mgr.bufferedSlabCompletionThreshold)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		// Move the buffer from incomplete to complete if it is now complete.
 		if complete {
@@ -278,10 +278,22 @@ func (mgr *SlabBufferManager) AddPartialSlab(ctx context.Context, data []byte, m
 			return nil
 		}()
 		if err != nil {
-			return nil, fmt.Errorf("failed to update size/complete in db: %w", err)
+			return nil, 0, fmt.Errorf("failed to update size/complete in db: %w", err)
 		}
 	}
-	return slabs, nil
+
+	return slabs, mgr.BufferSize(gid), nil
+}
+
+func (mgr *SlabBufferManager) BufferSize(gid bufferGroupID) (total int64) {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	for _, buffer := range append(mgr.completeBuffers[gid], mgr.incompleteBuffers[gid]...) {
+		buffer.mu.Lock()
+		total += buffer.size
+		buffer.mu.Unlock()
+	}
+	return
 }
 
 func (mgr *SlabBufferManager) FetchPartialSlab(ctx context.Context, ec object.EncryptionKey, offset, length uint32) ([]byte, error) {
@@ -441,7 +453,7 @@ func (buf *SlabBuffer) recordAppend(data []byte) (object.PartialSlab, []byte, bo
 	}
 }
 
-func (buf *SlabBuffer) commitAppend(data []byte, completionThreshold int64) (int64, bool, error) {
+func (buf *SlabBuffer) commitAppend(completionThreshold int64) (int64, bool, error) {
 	// Fetch the current size first. We know that we have at least synced the
 	// buffer up to this point upon success.
 	buf.mu.Lock()

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -242,13 +242,13 @@ func (w *worker) upload(ctx context.Context, r io.Reader, bucket, path string, o
 		return "", fmt.Errorf("couldn't upload object: %w", err)
 	}
 
-	// add parital slabs
+	// add partial slabs
+	var bufferSizeLimitReached bool
 	if len(partialSlabData) > 0 {
-		partialSlabs, err := w.bus.AddPartialSlab(ctx, partialSlabData, uint8(up.rs.MinShards), uint8(up.rs.TotalShards), up.contractSet)
+		obj.PartialSlabs, bufferSizeLimitReached, err = w.bus.AddPartialSlab(ctx, partialSlabData, uint8(up.rs.MinShards), uint8(up.rs.TotalShards), up.contractSet)
 		if err != nil {
 			return "", err
 		}
-		obj.PartialSlabs = partialSlabs
 	}
 
 	// persist the object
@@ -257,9 +257,19 @@ func (w *worker) upload(ctx context.Context, r io.Reader, bucket, path string, o
 		return "", fmt.Errorf("couldn't add object: %w", err)
 	}
 
-	// if packing was enabled try uploading packed slabs in a separate goroutine
+	// if packing was enabled try uploading packed slabs
 	if up.packing {
-		go w.tryUploadPackedSlabs(up.rs, up.contractSet)
+		// if we reached the buffer size limit, we upload packed slabs synchronously
+		if bufferSizeLimitReached {
+			ctx, cancel := context.WithTimeout(ctx, defaultPackedSlabsUploadTimeout)
+			defer cancel()
+			_, err := w.uploadPackedSlabs(ctx, up.rs, up.contractSet, 5)
+			if err != nil {
+				w.logger.Errorf("couldn't upload packed slabs, err: %v", err)
+			}
+		} else {
+			go w.threadedUploadPackedSlabs(up.rs, up.contractSet)
+		}
 	}
 	return etag, nil
 }
@@ -278,12 +288,12 @@ func (w *worker) uploadMultiPart(ctx context.Context, r io.Reader, bucket, path,
 	}
 
 	// add parital slabs
+	var bufferSizeLimitReached bool
 	if len(partialSlabData) > 0 {
-		partialSlabs, err := w.bus.AddPartialSlab(ctx, partialSlabData, uint8(up.rs.MinShards), uint8(up.rs.TotalShards), up.contractSet)
+		obj.PartialSlabs, bufferSizeLimitReached, err = w.bus.AddPartialSlab(ctx, partialSlabData, uint8(up.rs.MinShards), uint8(up.rs.TotalShards), up.contractSet)
 		if err != nil {
 			return "", err
 		}
-		obj.PartialSlabs = partialSlabs
 	}
 
 	// persist the part
@@ -292,14 +302,24 @@ func (w *worker) uploadMultiPart(ctx context.Context, r io.Reader, bucket, path,
 		return "", fmt.Errorf("couldn't add multi part: %w", err)
 	}
 
-	// if packing was enabled try uploading packed slabs in a separate goroutine
+	// if packing was enabled try uploading packed slabs
 	if up.packing {
-		go w.tryUploadPackedSlabs(up.rs, up.contractSet)
+		// if we reached the buffer size limit, we upload packed slabs synchronously
+		if bufferSizeLimitReached {
+			ctx, cancel := context.WithTimeout(ctx, defaultPackedSlabsUploadTimeout)
+			defer cancel()
+			_, err := w.uploadPackedSlabs(ctx, up.rs, up.contractSet, 5)
+			if err != nil {
+				w.logger.Errorf("couldn't upload packed slabs, err: %v", err)
+			}
+		} else {
+			go w.threadedUploadPackedSlabs(up.rs, up.contractSet)
+		}
 	}
 	return etag, nil
 }
 
-func (w *worker) tryUploadPackedSlabs(rs api.RedundancySettings, contractSet string) {
+func (w *worker) threadedUploadPackedSlabs(rs api.RedundancySettings, contractSet string) {
 	key := fmt.Sprintf("%d-%d_%s", rs.MinShards, rs.TotalShards, contractSet)
 
 	w.uploadsMu.Lock()
@@ -319,34 +339,37 @@ func (w *worker) tryUploadPackedSlabs(rs api.RedundancySettings, contractSet str
 
 	// keep uploading packed slabs until we're done
 	for {
-		// fetch packed slabs
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-		packedSlabs, err := w.bus.PackedSlabsForUpload(ctx, defaultPackedSlabsLockDuration, uint8(rs.MinShards), uint8(rs.TotalShards), contractSet, defaultPackedSlabsLimit)
+		uploaded, err := w.uploadPackedSlabs(context.Background(), rs, contractSet, defaultPackedSlabsLimit)
 		if err != nil {
-			w.logger.Errorf("couldn't fetch packed slabs from bus: %v", err)
-			cancel()
+			w.logger.Errorf("couldn't upload packed slabs, err: %v", err)
 			return
-		}
-		cancel()
-
-		// if there's no packed slabs, we're done
-		if len(packedSlabs) == 0 {
+		} else if uploaded == 0 {
 			return
-		}
-
-		// upload packed slabs
-		for _, ps := range packedSlabs {
-			if err := w.uploadPackedSlab(ps, rs, contractSet); err != nil {
-				w.logger.Errorf("failed to upload packed slab, err: %v", err)
-				return
-			}
 		}
 	}
 }
 
-func (w *worker) uploadPackedSlab(ps api.PackedSlab, rs api.RedundancySettings, contractSet string) error {
+func (w *worker) uploadPackedSlabs(ctx context.Context, rs api.RedundancySettings, contractSet string, limit int) (uploaded int, err error) {
+	// fetch packed slabs
+	packedSlabs, err := w.bus.PackedSlabsForUpload(ctx, defaultPackedSlabsLockDuration, uint8(rs.MinShards), uint8(rs.TotalShards), contractSet, limit)
+	if err != nil {
+		return 0, fmt.Errorf("couldn't fetch packed slabs from bus: %v", err)
+	}
+
+	// upload packed slabs
+	for _, ps := range packedSlabs {
+		err = w.uploadPackedSlab(ctx, ps, rs, contractSet)
+		if err != nil {
+			return
+		}
+		uploaded++
+	}
+	return
+}
+
+func (w *worker) uploadPackedSlab(ctx context.Context, ps api.PackedSlab, rs api.RedundancySettings, contractSet string) error {
 	// create a context with sane timeout
-	ctx, cancel := context.WithTimeout(context.Background(), defaultPackedSlabsUploadTimeout)
+	ctx, cancel := context.WithTimeout(ctx, defaultPackedSlabsUploadTimeout)
 	defer cancel()
 
 	// fetch contracts

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -166,7 +166,7 @@ type Bus interface {
 
 	AddMultipartPart(ctx context.Context, bucket, path, contractSet, uploadID string, partNumber int, slices []object.SlabSlice, partialSlabs []object.PartialSlab, etag string, usedContracts map[types.PublicKey]types.FileContractID) (err error)
 
-	AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.PartialSlab, err error)
+	AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.PartialSlab, slabBufferMaxSizeSoftReached bool, err error)
 	FetchPartialSlab(ctx context.Context, key object.EncryptionKey, offset, length uint32) ([]byte, error)
 	Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
 


### PR DESCRIPTION
This PR extends the `UploadPackingSettings` with a new setting called `SlabBufferMaxSizeSoft`. It's essentially a threshold value after which we'll start synchronously uploading packed slabs with every consecutive upload until the buffer size drops this value again. This essentially just "blocks" parallel uploaders for a bit, giving the background loop a chance to catch up and offload some of the slab buffers on to the network.

I decided not to add any compat code for current `renterd`'s out there since having a 0 value essentially reverts to blocking uploads (which we had before). Default value is 4GiB, which is on the low side but fine I think.

