### PR TITLE
Upload Priority

### DIFF
--- a/worker/migrations.go
+++ b/worker/migrations.go
@@ -94,16 +94,8 @@ func migrateSlab(ctx context.Context, d *downloadManager, u *uploadManager, s *o
 		}
 	}
 
-	// prioritise this migration
-	lockPriority := lockingPriorityMigrations
-	if s.Health < .25 {
-		lockPriority = lockingPriorityUpload + 1
-	} else if s.Health < .5 {
-		lockPriority = lockingPriorityUpload
-	}
-
 	// migrate the shards
-	uploaded, used, err := u.UploadShards(ctx, shards, allowed, bh, lockPriority)
+	uploaded, used, err := u.UploadShards(ctx, shards, allowed, bh, lockingPriorityUpload)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to upload slab for migration: %w", err)
 	}

--- a/worker/migrations.go
+++ b/worker/migrations.go
@@ -94,8 +94,16 @@ func migrateSlab(ctx context.Context, d *downloadManager, u *uploadManager, s *o
 		}
 	}
 
+	// prioritise this migration
+	lockPriority := lockingPriorityMigrations
+	if s.Health < .25 {
+		lockPriority = lockingPriorityUpload + 1
+	} else if s.Health < .5 {
+		lockPriority = lockingPriorityUpload
+	}
+
 	// migrate the shards
-	uploaded, used, err := u.Migrate(ctx, shards, allowed, bh)
+	uploaded, used, err := u.UploadShards(ctx, shards, allowed, bh, lockPriority)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to upload slab for migration: %w", err)
 	}

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -340,11 +340,11 @@ func (w *worker) tryUploadPackedSlabs(ctx context.Context, rs api.RedundancySett
 	// if we want to block, try and upload one packed slab synchronously, we use
 	// a slightly higher upload priority to avoid reaching the context deadline
 	if block {
-		_, err = w.uploadPackedSlabs(ctx, defaultPackedSlabsLockDuration, rs, contractSet, defaultPackedSlabsLimit, lockingPriorityUpload+1)
+		_, err = w.uploadPackedSlabs(ctx, defaultPackedSlabsLockDuration, rs, contractSet, defaultPackedSlabsLimit, lockingPriorityBlockedUpload)
 	}
 
 	// make sure there's a goroutine uploading the remainder of the packed slabs
-	go w.threadedUploadPackedSlabs(rs, contractSet, lockingPriorityUpload-1)
+	go w.threadedUploadPackedSlabs(rs, contractSet, lockingPriorityBackgroundUpload)
 	return
 }
 

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -344,7 +344,7 @@ func (w *worker) tryUploadPackedSlabs(ctx context.Context, rs api.RedundancySett
 	}
 
 	// make sure there's a goroutine uploading the remainder of the packed slabs
-	go w.threadedUploadPackedSlabs(rs, contractSet, lockingPriorityUpload)
+	go w.threadedUploadPackedSlabs(rs, contractSet, lockingPriorityUpload-1)
 	return
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -48,10 +48,9 @@ const (
 	lockingPriorityRenew                  = 80
 	lockingPriorityPriceTable             = 60
 	lockingPriorityFunding                = 40
-	lockingPrioritySyncing                = 30
-	lockingPriorityPruning                = 20
-	lockingPriorityUpload                 = 10
-	lockingPriorityMigrations             = 1 // lowest
+	lockingPrioritySyncing                = 20
+	lockingPriorityPruning                = 10
+	lockingPriorityUpload                 = 1 // lowest
 )
 
 var privateSubnets []*net.IPNet

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -48,9 +48,10 @@ const (
 	lockingPriorityRenew                  = 80
 	lockingPriorityPriceTable             = 60
 	lockingPriorityFunding                = 40
-	lockingPrioritySyncing                = 20
-	lockingPriorityPruning                = 10
-	lockingPriorityUpload                 = 1 // lowest
+	lockingPrioritySyncing                = 30
+	lockingPriorityPruning                = 20
+	lockingPriorityUpload                 = 10
+	lockingPriorityMigrations             = 1 // lowest
 )
 
 var privateSubnets []*net.IPNet

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -44,13 +44,16 @@ const (
 	defaultLockTimeout          = time.Minute
 	defaultRevisionFetchTimeout = 30 * time.Second
 
-	lockingPriorityActiveContractRevision = 100 // highest
+	lockingPriorityActiveContractRevision = 100
 	lockingPriorityRenew                  = 80
 	lockingPriorityPriceTable             = 60
 	lockingPriorityFunding                = 40
-	lockingPrioritySyncing                = 20
-	lockingPriorityPruning                = 10
-	lockingPriorityUpload                 = 1 // lowest
+	lockingPrioritySyncing                = 30
+	lockingPriorityPruning                = 20
+
+	lockingPriorityBlockedUpload    = 15
+	lockingPriorityUpload           = 10
+	lockingPriorityBackgroundUpload = 5
 )
 
 var privateSubnets []*net.IPNet


### PR DESCRIPTION
This PR gets rid of `Migrate` in the upload manager and now exposes `UploadShards`. We were using `.Migrate` in places where it doesn't really make sense only because that method allowed uploading shards individually. I also exposed a `lockPriority` that allows prioritising synchronous packed slab uploads as well as deprioritising the asynchronous ones. I decided to bump the lock and default timeout from 5 to 10 minutes to compensate for that. It should get rid of the context deadline exceeded error Nate was seeing, even though that error is not that big of a deal if it's not happening all the time.