### PR TITLE
Fix Upload Overdrive

### DIFF
--- a/worker/upload.go
+++ b/worker/upload.go
@@ -1071,7 +1071,7 @@ func (u *upload) uploadShards(ctx context.Context, shards [][]byte, nextSlabChan
 
 	// launch all shard uploads
 	for _, upload := range requests {
-		if err := slab.launch(upload); err != nil {
+		if _, err := slab.launch(upload); err != nil {
 			return nil, err
 		}
 	}
@@ -1109,9 +1109,11 @@ func (u *upload) uploadShards(ctx context.Context, shards [][]byte, nextSlabChan
 
 		// relaunch non-overdrive uploads
 		if !done && resp.err != nil && !resp.req.overdrive {
-			if err := slab.launch(resp.req); err != nil {
+			if overdriving, err := slab.launch(resp.req); err != nil {
 				u.mgr.logger.Errorf("failed to relaunch a sector upload, err %v", err)
-				break // fail the upload
+				if !overdriving {
+					break // fail the upload
+				}
 			}
 		}
 
@@ -1412,17 +1414,18 @@ func (s *slabUpload) inflight() uint64 {
 	return s.numInflight
 }
 
-func (s *slabUpload) launch(req *sectorUploadReq) error {
+func (s *slabUpload) launch(req *sectorUploadReq) (overdriving bool, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	// launch the req
-	err := s.mgr.launch(req)
+	err = s.mgr.launch(req)
 	if err != nil {
+		overdriving = req.overdrive && s.overdriving[req.sectorIndex] > 0
 		span := trace.SpanFromContext(req.ctx)
 		span.RecordError(err)
 		span.End()
-		return err
+		return
 	}
 
 	// update the state
@@ -1431,9 +1434,9 @@ func (s *slabUpload) launch(req *sectorUploadReq) error {
 	if req.overdrive {
 		s.lastOverdrive = time.Now()
 		s.overdriving[req.sectorIndex]++
+		overdriving = true
 	}
-
-	return nil
+	return
 }
 
 func (s *slabUpload) overdrive(ctx context.Context, respChan chan sectorUploadResp) (resetTimer func()) {
@@ -1486,7 +1489,7 @@ func (s *slabUpload) overdrive(ctx context.Context, respChan chan sectorUploadRe
 				if canOverdrive() {
 					req := s.nextRequest(respChan)
 					if req != nil {
-						_ = s.launch(req) // ignore error
+						_, _ = s.launch(req) // ignore error
 					}
 				}
 				resetTimer()
@@ -1547,6 +1550,11 @@ func (s *slabUpload) overdrivePct() float64 {
 func (s *slabUpload) receive(resp sectorUploadResp) (finished bool, next bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// update the state
+	if resp.req.overdrive {
+		s.overdriving[resp.req.sectorIndex]--
+	}
 
 	// failed reqs can't complete the upload
 	s.numInflight--

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -1418,6 +1418,11 @@ func (s *slabUpload) launch(req *sectorUploadReq) (overdriving bool, err error) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// nothing to do
+	if req == nil {
+		return false, nil
+	}
+
 	// launch the req
 	err = s.mgr.launch(req)
 	if err != nil {
@@ -1487,10 +1492,7 @@ func (s *slabUpload) overdrive(ctx context.Context, respChan chan sectorUploadRe
 				return
 			case <-timer.C:
 				if canOverdrive() {
-					req := s.nextRequest(respChan)
-					if req != nil {
-						_, _ = s.launch(req) // ignore error
-					}
+					_, _ = s.launch(s.nextRequest(respChan)) // ignore result
 				}
 				resetTimer()
 			}

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -1403,7 +1403,7 @@ func (s *slabUpload) finish() ([]object.Sector, error) {
 
 	remaining := len(s.remaining)
 	if remaining > 0 {
-		return nil, fmt.Errorf("failed to upload slab: remaining=%d, inflight=%d, launched=%d uploaders=%d errors=%w", remaining, s.numInflight, s.numLaunched, s.mgr.numUploaders(), s.errs)
+		return nil, fmt.Errorf("failed to upload slab: remaining=%d, inflight=%d, launched=%d uploaders=%d errors=%d %w", remaining, s.numInflight, s.numLaunched, s.mgr.numUploaders(), len(s.errs), s.errs)
 	}
 	return s.sectors, nil
 }


### PR DESCRIPTION
This PR came from a community member copy pasting some logging wrt failed uploads:

```
couldn't upload object: couldn't upload object: failed to upload slab: remaining=3, inflight=7, launched=43 uploaders=45 errors=
d6e647d7: AppendSector: WriteResponse: i/o timeout
43c0e39e: unable to fetch revision with account: LatestRevision: failed to fetch pricetable, err: host price table gouging: {{   } {   cost per TiB exceeds max ul price: ~33.86 SC > ~33.33 SC}}
494f866a: AppendSector: WriteResponse: i/o timeout
557a7150: AppendSector: WriteResponse: i/o timeout
63993ddc: AppendSector: WriteResponse: i/o timeout
78e8e981: AppendSector: ReadResponse: [failed to finalize write program; program finalizer failed; not enough storage remaining to accept sector]
fdc6ce9c: AppendSector: ReadResponse: [failed to finalize write program; program finalizer failed; not enough storage remaining to accept sector]
85510c2f: AppendSector: ReadResponse: [failed to finalize write program; program finalizer failed; not enough storage remaining to accept sector]
e0b137fb: AppendSector: ReadResponse: [failed to finalize write program; program finalizer failed; not enough storage remaining to accept sector]
```

The upload code is quite dense but rereading the condition on which we abort an upload made me realise we're not properly awaiting overdrives... Instead, when we fail to overdrive an original "upload request" (so 1 out of the 30 sectors), on error, we fail the upload.

edit: math seems to check out: 43 launched, 3 remaining so 27 already succeeded... meaning 16 are either inflight or errored out (which checks out we have 7 inflight and 9 errors), so of those 7 inflight jobs, 4 or overdrive jobs 
