### PR TITLE
Insufficient Bandwidth

### DIFF
--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -674,7 +674,7 @@ func padBandwidth(pt rhpv3.HostPriceTable, rc rhpv3.ResourceCost) rhpv3.Resource
 	}
 	minPacketSize := uint64(1460)
 	minIngress := pt.UploadBandwidthCost.Mul64(minPacketSize)
-	minEgress := pt.DownloadBandwidthCost.Mul64(3 * minPacketSize)
+	minEgress := pt.DownloadBandwidthCost.Mul64(3*minPacketSize + responseLeeway)
 	rc.Ingress = padCost(rc.Ingress, minIngress)
 	rc.Egress = padCost(rc.Egress, minEgress)
 	return rc


### PR DESCRIPTION
This PR <https://github.com/SiaFoundation/renterd/pull/502> increased our download budget because some calls were failing due to the infamous "insufficient budget for bandwidth" error. I believe Chris added padding but for very small files it's not enough.

I added logging with price table details (hit me up if you are interested, there's no hidden or 0H costs that aren't dealt with) but decided to just increase the padding 🤷‍♂️ . We can simplify the expected read cost when the entire network has upgraded to `hostd`, it were pretty arbitrary over-estimates to begin with. Verified that it works on my node. 

This was actually an issue highlighted by the integrity checker also, added logging but hadn't gotten around investigating it more closely.

Fixes #618
