### PR TITLE
Enable upload packing by default

### DIFF
--- a/build/env_default.go
+++ b/build/env_default.go
@@ -37,7 +37,7 @@ var (
 	// DefaultUploadPackingSettings define the default upload packing settings
 	// the bus is configured with on startup.
 	DefaultUploadPackingSettings = api.UploadPackingSettings{
-		Enabled:               false,
+		Enabled:               true,
 		SlabBufferMaxSizeSoft: 1 << 32, // 4 GiB
 	}
 

--- a/build/env_testnet.go
+++ b/build/env_testnet.go
@@ -39,7 +39,7 @@ var (
 	// DefaultUploadPackingSettings define the default upload packing settings
 	// the bus is configured with on startup.
 	DefaultUploadPackingSettings = api.UploadPackingSettings{
-		Enabled:                    false,
+		Enabled:                    true,
 		MaxDiskBufferSizeSoftLimit: 1 << 32, // 4 GiB
 	}
 

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -424,6 +424,10 @@ func newTestClusterCustom(dir, dbName string, funding bool, wk types.PrivateKey,
 	if err != nil {
 		return nil, err
 	}
+	err = busClient.UpdateSetting(context.Background(), api.SettingUploadPacking, api.UploadPackingSettings{Enabled: false})
+	if err != nil {
+		return nil, err
+	}
 
 	// Fund the bus.
 	if funding {


### PR DESCRIPTION
Upload packing has been released for a while and worked great so far. Time to not consider it experimental anymore and enable it by default. Advanced users can still disable it if they choose to do their own packing.