### PR TITLE
Release Assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -226,11 +226,11 @@ jobs:
       - name: Set build tag environment variable
         run: |
           if ( "${{ matrix.network }}" -eq "zen" ) {
-            echo "BUILD_TAGS=testnet netgo" >> $GITHUB_ENV
-            echo "ZIP_OUTPUT_SUFFIX=_zen" >> $GITHUB_ENV
+            "BUILD_TAGS=testnet netgo" >> $env:GITHUB_ENV
+            "ZIP_OUTPUT_SUFFIX=_zen" >> $env:GITHUB_ENV
           } else {
-            echo "BUILD_TAGS=netgo" >> $GITHUB_ENV
-            echo "ZIP_OUTPUT_SUFFIX=" >> $GITHUB_ENV
+            "BUILD_TAGS=netgo" >> $env:GITHUB_ENV
+            "ZIP_OUTPUT_SUFFIX=" >> $env:GITHUB_ENV
           }
       - name: Setup
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,10 +85,10 @@ jobs:
         run: |
           if [[ "${{ matrix.network }}" == "zen" ]]; then
             echo "BUILD_TAGS=testnet netgo" >> $GITHUB_ENV
-            echo "ZIP_OUTPUT=release/renterd_zen_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
+            echo "ZIP_OUTPUT_SUFFIX=_zen" >> $GITHUB_ENV
           else
             echo "BUILD_TAGS=netgo" >> $GITHUB_ENV
-            echo "ZIP_OUTPUT=release/renterd_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
+            echo "ZIP_OUTPUT_SUFFIX=" >> $GITHUB_ENV
           fi
       - name: Build amd64
         env:
@@ -97,6 +97,7 @@ jobs:
           GOARCH: amd64
         run: |
           mkdir -p release
