### PR TITLE
Add missing database indices

### DIFF
--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -253,6 +253,12 @@ func performMigrations(db *gorm.DB, logger *zap.SugaredLogger) error {
 				return performMigration00019_accountsShutdown(tx, logger)
 			},
 		},
+		{
+			ID: "00020_healthIndices",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration00020_healthIndices(tx, logger)
+			},
+		},
 	}
 	// Create migrator.
 	m := gormigrate.New(db, gormigrate.DefaultOptions, migrations)
@@ -887,5 +893,31 @@ func performMigration00019_accountsShutdown(txn *gorm.DB, logger *zap.SugaredLog
 		return fmt.Errorf("failed to update accounts: %w", err)
 	}
 	logger.Info("migration 00019_accounts_shutdown complete")
+	return nil
+}
+
+func performMigration00020_healthIndices(txn *gorm.DB, logger *zap.SugaredLogger) error {
+	logger.Info("performing migration 00020_healthIndices")
+	if !txn.Migrator().HasIndex(&dbSlab{}, "Health") {
+		if err := txn.Migrator().CreateIndex(&dbSlab{}, "Health"); err != nil {
+			return err
+		}
+	}
+	if !txn.Migrator().HasIndex(&dbSlab{}, "HealthValid") {
+		if err := txn.Migrator().CreateIndex(&dbSlab{}, "HealthValid"); err != nil {
+			return err
+		}
+	}
+	if !txn.Migrator().HasIndex(&dbSlab{}, "DBBufferedSlabID") {
+		if err := txn.Migrator().CreateIndex(&dbSlab{}, "DBBufferedSlabID"); err != nil {
+			return err
+		}
+	}
+	if !txn.Migrator().HasIndex(&dbObject{}, "etag") {
+		if err := txn.Migrator().CreateIndex(&dbObject{}, "etag"); err != nil {
+			return err
+		}
+	}
+	logger.Info("migration 00020_healthIndices complete")
 	return nil
 }

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -3,6 +3,8 @@ package stores
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
 
 	"github.com/go-gormigrate/gormigrate/v2"
 	"go.sia.tech/renterd/api"
@@ -254,9 +256,9 @@ func performMigrations(db *gorm.DB, logger *zap.SugaredLogger) error {
 			},
 		},
 		{
-			ID: "00020_healthIndices",
+			ID: "00020_missingIndices",
 			Migrate: func(tx *gorm.DB) error {
-				return performMigration00020_healthIndices(tx, logger)
+				return performMigration00020_missingIndices(tx, logger)
 			},
 		},
 	}
@@ -313,6 +315,31 @@ func initSchema(tx *gorm.DB) error {
 	return tx.Create(&dbBucket{
 		Name: api.DefaultBucketName,
 	}).Error
+}
+
+func detectMissingIndicesOnType(tx *gorm.DB, table interface{}, t reflect.Type, f func(dst interface{}, name string)) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.Anonymous {
+			detectMissingIndicesOnType(tx, table, field.Type, f)
+			continue
+		}
+		if !strings.Contains(field.Tag.Get("gorm"), "index") {
+			continue // no index tag
+		}
+		if !tx.Migrator().HasIndex(table, field.Name) {
+			f(table, field.Name)
+		}
+	}
+}
+
+func detectMissingIndices(tx *gorm.DB, f func(dst interface{}, name string)) {
+	for _, table := range tables {
+		detectMissingIndicesOnType(tx, table, reflect.TypeOf(table), f)
+	}
 }
 
 func setupJoinTables(tx *gorm.DB) error {
@@ -896,28 +923,18 @@ func performMigration00019_accountsShutdown(txn *gorm.DB, logger *zap.SugaredLog
 	return nil
 }
 
-func performMigration00020_healthIndices(txn *gorm.DB, logger *zap.SugaredLogger) error {
-	logger.Info("performing migration 00020_healthIndices")
-	if !txn.Migrator().HasIndex(&dbSlab{}, "Health") {
-		if err := txn.Migrator().CreateIndex(&dbSlab{}, "Health"); err != nil {
-			return err
+func performMigration00020_missingIndices(txn *gorm.DB, logger *zap.SugaredLogger) error {
+	logger.Info("performing migration 00020_missingIndices")
+	var err error
+	detectMissingIndices(txn, func(dst interface{}, name string) {
+		if err != nil {
+			return
 		}
+		err = txn.Migrator().CreateIndex(dst, name)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create missing indices: %w", err)
 	}
-	if !txn.Migrator().HasIndex(&dbSlab{}, "HealthValid") {
-		if err := txn.Migrator().CreateIndex(&dbSlab{}, "HealthValid"); err != nil {
-			return err
-		}
-	}
-	if !txn.Migrator().HasIndex(&dbSlab{}, "DBBufferedSlabID") {
-		if err := txn.Migrator().CreateIndex(&dbSlab{}, "DBBufferedSlabID"); err != nil {
-			return err
-		}
-	}
-	if !txn.Migrator().HasIndex(&dbObject{}, "etag") {
-		if err := txn.Migrator().CreateIndex(&dbObject{}, "etag"); err != nil {
-			return err
-		}
-	}
-	logger.Info("migration 00020_healthIndices complete")
+	logger.Info("migration 00020_missingIndices complete")
 	return nil
 }

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -145,6 +145,15 @@ func TestQueryPlan(t *testing.T) {
 		// contract_set_contracts
 		"SELECT * FROM contract_set_contracts WHERE db_contract_id = 1",
 		"SELECT * FROM contract_set_contracts WHERE db_contract_set_id = 1",
+
+		// slabs
+		"SELECT * FROM slabs WHERE health_valid = 1",
+		"SELECT * FROM slabs WHERE health > 0",
+		"SELECT * FROM slabs WHERE db_buffered_slab_id = 1",
+
+		// objects
+		"SELECT * FROM objects WHERE db_bucket_id = 1",
+		"SELECT * FROM objects WHERE etag = ''",
 	}
 
 	for _, query := range queries {

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -36,6 +36,9 @@ func newTestSQLStore(dir string) (*SQLStore, string, modules.ConsensusChangeID, 
 	if err != nil {
 		return nil, "", modules.ConsensusChangeID{}, err
 	}
+	detectMissingIndices(sqlStore.db, func(dst interface{}, name string) {
+		panic("no index can be missing")
+	})
 	err = sqlStore.SetContractSet(context.Background(), testContractSet, []types.FileContractID{})
 	return sqlStore, dbName, ccid, err
 }


### PR DESCRIPTION
I noticed that our Arequipa node was missing a few indices. This PR adds them.

NOTE: Seems like `AddColumn` doesn't create indices so `MigrateColumn` should be used instead.