### PR TITLE
Change Reconstruct to ReconstructSome to only reconstruct missing slabs for migration

### DIFF
--- a/object/slab_test.go
+++ b/object/slab_test.go
@@ -34,12 +34,35 @@ func TestReedSolomon(t *testing.T) {
 		partialShards[i] = nil
 	}
 	// reconstruct
-	if err := s.Reconstruct(partialShards); err != nil {
+	required := make([]bool, len(partialShards))
+	for i := range required {
+		required[i] = partialShards[i] == nil
+	}
+	if err := s.ReconstructSome(partialShards, required); err != nil {
 		t.Fatal(err)
 	}
 	for i := range shards {
 		if !bytes.Equal(shards[i], partialShards[i]) {
 			t.Error("failed to reconstruct shards")
+			break
+		}
+	}
+	// reconstruct one-by-one
+	for _, i := range frand.Perm(len(partialShards))[:7] {
+		partialShards[i] = nil
+	}
+	for i := 0; i < len(partialShards); i++ {
+		required := make([]bool, len(partialShards))
+		required[i] = true
+		if err := s.ReconstructSome(partialShards, required); err != nil {
+			t.Fatal(err)
+		} else if len(partialShards[i]) == 0 {
+			t.Error("failed to reconstruct shard", i)
+		}
+	}
+	for i := range shards {
+		if !bytes.Equal(shards[i], partialShards[i]) {
+			t.Fatal("failed to reconstruct shards")
 			break
 		}
 	}
@@ -109,6 +132,7 @@ func BenchmarkReedSolomon(b *testing.B) {
 	benchReconstruct := func(m, n, r uint8) func(*testing.B) {
 		s, data, shards := makeSlab(m, n)
 		s.Encode(data, shards)
+		required := make([]bool, len(shards))
 		return func(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(shards[0])) * int64(r))
@@ -116,7 +140,10 @@ func BenchmarkReedSolomon(b *testing.B) {
 				for j := range shards[:r] {
 					shards[j] = shards[j][:0]
 				}
-				if err := s.Reconstruct(shards); err != nil {
+				for j := range required {
+					required[j] = len(shards[j]) == 0
+				}
+				if err := s.ReconstructSome(shards, required); err != nil {
 					b.Fatal(err)
 				}
 			}


### PR DESCRIPTION
This PR reduces the memory overhead of migrations by reducing the shards we reconstruct before starting the migration upload.

e.g. at 75% health a 10/30 slab is missing 5 shards. With this PR only 16 shards should be held in memory instead of 30. 