### PR TITLE
Have autopilot delete unconfirmed, pending contracts after some time

### DIFF
--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -633,6 +633,8 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 			toArchive[fcid] = errContractMaxRevisionNumber.Error()
 		} else if contract.RevisionNumber == math.MaxUint64 {
 			toArchive[fcid] = errContractMaxRevisionNumber.Error()
+		} else if contract.State == api.ContractStatePending && cs.BlockHeight-contract.StartHeight > 18 {
+			toArchive[fcid] = errContractNotConfirmed.Error()
 		}
 		if _, archived := toArchive[fcid]; archived {
 			toStopUsing[fcid] = toArchive[fcid]

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -26,6 +26,10 @@ const (
 	// currently has remaining.
 	minContractCollateralThresholdNumerator   = 10
 	minContractCollateralThresholdDenominator = 100
+
+	// contractConfirmationDeadline is the number of blocks since its start
+	// height we wait for a contract to appear on chain.
+	contractConfirmationDeadline = 18
 )
 
 var (
@@ -45,6 +49,7 @@ var (
 	errContractMaxRevisionNumber = errors.New("contract has reached max revision number")
 	errContractNoRevision        = errors.New("contract has no revision")
 	errContractExpired           = errors.New("contract has expired")
+	errContractNotConfirmed      = errors.New("contract hasn't been confirmed on chain in time")
 )
 
 type unusableHostResult struct {


### PR DESCRIPTION
To avoid contracts that don't get confirmed on chain or simply reorged from sticking around, the autopilot will delete them after 18 blocks of being pending which matches hostd's current behaviour. 