### PR TITLE
ui: v0.32.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	go.sia.tech/jape v0.10.1
 	go.sia.tech/mux v1.2.0
 	go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca
-	go.sia.tech/web/renterd v0.31.0
+	go.sia.tech/web/renterd v0.32.0
 	go.uber.org/zap v1.25.0
 	golang.org/x/crypto v0.14.0
 	golang.org/x/term v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca h1:aZMg2AKevn7jKx+wlusWQf
 go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca/go.mod h1:h/1afFwpxzff6/gG5i1XdAgPK7dEY6FaibhK7N5F86Y=
 go.sia.tech/web v0.0.0-20230817201630-c3d9328334b1 h1:qzS1HFVPuQlOyh17zqO4Qkz63Q0YwADGMt9YAiL9mrk=
 go.sia.tech/web v0.0.0-20230817201630-c3d9328334b1/go.mod h1:RKODSdOmR3VtObPAcGwQqm4qnqntDVFylbvOBbWYYBU=
-go.sia.tech/web/renterd v0.31.0 h1:bJ1nELQFBBZ/PnYckpUZLf7+cuRiapg0m5NfBdiqvBo=
-go.sia.tech/web/renterd v0.31.0/go.mod h1:FgXrdmAnu591a3h96RB/15pMZ74xO9457g902uE06BM=
+go.sia.tech/web/renterd v0.32.0 h1:oJOdQRiumh2lOY87fHPjQ90YUfob/8vSjz1z85qR2z0=
+go.sia.tech/web/renterd v0.32.0/go.mod h1:FgXrdmAnu591a3h96RB/15pMZ74xO9457g902uE06BM=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=


### PR DESCRIPTION
- Wallet now instructs new users to fund their wallet when there are no transactions yet.
- Hosts last scan column now properly displays unscanned values rather than a very large time ago value.
- The wallet balance tooltip now shows spendable confirmed and unconfirmed values.
- The maxDowntimeHours setting default value is now 336.
- Added support for the minRecentScanFailures autopilot hosts setting.
- Siacoin and number input placeholders now match the suggested value.
- Extremely small siacoin values will now show as hastings by default rather than 0SC.
- Fixed an issue where the wallet balance graph would not show the first data point.
- The autopilot loop is now triggered after settings are successfully updated.
- Files are now paginated.
- Refined the warnings in the files feature navbar and file explorer empty states.
- Onboarding fund wallet step now requires >0 SC instead of a full allowance.
- Wallet balance evolution graph is now hidden until at least 1 data point is available.
- The hosts table now has a last announcement column instead of the known since column.