### PR TITLE
Reduce ram used when downloading lots of small files

### DIFF
--- a/worker/download.go
+++ b/worker/download.go
@@ -815,7 +815,7 @@ func (d *downloader) execute(req *sectorDownloadReq) (err error) {
 	}()
 
 	// download the sector
-	buf := bytes.NewBuffer(make([]byte, 0, rhpv2.SectorSize))
+	buf := bytes.NewBuffer(make([]byte, 0, req.length))
 	err = d.host.DownloadSector(req.ctx, buf, req.root, req.offset, req.length)
 	if err != nil {
 		req.fail(err)


### PR DESCRIPTION
Looks like we were always preallocating a full sector when downloading a sector from a host even if we were only interested in a small part of it. When downloading lots of small files like text files this might end up allocating a lot of memory in a short time. 