### PR TITLE
Pruning Fixes

### DIFF
--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -662,7 +662,7 @@ func (h *host) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte,
 
 	// record spending
 	h.contractSpendingRecorder.Record(rev.ParentID, rev.RevisionNumber, rev.Filesize, api.ContractSpending{Uploads: cost})
-	return root, err
+	return root, nil
 }
 
 // padBandwitdh pads the bandwidth to the next multiple of 1460 bytes.  1460


### PR DESCRIPTION
We are returning deleted and remaining as num roots instead of num bytes. It should be number of bytes to be consistent with ContractPrunableData which returns the amount of prunable data in bytes.  We're also recording spending in defer which I think is causing faulty updates of the contract's revision number/filesize in case an error occurs. Since the recorder has batching there's no reason not to record the spend in every iteration.