### PR TITLE
IP Filter

### DIFF
--- a/autopilot/ipfilter.go
+++ b/autopilot/ipfilter.go
@@ -2,6 +2,7 @@ package autopilot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -20,29 +21,86 @@ const (
 	resolverLookupTimeout = 5 * time.Second
 )
 
+var (
+	errNoSuchHost        = errors.New("no such host")
+	errTooManyAddresses  = errors.New("host has more than two addresses, or two of the same type")
+	errUnparsableAddress = errors.New("host address could not be parsed to a subnet")
+)
+
 type resolver interface {
 	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
 }
 
 type ipFilter struct {
-	subnets  map[string]string
-	resolver resolver
-	timeout  time.Duration
+	hostIPToSubnetsCache map[string][]string
+	subnets              map[string]string
+	resolver             resolver
+	timeout              time.Duration
 
 	logger *zap.SugaredLogger
 }
 
 func newIPFilter(logger *zap.SugaredLogger) *ipFilter {
 	return &ipFilter{
-		subnets:  make(map[string]string),
-		resolver: &net.Resolver{},
-		timeout:  resolverLookupTimeout,
+		hostIPToSubnetsCache: make(map[string][]string),
+		subnets:              make(map[string]string),
+		resolver:             &net.Resolver{},
+		timeout:              resolverLookupTimeout,
 
 		logger: logger,
 	}
 }
 
-func (f *ipFilter) isRedundantIP(hostIP string, hostKey types.PublicKey) bool {
+func (f *ipFilter) IsRedundantIP(hostIP string, hostKey types.PublicKey) bool {
+	// perform DNS lookup
+	subnets, err := f.performDNSLookup(hostIP)
+	if err != nil {
+		if !strings.Contains(err.Error(), errNoSuchHost.Error()) {
+			f.logger.Errorf("failed to check for redundant IP, treating host %v with IP %v as redundant, err: %v", hostKey, hostIP, err)
+		}
+		return true
+	}
+
+	// if the lookup failed parse out the host
+	if len(subnets) == 0 {
+		f.logger.Errorf("failed to check for redundant IP, treating host %v with IP %v as redundant, err: %v", hostKey, hostIP, errUnparsableAddress)
+		return true
+	}
+
+	// we register all subnets under the host key, so we can safely use the
+	// first subnet to check whether we already know this host
+	host, found := f.subnets[subnets[0]]
+	if !found {
+		for _, subnet := range subnets {
+			f.subnets[subnet] = hostKey.String()
+		}
+		return false
+	}
+
+	// if the given host matches the known host, it's not redundant
+	sameHost := host == hostKey.String()
+	return !sameHost
+}
+
+// Resetting clears the subnets, but not the cache, allowing to rebuild the IP
+// filter with a list of hosts.
+func (f *ipFilter) Reset() {
+	f.subnets = make(map[string]string)
+}
+
+func (f *ipFilter) performDNSLookup(hostIP string) ([]string, error) {
+	// check the cache
+	subnets, found := f.hostIPToSubnetsCache[hostIP]
+	if found {
+		return subnets, nil
+	}
+
+	// lookup all IP addresses for the given host
+	host, _, err := net.SplitHostPort(hostIP)
+	if err != nil {
+		return nil, err
+	}
+
 	// create a context
 	ctx := context.Background()
 	if f.timeout > 0 {
@@ -51,40 +109,28 @@ func (f *ipFilter) isRedundantIP(hostIP string, hostKey types.PublicKey) bool {
 		defer cancel()
 	}
 
-	// lookup all IP addresses for the given host
-	host, _, err := net.SplitHostPort(hostIP)
+	// lookup IP addresses
+	addrs, err := f.resolver.LookupIPAddr(ctx, host)
 	if err != nil {
-		return true
-	}
-	addresses, err := f.resolver.LookupIPAddr(ctx, host)
-	if err != nil {
-		if !strings.Contains(err.Error(), "no such host") {
-			f.logger.Debugf("failed to lookup IP for host %v, err: %v", hostKey, err)
-		}
-		return true
+		return nil, err
 	}
 
-	// filter hosts associated with more than two addresses or two of the same type
-	if len(addresses) > 2 || (len(addresses) == 2) && (len(addresses[0].IP) == len(addresses[1].IP)) {
-		return true
+	// filter out hosts associated with more than two addresses or two of the same type
+	if len(addrs) > 2 || (len(addrs) == 2) && (len(addrs[0].IP) == len(addrs[1].IP)) {
+		return nil, errTooManyAddresses
 	}
 
-	// check whether the host's subnet was already in the list, if it is in the
-	// list we compare the cached net address with the one from the host being
-	// filtered as it might be the same host
-	var filter bool
-	for _, subnet := range subnets(addresses) {
-		original, exists := f.subnets[subnet]
-		if exists && hostKey.String() != original {
-			filter = true
-		} else if !exists {
-			f.subnets[subnet] = hostKey.String()
-		}
+	// parse out subnets
+	subnets = parseSubnets(addrs)
+
+	// cache them and return
+	if len(subnets) > 0 {
+		f.hostIPToSubnetsCache[hostIP] = subnets
 	}
-	return filter
+	return subnets, nil
 }
 
-func subnets(addresses []net.IPAddr) []string {
+func parseSubnets(addresses []net.IPAddr) []string {
 	subnets := make([]string, 0, len(addresses))
 
 	for _, address := range addresses {

--- a/autopilot/ipfilter.go
+++ b/autopilot/ipfilter.go
@@ -37,9 +37,9 @@ var (
 type (
 	ipFilter struct {
 		subnetToHostKey map[string]string
-		resolver        *ipResolver
 
-		logger *zap.SugaredLogger
+		resolver *ipResolver
+		logger   *zap.SugaredLogger
 	}
 )
 
@@ -47,8 +47,9 @@ func (c *contractor) newIPFilter() *ipFilter {
 	c.resolver.pruneCache()
 	return &ipFilter{
 		subnetToHostKey: make(map[string]string),
-		resolver:        c.resolver,
-		logger:          c.logger,
+
+		resolver: c.resolver,
+		logger:   c.logger,
 	}
 }
 


### PR DESCRIPTION
Our IP filter isn't always able to resolve the host IP. When we encounter an error, we consider the host's IP as redundant, causing unnecessary churn at times. This PR doesn't really change that but whilst trying to figure out where the churn was coming from I found some stuff I wanted to improve or suggest.

I'm not sure whether we can really handle the errors better unfortunately... Currently we treat any error to resolve a host's IP as a redundant IP, this will definitely cause some churn since sometimes we run into ` server misbehaving` errors. We now log them at least so we're more aware.

edit: @ChrisSchinnerl I refactored it a little because I wanted to get rid of the `.Reset()` and find a reasonably good spot to prune the cache. You can now ask the contractor for a `newIPFilter` that wraps a resolver type that has a cache.