### PR TITLE
Resync accounts upon unclean shutdown

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -13,6 +13,7 @@ type (
 		ID rhpv3.Account `json:"id"`
 
 		// CleanShutdown indicates whether the account was saved during a clean
+		// shutdown
 		CleanShutdown bool `json:"cleanShutdown"`
 
 		// HostKey describes the host the account was created with.

--- a/api/account.go
+++ b/api/account.go
@@ -12,6 +12,9 @@ type (
 		// ID identifies an account. It's a public key.
 		ID rhpv3.Account `json:"id"`
 
+		// CleanShutdown indicates whether the account was saved during a clean
+		CleanShutdown bool `json:"cleanShutdown"`
+
 		// HostKey describes the host the account was created with.
 		HostKey types.PublicKey `json:"hostKey"`
 

--- a/bus/accounts.go
+++ b/bus/accounts.go
@@ -158,12 +158,11 @@ func (a *accounts) SetBalance(id rhpv3.Account, hk types.PublicKey, balance *big
 	delta := new(big.Int).Sub(balance, acc.Balance)
 	balanceBefore := acc.Balance.String()
 	driftBefore := acc.Drift.String()
-	if !acc.CleanShutdown {
-		acc.CleanShutdown = true
-	} else {
+	if acc.CleanShutdown {
 		acc.Drift = acc.Drift.Add(acc.Drift, delta)
 	}
 	acc.Balance.Set(balance)
+	acc.CleanShutdown = true
 	acc.RequiresSync = false // resetting the balance resets the sync field
 	acc.mu.Unlock()
 
@@ -212,11 +211,12 @@ func (a *accounts) ScheduleSync(id rhpv3.Account, hk types.PublicKey) error {
 
 func (a *account) convert() api.Account {
 	return api.Account{
-		ID:           a.ID,
-		Balance:      new(big.Int).Set(a.Balance),
-		Drift:        new(big.Int).Set(a.Drift),
-		HostKey:      a.HostKey,
-		RequiresSync: a.RequiresSync,
+		ID:            a.ID,
+		Balance:       new(big.Int).Set(a.Balance),
+		CleanShutdown: a.CleanShutdown,
+		Drift:         new(big.Int).Set(a.Drift),
+		HostKey:       a.HostKey,
+		RequiresSync:  a.RequiresSync,
 	}
 }
 

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -166,6 +166,7 @@ type (
 	EphemeralAccountStore interface {
 		Accounts(context.Context) ([]api.Account, error)
 		SaveAccounts(context.Context, []api.Account) error
+		SetUncleanShutdown() error
 	}
 )
 
@@ -1843,6 +1844,12 @@ func New(s Syncer, am *alerts.Manager, hm *webhooks.Manager, cm ChainManager, tp
 		return nil, err
 	}
 	b.accounts = newAccounts(accounts, b.logger)
+
+	// Mark the shutdown as unclean. This will be overwritten when/if the
+	// accounts are saved on shutdown.
+	if err := eas.SetUncleanShutdown(); err != nil {
+		return nil, fmt.Errorf("failed to mark account shutdown as unclean: %w", err)
+	}
 	return b, nil
 }
 

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1156,6 +1156,26 @@ func TestEphemeralAccounts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Newly created accounts are !cleanShutdown. Simulate a sync to change
+	// that.
+	for _, acc := range accounts {
+		if acc.CleanShutdown {
+			t.Fatal("new account should indicate an unclean shutdown")
+		} else if acc.RequiresSync {
+			t.Fatal("new account should not require a sync")
+		}
+		if err := cluster.Bus.SetBalance(context.Background(), acc.ID, acc.HostKey, acc.Balance); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Fetch accounts again.
+	accounts, err = cluster.Bus.Accounts(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	acc := accounts[0]
 	minExpectedBalance := types.Siacoins(1).Sub(types.NewCurrency64(1))
 	if acc.Balance.Cmp(minExpectedBalance.Big()) < 0 {
@@ -1166,6 +1186,9 @@ func TestEphemeralAccounts(t *testing.T) {
 	}
 	if acc.HostKey != types.PublicKey(host.PublicKey()) {
 		t.Fatal("wrong host")
+	}
+	if !acc.CleanShutdown {
+		t.Fatal("account should indicate a clean shutdown")
 	}
 
 	// Fetch account from bus directly.

--- a/stores/accounts.go
+++ b/stores/accounts.go
@@ -18,7 +18,7 @@ type (
 		AccountID publicKey `gorm:"unique;NOT NULL;size:32"`
 
 		// CleanShutdown indicates whether the account was saved during a clean
-		// shutdown.
+		// shutdown shutdown.
 		CleanShutdown bool `gorm:"default:false"`
 
 		// Host describes the host the account was created with.

--- a/stores/accounts.go
+++ b/stores/accounts.go
@@ -71,6 +71,7 @@ func (s *SQLStore) Accounts(ctx context.Context) ([]api.Account, error) {
 // drift.
 func (s *SQLStore) SetUncleanShutdown() error {
 	return s.db.Model(&dbAccount{}).
+		Where("TRUE").
 		Updates(map[string]interface{}{
 			"clean_shutdown": false,
 			"requires_sync":  true,


### PR DESCRIPTION
To avoid adding a huge amount of drift to accounts whenever the bus isn't shut down correctly, we mark accounts as not being shut down cleanly and then avoid adding the drift the next time we sync the account.