### PR TITLE
Move S3 authentication logic into `renterd`

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/SiaFoundation/gofakes3"
 	"go.sia.tech/core/consensus"
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
+	"go.sia.tech/gofakes3"
 	"go.sia.tech/jape"
 	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/renterd/api"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module go.sia.tech/renterd
 go 1.20
 
 require (
-	github.com/SiaFoundation/gofakes3 v0.0.0-20230919115219-af470842bcfa
 	github.com/go-gormigrate/gormigrate/v2 v2.1.0
 	github.com/google/go-cmp v0.5.9
 	github.com/gotd/contrib v0.19.0
@@ -18,6 +17,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
 	go.sia.tech/core v0.1.12-0.20230529164041-6347a98003be
+	go.sia.tech/gofakes3 v0.0.0-20230926110632-5b2c588c6928
 	go.sia.tech/hostd v0.1.4
 	go.sia.tech/jape v0.9.1-0.20230525021720-ecf031ecbffb
 	go.sia.tech/mux v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/SiaFoundation/gofakes3 v0.0.0-20230919115219-af470842bcfa h1:CMKw/7lpPrLLZaT+sFQysXEE7Zgj8Iqz+dUuaYrh0wg=
-github.com/SiaFoundation/gofakes3 v0.0.0-20230919115219-af470842bcfa/go.mod h1:pm3DyXGoeF7/gka6OYDqAW4E5hkcnXm/GfUagzztlxk=
-github.com/SiaFoundation/gofakes3 v0.0.0-20230920080442-785341635c3a h1:upsVYvk3Wg6+bOjduZpc4Fmf7nVgCR+F7oUH9GNkPE4=
-github.com/SiaFoundation/gofakes3 v0.0.0-20230920080442-785341635c3a/go.mod h1:pm3DyXGoeF7/gka6OYDqAW4E5hkcnXm/GfUagzztlxk=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
@@ -236,13 +232,10 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -311,6 +304,8 @@ go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lI
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.sia.tech/core v0.1.12-0.20230529164041-6347a98003be h1:fKfwYsCF5ua3Z/NNdLU+4sS9MM6M4EetMA0V4Y8zPKg=
 go.sia.tech/core v0.1.12-0.20230529164041-6347a98003be/go.mod h1:D17UWSn99SEfQnEaR9G9n6Kz9+BwqMoUgZ6Cl424LsQ=
+go.sia.tech/gofakes3 v0.0.0-20230926110632-5b2c588c6928 h1:W4deJEIzIODrBkwU5coScxKWLKhwPsegnyJPB6CnFeQ=
+go.sia.tech/gofakes3 v0.0.0-20230926110632-5b2c588c6928/go.mod h1:PlsiVCn6+wssrR7bsOIlZm0DahsVrDydrlbjY4F14sg=
 go.sia.tech/hostd v0.1.4 h1:r6PSo8ed0hmxjf4pvFQfRCfGk/DVRd/R/T9K9B0JhJ4=
 go.sia.tech/hostd v0.1.4/go.mod h1:o+Z9ZGJZRY31MvRNXyyAlmBHjjiTE/3TgAB4pCHgr2c=
 go.sia.tech/jape v0.9.1-0.20230525021720-ecf031ecbffb h1:yLDEqkqC19E/HgBoq2Uhw9oH3SMNRyeRjZ7Ep4dPKR8=

--- a/internal/testing/s3_test.go
+++ b/internal/testing/s3_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SiaFoundation/gofakes3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/minio/minio-go/v7"
 	rhpv2 "go.sia.tech/core/rhp/v2"
+	"go.sia.tech/gofakes3"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/s3"
 	"go.uber.org/zap"

--- a/s3/authentication.go
+++ b/s3/authentication.go
@@ -1,0 +1,236 @@
+package s3
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"go.sia.tech/gofakes3"
+	"go.sia.tech/gofakes3/signature"
+)
+
+var (
+	_ gofakes3.AuthenticatedBackend = (*authenticatedBackend)(nil)
+	_ gofakes3.Backend              = (*authenticatedBackend)(nil)
+	_ gofakes3.MultipartBackend     = (*authenticatedBackend)(nil)
+)
+
+type (
+	unauthenticatedBackend interface {
+		gofakes3.Backend
+		gofakes3.MultipartBackend
+	}
+
+	authenticatedBackend struct {
+		backend    unauthenticatedBackend
+		v4AuthPair map[string]string
+	}
+
+	permissions struct {
+		ListBuckets             bool
+		ListBucket              bool
+		CreateBucket            bool
+		BucketExists            bool
+		DeleteBucket            bool
+		GetObject               bool
+		HeadObject              bool
+		DeleteObject            bool
+		PutObject               bool
+		DeleteMulti             bool
+		CopyObject              bool
+		CreateMultipartUpload   bool
+		UploadPart              bool
+		ListMultipartUpload     bool
+		ListParts               bool
+		AbortMultipartUpload    bool
+		CompleteMultipartUpload bool
+	}
+
+	contextKey int
+)
+
+var (
+	permissionKey contextKey
+
+	// rootPerms are used for requests that were successfully authenticated
+	// using v4 signatures.
+	rootPerms = permissions{
+		ListBuckets:             true,
+		ListBucket:              true,
+		CreateBucket:            true,
+		BucketExists:            true,
+		DeleteBucket:            true,
+		GetObject:               true,
+		HeadObject:              true,
+		DeleteObject:            true,
+		PutObject:               true,
+		DeleteMulti:             true,
+		CopyObject:              true,
+		CreateMultipartUpload:   true,
+		UploadPart:              true,
+		ListMultipartUpload:     true,
+		ListParts:               true,
+		AbortMultipartUpload:    true,
+		CompleteMultipartUpload: true,
+	}
+
+	// noAccessPerms grant access to nothing.
+	noAccessPerms = permissions{}
+)
+
+func permsFromCtx(ctx context.Context) permissions {
+	if perms, ok := ctx.Value(permissionKey).(*permissions); ok {
+		return *perms
+	}
+	return noAccessPerms
+}
+
+func newAuthenticatedBackend(b unauthenticatedBackend, keyPairs map[string]string) *authenticatedBackend {
+	return &authenticatedBackend{
+		v4AuthPair: keyPairs,
+	}
+}
+
+func (b *authenticatedBackend) AuthenticationMiddleware(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, rq *http.Request) {
+		perms := noAccessPerms
+		if len(b.v4AuthPair) > 0 {
+			if rq.Header.Get("Authorization") == "" {
+				// No auth header, we use guest permissions.
+				// TODO: guest permissions
+			} else if result := signature.V4SignVerify(rq); result != signature.ErrNone {
+				// Authentication attempted but failed.
+				resp := signature.GetAPIError(result)
+				w.WriteHeader(resp.HTTPStatusCode)
+				w.Header().Add("content-type", "application/xml")
+				_, _ = w.Write(signature.EncodeAPIErrorToResponse(resp))
+				return
+			} else {
+				// Authenticated request, treat as root user.
+				perms = rootPerms
+			}
+		}
+		// Add permissions to context.
+		ctx := context.WithValue(rq.Context(), permissionKey, &perms)
+		handler.ServeHTTP(w, rq.WithContext(ctx))
+	})
+}
+
+func (b *authenticatedBackend) ListBuckets(ctx context.Context) ([]gofakes3.BucketInfo, error) {
+	if !permsFromCtx(ctx).ListBuckets {
+		return nil, gofakes3.ErrAccessDenied
+	}
+	return b.backend.ListBuckets(ctx)
+}
+
+func (b *authenticatedBackend) ListBucket(ctx context.Context, bucketName string, prefix *gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
+	if !permsFromCtx(ctx).ListBucket {
+		return nil, gofakes3.ErrAccessDenied
+	}
+	return b.backend.ListBucket(ctx, bucketName, prefix, page)
+}
+
+func (b *authenticatedBackend) CreateBucket(ctx context.Context, name string) error {
+	if !permsFromCtx(ctx).CreateBucket {
+		return gofakes3.ErrAccessDenied
+	}
+	return b.backend.CreateBucket(ctx, name)
+}
+
+func (b *authenticatedBackend) BucketExists(ctx context.Context, name string) (bool, error) {
+	if !permsFromCtx(ctx).BucketExists {
+		return false, gofakes3.ErrAccessDenied
+	}
+	return b.backend.BucketExists(ctx, name)
+}
+
+func (b *authenticatedBackend) DeleteBucket(ctx context.Context, name string) error {
+	if !permsFromCtx(ctx).DeleteBucket {
+		return gofakes3.ErrAccessDenied
+	}
+	return b.backend.DeleteBucket(ctx, name)
+}
+
+func (b *authenticatedBackend) GetObject(ctx context.Context, bucketName, objectName string, rangeRequest *gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
+	if !permsFromCtx(ctx).GetObject {
+		return nil, gofakes3.ErrAccessDenied
+	}
+	return b.backend.GetObject(ctx, bucketName, objectName, rangeRequest)
+}
+
+func (b *authenticatedBackend) HeadObject(ctx context.Context, bucketName, objectName string) (*gofakes3.Object, error) {
+	if !permsFromCtx(ctx).HeadObject {
+		return nil, gofakes3.ErrAccessDenied
+	}
+	return b.backend.HeadObject(ctx, bucketName, objectName)
+}
+
+func (b *authenticatedBackend) DeleteObject(ctx context.Context, bucketName, objectName string) (gofakes3.ObjectDeleteResult, error) {
+	if !permsFromCtx(ctx).DeleteObject {
+		return gofakes3.ObjectDeleteResult{}, gofakes3.ErrAccessDenied
+	}
+	return b.backend.DeleteObject(ctx, bucketName, objectName)
+}
+
+func (b *authenticatedBackend) PutObject(ctx context.Context, bucketName, key string, meta map[string]string, input io.Reader, size int64) (gofakes3.PutObjectResult, error) {
+	if !permsFromCtx(ctx).PutObject {
+		return gofakes3.PutObjectResult{}, gofakes3.ErrAccessDenied
+	}
+	return b.backend.PutObject(ctx, bucketName, key, meta, input, size)
+}
+
+func (b *authenticatedBackend) DeleteMulti(ctx context.Context, bucketName string, objects ...string) (gofakes3.MultiDeleteResult, error) {
+	if !permsFromCtx(ctx).DeleteMulti {
+		return gofakes3.MultiDeleteResult{}, gofakes3.ErrAccessDenied
+	}
+	return b.backend.DeleteMulti(ctx, bucketName, objects...)
+}
+
+func (b *authenticatedBackend) CopyObject(ctx context.Context, srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (gofakes3.CopyObjectResult, error) {
+	if !permsFromCtx(ctx).CopyObject {
+		return gofakes3.CopyObjectResult{}, gofakes3.ErrAccessDenied
+	}
+	return b.backend.CopyObject(ctx, srcBucket, srcKey, dstBucket, dstKey, meta)
+}
+
+func (b *authenticatedBackend) CreateMultipartUpload(ctx context.Context, bucket, key string, meta map[string]string) (gofakes3.UploadID, error) {
+	if !permsFromCtx(ctx).CreateMultipartUpload {
+		return "", gofakes3.ErrAccessDenied
+	}
+	return b.backend.CreateMultipartUpload(ctx, bucket, key, meta)
+}
+
+func (b *authenticatedBackend) UploadPart(ctx context.Context, bucket, object string, id gofakes3.UploadID, partNumber int, contentLength int64, input io.Reader) (resp *gofakes3.UploadPartResult, err error) {
+	if !permsFromCtx(ctx).UploadPart {
+		return nil, gofakes3.ErrAccessDenied
+	}
+	return b.backend.UploadPart(ctx, bucket, object, id, partNumber, contentLength, input)
+}
+
+func (b *authenticatedBackend) ListMultipartUploads(ctx context.Context, bucket string, marker *gofakes3.UploadListMarker, prefix gofakes3.Prefix, limit int64) (*gofakes3.ListMultipartUploadsResult, error) {
+	if !permsFromCtx(ctx).ListMultipartUpload {
+		return nil, gofakes3.ErrAccessDenied
+	}
+	return b.backend.ListMultipartUploads(ctx, bucket, marker, prefix, limit)
+}
+
+func (b *authenticatedBackend) ListParts(ctx context.Context, bucket, object string, uploadID gofakes3.UploadID, marker int, limit int64) (*gofakes3.ListMultipartUploadPartsResult, error) {
+	if !permsFromCtx(ctx).ListParts {
+		return nil, gofakes3.ErrAccessDenied
+	}
+	return b.backend.ListParts(ctx, bucket, object, uploadID, marker, limit)
+}
+
+func (b *authenticatedBackend) AbortMultipartUpload(ctx context.Context, bucket, object string, id gofakes3.UploadID) error {
+	if !permsFromCtx(ctx).AbortMultipartUpload {
+		return gofakes3.ErrAccessDenied
+	}
+	return b.backend.AbortMultipartUpload(ctx, bucket, object, id)
+}
+
+func (b *authenticatedBackend) CompleteMultipartUpload(ctx context.Context, bucket, object string, id gofakes3.UploadID, input *gofakes3.CompleteMultipartUploadRequest) (resp *gofakes3.CompleteMultipartUploadResult, err error) {
+	if !permsFromCtx(ctx).CompleteMultipartUpload {
+		return nil, gofakes3.ErrAccessDenied
+	}
+	return b.backend.CompleteMultipartUpload(ctx, bucket, object, id, input)
+}

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/SiaFoundation/gofakes3"
+	"go.sia.tech/gofakes3"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/object"
 	"go.uber.org/zap"
@@ -34,8 +34,8 @@ type s3 struct {
 // ListBuckets returns a list of all buckets owned by the authenticated
 // sender of the request.
 // https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html
-func (s *s3) ListBuckets() ([]gofakes3.BucketInfo, error) {
-	buckets, err := s.b.ListBuckets(context.Background())
+func (s *s3) ListBuckets(ctx context.Context) ([]gofakes3.BucketInfo, error) {
+	buckets, err := s.b.ListBuckets(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list buckets: %w", err)
 	}
@@ -71,14 +71,7 @@ func (s *s3) ListBuckets() ([]gofakes3.BucketInfo, error) {
 //
 // TODO: This implementation is not ideal because it fetches all objects. We
 // will eventually want to support this type of pagination in the bus.
-func (s *s3) ListBucket(bucketName string, prefix *gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
-	exists, err := s.BucketExists(bucketName)
-	if err != nil {
-		return nil, err
-	} else if !exists {
-		return nil, gofakes3.BucketNotFound(bucketName)
-	}
-
+func (s *s3) ListBucket(ctx context.Context, bucketName string, prefix *gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
 	if prefix == nil {
 		prefix = &gofakes3.Prefix{}
 	}
@@ -97,6 +90,7 @@ func (s *s3) ListBucket(bucketName string, prefix *gofakes3.Prefix, page gofakes
 	}
 
 	var objects []api.ObjectMetadata
+	var err error
 	response := gofakes3.NewObjectList()
 	if prefix.HasDelimiter {
 		// Handle request with delimiter.
@@ -115,8 +109,10 @@ func (s *s3) ListBucket(bucketName string, prefix *gofakes3.Prefix, page gofakes
 			opts = append(opts, api.ObjectsWithPrefix(adjustedPrefix))
 		}
 		var res api.ObjectsResponse
-		res, err = s.b.Object(context.Background(), path, opts...)
-		if err != nil {
+		res, err = s.b.Object(ctx, path, opts...)
+		if err != nil && strings.Contains(err.Error(), api.ErrBucketNotFound.Error()) {
+			return nil, gofakes3.BucketNotFound(bucketName)
+		} else if err != nil {
 			return nil, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 		}
 		objects = res.Entries
@@ -127,8 +123,10 @@ func (s *s3) ListBucket(bucketName string, prefix *gofakes3.Prefix, page gofakes
 	} else {
 		// Handle request without delimiter.
 		var res api.ObjectsListResponse
-		res, err = s.b.ListObjects(context.Background(), bucketName, "/"+prefix.Prefix, page.Marker, int(page.MaxKeys))
-		if err != nil {
+		res, err = s.b.ListObjects(ctx, bucketName, "/"+prefix.Prefix, page.Marker, int(page.MaxKeys))
+		if err != nil && strings.Contains(err.Error(), api.ErrBucketNotFound.Error()) {
+			return nil, gofakes3.BucketNotFound(bucketName)
+		} else if err != nil {
 			return nil, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 		}
 		objects = res.Objects
@@ -165,8 +163,8 @@ func (s *s3) ListBucket(bucketName string, prefix *gofakes3.Prefix, page gofakes
 //
 // If the bucket already exists, a gofakes3.ResourceError with
 // gofakes3.ErrBucketAlreadyExists MUST be returned.
-func (s *s3) CreateBucket(name string) error {
-	if err := s.b.CreateBucket(context.Background(), name); err != nil && strings.Contains(err.Error(), api.ErrBucketExists.Error()) {
+func (s *s3) CreateBucket(ctx context.Context, name string) error {
+	if err := s.b.CreateBucket(ctx, name); err != nil && strings.Contains(err.Error(), api.ErrBucketExists.Error()) {
 		return gofakes3.ErrBucketAlreadyExists
 	} else if err != nil {
 		return gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
@@ -178,8 +176,8 @@ func (s *s3) CreateBucket(name string) error {
 // an error if the backend was unable to determine existence.
 //
 // TODO: backend could be improved to allow for checking specific dir in root.
-func (s *s3) BucketExists(name string) (bool, error) {
-	_, err := s.b.Bucket(context.Background(), name)
+func (s *s3) BucketExists(ctx context.Context, name string) (bool, error) {
+	_, err := s.b.Bucket(ctx, name)
 	if err != nil && strings.Contains(err.Error(), api.ErrBucketNotFound.Error()) {
 		return false, nil
 	} else if err != nil {
@@ -198,8 +196,8 @@ func (s *s3) BucketExists(name string) (bool, error) {
 // AWS does not validate the bucket's name for anything other than existence.
 // TODO: This check is not atomic. The backend needs to be updated to support
 // atomically checking whether a bucket is empty.
-func (s *s3) DeleteBucket(name string) error {
-	if err := s.b.DeleteBucket(context.Background(), name); err != nil && strings.Contains(err.Error(), api.ErrBucketNotEmpty.Error()) {
+func (s *s3) DeleteBucket(ctx context.Context, name string) error {
+	if err := s.b.DeleteBucket(ctx, name); err != nil && strings.Contains(err.Error(), api.ErrBucketNotEmpty.Error()) {
 		return gofakes3.ErrBucketNotEmpty
 	} else if err != nil && strings.Contains(err.Error(), api.ErrBucketNotFound.Error()) {
 		return gofakes3.BucketNotFound(name)
@@ -224,7 +222,7 @@ func (s *s3) DeleteBucket(name string) error {
 // If the backend is a VersionedBackend, GetObject retrieves the latest version.
 // TODO: Range requests starting from the end are not supported yet. Backend
 // needs to be updated for that.
-func (s *s3) GetObject(bucketName, objectName string, rangeRequest *gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
+func (s *s3) GetObject(ctx context.Context, bucketName, objectName string, rangeRequest *gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
 	if rangeRequest != nil && rangeRequest.FromEnd {
 		return nil, gofakes3.ErrorMessage(gofakes3.ErrNotImplemented, "range request from end not supported")
 	}
@@ -233,7 +231,7 @@ func (s *s3) GetObject(bucketName, objectName string, rangeRequest *gofakes3.Obj
 	if rangeRequest != nil {
 		opts = append(opts, api.DownloadWithRange(rangeRequest.Start, rangeRequest.End))
 	}
-	res, err := s.w.GetObject(context.Background(), bucketName, objectName, opts...)
+	res, err := s.w.GetObject(ctx, bucketName, objectName, opts...)
 	if err != nil && strings.Contains(err.Error(), api.ErrBucketNotFound.Error()) {
 		return nil, gofakes3.BucketNotFound(bucketName)
 	} else if err != nil && strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
@@ -273,8 +271,8 @@ func (s *s3) GetObject(bucketName, objectName string, rangeRequest *gofakes3.Obj
 //
 // HeadObject should return a NotFound() error if the object does not
 // exist.
-func (s *s3) HeadObject(bucketName, objectName string) (*gofakes3.Object, error) {
-	res, err := s.b.Object(context.Background(), objectName, api.ObjectsWithBucket(bucketName), api.ObjectsWithIgnoreDelim(true))
+func (s *s3) HeadObject(ctx context.Context, bucketName, objectName string) (*gofakes3.Object, error) {
+	res, err := s.b.Object(ctx, objectName, api.ObjectsWithBucket(bucketName), api.ObjectsWithIgnoreDelim(true))
 	if err != nil && strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
 		return nil, gofakes3.KeyNotFound(objectName)
 	} else if err != nil {
@@ -308,8 +306,8 @@ func (s *s3) HeadObject(bucketName, objectName string) (*gofakes3.Object, error)
 //	Removes the null version (if there is one) of an object and inserts a
 //	delete marker, which becomes the latest version of the object. If there
 //	isn't a null version, Amazon S3 does not remove any objects.
-func (s *s3) DeleteObject(bucketName, objectName string) (gofakes3.ObjectDeleteResult, error) {
-	err := s.b.DeleteObject(context.Background(), bucketName, objectName, false)
+func (s *s3) DeleteObject(ctx context.Context, bucketName, objectName string) (gofakes3.ObjectDeleteResult, error) {
+	err := s.b.DeleteObject(ctx, bucketName, objectName, false)
 	if err != nil && !strings.Contains(err.Error(), api.ErrBucketNotFound.Error()) {
 		return gofakes3.ObjectDeleteResult{}, gofakes3.BucketNotFound(bucketName)
 	} else if err != nil && !strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
@@ -328,8 +326,8 @@ func (s *s3) DeleteObject(bucketName, objectName string) (gofakes3.ObjectDeleteR
 // gofakes3.ReadAll() for this job rather than ioutil.ReadAll().
 // TODO: Metadata is currently ignored. The backend requires an update to
 // support it.
-func (s *s3) PutObject(bucketName, key string, meta map[string]string, input io.Reader, size int64) (gofakes3.PutObjectResult, error) {
-	err := s.w.UploadObject(context.Background(), input, key, api.UploadWithBucket(bucketName))
+func (s *s3) PutObject(ctx context.Context, bucketName, key string, meta map[string]string, input io.Reader, size int64) (gofakes3.PutObjectResult, error) {
+	err := s.w.UploadObject(ctx, input, key, api.UploadWithBucket(bucketName))
 	if err != nil {
 		return gofakes3.PutObjectResult{}, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 	}
@@ -338,10 +336,10 @@ func (s *s3) PutObject(bucketName, key string, meta map[string]string, input io.
 	}, nil
 }
 
-func (s *s3) DeleteMulti(bucketName string, objects ...string) (gofakes3.MultiDeleteResult, error) {
+func (s *s3) DeleteMulti(ctx context.Context, bucketName string, objects ...string) (gofakes3.MultiDeleteResult, error) {
 	var res gofakes3.MultiDeleteResult
 	for _, objectName := range objects {
-		err := s.b.DeleteObject(context.Background(), bucketName, objectName, false)
+		err := s.b.DeleteObject(ctx, bucketName, objectName, false)
 		if err != nil && !strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
 			res.Error = append(res.Error, gofakes3.ErrorResult{
 				Key:     objectName,
@@ -359,8 +357,8 @@ func (s *s3) DeleteMulti(bucketName string, objects ...string) (gofakes3.MultiDe
 }
 
 // TODO: use metadata when we have support for it
-func (s *s3) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (gofakes3.CopyObjectResult, error) {
-	obj, err := s.b.CopyObject(context.Background(), srcBucket, dstBucket, "/"+srcKey, "/"+dstKey)
+func (s *s3) CopyObject(ctx context.Context, srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (gofakes3.CopyObjectResult, error) {
+	obj, err := s.b.CopyObject(ctx, srcBucket, dstBucket, "/"+srcKey, "/"+dstKey)
 	if err != nil {
 		return gofakes3.CopyObjectResult{}, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 	}
@@ -370,23 +368,25 @@ func (s *s3) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, meta map[st
 	}, nil
 }
 
-func (s *s3) CreateMultipartUpload(bucket, key string, meta map[string]string) (gofakes3.UploadID, error) {
-	resp, err := s.b.CreateMultipartUpload(context.Background(), bucket, "/"+key, object.NoOpKey)
+func (s *s3) CreateMultipartUpload(ctx context.Context, bucket, key string, meta map[string]string) (gofakes3.UploadID, error) {
+	resp, err := s.b.CreateMultipartUpload(ctx, bucket, "/"+key, object.NoOpKey)
 	if err != nil {
 		return "", gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 	}
 	return gofakes3.UploadID(resp.UploadID), nil
 }
 
-func (s *s3) UploadPart(bucket, object string, id gofakes3.UploadID, partNumber int, contentLength int64, input io.Reader) (etag string, err error) {
-	etag, err = s.w.UploadMultipartUploadPart(context.Background(), input, object, string(id), partNumber, api.UploadWithDisabledPreshardingEncryption())
+func (s *s3) UploadPart(ctx context.Context, bucket, object string, id gofakes3.UploadID, partNumber int, contentLength int64, input io.Reader) (*gofakes3.UploadPartResult, error) {
+	etag, err := s.w.UploadMultipartUploadPart(ctx, input, object, string(id), partNumber, api.UploadWithDisabledPreshardingEncryption())
 	if err != nil {
-		return "", gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
+		return nil, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 	}
-	return etag, nil
+	return &gofakes3.UploadPartResult{
+		ETag: etag,
+	}, nil
 }
 
-func (s *s3) ListMultipartUploads(bucket string, marker *gofakes3.UploadListMarker, prefix gofakes3.Prefix, limit int64) (*gofakes3.ListMultipartUploadsResult, error) {
+func (s *s3) ListMultipartUploads(ctx context.Context, bucket string, marker *gofakes3.UploadListMarker, prefix gofakes3.Prefix, limit int64) (*gofakes3.ListMultipartUploadsResult, error) {
 	prefix.HasPrefix = prefix.Prefix != ""
 	prefix.HasDelimiter = prefix.Delimiter != ""
 	if prefix.HasDelimiter && prefix.Delimiter != "/" {
@@ -396,7 +396,7 @@ func (s *s3) ListMultipartUploads(bucket string, marker *gofakes3.UploadListMark
 	} else if marker != nil {
 		return nil, gofakes3.ErrorMessage(gofakes3.ErrNotImplemented, "marker not supported")
 	}
-	resp, err := s.b.MultipartUploads(context.Background(), bucket, "", "", "", int(limit))
+	resp, err := s.b.MultipartUploads(ctx, bucket, "", "", "", int(limit))
 	if err != nil {
 		return nil, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 	}
@@ -423,8 +423,8 @@ func (s *s3) ListMultipartUploads(bucket string, marker *gofakes3.UploadListMark
 	}, nil
 }
 
-func (s *s3) ListParts(bucket, object string, uploadID gofakes3.UploadID, marker int, limit int64) (*gofakes3.ListMultipartUploadPartsResult, error) {
-	resp, err := s.b.MultipartUploadParts(context.Background(), bucket, "/"+object, string(uploadID), marker, limit)
+func (s *s3) ListParts(ctx context.Context, bucket, object string, uploadID gofakes3.UploadID, marker int, limit int64) (*gofakes3.ListMultipartUploadPartsResult, error) {
+	resp, err := s.b.MultipartUploadParts(ctx, bucket, "/"+object, string(uploadID), marker, limit)
 	if err != nil {
 		return nil, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 	}
@@ -450,15 +450,15 @@ func (s *s3) ListParts(bucket, object string, uploadID gofakes3.UploadID, marker
 	}, nil
 }
 
-func (s *s3) AbortMultipartUpload(bucket, object string, id gofakes3.UploadID) error {
-	err := s.b.AbortMultipartUpload(context.Background(), bucket, "/"+object, string(id))
+func (s *s3) AbortMultipartUpload(ctx context.Context, bucket, object string, id gofakes3.UploadID) error {
+	err := s.b.AbortMultipartUpload(ctx, bucket, "/"+object, string(id))
 	if err != nil {
 		return gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 	}
 	return nil
 }
 
-func (s *s3) CompleteMultipartUpload(bucket, object string, id gofakes3.UploadID, input *gofakes3.CompleteMultipartUploadRequest) (versionID gofakes3.VersionID, etag string, err error) {
+func (s *s3) CompleteMultipartUpload(ctx context.Context, bucket, object string, id gofakes3.UploadID, input *gofakes3.CompleteMultipartUploadRequest) (*gofakes3.CompleteMultipartUploadResult, error) {
 	var parts []api.MultipartCompletedPart
 	for _, part := range input.Parts {
 		parts = append(parts, api.MultipartCompletedPart{
@@ -466,9 +466,12 @@ func (s *s3) CompleteMultipartUpload(bucket, object string, id gofakes3.UploadID
 			PartNumber: part.PartNumber,
 		})
 	}
-	resp, err := s.b.CompleteMultipartUpload(context.Background(), bucket, "/"+object, string(id), parts)
+	resp, err := s.b.CompleteMultipartUpload(ctx, bucket, "/"+object, string(id), parts)
 	if err != nil {
-		return "", "", gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
+		return nil, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 	}
-	return "", resp.ETag, nil
+	return &gofakes3.CompleteMultipartUploadResult{
+		VersionID: "",
+		ETag:      resp.ETag,
+	}, nil
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/SiaFoundation/gofakes3"
 	"go.sia.tech/core/types"
+	"go.sia.tech/gofakes3"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/object"
 	"go.uber.org/zap"
@@ -70,14 +70,14 @@ func New(b bus, w worker, logger *zap.SugaredLogger, opts Opts) (http.Handler, e
 		w:      w,
 		logger: namedLogger,
 	}
-	faker, err := gofakes3.New(backend,
+	faker, err := gofakes3.New(
+		newAuthenticatedBackend(backend, opts.AuthKeyPairs),
 		gofakes3.WithHostBucket(false),
 		gofakes3.WithLogger(&gofakes3Logger{
 			l: namedLogger,
 		}),
 		gofakes3.WithRequestID(rand.Uint64()),
 		gofakes3.WithoutVersioning(),
-		gofakes3.WithV4Auth(opts.AuthKeyPairs),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create s3 server: %w", err)


### PR DESCRIPTION
This PR is the first step towards persisting S3 keys in the bus as well as implementing more fine-grained access policies. 