+          ZIP_OUTPUT=release/renterd${{ env.ZIP_OUTPUT_SUFFIX }}_${GOOS}_${GOARCH}.zip
           go build -tags="$BUILD_TAGS" -trimpath -o bin/ -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
           cp README.md LICENSE bin/
           zip -qj $ZIP_OUTPUT bin/*
@@ -108,6 +109,7 @@ jobs:
           CC: aarch64-linux-gnu-gcc
         run: |
           mkdir -p release
+          ZIP_OUTPUT=release/renterd${{ env.ZIP_OUTPUT_SUFFIX }}_${GOOS}_${GOARCH}.zip
           go build -tags="$BUILD_TAGS" -trimpath -o bin/ -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
           cp README.md LICENSE bin/
           zip -qj $ZIP_OUTPUT bin/*
@@ -162,10 +164,10 @@ jobs:
         run: |
           if [[ "${{ matrix.network }}" == "zen" ]]; then
               echo "BUILD_TAGS=testnet netgo" >> $GITHUB_ENV
-              echo "ZIP_OUTPUT=release/renterd_zen_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
+              echo "ZIP_OUTPUT_SUFFIX=_zen" >> $GITHUB_ENV
           else
               echo "BUILD_TAGS=netgo" >> $GITHUB_ENV
-              echo "ZIP_OUTPUT=release/renterd_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
+              echo "ZIP_OUTPUT_SUFFIX=" >> $GITHUB_ENV
           fi
       - name: Build amd64
         env:
@@ -181,6 +183,7 @@ jobs:
           GOARCH: amd64
         run: |
           mkdir -p release
+          ZIP_OUTPUT=release/renterd${{ env.ZIP_OUTPUT_SUFFIX }}_${GOOS}_${GOARCH}.zip
           go build -tags="$BUILD_TAGS" -trimpath -o bin/ -a -ldflags '-s -w' ./cmd/renterd
           cp README.md LICENSE bin/
           /usr/bin/codesign --deep -f -v --timestamp -o runtime,library -s $APPLE_CERT_ID bin/renterd
@@ -200,6 +203,7 @@ jobs:
           GOARCH: arm64
         run: |
           mkdir -p release
+          ZIP_OUTPUT=release/renterd${{ env.ZIP_OUTPUT_SUFFIX }}_${GOOS}_${GOARCH}.zip
           go build -tags="$BUILD_TAGS" -trimpath -o bin/ -a -ldflags '-s -w' ./cmd/renterd
           cp README.md LICENSE bin/
           /usr/bin/codesign --deep -f -v --timestamp -o runtime,library -s $APPLE_CERT_ID bin/renterd
@@ -223,10 +227,10 @@ jobs:
         run: |
           if ( "${{ matrix.network }}" -eq "zen" ) {
             echo "BUILD_TAGS=testnet netgo" >> $GITHUB_ENV
-            echo "ZIP_OUTPUT=release/renterd_zen_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
+            echo "ZIP_OUTPUT_SUFFIX=_zen" >> $GITHUB_ENV
           } else {
             echo "BUILD_TAGS=netgo" >> $GITHUB_ENV
-            echo "ZIP_OUTPUT=release/renterd_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
+            echo "ZIP_OUTPUT_SUFFIX=" >> $GITHUB_ENV
           }
       - name: Setup
         shell: bash
@@ -241,6 +245,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p release
+          ZIP_OUTPUT=release/renterd${{ env.ZIP_OUTPUT_SUFFIX }}_${GOOS}_${GOARCH}.zip
           go build -tags="$BUILD_TAGS" -trimpath -o bin/ -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
           azuresigntool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v bin/renterd.exe
           cp README.md LICENSE bin/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - stable
+      - pj/build-tags
     tags: 
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        network: ["mainnet" , "testnet"]
+        network: ["mainnet" , "zen"]
     permissions:
       packages: write
     steps:
@@ -38,12 +38,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare environment variables
         run: |
-          if [[ "${{ matrix.network }}" == "testnet" ]]; then
+          if [[ "${{ matrix.network }}" == "zen" ]]; then
             echo "BUILD_TAGS=testnet netgo" >> $GITHUB_ENV
-            echo "DOCKER_METADATA_suffix=-testnet" >> $GITHUB_ENV
+            echo "DOCKER_METADATA_SUFFIX=-zen" >> $GITHUB_ENV
           else
             echo "BUILD_TAGS=netgo" >> $GITHUB_ENV
-            echo "DOCKER_METADATA_suffix=" >> $GITHUB_ENV
+            echo "DOCKER_METADATA_SUFFIX=" >> $GITHUB_ENV
           fi
       - uses: docker/metadata-action@v4
         name: Generate tags
@@ -51,7 +51,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
-            suffix=${{ env.DOCKER_METADATA_suffix }},onlatest=true
+            suffix=${{ env.DOCKER_METADATA_SUFFIX }},onlatest=true
           tags: |
             type=ref,event=branch
             type=sha,prefix=
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        network: ["mainnet" , "testnet"]
+        network: ["mainnet" , "zen"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -82,10 +82,12 @@ jobs:
           go generate ./...
       - name: Set build tag environment variable
         run: |
-          if [[ "${{ matrix.network }}" == "testnet" ]]; then
+          if [[ "${{ matrix.network }}" == "zen" ]]; then
             echo "BUILD_TAGS=testnet netgo" >> $GITHUB_ENV
+            echo "ZIP_OUTPUT=release/renterd_zen_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
           else
             echo "BUILD_TAGS=netgo" >> $GITHUB_ENV
+            echo "ZIP_OUTPUT=release/renterd_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
           fi
       - name: Build amd64
         env:
@@ -94,7 +96,6 @@ jobs:
           GOARCH: amd64
         run: |
           mkdir -p release
-          ZIP_OUTPUT=release/renterd_${{ matrix.network }}_${GOOS}_${GOARCH}.zip
           go build -tags="$BUILD_TAGS" -trimpath -o bin/ -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
           cp README.md LICENSE bin/
           zip -qj $ZIP_OUTPUT bin/*
@@ -106,7 +107,6 @@ jobs:
           CC: aarch64-linux-gnu-gcc
         run: |
           mkdir -p release
-          ZIP_OUTPUT=release/renterd_${{ matrix.network }}_${GOOS}_${GOARCH}.zip
           go build -tags="$BUILD_TAGS" -trimpath -o bin/ -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
           cp README.md LICENSE bin/
           zip -qj $ZIP_OUTPUT bin/*
@@ -118,7 +118,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        network: ["mainnet" , "testnet"]
+        network: ["mainnet" , "zen"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -159,10 +159,12 @@ jobs:
           go generate ./...
       - name: Set build tag environment variable
         run: |
-          if [[ "${{ matrix.network }}" == "testnet" ]]; then
-            echo "BUILD_TAGS=testnet netgo" >> $GITHUB_ENV
+          if [[ "${{ matrix.network }}" == "zen" ]]; then
+              echo "BUILD_TAGS=testnet netgo" >> $GITHUB_ENV
+              echo "ZIP_OUTPUT=release/renterd_zen_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
           else
-            echo "BUILD_TAGS=netgo" >> $GITHUB_ENV
+              echo "BUILD_TAGS=netgo" >> $GITHUB_ENV
+              echo "ZIP_OUTPUT=release/renterd_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
           fi
       - name: Build amd64
         env:
@@ -177,7 +179,6 @@ jobs:
           GOOS: darwin
           GOARCH: amd64
         run: |
-          ZIP_OUTPUT=release/renterd_${{ matrix.network }}_${GOOS}_${GOARCH}.zip
           mkdir -p release
           go build -tags="$BUILD_TAGS" -trimpath -o bin/ -a -ldflags '-s -w' ./cmd/renterd
           cp README.md LICENSE bin/
@@ -197,7 +198,6 @@ jobs:
           GOOS: darwin
           GOARCH: arm64
         run: |
-          ZIP_OUTPUT=release/renterd_${{ matrix.network }}_${GOOS}_${GOARCH}.zip
           mkdir -p release
           go build -tags="$BUILD_TAGS" -trimpath -o bin/ -a -ldflags '-s -w' ./cmd/renterd
           cp README.md LICENSE bin/
@@ -212,7 +212,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        network: ["mainnet" , "testnet"]
+        network: ["mainnet" , "zen"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -220,10 +220,12 @@ jobs:
           go-version: 'stable'
       - name: Set build tag environment variable
         run: |
-          if ( "${{ matrix.network }}" -eq "testnet" ) {
+          if ( "${{ matrix.network }}" -eq "zen" ) {
             echo "BUILD_TAGS=testnet netgo" >> $GITHUB_ENV
+            echo "ZIP_OUTPUT=release/renterd_zen_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
           } else {
             echo "BUILD_TAGS=netgo" >> $GITHUB_ENV
+            echo "ZIP_OUTPUT=release/renterd_${GOOS}_${GOARCH}.zip" >> $GITHUB_ENV
           }
       - name: Setup
         shell: bash
@@ -238,7 +240,6 @@ jobs:
         shell: bash
         run: |
           mkdir -p release
-          ZIP_OUTPUT=release/renterd_${{ matrix.network }}_${GOOS}_${GOARCH}.zip
           go build -tags="$BUILD_TAGS" -trimpath -o bin/ -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
           azuresigntool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v bin/renterd.exe
           cp README.md LICENSE bin/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
       - stable
-      - pj/build-tags
     tags: 
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'


### PR DESCRIPTION
Makes naming of release assets consistent with `hostd`.

To test it I temporarily added this branch to the triggers and verified the release asset names here:
https://github.com/SiaFoundation/renterd/pull/640/checks?sha=1d031557998ad087231e3420ae7e6d114404fe47

`NOTE`: I changed the docker tag suffix from `-testnet` to `-zen` to be more consistent with the naming we use for our release assets, making it inconsistent with `hostd` so maybe we can change it there too