### PR TITLE
Slow SQL

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -2251,7 +2251,7 @@ func invalidateSlabHealthByFCID(ctx context.Context, tx *gorm.DB, fcids []fileCo
 		UPDATE slabs SET health_valid_until = ? WHERE id in (
 			   SELECT *
 			   FROM (
-					   SELECT DISTINCT slabs.id
+					   SELECT slabs.id
 					   FROM slabs
 					   LEFT JOIN sectors se ON se.db_slab_id = slabs.id
 					   LEFT JOIN contract_sectors cs ON cs.db_sector_id = se.id


### PR DESCRIPTION
Health invalidation PR introduced slow SQL because I wanted to add a `DISTINCT`. Took me a while to realise that was the issue even though I was fully aware at the time of writing it might be an issue. I wanted to limit the number of ids in the result set in fear of exceeding the `IN` limit but I guess we'll have to revert to the old query. We're nowhere near that limit yet anyway.