### PR TITLE
Fix deletion of bucket failing for empty buckets with registered multipart uploads

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -311,7 +311,7 @@ func (b *bus) bucketHandlerDELETE(jc jape.Context) {
 	} else if name == "" {
 		jc.Error(errors.New("no name provided"), http.StatusBadRequest)
 		return
-	} else if jc.Check("failed to create bucket", b.ms.DeleteBucket(jc.Request.Context(), name)) != nil {
+	} else if jc.Check("failed to delete bucket", b.ms.DeleteBucket(jc.Request.Context(), name)) != nil {
 		return
 	}
 }

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -518,7 +518,7 @@ func (s *SQLStore) DeleteBucket(ctx context.Context, bucket string) error {
 		if res.Error != nil {
 			return res.Error
 		}
-		return nil
+		return pruneSlabs(tx)
 	})
 }
 

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -955,7 +955,9 @@ func performMigration00021_multipartUploadsBucketCascade(txn *gorm.DB, logger *z
 	}
 
 	// Add cascade constraint.
-	if err := txn.Migrator().AutoMigrate(&dbMultipartUpload{}); err != nil {
+	if err := txn.Migrator().DropConstraint(&dbMultipartUpload{}, "DBBucket"); err != nil {
+		return err
+	} else if err := txn.Migrator().CreateConstraint(&dbMultipartUpload{}, "DBBucket"); err != nil {
 		return err
 	}
 

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -22,9 +22,9 @@ type (
 		Model
 
 		Key        []byte
-		UploadID   string `gorm:"uniqueIndex;NOT NULL;size:64"`
-		ObjectID   string `gorm:"index;NOT NULL"`
-		DBBucket   dbBucket
+		UploadID   string            `gorm:"uniqueIndex;NOT NULL;size:64"`
+		ObjectID   string            `gorm:"index;NOT NULL"`
+		DBBucket   dbBucket          `gorm:"constraint:OnDelete:CASCADE"` // CASCADE to delete uploads when bucket is deleted
 		DBBucketID uint              `gorm:"index;NOT NULL"`
 		Parts      []dbMultipartPart `gorm:"constraint:OnDelete:CASCADE"` // CASCADE to delete parts too
 		MimeType   string            `gorm:"index"`
@@ -186,7 +186,7 @@ func (s *SQLStore) MultipartUploads(ctx context.Context, bucket, prefix, keyMark
 		err := tx.
 			Model(&dbMultipartUpload{}).
 			Joins("DBBucket").
-			Where("? AND ? AND ?", prefixExpr, keyMarkerExpr, uploadIDMarkerExpr).
+			Where("? AND ? AND ? AND DBBucket.name = ?", prefixExpr, keyMarkerExpr, uploadIDMarkerExpr, bucket).
 			Limit(limit).
 			Find(&dbUploads).
 			Error


### PR DESCRIPTION
If a bucket is deleted the leftover multipart uploads should just be deleted as well