### PR TITLE
Health Invalidation

### DIFF
--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -572,7 +572,7 @@ func (ss *SQLStore) RemoveOfflineHosts(ctx context.Context, minRecentFailures ui
 			}
 
 			// archive host contracts
-			if err := archiveContracts(tx, hcs, toArchive); err != nil {
+			if err := archiveContracts(ctx, tx, hcs, toArchive); err != nil {
 				return err
 			}
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -137,7 +137,7 @@ type (
 		DBBufferedSlabID uint `gorm:"index;default: NULL"`
 
 		Health           float64 `gorm:"index;default:1.0; NOT NULL"`
-		HealthValidUntil int64   `gorm:"index"`                   // unix timestamp
+		HealthValidUntil int64   `gorm:"index;default:0"`         // unix timestamp
 		Key              []byte  `gorm:"unique;NOT NULL;size:68"` // json string
 		MinShards        uint8   `gorm:"index"`
 		TotalShards      uint8   `gorm:"index"`

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1763,7 +1763,7 @@ func (s *SQLStore) UnhealthySlabs(ctx context.Context, healthCutoff float64, set
 		Select("slabs.key, slabs.health").
 		Joins("INNER JOIN contract_sets cs ON slabs.db_contract_set_id = cs.id").
 		Model(&dbSlab{}).
-		Where("health <= ? AND ? > health_valid_until AND cs.name = ?", healthCutoff, time.Now().Unix(), set).
+		Where("health <= ? AND cs.name = ?", healthCutoff, set).
 		Order("health ASC").
 		Limit(limit).
 		Find(&rows).

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -2181,8 +2181,6 @@ func invalidateSlabHealthByFCID(ctx context.Context, tx *gorm.DB, fcids []fileCo
 		return nil
 	}
 
-	ts := time.Now().UnixNano()
-
 	for {
 		if resp := tx.Debug().Exec(`
 		UPDATE slabs SET health_valid_until = ? WHERE id in (
@@ -2196,7 +2194,7 @@ func invalidateSlabHealthByFCID(ctx context.Context, tx *gorm.DB, fcids []fileCo
 					   WHERE c.fcid IN (?)
 					   LIMIT ?
 			   ) slab_ids
-		)`, ts, fcids, refreshHealthBatchSize); resp.Error != nil {
+		)`, time.Now().Add(-time.Second).UnixNano(), fcids, refreshHealthBatchSize); resp.Error != nil {
 			return fmt.Errorf("failed to invalidate slab health: %w", resp.Error)
 		} else if resp.RowsAffected < refreshHealthBatchSize {
 			break // done

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1763,7 +1763,7 @@ func (s *SQLStore) UnhealthySlabs(ctx context.Context, healthCutoff float64, set
 		Select("slabs.key, slabs.health").
 		Joins("INNER JOIN contract_sets cs ON slabs.db_contract_set_id = cs.id").
 		Model(&dbSlab{}).
-		Where("health <= ? AND ? < health_valid_until AND cs.name = ?", healthCutoff, time.Now().Unix(), set).
+		Where("health <= ? AND ? > health_valid_until AND cs.name = ?", healthCutoff, time.Now().Unix(), set).
 		Order("health ASC").
 		Limit(limit).
 		Find(&rows).

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1744,8 +1744,7 @@ func (s *SQLStore) createSlices(tx *gorm.DB, objID, multiPartID *uint, contractS
 		}
 		err = tx.Where(dbSlab{Key: slabKey}).
 			Assign(dbSlab{
-				DBContractSetID:  contractSetID,
-				HealthValidUntil: time.Now().UnixNano(),
+				DBContractSetID: contractSetID,
 			}).
 			FirstOrCreate(&slab).Error
 		if err != nil {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -137,8 +137,8 @@ type (
 		DBBufferedSlabID uint `gorm:"index;default: NULL"`
 
 		Health           float64 `gorm:"index;default:1.0; NOT NULL"`
-		HealthValidUntil int64   `gorm:"index;default:0"`         // unix timestamp
-		Key              []byte  `gorm:"unique;NOT NULL;size:68"` // json string
+		HealthValidUntil int64   `gorm:"index;default:0; NOT NULL"` // unix timestamp
+		Key              []byte  `gorm:"unique;NOT NULL;size:68"`   // json string
 		MinShards        uint8   `gorm:"index"`
 		TotalShards      uint8   `gorm:"index"`
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -125,7 +125,7 @@ type (
 		DBBufferedSlabID uint `gorm:"index;default: NULL"`
 
 		Health           float64 `gorm:"index;default:1.0; NOT NULL"`
-		HealthValidUntil int64   `gorm:"index"`                   // unix timestap
+		HealthValidUntil int64   `gorm:"index"`                   // unix timestamp
 		Key              []byte  `gorm:"unique;NOT NULL;size:68"` // json string
 		MinShards        uint8   `gorm:"index"`
 		TotalShards      uint8   `gorm:"index"`

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -125,7 +125,7 @@ type (
 		DBBufferedSlabID uint `gorm:"index;default: NULL"`
 
 		Health           float64 `gorm:"index;default:1.0; NOT NULL"`
-		HealthValidUntil int64   `gorm:"index"`                   // unix nano
+		HealthValidUntil int64   `gorm:"index"`                   // unix timestap
 		Key              []byte  `gorm:"unique;NOT NULL;size:68"` // json string
 		MinShards        uint8   `gorm:"index"`
 		TotalShards      uint8   `gorm:"index"`

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -23,8 +23,8 @@ const (
 	// 10/30 erasure coding and takes <1s to execute on an SSD in SQLite.
 	refreshHealthBatchSize = 10000
 
-	refreshHealthMinHealthValidity = time.Hour
-	refreshHealthMaxHealthValidity = 4 * time.Hour
+	refreshHealthMinHealthValidity = 12 * time.Hour
+	refreshHealthMaxHealthValidity = 72 * time.Hour
 )
 
 var (

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3619,7 +3619,7 @@ func TestDeleteHostSector(t *testing.T) {
 		DBContractSetID:  1,
 		Key:              []byte(object.GenerateEncryptionKey().String()),
 		Health:           1.0,
-		HealthValidUntil: time.Now().Add(time.Hour).UnixNano(),
+		HealthValidUntil: time.Now().Add(time.Hour).Unix(),
 		TotalShards:      1,
 		Shards: []dbSector{
 			{
@@ -3765,7 +3765,7 @@ func TestSlabHealthInvalidation(t *testing.T) {
 		} else if err := ss.db.Model(&dbSlab{}).Where(&dbSlab{Key: key}).Take(&slab).Error; err != nil {
 			t.Fatal(err)
 		} else if slab.HealthValid() != expected {
-			t.Fatal("unexpected health valid", slab.HealthValid(), slab.HealthValidUntil, time.Now(), time.Unix(0, slab.HealthValidUntil))
+			t.Fatal("unexpected health valid", slab.HealthValid(), slab.HealthValidUntil, time.Now(), time.Unix(slab.HealthValidUntil, 0))
 		}
 	}
 
@@ -3905,7 +3905,7 @@ func TestSlabHealthInvalidation(t *testing.T) {
 		now := time.Now()
 		min := now.Add(refreshHealthMinHealthValidity)
 		max := now.Add(refreshHealthMaxHealthValidity)
-		validUntil := time.Unix(0, slab.HealthValidUntil)
+		validUntil := time.Unix(slab.HealthValidUntil, 0)
 		if !(min.Before(validUntil) && max.After(validUntil)) {
 			t.Fatal("valid until not in boundaries", min, max, validUntil, now)
 		}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1590,7 +1590,7 @@ func TestUnhealthySlabs(t *testing.T) {
 	}
 	fcid1, fcid2, fcid3, fcid4 := fcids[0], fcids[1], fcids[2], fcids[3]
 
-	// select the first three contracts as good contracts
+	// update the contract set
 	goodContracts := []types.FileContractID{fcid1, fcid2, fcid3}
 	if err := ss.SetContractSet(context.Background(), testContractSet, goodContracts); err != nil {
 		t.Fatal(err)

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3765,7 +3765,7 @@ func TestSlabHealthInvalidation(t *testing.T) {
 		} else if err := ss.db.Model(&dbSlab{}).Where(&dbSlab{Key: key}).Take(&slab).Error; err != nil {
 			t.Fatal(err)
 		} else if slab.HealthValid() != expected {
-			t.Fatal("unexpected health valid", slab.HealthValid(), slab.HealthValidUntil)
+			t.Fatal("unexpected health valid", slab.HealthValid(), slab.HealthValidUntil, time.Now(), time.Unix(0, slab.HealthValidUntil))
 		}
 	}
 

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3705,6 +3705,7 @@ func TestUpdateSlabSanityChecks(t *testing.T) {
 	slab := object.Slab{
 		Key:    object.GenerateEncryptionKey(),
 		Shards: shards,
+		Health: 1,
 	}
 
 	// set slab.
@@ -3721,7 +3722,7 @@ func TestUpdateSlabSanityChecks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(slab, rSlab) {
-		t.Fatal("unexpected slab", cmp.Diff(slab, rSlab))
+		t.Fatal("unexpected slab", cmp.Diff(slab, rSlab, cmp.AllowUnexported(object.EncryptionKey{})))
 	}
 
 	// change the length to fail the update.

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1130,6 +1130,7 @@ func TestSQLMetadataStore(t *testing.T) {
 		slabs[i].Shards[0].Model = Model{}
 		slabs[i].Shards[0].Contracts[0].Model = Model{}
 		slabs[i].Shards[0].Contracts[0].Host.Model = Model{}
+		slabs[i].HealthValidUntil = 0
 	}
 	if !reflect.DeepEqual(slab1, expectedObjSlab1) {
 		t.Fatal("mismatch", cmp.Diff(slab1, expectedObjSlab1))

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3615,11 +3615,11 @@ func TestDeleteHostSector(t *testing.T) {
 	// create a healthy slab with one sector that is uploaded to all contracts.
 	root := types.Hash256{1, 2, 3}
 	slab := dbSlab{
-		DBContractSetID: 1,
-		Key:             []byte(object.GenerateEncryptionKey().String()),
-		Health:          1.0,
-		HealthValid:     true,
-		TotalShards:     1,
+		DBContractSetID:  1,
+		Key:              []byte(object.GenerateEncryptionKey().String()),
+		Health:           1.0,
+		HealthValidUntil: time.Now().Add(time.Hour).UnixNano(),
+		TotalShards:      1,
 		Shards: []dbSector{
 			{
 				Contracts:  dbContracts,
@@ -3660,7 +3660,7 @@ func TestDeleteHostSector(t *testing.T) {
 	var s dbSlab
 	if err := ss.db.Preload("Shards").Take(&s).Error; err != nil {
 		t.Fatal(err)
-	} else if s.HealthValid {
+	} else if s.HealthValid() {
 		t.Fatal("expected health to be invalid")
 	} else if s.Shards[0].LatestHost != publicKey(hk2) {
 		t.Fatal("expected hk2 to be latest host", types.PublicKey(s.Shards[0].LatestHost))
@@ -3744,5 +3744,168 @@ func TestUpdateSlabSanityChecks(t *testing.T) {
 	}
 	if err := ss.UpdateSlab(context.Background(), reversedSlab, testContractSet, usedContracts); !errors.Is(err, errShardRootChanged) {
 		t.Fatal(err)
+	}
+}
+
+func TestSlabHealthInvalidation(t *testing.T) {
+	// create db
+	cfg := defaultTestSQLStoreConfig
+	ss := newTestSQLStore(t, cfg)
+	defer ss.Close()
+
+	// define a helper to assert the health validity of a given slab
+	assertHealthValid := func(slabKey object.EncryptionKey, expected bool) {
+		t.Helper()
+
+		var slab dbSlab
+		if key, err := slabKey.MarshalText(); err != nil {
+			t.Fatal(err)
+		} else if err := ss.db.Model(&dbSlab{}).Where(&dbSlab{Key: key}).Take(&slab).Error; err != nil {
+			t.Fatal(err)
+		} else if slab.HealthValid() != expected {
+			t.Fatal("unexpected health valid", slab.HealthValid(), slab.HealthValidUntil)
+		}
+	}
+
+	// define a helper to refresh the health
+	refreshHealth := func(slabKeys ...object.EncryptionKey) {
+		t.Helper()
+
+		// refresh health
+		if err := ss.RefreshHealth(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+
+		// assert all slabs
+		for _, slabKey := range slabKeys {
+			assertHealthValid(slabKey, true)
+		}
+	}
+
+	// add hosts and contracts
+	hks, err := ss.addTestHosts(4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fcids, _, err := ss.addTestContracts(hks)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// prepare a slab with pieces on h1 and h2
+	s1 := object.GenerateEncryptionKey()
+	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "o1", testContractSet, testETag, testMimeType, object.Object{
+		Key: object.GenerateEncryptionKey(),
+		Slabs: []object.SlabSlice{{Slab: object.Slab{
+			Key: s1,
+			Shards: []object.Sector{
+				{Host: hks[0], Root: types.Hash256{0}},
+				{Host: hks[1], Root: types.Hash256{1}},
+			},
+		}}},
+	}, map[types.PublicKey]types.FileContractID{hks[0]: fcids[0], hks[1]: fcids[1]})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// prepare a slab with pieces on h3 and h4
+	s2 := object.GenerateEncryptionKey()
+	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "o2", testContractSet, testETag, testMimeType, object.Object{
+		Key: object.GenerateEncryptionKey(),
+		Slabs: []object.SlabSlice{{Slab: object.Slab{
+			Key: s2,
+			Shards: []object.Sector{
+				{Host: hks[2], Root: types.Hash256{2}},
+				{Host: hks[3], Root: types.Hash256{3}},
+			},
+		}}},
+	}, map[types.PublicKey]types.FileContractID{hks[2]: fcids[2], hks[3]: fcids[3]})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert there are 0 contracts in the contract set
+	cscs, err := ss.ContractSetContracts(context.Background(), testContractSet)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(cscs) != 0 {
+		t.Fatal("expected 0 contracts", len(cscs))
+	}
+
+	// refresh health
+	refreshHealth(s1, s2)
+
+	// add 2 contracts to the contract set
+	if err := ss.SetContractSet(context.Background(), testContractSet, fcids[:2]); err != nil {
+		t.Fatal(err)
+	}
+	assertHealthValid(s1, false)
+	assertHealthValid(s2, true)
+
+	// refresh health
+	refreshHealth(s1, s2)
+
+	// switch out the contract set with two new contracts
+	if err := ss.SetContractSet(context.Background(), testContractSet, fcids[2:]); err != nil {
+		t.Fatal(err)
+	}
+	assertHealthValid(s1, false)
+	assertHealthValid(s2, false)
+
+	// assert there are 2 contracts in the contract set
+	cscs, err = ss.ContractSetContracts(context.Background(), testContractSet)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(cscs) != 2 {
+		t.Fatal("expected 2 contracts", len(cscs))
+	} else if cscs[0].ID != (types.FileContractID{3}) || cscs[1].ID != (types.FileContractID{4}) {
+		t.Fatal("unexpected contracts", cscs)
+	}
+
+	// refresh health
+	refreshHealth(s1, s2)
+
+	// archive the contract for h3 and assert s2 was invalidated
+	if err := ss.ArchiveContract(context.Background(), types.FileContractID{3}, "test"); err != nil {
+		t.Fatal(err)
+	}
+	assertHealthValid(s1, true)
+	assertHealthValid(s2, false)
+
+	// archive the contract for h1 and assert s1 was invalidated
+	if err := ss.ArchiveContract(context.Background(), types.FileContractID{1}, "test"); err != nil {
+		t.Fatal(err)
+	}
+	assertHealthValid(s1, false)
+	assertHealthValid(s2, false)
+
+	// assert the health validity is always updated to a random time in the future that matches the boundaries
+	for i := 0; i < 1e3; i++ {
+		// reset health validity
+		if tx := ss.db.Exec("UPDATE slabs SET health_valid_until = 0;"); tx.Error != nil {
+			t.Fatal(err)
+		}
+
+		// refresh health
+		if err := ss.RefreshHealth(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+
+		// fetch slab
+		var slab dbSlab
+		if key, err := s1.MarshalText(); err != nil {
+			t.Fatal(err)
+		} else if err := ss.db.Model(&dbSlab{}).Where(&dbSlab{Key: key}).Take(&slab).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		// assert it's validity is within expected bounds
+		now := time.Now()
+		min := now.Add(refreshHealthMinHealthValidity)
+		max := now.Add(refreshHealthMaxHealthValidity)
+		validUntil := time.Unix(0, slab.HealthValidUntil)
+		if !(min.Before(validUntil) && max.After(validUntil)) {
+			t.Fatal("valid until not in boundaries", min, max, validUntil, now)
+		}
 	}
 }

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -1173,7 +1173,7 @@ func performMigration00026_healthValidUntilColumn(txn *gorm.DB, logger *zap.Suga
 
 	// Use 'AutoMigrate' to add 'health_valid_until'.
 	if err := txn.Table("slabs").Migrator().AutoMigrate(&struct {
-		HealthValidUntil int64 `gorm:"index"` // unix timestamp
+		HealthValidUntil int64 `gorm:"index;default:0; NOT NULL"` // unix timestamp
 	}{}); err != nil {
 		return err
 	}

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -267,6 +267,12 @@ func performMigrations(db *gorm.DB, logger *zap.SugaredLogger) error {
 				return performMigration00021_multipartUploadsBucketCascade(tx, logger)
 			},
 		},
+		{
+			ID: "00022_healthValidUntilColumn",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration00022_healthValidUntilColumn(tx, logger)
+			},
+		},
 	}
 	// Create migrator.
 	m := gormigrate.New(db, gormigrate.DefaultOptions, migrations)
@@ -971,5 +977,21 @@ func performMigration00021_multipartUploadsBucketCascade(txn *gorm.DB, logger *z
 		}
 	}
 	logger.Info("migration 00021_multipoartUploadsBucketCascade complete")
+	return nil
+}
+
+func performMigration00022_healthValidUntilColumn(txn *gorm.DB, logger *zap.SugaredLogger) error {
+	logger.Info("performing migration 00022_healthValidUntilColumn")
+	if !txn.Migrator().HasColumn(&dbSlab{}, "health_valid_until") {
+		if err := txn.Migrator().AddColumn(&dbSlab{}, "health_valid_until"); err != nil {
+			return err
+		}
+	}
+	if txn.Migrator().HasColumn(&dbSlab{}, "health_valid") {
+		if err := txn.Migrator().DropColumn(&dbSlab{}, "health_valid"); err != nil {
+			return err
+		}
+	}
+	logger.Info("migration 00022_healthValidUntilColumn complete")
 	return nil
 }

--- a/stores/slabbuffer.go
+++ b/stores/slabbuffer.go
@@ -520,10 +520,11 @@ func createSlabBuffer(tx *gorm.DB, contractSetID uint, dir string, minShards, to
 	}
 	createdSlab := dbBufferedSlab{
 		DBSlab: dbSlab{
-			DBContractSetID: contractSetID,
-			Key:             key,
-			MinShards:       minShards,
-			TotalShards:     totalShards,
+			DBContractSetID:  contractSetID,
+			Key:              key,
+			HealthValidUntil: time.Now().UnixNano(),
+			MinShards:        minShards,
+			TotalShards:      totalShards,
 		},
 		Complete: false,
 		Size:     0,

--- a/stores/slabbuffer.go
+++ b/stores/slabbuffer.go
@@ -520,11 +520,10 @@ func createSlabBuffer(tx *gorm.DB, contractSetID uint, dir string, minShards, to
 	}
 	createdSlab := dbBufferedSlab{
 		DBSlab: dbSlab{
-			DBContractSetID:  contractSetID,
-			Key:              key,
-			HealthValidUntil: time.Now().UnixNano(),
-			MinShards:        minShards,
-			TotalShards:      totalShards,
+			DBContractSetID: contractSetID,
+			Key:             key,
+			MinShards:       minShards,
+			TotalShards:     totalShards,
 		},
 		Complete: false,
 		Size:     0,

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"go.sia.tech/siad/modules"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 	"lukechampine.com/frand"
 )
@@ -40,11 +42,12 @@ type testSQLStoreConfig struct {
 	dbName          string
 	dbMetricsName   string
 	dir             string
+	ephemeral       bool
 	skipMigrate     bool
 	skipContractSet bool
 }
 
-var defaultTestSQLStoreConfig = testSQLStoreConfig{}
+var defaultTestSQLStoreConfig = testSQLStoreConfig{ephemeral: true}
 
 // newTestSQLStore creates a new SQLStore for testing.
 func newTestSQLStore(t *testing.T, cfg testSQLStoreConfig) *testSQLStore {
@@ -61,7 +64,14 @@ func newTestSQLStore(t *testing.T, cfg testSQLStoreConfig) *testSQLStore {
 	if dbMetricsName == "" {
 		dbMetricsName = hex.EncodeToString(frand.Bytes(32)) // random name for metrics db
 	}
-	conn := NewEphemeralSQLiteConnection(dbName)
+
+	var conn gorm.Dialector
+	if cfg.ephemeral {
+		conn = NewEphemeralSQLiteConnection(dbName)
+	} else {
+		conn = NewSQLiteConnection(filepath.Join(cfg.dir, "db.sqlite"))
+	}
+
 	walletAddrs := types.Address(frand.Entropy256())
 	alerts := alerts.WithOrigin(alerts.NewManager(), "test")
 	sqlStore, ccid, err := NewSQLStore(conn, alerts, dir, !cfg.skipMigrate, time.Hour, time.Second, walletAddrs, 0, zap.NewNop().Sugar(), newTestLogger())
@@ -208,7 +218,7 @@ func TestQueryPlan(t *testing.T) {
 		"SELECT * FROM contract_set_contracts WHERE db_contract_set_id = 1",
 
 		// slabs
-		"SELECT * FROM slabs WHERE health_valid = 1",
+		"SELECT * FROM slabs WHERE health_valid_until > 0",
 		"SELECT * FROM slabs WHERE health > 0",
 		"SELECT * FROM slabs WHERE db_buffered_slab_id = 1",
 

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -42,12 +42,12 @@ type testSQLStoreConfig struct {
 	dbName          string
 	dbMetricsName   string
 	dir             string
-	ephemeral       bool
+	persistent      bool
 	skipMigrate     bool
 	skipContractSet bool
 }
 
-var defaultTestSQLStoreConfig = testSQLStoreConfig{ephemeral: true}
+var defaultTestSQLStoreConfig = testSQLStoreConfig{}
 
 // newTestSQLStore creates a new SQLStore for testing.
 func newTestSQLStore(t *testing.T, cfg testSQLStoreConfig) *testSQLStore {
@@ -66,10 +66,10 @@ func newTestSQLStore(t *testing.T, cfg testSQLStoreConfig) *testSQLStore {
 	}
 
 	var conn gorm.Dialector
-	if cfg.ephemeral {
-		conn = NewEphemeralSQLiteConnection(dbName)
-	} else {
+	if cfg.persistent {
 		conn = NewSQLiteConnection(filepath.Join(cfg.dir, "db.sqlite"))
+	} else {
+		conn = NewEphemeralSQLiteConnection(dbName)
 	}
 
 	walletAddrs := types.Address(frand.Entropy256())


### PR DESCRIPTION
I noticed an issue on our nodes where migrations were seemingly migrating too many shards. After some digging I found out that health was misrepresented. We were migrating 15 sectors on a .75 health slab only because the .75 was wrong. This means we have a bug in our health invalidation but I wasn't able to pinpoint where we're failing to invalidate slabs.

This PR hardens us against that. It does so by changing `health_valid` from a bool to a random timestamp in the future. The validity period is chosen randomly between 12 and 72 hours from the time the health was refreshed. By doing so we effectively avoid having to recalculate the health of all invalidated slabs at once.

I considered using GORM hooks for the invalidation by they have a very weird way of handling associations. When you delete an association you only `NULL` the reference and you don't actually go and delete the entity. This makes it so that we can't use hooks for the invalidation because it would only trigger when we add a contract to the set and not when we remove one.

I'm still quite annoyed I wasn't able to pinpoint where it was happening, it's quite tricky to debug and looking at our `renterd.log` we sometimes fail to invalidate because of database locking. Moving to a validity period ensures we periodically recalculate a slab's health is definitely a good idea I think.