### PR TITLE
Contractor Refactor

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1302,7 +1302,7 @@ func (c *contractor) candidateHosts(ctx context.Context, w Worker, hosts []hostd
 
 func randSelectHosts(candidates map[types.PublicKey]scoredHost, wanted, rounds int) ([]hostdb.Host, float64, error) {
 	var lowestScores []float64
-	var selectedHosts map[types.PublicKey]scoredHost
+	selectedHosts := make(map[types.PublicKey]scoredHost)
 
 	// perform the random select 'rounds' time
 	for r := 0; r < rounds; r++ {
@@ -1339,7 +1339,7 @@ func randSelectHosts(candidates map[types.PublicKey]scoredHost, wanted, rounds i
 		lowestScores = append(lowestScores, lowestScore)
 	}
 
-	// calculate the lowest score as the  median of the lowest score if every individual round
+	// calculate the lowest score
 	lowestScore, err := stats.Float64Data(lowestScores).Median()
 	if err != nil {
 		return nil, 0, err

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1345,6 +1345,7 @@ func randSelectHosts(candidates map[types.PublicKey]scoredHost, wanted, rounds i
 		return nil, 0, err
 	}
 
+	// select up to 'wanted' hosts with the highest score
 	var hosts []hostdb.Host
 	for _, h := range selectedHosts {
 		hosts = append(hosts, h.host)


### PR DESCRIPTION
Triggered by redundant logging I did a small refactor of the contractor. 

```
2023-10-09T07:41:55Z	DEBUG	autopilot.contractor	autopilot/contractor.go:1221	looking for 350 candidate hosts
2023-10-09T07:41:55Z	DEBUG	autopilot.contractor	autopilot/contractor.go:1256	selected 492 candidate hosts out of 509	{"excluded": 0, "notcompletedscan": 17}
2023-10-09T07:41:55Z	DEBUG	autopilot.contractor	autopilot/contractor.go:1288	scored 285 candidate hosts out of 492, took 10.609435ms	{"zeroscore": 87, "unusable": 207}
2023-10-09T07:41:55Z	WARN	autopilot.contractor	autopilot/contractor.go:1312	only found 285 candidate host(s) out of the 350 we wanted	{"offline": 111, "lowscore": 25, "gouging": 62, "notacceptingcontracts": 86}
2023-10-09T07:41:55Z	DEBUG	autopilot.contractor	autopilot/contractor.go:1221	looking for 350 candidate hosts
2023-10-09T07:41:55Z	DEBUG	autopilot.contractor	autopilot/contractor.go:1256	selected 492 candidate hosts out of 509	{"excluded": 0, "notcompletedscan": 17}
2023-10-09T07:41:55Z	DEBUG	autopilot.contractor	autopilot/contractor.go:1288	scored 285 candidate hosts out of 492, took 10.099587ms	{"zeroscore": 87, "unusable": 207}
2023-10-09T07:41:55Z	WARN	autopilot.contractor	autopilot/contractor.go:1312	only found 285 candidate host(s) out of the 350 we wanted	{"offline": 111, "lowscore": 25, "gouging": 62, "notacceptingcontracts": 86}
...
2023-10-09T07:41:55Z	DEBUG	autopilot.contractor	autopilot/contractor.go:1288	scored 285 candidate hosts out of 492, took 15.499845ms	{"zeroscore": 87, "unusable": 207}
2023-10-09T07:41:55Z	WARN	autopilot.contractor	autopilot/contractor.go:1312	only found 285 candidate host(s) out of the 350 we wanted	{"offline": 111, "lowscore": 25, "gouging": 62, "notacceptingcontracts": 86}
2023-10-09T07:41:55Z	INFO	autopilot.contractor	autopilot/contractor.go:1214	finished computing minScore	{"minScore": 0.000000000000000000020525997679292545, "lowestScore": 0.000000000000000010262998839646272}
```