### PR TITLE
fix RHPPruneContractResponse, remove unused type, update ipfilter cache

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -69,13 +69,6 @@ type (
 )
 
 type (
-	// An Action is an autopilot operation.
-	Action struct {
-		Timestamp time.Time
-		Type      string
-		Action    interface{ isAction() }
-	}
-
 	// AutopilotTriggerRequest is the request object used by the /debug/trigger
 	// endpoint
 	AutopilotTriggerRequest struct {
@@ -101,6 +94,14 @@ type (
 		StartTime time.Time `json:"startTime"`
 		BuildState
 	}
+)
+
+type (
+	// HostHandlerResponse is the response type for the /host/:hostkey endpoint.
+	HostHandlerResponse struct {
+		Host   hostdb.Host                `json:"host"`
+		Checks *HostHandlerResponseChecks `json:"checks,omitempty"`
+	}
 
 	HostHandlerResponseChecks struct {
 		Gouging          bool                 `json:"gouging"`
@@ -109,12 +110,6 @@ type (
 		ScoreBreakdown   HostScoreBreakdown   `json:"scoreBreakdown"`
 		Usable           bool                 `json:"usable"`
 		UnusableReasons  []string             `json:"unusableReasons"`
-	}
-
-	// HostHandlerResponse is the response type for the /host/:hostkey endpoint.
-	HostHandlerResponse struct {
-		Host   hostdb.Host                `json:"host"`
-		Checks *HostHandlerResponseChecks `json:"checks,omitempty"`
 	}
 
 	HostGougingBreakdown struct {

--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -309,6 +309,10 @@ func (w *worker) PruneContract(ctx context.Context, hostIP string, hostKey types
 				if deleted < uint64(len(indices)) {
 					remaining = uint64(len(indices)) - deleted
 				}
+
+				// return sizes instead of number of roots
+				deleted *= rhpv2.SectorSize
+				remaining *= rhpv2.SectorSize
 				return
 			})
 		})


### PR DESCRIPTION
We are returning `deleted` and `remaining` as num roots instead of num bytes. It should be number of bytes to be consistent with `ContractPrunableData` which returns the amount of prunable data in bytes.