### PR TITLE
Deprecate Wallet Routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,9 @@ API to the host system and the gateway to the world.
 
 ## Wallet
 
-Make sure the wallet is funded, it's a good rule of thumb to have at least twice the allowance in the wallet. Fetch the wallet's address and transfer some money. Verify the wallet's balance is not zero using the following endpoints:
+Make sure the wallet is funded, it's a good rule of thumb to have at least twice the allowance in the wallet. Fetch the wallet's address and transfer some money. Verify the wallet's balance is not zero using the following endpoint:
 
-- `GET /api/bus/wallet/address`
-- `GET /api/bus/wallet/balance`
+- `GET /api/bus/wallet`
 
 The autopilot will automatically redistribute the wallet funds over a certain number of outputs that make sense with regards to the autopilot's configuration. Contract formation and renewals work best when the autopilot has a good amount of outputs at its disposal. It's definitely a good idea to verify whether this is the case because if not it means that it's likely the autopilot is misconfigured, in which case the logs should be of help.
 

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -325,18 +325,6 @@ func (b *bus) walletHandler(jc jape.Context) {
 	})
 }
 
-func (b *bus) walletBalanceHandler(jc jape.Context) {
-	_, balance, _, err := b.w.Balance()
-	if jc.Check("couldn't fetch wallet balance", err) != nil {
-		return
-	}
-	jc.Encode(balance)
-}
-
-func (b *bus) walletAddressHandler(jc jape.Context) {
-	jc.Encode(b.w.Address())
-}
-
 func (b *bus) walletTransactionsHandler(jc jape.Context) {
 	var before, since time.Time
 	offset := 0
@@ -1988,8 +1976,6 @@ func (b *bus) Handler() http.Handler {
 		"POST   /txpool/broadcast":      b.txpoolBroadcastHandler,
 
 		"GET    /wallet":               b.walletHandler,
-		"GET    /wallet/balance":       b.walletBalanceHandler, // deprecated
-		"GET    /wallet/address":       b.walletAddressHandler, // deprecated
 		"GET    /wallet/transactions":  b.walletTransactionsHandler,
 		"GET    /wallet/outputs":       b.walletOutputsHandler,
 		"POST   /wallet/fund":          b.walletFundHandler,

--- a/bus/client.go
+++ b/bus/client.go
@@ -181,18 +181,6 @@ func (c *Client) Wallet(ctx context.Context) (resp api.WalletResponse, err error
 	return
 }
 
-// WalletBalance returns the current wallet balance.
-func (c *Client) WalletBalance(ctx context.Context) (bal types.Currency, err error) {
-	err = c.c.WithContext(ctx).GET("/wallet/balance", &bal)
-	return
-}
-
-// WalletAddress returns an address controlled by the wallet.
-func (c *Client) WalletAddress(ctx context.Context) (resp types.Address, err error) {
-	err = c.c.WithContext(ctx).GET("/wallet/address", &resp)
-	return
-}
-
 // WalletOutputs returns the set of unspent outputs controlled by the wallet.
 func (c *Client) WalletOutputs(ctx context.Context) (resp []wallet.SiacoinElement, err error) {
 	err = c.c.WithContext(ctx).GET("/wallet/outputs", &resp)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1612,7 +1612,7 @@ func TestUploadDownloadSameHost(t *testing.T) {
 	}
 
 	// get wallet address
-	renterAddress, err := cluster.Bus.WalletAddress(context.Background())
+	wallet, err := cluster.Bus.Wallet(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1627,7 +1627,7 @@ func TestUploadDownloadSameHost(t *testing.T) {
 	c := contracts[0]
 
 	// form 2 more contracts with the same host
-	rev2, _, err := cluster.Worker.RHPForm(context.Background(), c.WindowStart, c.HostKey, c.HostIP, renterAddress, c.RenterFunds(), c.Revision.ValidHostPayout())
+	rev2, _, err := cluster.Worker.RHPForm(context.Background(), c.WindowStart, c.HostKey, c.HostIP, wallet.Address, c.RenterFunds(), c.Revision.ValidHostPayout())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1635,7 +1635,7 @@ func TestUploadDownloadSameHost(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rev3, _, err := cluster.Worker.RHPForm(context.Background(), c.WindowStart, c.HostKey, c.HostIP, renterAddress, c.RenterFunds(), c.Revision.ValidHostPayout())
+	rev3, _, err := cluster.Worker.RHPForm(context.Background(), c.WindowStart, c.HostKey, c.HostIP, wallet.Address, c.RenterFunds(), c.Revision.ValidHostPayout())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We deprecated these two routes a while ago in favour of `/wallet`, time to remove them. Confirmed with Alex UI is good to go.