### PR TITLE
Add support for pre-sharding encryption to native multipart upload

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -76,6 +76,10 @@ var (
 	// database.
 	ErrHostNotFound = errors.New("host doesn't exist in hostdb")
 
+	// ErrMultipartUploadNotFound is returned if the specified multipart upload
+	// wasn't found.
+	ErrMultipartUploadNotFound = errors.New("multipart upload not found")
+
 	// ErrPartNotFound is returned if the specified part of a multipart upload
 	// wasn't found.
 	ErrPartNotFound = errors.New("multipart upload part not found")
@@ -557,12 +561,17 @@ type (
 		Limit          int    `json:"limit"`
 	}
 	MultipartListUploadsResponse struct {
-		Uploads []MultipartListUploadItem `json:"uploads"`
+		HasMore            bool              `json:"hasMore"`
+		NextPathMarker     string            `json:"nextMarker"`
+		NextUploadIDMarker string            `json:"nextUploadIDMarker"`
+		Uploads            []MultipartUpload `json:"uploads"`
 	}
-	MultipartListUploadItem struct {
-		Path      string    `json:"path"`
-		UploadID  string    `json:"uploadID"`
-		CreatedAt time.Time `json:"createdAt"`
+	MultipartUpload struct {
+		Bucket    string               `json:"bucket"`
+		Key       object.EncryptionKey `json:"key"`
+		Path      string               `json:"path"`
+		UploadID  string               `json:"uploadID"`
+		CreatedAt time.Time            `json:"createdAt"`
 	}
 	MultipartListPartsRequest struct {
 		Bucket           string `json:"bucket"`

--- a/api/worker.go
+++ b/api/worker.go
@@ -235,6 +235,12 @@ func UploadWithDisabledPreshardingEncryption() UploadOption {
 	}
 }
 
+func UploadWithEncryptionOffset(offset int64) UploadOption {
+	return func(v url.Values) {
+		v.Set("offset", fmt.Sprint(offset))
+	}
+}
+
 type DownloadRange struct {
 	Start  int64
 	Length int64

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1890,7 +1890,7 @@ func (b *bus) multipartHandlerUploadPartPUT(jc jape.Context) {
 
 func (b *bus) multipartHandlerUploadGET(jc jape.Context) {
 	resp, err := b.ms.MultipartUpload(jc.Request.Context(), jc.PathParam("id"))
-	if jc.Check("failed to list multipart uploads", err) != nil {
+	if jc.Check("failed to get multipart upload", err) != nil {
 		return
 	}
 	jc.Encode(resp)

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -126,6 +126,7 @@ type (
 		AddMultipartPart(ctx context.Context, bucket, path, contractSet, uploadID string, partNumber int, slices []object.SlabSlice, partialSlab []object.PartialSlab, etag string, usedContracts map[types.PublicKey]types.FileContractID) (err error)
 		CompleteMultipartUpload(ctx context.Context, bucket, path string, uploadID string, parts []api.MultipartCompletedPart) (_ api.MultipartCompleteResponse, err error)
 		CreateMultipartUpload(ctx context.Context, bucket, path string, ec object.EncryptionKey) (api.MultipartCreateResponse, error)
+		MultipartUpload(ctx context.Context, uploadID string) (resp api.MultipartUpload, _ error)
 		MultipartUploads(ctx context.Context, bucket, prefix, keyMarker, uploadIDMarker string, maxUploads int) (resp api.MultipartListUploadsResponse, _ error)
 		MultipartUploadParts(ctx context.Context, bucket, object string, uploadID string, marker int, limit int64) (resp api.MultipartListPartsResponse, _ error)
 
@@ -1887,6 +1888,14 @@ func (b *bus) multipartHandlerUploadPartPUT(jc jape.Context) {
 	}
 }
 
+func (b *bus) multipartHandlerUploadGET(jc jape.Context) {
+	resp, err := b.ms.MultipartUpload(jc.Request.Context(), jc.PathParam("id"))
+	if jc.Check("failed to list multipart uploads", err) != nil {
+		return
+	}
+	jc.Encode(resp)
+}
+
 func (b *bus) multipartHandlerListUploadsPOST(jc jape.Context) {
 	var req api.MultipartListUploadsRequest
 	if jc.Decode(&req) != nil {
@@ -2034,6 +2043,7 @@ func (b *bus) Handler() http.Handler {
 		"POST   /multipart/abort":       b.multipartHandlerAbortPOST,
 		"POST   /multipart/complete":    b.multipartHandlerCompletePOST,
 		"PUT    /multipart/part":        b.multipartHandlerUploadPartPUT,
+		"GET    /multipart/upload/:id":  b.multipartHandlerUploadGET,
 		"POST   /multipart/listuploads": b.multipartHandlerListUploadsPOST,
 		"POST   /multipart/listparts":   b.multipartHandlerListPartsPOST,
 

--- a/bus/client.go
+++ b/bus/client.go
@@ -996,6 +996,11 @@ func (c *Client) CompleteMultipartUpload(ctx context.Context, bucket, path strin
 	return
 }
 
+func (c *Client) MultipartUpload(ctx context.Context, uploadID string) (resp api.MultipartUpload, err error) {
+	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/multipart/upload/%s", uploadID), &resp)
+	return
+}
+
 func (c *Client) MultipartUploads(ctx context.Context, bucket, prefix, keyMarker, uploadIDMarker string, maxUploads int) (resp api.MultipartListUploadsResponse, err error) {
 	err = c.c.WithContext(ctx).POST("/multipart/listuploads", api.MultipartListUploadsRequest{
 		Bucket:         bucket,

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -418,6 +418,7 @@ func (s *SQLStore) retryTransaction(fc func(tx *gorm.DB) error, opts ...*sql.TxO
 			errors.Is(err, api.ErrBucketNotFound) ||
 			errors.Is(err, api.ErrBucketNotEmpty) ||
 			errors.Is(err, api.ErrContractNotFound) ||
+			errors.Is(err, api.ErrMultipartUploadNotFound) ||
 			errors.Is(err, api.ErrPartNotFound) {
 			return true
 		}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -165,6 +165,7 @@ type Bus interface {
 	DeleteObject(ctx context.Context, bucket, path string, batch bool) error
 
 	AddMultipartPart(ctx context.Context, bucket, path, contractSet, uploadID string, partNumber int, slices []object.SlabSlice, partialSlabs []object.PartialSlab, etag string, usedContracts map[types.PublicKey]types.FileContractID) (err error)
+	MultipartUpload(ctx context.Context, uploadID string) (resp api.MultipartUpload, err error)
 
 	AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.PartialSlab, err error)
 	FetchPartialSlab(ctx context.Context, key object.EncryptionKey, offset, length uint32) ([]byte, error)
@@ -1215,16 +1216,15 @@ func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {
 	if jc.DecodeForm("disablepreshardingencryption", &disablePreshardingEncryption) != nil {
 		return
 	}
-	if !disablePreshardingEncryption {
-		jc.Error(errors.New("presharding encryption is not yet supported for multipart uploads"), http.StatusNotImplemented)
-		return
-	}
 	if !disablePreshardingEncryption && jc.Request.FormValue("offset") == "" {
 		jc.Error(errors.New("if presharding encryption isn't disabled, the offset needs to be set"), http.StatusBadRequest)
 		return
 	}
-	var offset uint64
+	var offset int
 	if jc.DecodeForm("offset", &offset) != nil {
+		return
+	} else if offset < 0 {
+		jc.Error(errors.New("offset must be positive"), http.StatusBadRequest)
 		return
 	}
 
@@ -1238,7 +1238,13 @@ func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {
 	if disablePreshardingEncryption {
 		opts = append(opts, WithCustomKey(object.NoOpKey))
 	} else {
-		opts = append(opts, WithCustomEncryptionOffset(offset))
+		upload, err := w.bus.MultipartUpload(jc.Request.Context(), uploadID)
+		if err != nil {
+			jc.Error(err, http.StatusBadRequest)
+			return
+		}
+		opts = append(opts, WithCustomEncryptionOffset(uint64(offset)))
+		opts = append(opts, WithCustomKey(upload.Key))
 	}
 
 	// attach gouging checker to the context


### PR DESCRIPTION
This is a f/u to enable pre-sharding encryption when using the native multipart upload API. The S3 API doesn't support it so it was disabled by default but through the native API we can actually provide an encryption offset.
Also adds some general testing for the native API since we only had testing for multipart uploads through S3.