### PR TITLE
Block Until Funded

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -242,6 +242,16 @@ func (ap *Autopilot) Run() error {
 				return
 			}
 
+			// block until the autopilot is funded
+			if funded, interrupted := ap.blockUntilFunded(ap.ticker.C); !funded {
+				if interrupted {
+					close(tickerFired)
+					return
+				}
+				ap.logger.Error("autopilot stopped before wallet got funded")
+				return
+			}
+
 			// Trace/Log worker id chosen for this maintenance iteration.
 			workerID, err := w.ID(ctx)
 			if err != nil {
@@ -375,6 +385,39 @@ func (ap *Autopilot) blockUntilConfigured(interrupt <-chan time.Time) (configure
 			ap.logger.Errorf("autopilot is unable to fetch its configuration from the bus, err: %v", err)
 		}
 		if err != nil {
+			select {
+			case <-ap.stopChan:
+				return false, false
+			case <-interrupt:
+				return false, true
+			case <-ticker.C:
+				continue
+			}
+		}
+		return true, false
+	}
+}
+
+func (ap *Autopilot) blockUntilFunded(interrupt <-chan time.Time) (funded, interrupted bool) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	var once sync.Once
+
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		wallet, err := ap.bus.Wallet(ctx)
+		funded := !wallet.Confirmed.Add(wallet.Unconfirmed).IsZero()
+		cancel()
+
+		// if an error occurred, or if we're not funded, we continue
+		if err != nil {
+			ap.logger.Errorf("failed to get wallet info, err: %v", err)
+		} else if wallet.Confirmed.Add(wallet.Unconfirmed).IsZero() {
+			once.Do(func() { ap.logger.Info("autopilot is waiting for wallet to get funded...") })
+		}
+
+		if err != nil || !funded {
 			select {
 			case <-ap.stopChan:
 				return false, false


### PR DESCRIPTION
This PR blocks until the autopilot is funded. This usually only happens once, because we strict compare against 0H, but is important for FTUE. If you aren't immediately requesting funds from the faucet, you might have synced both the wallet and consensus, leaving you in a situation where you have to wait for the next iteration of the autopilot loop to have it form contracts (which is 30' worst case by default).

