### PR TITLE
MultipartUpload indices

### DIFF
--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -1218,7 +1218,7 @@ func performMigration000027_addMultipartUploadIndices(txn *gorm.DB, logger *zap.
 	}
 
 	// Use 'AutoMigrate' to add missing indices
-	if err := txn.Table("slabs").Migrator().AutoMigrate(&struct {
+	if err := txn.Table("multipart_uploads").Migrator().AutoMigrate(&struct {
 		ObjectID   string `gorm:"index:idx_multipart_uploads_object_id;NOT NULL"`
 		DBBucketID uint   `gorm:"index:idx_multipart_uploads_db_bucket_id;NOT NULL"`
 		MimeType   string `gorm:"index:idx_multipart_uploads_mime_type"`

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -23,11 +23,11 @@ type (
 
 		Key        []byte
 		UploadID   string            `gorm:"uniqueIndex;NOT NULL;size:64"`
-		ObjectID   string            `gorm:"index;NOT NULL"`
+		ObjectID   string            `gorm:"index:idx_multipart_uploads_object_id;NOT NULL"`
 		DBBucket   dbBucket          `gorm:"constraint:OnDelete:CASCADE"` // CASCADE to delete uploads when bucket is deleted
-		DBBucketID uint              `gorm:"index;NOT NULL"`
+		DBBucketID uint              `gorm:"index:idx_multipart_uploads_db_bucket_id;NOT NULL"`
 		Parts      []dbMultipartPart `gorm:"constraint:OnDelete:CASCADE"` // CASCADE to delete parts too
-		MimeType   string            `gorm:"index"`
+		MimeType   string            `gorm:"index:idx_multipart_uploads_mime_type"`
 	}
 
 	dbMultipartPart struct {


### PR DESCRIPTION
I noticed we have some indices missing:

```
2023-11-06T14:54:34Z	WARN	stores/sql.go:163	missing index	{"table": "dbMultipartUpload", "field": "ObjectID"}
2023-11-06T14:54:34Z	WARN	stores/sql.go:163	missing index	{"table": "dbMultipartUpload", "field": "DBBucketID"}
2023-11-06T14:54:34Z	WARN	stores/sql.go:163	missing index	{"table": "dbMultipartUpload", "field": "MimeType"}
```

After pushing the migration I noticed this migration, which we could duplicate.
I figured being explicit is better but it doesn't really matter I guess.

```
		{
			ID: "00020_missingIndices",
			Migrate: func(tx *gorm.DB) error {
				return performMigration00020_missingIndices(tx, logger)
			},
		},
```

@ChrisSchinnerl  did we manually manipulate that table? It almost seems as if those indices were dropped manually or something... Keeping it as a `DRAFT` until we know for sure what happened.