### PR TITLE
Add tracking of on-chain state for contract 

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -107,6 +107,7 @@ type ConsensusNetwork struct {
 type ContractsIDAddRequest struct {
 	Contract    rhpv2.ContractRevision `json:"contract"`
 	StartHeight uint64                 `json:"startHeight"`
+	State       string                 `json:"state,omitempty"`
 	TotalCost   types.Currency         `json:"totalCost"`
 }
 
@@ -122,6 +123,7 @@ type ContractsIDRenewedRequest struct {
 	Contract    rhpv2.ContractRevision `json:"contract"`
 	RenewedFrom types.FileContractID   `json:"renewedFrom"`
 	StartHeight uint64                 `json:"startHeight"`
+	State       string                 `json:"state,omitempty"`
 	TotalCost   types.Currency         `json:"totalCost"`
 }
 

--- a/api/contract.go
+++ b/api/contract.go
@@ -5,6 +5,15 @@ import (
 	"go.sia.tech/core/types"
 )
 
+const (
+	ContractStateInvalid  = "invalid"
+	ContractStateUnknown  = "unknown"
+	ContractStatePending  = "pending"
+	ContractStateActive   = "active"
+	ContractStateComplete = "complete"
+	ContractStateFailed   = "failed"
+)
+
 type (
 	// A Contract wraps the contract metadata with the latest contract revision.
 	Contract struct {
@@ -31,6 +40,7 @@ type (
 		RevisionNumber uint64 `json:"revisionNumber"`
 		Size           uint64 `json:"size"`
 		StartHeight    uint64 `json:"startHeight"`
+		State          string `json:"state"`
 		WindowStart    uint64 `json:"windowStart"`
 		WindowEnd      uint64 `json:"windowEnd"`
 
@@ -68,6 +78,7 @@ type (
 		RevisionNumber uint64 `json:"revisionNumber"`
 		Size           uint64 `json:"size"`
 		StartHeight    uint64 `json:"startHeight"`
+		State          string `json:"state"`
 		WindowStart    uint64 `json:"windowStart"`
 		WindowEnd      uint64 `json:"windowEnd"`
 	}

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -55,8 +55,8 @@ type Bus interface {
 
 	// contracts
 	Contracts(ctx context.Context) (contracts []api.ContractMetadata, err error)
-	AddContract(ctx context.Context, c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64) (api.ContractMetadata, error)
-	AddRenewedContract(ctx context.Context, c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, renewedFrom types.FileContractID) (api.ContractMetadata, error)
+	AddContract(ctx context.Context, c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, state string) (api.ContractMetadata, error)
+	AddRenewedContract(ctx context.Context, c rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, renewedFrom types.FileContractID, state string) (api.ContractMetadata, error)
 	AncestorContracts(ctx context.Context, id types.FileContractID, minStartHeight uint64) ([]api.ArchivedContract, error)
 	ArchiveContracts(ctx context.Context, toArchive map[types.FileContractID]string) error
 	ContractSetContracts(ctx context.Context, set string) ([]api.ContractMetadata, error)

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1335,7 +1335,7 @@ func (c *contractor) renewContract(ctx context.Context, w Worker, ci contractInf
 	*budget = budget.Sub(renterFunds)
 
 	// persist the contract
-	renewedContract, err := c.ap.bus.AddRenewedContract(ctx, newRevision, renterFunds, cs.BlockHeight, fcid)
+	renewedContract, err := c.ap.bus.AddRenewedContract(ctx, newRevision, renterFunds, cs.BlockHeight, fcid, api.ContractStatePending)
 	if err != nil {
 		c.logger.Errorw(fmt.Sprintf("renewal failed to persist, err: %v", err), "hk", hk, "fcid", fcid)
 		return api.ContractMetadata{}, false, err
@@ -1423,7 +1423,7 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 	*budget = budget.Sub(renterFunds)
 
 	// persist the contract
-	refreshedContract, err := c.ap.bus.AddRenewedContract(ctx, newRevision, renterFunds, cs.BlockHeight, contract.ID)
+	refreshedContract, err := c.ap.bus.AddRenewedContract(ctx, newRevision, renterFunds, cs.BlockHeight, contract.ID, api.ContractStatePending)
 	if err != nil {
 		c.logger.Errorw(fmt.Sprintf("refresh failed, err: %v", err), "hk", hk, "fcid", fcid)
 		return api.ContractMetadata{}, false, err
@@ -1495,7 +1495,7 @@ func (c *contractor) formContract(ctx context.Context, w Worker, host hostdb.Hos
 	*budget = budget.Sub(renterFunds)
 
 	// persist contract in store
-	formedContract, err := c.ap.bus.AddContract(ctx, contract, renterFunds, cs.BlockHeight)
+	formedContract, err := c.ap.bus.AddContract(ctx, contract, renterFunds, cs.BlockHeight, api.ContractStatePending)
 	if err != nil {
 		c.logger.Errorw(fmt.Sprintf("contract formation failed, err: %v", err), "hk", hk)
 		return api.ContractMetadata{}, true, err

--- a/bus/client/contracts.go
+++ b/bus/client/contracts.go
@@ -13,21 +13,23 @@ import (
 )
 
 // AddContract adds the provided contract to the metadata store.
-func (c *Client) AddContract(ctx context.Context, contract rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64) (added api.ContractMetadata, err error) {
+func (c *Client) AddContract(ctx context.Context, contract rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, state string) (added api.ContractMetadata, err error) {
 	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/contract/%s", contract.ID()), api.ContractsIDAddRequest{
 		Contract:    contract,
 		StartHeight: startHeight,
+		State:       state,
 		TotalCost:   totalCost,
 	}, &added)
 	return
 }
 
 // AddRenewedContract adds the provided contract to the metadata store.
-func (c *Client) AddRenewedContract(ctx context.Context, contract rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, renewedFrom types.FileContractID) (renewed api.ContractMetadata, err error) {
+func (c *Client) AddRenewedContract(ctx context.Context, contract rhpv2.ContractRevision, totalCost types.Currency, startHeight uint64, renewedFrom types.FileContractID, state string) (renewed api.ContractMetadata, err error) {
 	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/contract/%s/renewed", contract.ID()), api.ContractsIDRenewedRequest{
 		Contract:    contract,
 		RenewedFrom: renewedFrom,
 		StartHeight: startHeight,
+		State:       state,
 		TotalCost:   totalCost,
 	}, &renewed)
 	return

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1245,11 +1245,11 @@ func TestUploadDownloadSameHost(t *testing.T) {
 	// form 2 more contracts with the same host
 	rev2, _, err := cluster.Worker.RHPForm(context.Background(), c.WindowStart, c.HostKey, c.HostIP, wallet.Address, c.RenterFunds(), c.Revision.ValidHostPayout())
 	tt.OK(err)
-	c2, err := cluster.Bus.AddContract(context.Background(), rev2, c.TotalCost, c.StartHeight)
+	c2, err := cluster.Bus.AddContract(context.Background(), rev2, c.TotalCost, c.StartHeight, api.ContractStatePending)
 	tt.OK(err)
 	rev3, _, err := cluster.Worker.RHPForm(context.Background(), c.WindowStart, c.HostKey, c.HostIP, wallet.Address, c.RenterFunds(), c.Revision.ValidHostPayout())
 	tt.OK(err)
-	c3, err := cluster.Bus.AddContract(context.Background(), rev3, c.TotalCost, c.StartHeight)
+	c3, err := cluster.Bus.AddContract(context.Background(), rev3, c.TotalCost, c.StartHeight, api.ContractStatePending)
 	tt.OK(err)
 
 	// create a contract set with all 3 contracts

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -33,10 +33,6 @@ const (
 	// database per batch. Empirically tested to verify that this is a value
 	// that performs reasonably well.
 	hostRetrievalBatchSize = 10000
-
-	// number of blocks between a contract's 'startHeight' and the block we
-	// delete the contract if it hasn't appeared on-chain yet.
-	pendingContractPruneThreshold = 18
 )
 
 var (

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -64,7 +64,7 @@ type (
 		FCID        fileContractID `gorm:"unique;index;NOT NULL;column:fcid;size:32"`
 		RenewedFrom fileContractID `gorm:"index;size:32"`
 
-		State          contractState `gorm:"index;NOT NULL"`
+		State          contractState `gorm:"index;NOT NULL;default:0"`
 		TotalCost      currency
 		ProofHeight    uint64 `gorm:"index;default:0"`
 		RevisionHeight uint64 `gorm:"index;default:0"`

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -240,6 +240,7 @@ func TestSQLContractStore(t *testing.T) {
 		HostIP:      "address",
 		HostKey:     hk,
 		StartHeight: 100,
+		State:       api.ContractStatePending,
 		WindowStart: 400,
 		WindowEnd:   500,
 		RenewedFrom: types.FileContractID{},
@@ -640,6 +641,7 @@ func TestRenewedContract(t *testing.T) {
 		StartHeight: newContractStartHeight,
 		RenewedFrom: fcid1,
 		Size:        rhpv2.SectorSize,
+		State:       api.ContractStatePending,
 		Spending: api.ContractSpending{
 			Uploads:     types.ZeroCurrency,
 			Downloads:   types.ZeroCurrency,
@@ -678,6 +680,7 @@ func TestRenewedContract(t *testing.T) {
 			WindowStart:    2,
 			WindowEnd:      3,
 			Size:           rhpv2.SectorSize,
+			State:          contractStatePending,
 
 			UploadSpending:      currency(types.Siacoins(1)),
 			DownloadSpending:    currency(types.Siacoins(2)),
@@ -755,6 +758,7 @@ func TestAncestorsContracts(t *testing.T) {
 			RenewedTo:   fcids[len(fcids)-1-i],
 			StartHeight: 2,
 			Size:        4096,
+			State:       api.ContractStatePending,
 			WindowStart: 400,
 			WindowEnd:   500,
 		}) {
@@ -1067,6 +1071,7 @@ func TestSQLMetadataStore(t *testing.T) {
 							WindowStart:    400,
 							WindowEnd:      500,
 							Size:           4096,
+							State:          contractStatePending,
 
 							UploadSpending:      zeroCurrency,
 							DownloadSpending:    zeroCurrency,
@@ -1104,6 +1109,7 @@ func TestSQLMetadataStore(t *testing.T) {
 							WindowStart:    400,
 							WindowEnd:      500,
 							Size:           4096,
+							State:          contractStatePending,
 
 							UploadSpending:      zeroCurrency,
 							DownloadSpending:    zeroCurrency,

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -231,7 +231,7 @@ func TestSQLContractStore(t *testing.T) {
 	// Insert it.
 	totalCost := types.NewCurrency64(456)
 	startHeight := uint64(100)
-	returned, err := ss.AddContract(ctx, c, totalCost, startHeight)
+	returned, err := ss.AddContract(ctx, c, totalCost, startHeight, api.ContractStatePending)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -486,7 +486,7 @@ func TestRenewedContract(t *testing.T) {
 	oldContractTotal := types.NewCurrency64(111)
 	oldContractStartHeight := uint64(100)
 	ctx := context.Background()
-	added, err := ss.AddContract(ctx, c, oldContractTotal, oldContractStartHeight)
+	added, err := ss.AddContract(ctx, c, oldContractTotal, oldContractStartHeight, api.ContractStatePending)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -500,7 +500,7 @@ func TestRenewedContract(t *testing.T) {
 	c2 := c
 	c2.Revision.ParentID = fcid2
 	c2.Revision.UnlockConditions = uc2
-	_, err = ss.AddContract(ctx, c2, oldContractTotal, oldContractStartHeight)
+	_, err = ss.AddContract(ctx, c2, oldContractTotal, oldContractStartHeight, api.ContractStatePending)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -589,7 +589,7 @@ func TestRenewedContract(t *testing.T) {
 	}
 	newContractTotal := types.NewCurrency64(222)
 	newContractStartHeight := uint64(200)
-	if _, err := ss.AddRenewedContract(ctx, rev, newContractTotal, newContractStartHeight, fcid1); err != nil {
+	if _, err := ss.AddRenewedContract(ctx, rev, newContractTotal, newContractStartHeight, fcid1, api.ContractStatePending); err != nil {
 		t.Fatal(err)
 	}
 
@@ -709,7 +709,7 @@ func TestRenewedContract(t *testing.T) {
 	newContractStartHeight = uint64(300)
 
 	// Assert the renewed contract is returned
-	renewedContract, err := ss.AddRenewedContract(ctx, rev, newContractTotal, newContractStartHeight, fcid1Renewed)
+	renewedContract, err := ss.AddRenewedContract(ctx, rev, newContractTotal, newContractStartHeight, fcid1Renewed, api.ContractStatePending)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -839,12 +839,12 @@ func (s *SQLStore) addTestContracts(keys []types.PublicKey) (fcids []types.FileC
 
 func (s *SQLStore) addTestContract(fcid types.FileContractID, hk types.PublicKey) (api.ContractMetadata, error) {
 	rev := testContractRevision(fcid, hk)
-	return s.AddContract(context.Background(), rev, types.ZeroCurrency, 0)
+	return s.AddContract(context.Background(), rev, types.ZeroCurrency, 0, api.ContractStatePending)
 }
 
 func (s *SQLStore) addTestRenewedContract(fcid, renewedFrom types.FileContractID, hk types.PublicKey, startHeight uint64) (api.ContractMetadata, error) {
 	rev := testContractRevision(fcid, hk)
-	return s.AddRenewedContract(context.Background(), rev, types.ZeroCurrency, startHeight, renewedFrom)
+	return s.AddRenewedContract(context.Background(), rev, types.ZeroCurrency, startHeight, renewedFrom, api.ContractStatePending)
 }
 
 func (s *SQLStore) contractsCount() (cnt int64, err error) {
@@ -3486,7 +3486,7 @@ func TestMarkSlabUploadedAfterRenew(t *testing.T) {
 			},
 		},
 	}
-	_, err = ss.AddRenewedContract(context.Background(), rev, types.NewCurrency64(1), 100, fcid)
+	_, err = ss.AddRenewedContract(context.Background(), rev, types.NewCurrency64(1), 100, fcid, api.ContractStatePending)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is the preparation for another PR which adds automatic pruning of contracts to the autopilot if they don't appear on chain.

It adds the following possible states to a contract which get updated by the bus as it receives incoming blocks

- "pending" - default for contracts added to the bus
- "active" - is set as soon a contract appears on chain
- "complete" - is set as soon as the storage proof appears on chain
- "failed" - is set when an active contract doesn't become 'complete' by the end of its proof window