### PR TITLE
Metrics: Update endpoint to use intervals 

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -593,13 +593,7 @@ type (
 	}
 
 	ContractSetMetricsQueryOpts struct {
-		After  time.Time
-		Before time.Time
-
 		Name string
-
-		Offset int
-		Limit  int
 	}
 
 	ContractSetChurnMetric struct {
@@ -611,15 +605,9 @@ type (
 	}
 
 	ContractSetChurnMetricsQueryOpts struct {
-		After  time.Time
-		Before time.Time
-
 		Name      string
 		Direction string
 		Reason    string
-
-		Offset int
-		Limit  int
 	}
 
 	PerformanceMetric struct {
@@ -631,16 +619,9 @@ type (
 	}
 
 	PerformanceMetricsQueryOpts struct {
-		After  time.Time
-		Before time.Time
-
-		Action   string
-		Host     types.PublicKey
-		Origin   string
-		Duration time.Duration
-
-		Offset int
-		Limit  int
+		Action string
+		Host   types.PublicKey
+		Origin string
 	}
 
 	ContractMetric struct {
@@ -661,13 +642,7 @@ type (
 	}
 
 	ContractMetricsQueryOpts struct {
-		After  time.Time
-		Before time.Time
-
 		FCID types.FileContractID
 		Host types.PublicKey
-
-		Offset int
-		Limit  int
 	}
 )

--- a/api/bus.go
+++ b/api/bus.go
@@ -597,11 +597,11 @@ type (
 	}
 
 	ContractSetChurnMetric struct {
-		Direction string               `json:"direction"`
-		FCID      types.FileContractID `json:"fcid"`
-		Name      string               `json:"name"`
-		Reason    string               `json:"reason,omitempty"`
-		Timestamp time.Time            `json:"timestamp"`
+		Direction  string               `json:"direction"`
+		ContractID types.FileContractID `json:"contractID"`
+		Name       string               `json:"name"`
+		Reason     string               `json:"reason,omitempty"`
+		Timestamp  time.Time            `json:"timestamp"`
 	}
 
 	ContractSetChurnMetricsQueryOpts struct {
@@ -612,23 +612,23 @@ type (
 
 	PerformanceMetric struct {
 		Action    string          `json:"action"`
-		Host      types.PublicKey `json:"host"`
+		HostKey   types.PublicKey `json:"host"`
 		Origin    string          `json:"origin"`
 		Duration  time.Duration   `json:"duration"`
 		Timestamp time.Time       `json:"timestamp"`
 	}
 
 	PerformanceMetricsQueryOpts struct {
-		Action string
-		Host   types.PublicKey
-		Origin string
+		Action  string
+		HostKey types.PublicKey
+		Origin  string
 	}
 
 	ContractMetric struct {
 		Timestamp time.Time `json:"timestamp"`
 
-		FCID types.FileContractID `json:"fcid"`
-		Host types.PublicKey      `json:"host"`
+		ContractID types.FileContractID `json:"contractID"`
+		HostKey    types.PublicKey      `json:"hostKey"`
 
 		RemainingCollateral types.Currency `json:"remainingCollateral"`
 		RemainingFunds      types.Currency `json:"remainingFunds"`
@@ -642,7 +642,7 @@ type (
 	}
 
 	ContractMetricsQueryOpts struct {
-		FCID types.FileContractID
-		Host types.PublicKey
+		ContractID types.FileContractID
+		HostKey    types.PublicKey
 	}
 )

--- a/api/bus.go
+++ b/api/bus.go
@@ -612,7 +612,7 @@ type (
 
 	PerformanceMetric struct {
 		Action    string          `json:"action"`
-		HostKey   types.PublicKey `json:"host"`
+		HostKey   types.PublicKey `json:"hostKey"`
 		Origin    string          `json:"origin"`
 		Duration  time.Duration   `json:"duration"`
 		Timestamp time.Time       `json:"timestamp"`

--- a/api/params.go
+++ b/api/params.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"net/url"
 	"strconv"
 	"time"
 
@@ -74,7 +73,7 @@ func (s *ParamString) UnmarshalText(b []byte) error {
 }
 
 // String implements fmt.Stringer.
-func (t TimeRFC3339) String() string { return url.QueryEscape((time.Time)(t).Format(time.RFC3339)) }
+func (t TimeRFC3339) String() string { return (time.Time)(t).Format(time.RFC3339Nano) }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (t *TimeRFC3339) UnmarshalText(b []byte) error { return (*time.Time)(t).UnmarshalText(b) }

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -450,19 +450,19 @@ func (c *contractor) computeContractSetChanged(ctx context.Context, name string,
 	var metrics []api.ContractSetChurnMetric
 	for _, fcid := range added {
 		metrics = append(metrics, api.ContractSetChurnMetric{
-			Name:      c.ap.state.cfg.Contracts.Set,
-			FCID:      fcid,
-			Direction: api.ChurnDirAdded,
-			Timestamp: now,
+			Name:       c.ap.state.cfg.Contracts.Set,
+			ContractID: fcid,
+			Direction:  api.ChurnDirAdded,
+			Timestamp:  now,
 		})
 	}
 	for _, fcid := range removed {
 		metrics = append(metrics, api.ContractSetChurnMetric{
-			Name:      c.ap.state.cfg.Contracts.Set,
-			FCID:      fcid,
-			Direction: api.ChurnDirRemoved,
-			Reason:    removedReasons[fcid.String()],
-			Timestamp: now,
+			Name:       c.ap.state.cfg.Contracts.Set,
+			ContractID: fcid,
+			Direction:  api.ChurnDirRemoved,
+			Reason:     removedReasons[fcid.String()],
+			Timestamp:  now,
 		})
 	}
 	if len(metrics) > 0 {

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1829,9 +1829,9 @@ func (b *bus) metricsHandlerGET(jc jape.Context) {
 	case api.MetricContract:
 		var metrics []api.ContractMetric
 		var opts api.ContractMetricsQueryOpts
-		if jc.DecodeForm("fcid", &opts.FCID) != nil {
+		if jc.DecodeForm("fcid", &opts.ContractID) != nil {
 			return
-		} else if jc.DecodeForm("host", &opts.Host) != nil {
+		} else if jc.DecodeForm("host", &opts.HostKey) != nil {
 			return
 		} else if metrics, err = b.mtrcs.ContractMetrics(jc.Request.Context(), start, n, interval, opts); jc.Check("failed to get contract metrics", err) != nil {
 			return

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1829,9 +1829,9 @@ func (b *bus) metricsHandlerGET(jc jape.Context) {
 	case api.MetricContract:
 		var metrics []api.ContractMetric
 		var opts api.ContractMetricsQueryOpts
-		if jc.DecodeForm("fcid", &opts.ContractID) != nil {
+		if jc.DecodeForm("contractID", &opts.ContractID) != nil {
 			return
-		} else if jc.DecodeForm("host", &opts.HostKey) != nil {
+		} else if jc.DecodeForm("hostKey", &opts.HostKey) != nil {
 			return
 		} else if metrics, err = b.mtrcs.ContractMetrics(jc.Request.Context(), start, n, interval, opts); jc.Check("failed to get contract metrics", err) != nil {
 			return

--- a/bus/client/metrics.go
+++ b/bus/client/metrics.go
@@ -59,11 +59,11 @@ func (c *Client) ContractMetrics(ctx context.Context, start time.Time, n uint64,
 	values.Set("start", api.TimeRFC3339(start).String())
 	values.Set("n", fmt.Sprint(n))
 	values.Set("interval", api.DurationMS(interval).String())
-	if opts.FCID != (types.FileContractID{}) {
-		values.Set("fcid", opts.FCID.String())
+	if opts.ContractID != (types.FileContractID{}) {
+		values.Set("fcid", opts.ContractID.String())
 	}
-	if opts.Host != (types.PublicKey{}) {
-		values.Set("host", opts.Host.String())
+	if opts.HostKey != (types.PublicKey{}) {
+		values.Set("host", opts.HostKey.String())
 	}
 	var resp []api.ContractMetric
 	err := c.c.WithContext(ctx).GET(fmt.Sprintf("/metric/%s?%s", api.MetricContract, values.Encode()), &resp)

--- a/bus/client/metrics.go
+++ b/bus/client/metrics.go
@@ -19,7 +19,7 @@ func (c *Client) ContractSetMetrics(ctx context.Context, start time.Time, n uint
 		values.Set("name", opts.Name)
 	}
 	var resp []api.ContractSetMetric
-	err := c.c.WithContext(ctx).GET(fmt.Sprintf("/metric/%s?"+values.Encode(), api.MetricContractSet), &resp)
+	err := c.c.WithContext(ctx).GET(fmt.Sprintf("/metric/%s?%s", api.MetricContractSet, values.Encode()), &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (c *Client) ContractSetChurnMetrics(ctx context.Context, start time.Time, n
 		values.Set("reason", string(opts.Reason))
 	}
 	var resp []api.ContractSetChurnMetric
-	err := c.c.WithContext(ctx).GET(fmt.Sprintf("/metric/%s?"+values.Encode(), api.MetricContractSetChurn), &resp)
+	err := c.c.WithContext(ctx).GET(fmt.Sprintf("/metric/%s?%s", api.MetricContractSetChurn, values.Encode()), &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (c *Client) ContractMetrics(ctx context.Context, start time.Time, n uint64,
 		values.Set("host", opts.Host.String())
 	}
 	var resp []api.ContractMetric
-	err := c.c.WithContext(ctx).GET(fmt.Sprintf("/metric/%s?"+values.Encode(), api.MetricContract), &resp)
+	err := c.c.WithContext(ctx).GET(fmt.Sprintf("/metric/%s?%s", api.MetricContract, values.Encode()), &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/bus/client/metrics.go
+++ b/bus/client/metrics.go
@@ -63,7 +63,7 @@ func (c *Client) ContractMetrics(ctx context.Context, start time.Time, n uint64,
 		values.Set("fcid", opts.ContractID.String())
 	}
 	if opts.HostKey != (types.PublicKey{}) {
-		values.Set("host", opts.HostKey.String())
+		values.Set("hostKey", opts.HostKey.String())
 	}
 	var resp []api.ContractMetric
 	err := c.c.WithContext(ctx).GET(fmt.Sprintf("/metric/%s?%s", api.MetricContract, values.Encode()), &resp)

--- a/bus/client/metrics.go
+++ b/bus/client/metrics.go
@@ -10,22 +10,13 @@ import (
 	"go.sia.tech/renterd/api"
 )
 
-func (c *Client) ContractSetMetrics(ctx context.Context, opts api.ContractSetMetricsQueryOpts) ([]api.ContractSetMetric, error) {
+func (c *Client) ContractSetMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.ContractSetMetricsQueryOpts) ([]api.ContractSetMetric, error) {
 	values := url.Values{}
-	if opts.After != (time.Time{}) {
-		values.Set("after", api.TimeRFC3339(opts.After).String())
-	}
-	if opts.Before != (time.Time{}) {
-		values.Set("before", api.TimeRFC3339(opts.Before).String())
-	}
+	values.Set("start", api.TimeRFC3339(start).String())
+	values.Set("n", fmt.Sprint(n))
+	values.Set("interval", api.DurationMS(interval).String())
 	if opts.Name != "" {
 		values.Set("name", opts.Name)
-	}
-	if opts.Offset != 0 {
-		values.Set("offset", fmt.Sprint(opts.Offset))
-	}
-	if opts.Limit != 0 {
-		values.Set("limit", fmt.Sprint(opts.Limit))
 	}
 	var resp []api.ContractSetMetric
 	err := c.c.WithContext(ctx).GET(fmt.Sprintf("/metric/%s?"+values.Encode(), api.MetricContractSet), &resp)
@@ -35,14 +26,11 @@ func (c *Client) ContractSetMetrics(ctx context.Context, opts api.ContractSetMet
 	return resp, nil
 }
 
-func (c *Client) ContractSetChurnMetrics(ctx context.Context, opts api.ContractSetChurnMetricsQueryOpts) ([]api.ContractSetChurnMetric, error) {
+func (c *Client) ContractSetChurnMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.ContractSetChurnMetricsQueryOpts) ([]api.ContractSetChurnMetric, error) {
 	values := url.Values{}
-	if opts.After != (time.Time{}) {
-		values.Set("after", api.TimeRFC3339(opts.After).String())
-	}
-	if opts.Before != (time.Time{}) {
-		values.Set("before", api.TimeRFC3339(opts.Before).String())
-	}
+	values.Set("start", api.TimeRFC3339(start).String())
+	values.Set("n", fmt.Sprint(n))
+	values.Set("interval", api.DurationMS(interval).String())
 	if opts.Name != "" {
 		values.Set("name", opts.Name)
 	}
@@ -51,12 +39,6 @@ func (c *Client) ContractSetChurnMetrics(ctx context.Context, opts api.ContractS
 	}
 	if opts.Reason != "" {
 		values.Set("reason", string(opts.Reason))
-	}
-	if opts.Offset != 0 {
-		values.Set("offset", fmt.Sprint(opts.Offset))
-	}
-	if opts.Limit != 0 {
-		values.Set("limit", fmt.Sprint(opts.Limit))
 	}
 	var resp []api.ContractSetChurnMetric
 	err := c.c.WithContext(ctx).GET(fmt.Sprintf("/metric/%s?"+values.Encode(), api.MetricContractSetChurn), &resp)
@@ -72,25 +54,16 @@ func (c *Client) RecordContractSetChurnMetric(ctx context.Context, metrics ...ap
 	})
 }
 
-func (c *Client) ContractMetrics(ctx context.Context, opts api.ContractMetricsQueryOpts) ([]api.ContractMetric, error) {
+func (c *Client) ContractMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.ContractMetricsQueryOpts) ([]api.ContractMetric, error) {
 	values := url.Values{}
-	if opts.After != (time.Time{}) {
-		values.Set("after", api.TimeRFC3339(opts.After).String())
-	}
-	if opts.Before != (time.Time{}) {
-		values.Set("before", api.TimeRFC3339(opts.Before).String())
-	}
+	values.Set("start", api.TimeRFC3339(start).String())
+	values.Set("n", fmt.Sprint(n))
+	values.Set("interval", api.DurationMS(interval).String())
 	if opts.FCID != (types.FileContractID{}) {
 		values.Set("fcid", opts.FCID.String())
 	}
 	if opts.Host != (types.PublicKey{}) {
 		values.Set("host", opts.Host.String())
-	}
-	if opts.Offset != 0 {
-		values.Set("offset", fmt.Sprint(opts.Offset))
-	}
-	if opts.Limit != 0 {
-		values.Set("limit", fmt.Sprint(opts.Limit))
 	}
 	var resp []api.ContractMetric
 	err := c.c.WithContext(ctx).GET(fmt.Sprintf("/metric/%s?"+values.Encode(), api.MetricContract), &resp)

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1965,7 +1965,7 @@ func TestBusRecordedMetrics(t *testing.T) {
 	defer cluster.Shutdown()
 
 	// Get contract set metrics.
-	csMetrics, err := cluster.Bus.ContractSetMetrics(context.Background(), api.ContractSetMetricsQueryOpts{})
+	csMetrics, err := cluster.Bus.ContractSetMetrics(context.Background(), startTime, math.MaxUint64, time.Second, api.ContractSetMetricsQueryOpts{})
 	cluster.tt.OK(err)
 
 	for i := 0; i < len(csMetrics); i++ {
@@ -1989,7 +1989,7 @@ func TestBusRecordedMetrics(t *testing.T) {
 	}
 
 	// Get churn metrics. Should have 1 for the new contract.
-	cscMetrics, err := cluster.Bus.ContractSetChurnMetrics(context.Background(), api.ContractSetChurnMetricsQueryOpts{})
+	cscMetrics, err := cluster.Bus.ContractSetChurnMetrics(context.Background(), startTime, math.MaxUint64, time.Second, api.ContractSetChurnMetricsQueryOpts{})
 	cluster.tt.OK(err)
 
 	if len(cscMetrics) != 1 {
@@ -2008,7 +2008,7 @@ func TestBusRecordedMetrics(t *testing.T) {
 	var cMetrics []api.ContractMetric
 	cluster.tt.Retry(100, 100*time.Millisecond, func() error {
 		// Retry fetching metrics since they are buffered.
-		cMetrics, err = cluster.Bus.ContractMetrics(context.Background(), api.ContractMetricsQueryOpts{})
+		cMetrics, err = cluster.Bus.ContractMetrics(context.Background(), startTime, math.MaxUint64, time.Second, api.ContractMetricsQueryOpts{})
 		cluster.tt.OK(err)
 		if len(cMetrics) != 1 {
 			return fmt.Errorf("expected 1 metric, got %v", len(cMetrics))

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1965,7 +1965,7 @@ func TestBusRecordedMetrics(t *testing.T) {
 	defer cluster.Shutdown()
 
 	// Get contract set metrics.
-	csMetrics, err := cluster.Bus.ContractSetMetrics(context.Background(), startTime, math.MaxUint64, time.Second, api.ContractSetMetricsQueryOpts{})
+	csMetrics, err := cluster.Bus.ContractSetMetrics(context.Background(), startTime, math.MaxUint32, time.Second, api.ContractSetMetricsQueryOpts{})
 	cluster.tt.OK(err)
 
 	for i := 0; i < len(csMetrics); i++ {
@@ -1989,7 +1989,7 @@ func TestBusRecordedMetrics(t *testing.T) {
 	}
 
 	// Get churn metrics. Should have 1 for the new contract.
-	cscMetrics, err := cluster.Bus.ContractSetChurnMetrics(context.Background(), startTime, math.MaxUint64, time.Second, api.ContractSetChurnMetricsQueryOpts{})
+	cscMetrics, err := cluster.Bus.ContractSetChurnMetrics(context.Background(), startTime, math.MaxUint32, time.Second, api.ContractSetChurnMetricsQueryOpts{})
 	cluster.tt.OK(err)
 
 	if len(cscMetrics) != 1 {
@@ -2008,7 +2008,7 @@ func TestBusRecordedMetrics(t *testing.T) {
 	var cMetrics []api.ContractMetric
 	cluster.tt.Retry(100, 100*time.Millisecond, func() error {
 		// Retry fetching metrics since they are buffered.
-		cMetrics, err = cluster.Bus.ContractMetrics(context.Background(), startTime, math.MaxUint64, time.Second, api.ContractMetricsQueryOpts{})
+		cMetrics, err = cluster.Bus.ContractMetrics(context.Background(), startTime, math.MaxUint32, time.Second, api.ContractMetricsQueryOpts{})
 		cluster.tt.OK(err)
 		if len(cMetrics) != 1 {
 			return fmt.Errorf("expected 1 metric, got %v", len(cMetrics))

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1996,7 +1996,7 @@ func TestBusRecordedMetrics(t *testing.T) {
 		t.Fatalf("expected 1 metric, got %v", len(cscMetrics))
 	} else if m := cscMetrics[0]; m.Direction != api.ChurnDirAdded {
 		t.Fatalf("expected added churn, got %v", m.Direction)
-	} else if m.FCID == (types.FileContractID{}) {
+	} else if m.ContractID == (types.FileContractID{}) {
 		t.Fatal("expected non-zero FCID")
 	} else if m.Name != testContractSet {
 		t.Fatalf("expected contract set %v, got %v", testContractSet, m.Name)
@@ -2020,9 +2020,9 @@ func TestBusRecordedMetrics(t *testing.T) {
 		t.Fatalf("expected 1 metric, got %v", len(cMetrics))
 	} else if m := cMetrics[0]; !startTime.Before(m.Timestamp) {
 		t.Fatalf("expected time to be after start time, got %v", m.Timestamp)
-	} else if m.FCID == (types.FileContractID{}) {
+	} else if m.ContractID == (types.FileContractID{}) {
 		t.Fatal("expected non-zero FCID")
-	} else if m.Host == (types.PublicKey{}) {
+	} else if m.HostKey == (types.PublicKey{}) {
 		t.Fatal("expected non-zero Host")
 	} else if m.RemainingCollateral == (types.Currency{}) {
 		t.Fatal("expected non-zero RemainingCollateral")

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1183,8 +1183,8 @@ func (s *SQLStore) RecordContractSpending(ctx context.Context, records []api.Con
 			}
 			m := api.ContractMetric{
 				Timestamp:           time.Now(),
-				FCID:                fcid,
-				Host:                types.PublicKey(contract.Host.PublicKey),
+				ContractID:          fcid,
+				HostKey:             types.PublicKey(contract.Host.PublicKey),
 				RemainingCollateral: remainingCollateral,
 				RemainingFunds:      latestValues[fcid].validRenterPayout,
 				RevisionNumber:      latestValues[fcid].revision,

--- a/stores/metrics.go
+++ b/stores/metrics.go
@@ -94,9 +94,8 @@ func scopePeriods(db, tx *gorm.DB, table string, start time.Time, n uint64, inte
 		Where("timestamp >= ? AND timestamp < ?", unixTimeMS(start), unixTimeMS(end)).
 		Group("period")
 	return tx.Table(table).
-		Joins(fmt.Sprintf("INNER JOIN (?) periods ON periods.min_time = %s.timestamp", table), inner).
-		Group("timestamp").
-		Order("timestamp ASC")
+		Joins(fmt.Sprintf("INNER JOIN (?) periods ON %s.id IN (SELECT id FROM %s WHERE timestamp = periods.min_time ORDER BY id ASC LIMIT 1)", table, table), inner).
+		Group("timestamp")
 }
 
 func (s *SQLStore) contractSetMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.ContractSetMetricsQueryOpts) ([]dbContractSetMetric, error) {

--- a/stores/metrics.go
+++ b/stores/metrics.go
@@ -94,7 +94,7 @@ func scopePeriods(db, tx *gorm.DB, table string, start time.Time, n uint64, inte
 		Where("timestamp >= ? AND timestamp < ?", unixTimeMS(start), unixTimeMS(end)).
 		Group("period")
 	return tx.Table(table).
-		Joins(fmt.Sprintf("INNER JOIN (?) periods ON %s.id IN (SELECT id FROM %s WHERE timestamp = periods.min_time ORDER BY id ASC LIMIT 1)", table, table), inner).
+		Joins(fmt.Sprintf("INNER JOIN (?) periods ON %s.timestamp = periods.min_time", table), inner).
 		Group("timestamp")
 }
 

--- a/stores/metrics.go
+++ b/stores/metrics.go
@@ -90,11 +90,11 @@ func (dbPerformanceMetric) TableName() string      { return "performance" }
 func scopePeriods(db, tx *gorm.DB, table string, start time.Time, n uint64, interval time.Duration) *gorm.DB {
 	end := start.Add(time.Duration(n) * interval)
 	inner := db.Table(table).
-		Select("id, MIN(timestamp), (timestamp - ?) / ? * ? AS period", unixTimeMS(start), interval.Milliseconds(), interval.Milliseconds()).
+		Select("MIN(timestamp) AS min_time, (timestamp - ?) / ? * ? AS period", unixTimeMS(start), interval.Milliseconds(), interval.Milliseconds()).
 		Where("timestamp >= ? AND timestamp < ?", unixTimeMS(start), unixTimeMS(end)).
 		Group("period")
 	return tx.Table(table).
-		Joins(fmt.Sprintf("INNER JOIN (?) periods ON periods.id = %s.id", table), inner).
+		Joins(fmt.Sprintf("INNER JOIN (?) periods ON periods.min_time = %s.timestamp", table), inner).
 		Order("timestamp ASC")
 }
 

--- a/stores/metrics.go
+++ b/stores/metrics.go
@@ -95,6 +95,7 @@ func scopePeriods(db, tx *gorm.DB, table string, start time.Time, n uint64, inte
 		Group("period")
 	return tx.Table(table).
 		Joins(fmt.Sprintf("INNER JOIN (?) periods ON periods.min_time = %s.timestamp", table), inner).
+		Group("timestamp").
 		Order("timestamp ASC")
 }
 

--- a/stores/metrics.go
+++ b/stores/metrics.go
@@ -82,6 +82,11 @@ func (dbContractSetMetric) TableName() string      { return "contract_sets" }
 func (dbContractSetChurnMetric) TableName() string { return "contract_sets_churn" }
 func (dbPerformanceMetric) TableName() string      { return "performance" }
 
+// scopePeriods is the core of all methods retrieving metrics. By using integer
+// division rounding combined with a GROUP BY operation, all rows of a table are
+// split into intervals and the row with the lowest timestamp for each interval
+// is returned. The result is then joined with the original table to retrieve
+// only the metrics we want.
 func scopePeriods(db, tx *gorm.DB, table string, start time.Time, n uint64, interval time.Duration) *gorm.DB {
 	end := start.Add(time.Duration(n) * interval)
 	inner := db.Table(table).

--- a/stores/metrics_test.go
+++ b/stores/metrics_test.go
@@ -97,11 +97,11 @@ func TestContractChurnSetMetrics(t *testing.T) {
 				for _, recordedTime := range times {
 					fcid := types.FileContractID{i}
 					if err := ss.RecordContractSetChurnMetric(context.Background(), api.ContractSetChurnMetric{
-						Timestamp: recordedTime,
-						Name:      set,
-						Direction: dir,
-						Reason:    reason,
-						FCID:      fcid,
+						Timestamp:  recordedTime,
+						Name:       set,
+						Direction:  dir,
+						Reason:     reason,
+						ContractID: fcid,
 					}); err != nil {
 						t.Fatal(err)
 					}
@@ -175,7 +175,7 @@ func TestPerformanceMetrics(t *testing.T) {
 							Action:    action,
 							Timestamp: recordedTime,
 							Duration:  duration,
-							Host:      host,
+							HostKey:   host,
 							Origin:    origin,
 						}); err != nil {
 							t.Fatal(err)
@@ -217,9 +217,9 @@ func TestPerformanceMetrics(t *testing.T) {
 	})
 
 	// Filter by hosts.
-	assertMetrics(start, 3, time.Millisecond, api.PerformanceMetricsQueryOpts{Host: hosts[0]}, 3, func(m api.PerformanceMetric) {
-		if m.Host != hosts[0] {
-			t.Fatalf("expected hosts to be %v, got %v", hosts[0], m.Host)
+	assertMetrics(start, 3, time.Millisecond, api.PerformanceMetricsQueryOpts{HostKey: hosts[0]}, 3, func(m api.PerformanceMetric) {
+		if m.HostKey != hosts[0] {
+			t.Fatalf("expected hosts to be %v, got %v", hosts[0], m.HostKey)
 		}
 	})
 
@@ -244,8 +244,8 @@ func TestContractMetrics(t *testing.T) {
 		for _, recordedTime := range times {
 			metric := api.ContractMetric{
 				Timestamp:           recordedTime,
-				FCID:                types.FileContractID{i},
-				Host:                host,
+				ContractID:          types.FileContractID{i},
+				HostKey:             host,
 				RemainingCollateral: types.MaxCurrency,
 				RemainingFunds:      types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
 				RevisionNumber:      math.MaxUint64,
@@ -255,7 +255,7 @@ func TestContractMetrics(t *testing.T) {
 				DeleteSpending:      types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
 				ListSpending:        types.NewCurrency64(1),
 			}
-			fcid2Metric[metric.FCID] = metric
+			fcid2Metric[metric.ContractID] = metric
 			if err := ss.RecordContractMetric(context.Background(), metric); err != nil {
 				t.Fatal(err)
 			}
@@ -277,8 +277,8 @@ func TestContractMetrics(t *testing.T) {
 			t.Fatal("expected metrics to be sorted by time")
 		}
 		for _, m := range metrics {
-			if !cmp.Equal(m, fcid2Metric[m.FCID]) {
-				t.Fatal("unexpected metric", cmp.Diff(m, fcid2Metric[m.FCID]))
+			if !cmp.Equal(m, fcid2Metric[m.ContractID]) {
+				t.Fatal("unexpected metric", cmp.Diff(m, fcid2Metric[m.ContractID]))
 			}
 			cmpFn(m)
 		}
@@ -289,17 +289,17 @@ func TestContractMetrics(t *testing.T) {
 	assertMetrics(start, 3, time.Millisecond, api.ContractMetricsQueryOpts{}, 3, func(m api.ContractMetric) {})
 
 	// Query by host.
-	assertMetrics(start, 3, time.Millisecond, api.ContractMetricsQueryOpts{Host: hosts[0]}, 3, func(m api.ContractMetric) {
-		if m.Host != hosts[0] {
-			t.Fatalf("expected host to be %v, got %v", hosts[0], m.Host)
+	assertMetrics(start, 3, time.Millisecond, api.ContractMetricsQueryOpts{HostKey: hosts[0]}, 3, func(m api.ContractMetric) {
+		if m.HostKey != hosts[0] {
+			t.Fatalf("expected host to be %v, got %v", hosts[0], m.HostKey)
 		}
 	})
 
 	// Query by fcid.
 	fcid := types.FileContractID{2}
-	assertMetrics(start, 3, time.Millisecond, api.ContractMetricsQueryOpts{FCID: fcid}, 1, func(m api.ContractMetric) {
-		if m.FCID != fcid {
-			t.Fatalf("expected fcid to be %v, got %v", fcid, m.FCID)
+	assertMetrics(start, 3, time.Millisecond, api.ContractMetricsQueryOpts{ContractID: fcid}, 1, func(m api.ContractMetric) {
+		if m.ContractID != fcid {
+			t.Fatalf("expected fcid to be %v, got %v", fcid, m.ContractID)
 		}
 	})
 }

--- a/stores/metrics_test.go
+++ b/stores/metrics_test.go
@@ -18,7 +18,7 @@ func TestContractSetMetrics(t *testing.T) {
 	ss := newTestSQLStore(t, defaultTestSQLStoreConfig)
 	defer ss.Close()
 
-	metrics, err := ss.ContractSetMetrics(context.Background(), api.ContractSetMetricsQueryOpts{})
+	metrics, err := ss.ContractSetMetrics(context.Background(), testStart, 1, time.Minute, api.ContractSetMetricsQueryOpts{})
 	if err != nil {
 		t.Fatal(err)
 	} else if len(metrics) != 1 {
@@ -35,7 +35,7 @@ func TestContractSetMetrics(t *testing.T) {
 	// The recorded timestamps are out of order to test that the query ordery by
 	// time.
 	cs := t.Name()
-	times := []time.Time{time.UnixMilli(3), time.UnixMilli(1), time.UnixMilli(2)}
+	times := []time.Time{time.UnixMilli(200), time.UnixMilli(100), time.UnixMilli(150)}
 	for i, recordedTime := range times {
 		if err := ss.RecordContractSetMetric(context.Background(), api.ContractSetMetric{
 			Contracts: i + 1,
@@ -46,14 +46,14 @@ func TestContractSetMetrics(t *testing.T) {
 		}
 	}
 
-	assertMetrics := func(opts api.ContractSetMetricsQueryOpts, expected int, contracts []int) {
+	assertMetrics := func(start time.Time, n uint64, interval time.Duration, opts api.ContractSetMetricsQueryOpts, expected int, contracts []int) {
 		t.Helper()
-		metrics, err := ss.ContractSetMetrics(context.Background(), opts)
+		metrics, err := ss.ContractSetMetrics(context.Background(), start, n, interval, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if len(metrics) != expected {
-			t.Fatalf("expected %v metrics, got %v", expected, len(metrics))
+			t.Fatalf("expected %v metrics, got %v: %v", expected, len(metrics), metrics)
 		} else if !sort.SliceIsSorted(metrics, func(i, j int) bool {
 			return time.Time(metrics[i].Timestamp).Before(time.Time(metrics[j].Timestamp))
 		}) {
@@ -66,16 +66,19 @@ func TestContractSetMetrics(t *testing.T) {
 		}
 	}
 
-	// Check that we have 4 metrics now.
-	assertMetrics(api.ContractSetMetricsQueryOpts{}, 4, []int{2, 3, 1, 0})
+	// Start at unix timestamp 100ms and fetch 3 period at a 50ms interval. This
+	// should return 3 metrics.
+	start := time.UnixMilli(100)
+	assertMetrics(start, 3, 50*time.Millisecond, api.ContractSetMetricsQueryOpts{}, 3, []int{2, 3, 1})
+
+	// Start at the same timestamp but fetch 2 period at 100ms each.
+	assertMetrics(start, 2, 51*time.Millisecond, api.ContractSetMetricsQueryOpts{}, 2, []int{2, 1})
 
 	// Query all metrics by contract set.
-	assertMetrics(api.ContractSetMetricsQueryOpts{Name: cs}, 3, []int{2, 3, 1})
+	assertMetrics(start, 3, 50*time.Millisecond, api.ContractSetMetricsQueryOpts{Name: cs}, 3, []int{2, 3, 1})
 
 	// Query the metric in the middle of the 3 we added.
-	after := time.UnixMilli(1)  // 'after' is exclusive
-	before := time.UnixMilli(2) // 'before' is inclusive
-	assertMetrics(api.ContractSetMetricsQueryOpts{After: after, Before: before}, 1, []int{3})
+	assertMetrics(time.UnixMilli(150), 1, 50*time.Millisecond, api.ContractSetMetricsQueryOpts{Name: cs}, 1, []int{3})
 }
 
 func TestContractChurnSetMetrics(t *testing.T) {
@@ -108,9 +111,9 @@ func TestContractChurnSetMetrics(t *testing.T) {
 		}
 	}
 
-	assertMetrics := func(opts api.ContractSetChurnMetricsQueryOpts, expected int, cmp func(api.ContractSetChurnMetric)) {
+	assertMetrics := func(start time.Time, n uint64, interval time.Duration, opts api.ContractSetChurnMetricsQueryOpts, expected int, cmp func(api.ContractSetChurnMetric)) {
 		t.Helper()
-		metrics, err := ss.ContractSetChurnMetrics(context.Background(), opts)
+		metrics, err := ss.ContractSetChurnMetrics(context.Background(), start, n, interval, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -127,33 +130,25 @@ func TestContractChurnSetMetrics(t *testing.T) {
 	}
 
 	// Query without any filters.
-	assertMetrics(api.ContractSetChurnMetricsQueryOpts{}, 24, func(m api.ContractSetChurnMetric) {})
+	start := time.UnixMilli(1)
+	assertMetrics(start, 3, time.Millisecond, api.ContractSetChurnMetricsQueryOpts{}, 3, func(m api.ContractSetChurnMetric) {})
 
 	// Query by set name.
-	assertMetrics(api.ContractSetChurnMetricsQueryOpts{Name: sets[0]}, 12, func(m api.ContractSetChurnMetric) {
+	assertMetrics(start, 3, time.Millisecond, api.ContractSetChurnMetricsQueryOpts{Name: sets[0]}, 3, func(m api.ContractSetChurnMetric) {
 		if m.Name != sets[0] {
 			t.Fatalf("expected name to be %v, got %v", sets[0], m.Name)
 		}
 	})
 
-	// Query by time.
-	after := time.UnixMilli(2)  // 'after' is exclusive
-	before := time.UnixMilli(3) // 'before' is inclusive
-	assertMetrics(api.ContractSetChurnMetricsQueryOpts{After: after, Before: before}, 8, func(m api.ContractSetChurnMetric) {
-		if !m.Timestamp.Equal(before) {
-			t.Fatalf("expected time to be %v, got %v", before, time.Time(m.Timestamp).UnixMilli())
-		}
-	})
-
 	// Query by direction.
-	assertMetrics(api.ContractSetChurnMetricsQueryOpts{Direction: directions[0]}, 12, func(m api.ContractSetChurnMetric) {
+	assertMetrics(start, 3, time.Millisecond, api.ContractSetChurnMetricsQueryOpts{Direction: directions[0]}, 3, func(m api.ContractSetChurnMetric) {
 		if m.Direction != directions[0] {
 			t.Fatalf("expected direction to be %v, got %v", directions[1], m.Direction)
 		}
 	})
 
 	// Query by reason.
-	assertMetrics(api.ContractSetChurnMetricsQueryOpts{Reason: reasons[0]}, 12, func(m api.ContractSetChurnMetric) {
+	assertMetrics(start, 3, time.Millisecond, api.ContractSetChurnMetricsQueryOpts{Reason: reasons[0]}, 3, func(m api.ContractSetChurnMetric) {
 		if m.Reason != reasons[0] {
 			t.Fatalf("expected reason to be %v, got %v", reasons[0], m.Reason)
 		}
@@ -192,9 +187,9 @@ func TestPerformanceMetrics(t *testing.T) {
 		}
 	}
 
-	assertMetrics := func(opts api.PerformanceMetricsQueryOpts, expected int, cmp func(api.PerformanceMetric)) {
+	assertMetrics := func(start time.Time, n uint64, interval time.Duration, opts api.PerformanceMetricsQueryOpts, expected int, cmp func(api.PerformanceMetric)) {
 		t.Helper()
-		metrics, err := ss.PerformanceMetrics(context.Background(), opts)
+		metrics, err := ss.PerformanceMetrics(context.Background(), start, n, interval, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -211,42 +206,27 @@ func TestPerformanceMetrics(t *testing.T) {
 	}
 
 	// Query without any filters.
-	assertMetrics(api.PerformanceMetricsQueryOpts{}, 48, func(m api.PerformanceMetric) {})
+	start := time.UnixMilli(1)
+	assertMetrics(start, 3, time.Millisecond, api.PerformanceMetricsQueryOpts{}, 3, func(m api.PerformanceMetric) {})
 
 	// Filter by actions.
-	assertMetrics(api.PerformanceMetricsQueryOpts{Action: actions[0]}, 24, func(m api.PerformanceMetric) {
+	assertMetrics(start, 3, time.Millisecond, api.PerformanceMetricsQueryOpts{Action: actions[0]}, 3, func(m api.PerformanceMetric) {
 		if m.Action != actions[0] {
 			t.Fatalf("expected action to be %v, got %v", actions[0], m.Action)
 		}
 	})
 
 	// Filter by hosts.
-	assertMetrics(api.PerformanceMetricsQueryOpts{Host: hosts[0]}, 24, func(m api.PerformanceMetric) {
+	assertMetrics(start, 3, time.Millisecond, api.PerformanceMetricsQueryOpts{Host: hosts[0]}, 3, func(m api.PerformanceMetric) {
 		if m.Host != hosts[0] {
 			t.Fatalf("expected hosts to be %v, got %v", hosts[0], m.Host)
 		}
 	})
 
 	// Filter by reporters.
-	assertMetrics(api.PerformanceMetricsQueryOpts{Origin: origins[0]}, 24, func(m api.PerformanceMetric) {
+	assertMetrics(start, 3, time.Millisecond, api.PerformanceMetricsQueryOpts{Origin: origins[0]}, 3, func(m api.PerformanceMetric) {
 		if m.Origin != origins[0] {
 			t.Fatalf("expected origin to be %v, got %v", origins[0], m.Origin)
-		}
-	})
-
-	// Filter by duration.
-	assertMetrics(api.PerformanceMetricsQueryOpts{Duration: durations[0]}, 24, func(m api.PerformanceMetric) {
-		if m.Duration != durations[0] {
-			t.Fatalf("expected duration to be %v, got %v", durations[0], m.Duration)
-		}
-	})
-
-	// Filter by time.
-	after := time.UnixMilli(2)  // 'after' is exclusive
-	before := time.UnixMilli(3) // 'before' is inclusive
-	assertMetrics(api.PerformanceMetricsQueryOpts{After: after, Before: before}, 16, func(m api.PerformanceMetric) {
-		if !m.Timestamp.Equal(before) {
-			t.Fatalf("expected time to be %v, got %v", before, m.Timestamp)
 		}
 	})
 }
@@ -283,9 +263,9 @@ func TestContractMetrics(t *testing.T) {
 		}
 	}
 
-	assertMetrics := func(opts api.ContractMetricsQueryOpts, expected int, cmpFn func(api.ContractMetric)) {
+	assertMetrics := func(start time.Time, n uint64, interval time.Duration, opts api.ContractMetricsQueryOpts, expected int, cmpFn func(api.ContractMetric)) {
 		t.Helper()
-		metrics, err := ss.ContractMetrics(context.Background(), opts)
+		metrics, err := ss.ContractMetrics(context.Background(), start, n, interval, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -305,10 +285,11 @@ func TestContractMetrics(t *testing.T) {
 	}
 
 	// Query without any filters.
-	assertMetrics(api.ContractMetricsQueryOpts{}, 6, func(m api.ContractMetric) {})
+	start := time.UnixMilli(1)
+	assertMetrics(start, 3, time.Millisecond, api.ContractMetricsQueryOpts{}, 3, func(m api.ContractMetric) {})
 
 	// Query by host.
-	assertMetrics(api.ContractMetricsQueryOpts{Host: hosts[0]}, 3, func(m api.ContractMetric) {
+	assertMetrics(start, 3, time.Millisecond, api.ContractMetricsQueryOpts{Host: hosts[0]}, 3, func(m api.ContractMetric) {
 		if m.Host != hosts[0] {
 			t.Fatalf("expected host to be %v, got %v", hosts[0], m.Host)
 		}
@@ -316,18 +297,9 @@ func TestContractMetrics(t *testing.T) {
 
 	// Query by fcid.
 	fcid := types.FileContractID{2}
-	assertMetrics(api.ContractMetricsQueryOpts{FCID: fcid}, 1, func(m api.ContractMetric) {
+	assertMetrics(start, 3, time.Millisecond, api.ContractMetricsQueryOpts{FCID: fcid}, 1, func(m api.ContractMetric) {
 		if m.FCID != fcid {
 			t.Fatalf("expected fcid to be %v, got %v", fcid, m.FCID)
-		}
-	})
-
-	// Query by time.
-	after := time.UnixMilli(2)  // 'after' is exclusive
-	before := time.UnixMilli(3) // 'before' is inclusive
-	assertMetrics(api.ContractMetricsQueryOpts{After: after, Before: before}, 2, func(m api.ContractMetric) {
-		if !m.Timestamp.Equal(before) {
-			t.Fatalf("expected time to be %v, got %v", before, m.Timestamp)
 		}
 	})
 }


### PR DESCRIPTION
This updates the metrics endpoint to be more consistent with the `hostd` endpoint by requiring the client to provide a start time, a number of intervals to fetch as well as the length of an interval.

The updated query attempts to split up all the metrics over a specific timeframe into intervals and returns the first metric per interval if any. 