### PR TITLE
ui: v0.33.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	go.sia.tech/jape v0.11.0
 	go.sia.tech/mux v1.2.0
 	go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca
-	go.sia.tech/web/renterd v0.32.0
+	go.sia.tech/web/renterd v0.33.0
 	go.uber.org/zap v1.25.0
 	golang.org/x/crypto v0.15.0
 	golang.org/x/term v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca h1:aZMg2AKevn7jKx+wlusWQf
 go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca/go.mod h1:h/1afFwpxzff6/gG5i1XdAgPK7dEY6FaibhK7N5F86Y=
 go.sia.tech/web v0.0.0-20230817201630-c3d9328334b1 h1:qzS1HFVPuQlOyh17zqO4Qkz63Q0YwADGMt9YAiL9mrk=
 go.sia.tech/web v0.0.0-20230817201630-c3d9328334b1/go.mod h1:RKODSdOmR3VtObPAcGwQqm4qnqntDVFylbvOBbWYYBU=
-go.sia.tech/web/renterd v0.32.0 h1:oJOdQRiumh2lOY87fHPjQ90YUfob/8vSjz1z85qR2z0=
-go.sia.tech/web/renterd v0.32.0/go.mod h1:FgXrdmAnu591a3h96RB/15pMZ74xO9457g902uE06BM=
+go.sia.tech/web/renterd v0.33.0 h1:3RJM+Kup3bKDyFcQI51ImyItEkLOdgZ5U/OwO3UBWPY=
+go.sia.tech/web/renterd v0.33.0/go.mod h1:FgXrdmAnu591a3h96RB/15pMZ74xO9457g902uE06BM=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=


### PR DESCRIPTION
- The configuration now has zen-specific suggested/default values for number of contract hosts and shard values.
- The bucket context menu now allows you to edit the bucket policy and toggle the read access between public and private.
- The simple configuration mode now shows download and upload estimates and pricing.
- Currency display can now be configured to siacoin, fiat, or both along with a preference for when only one can be displayed.
- Fixed an issue with file search where selecting a file would navigate to the path without the bucket.
- The configuration now includes a setting for a migration surcharge multiplier which allows you to set a factor for increasing the max download price when trying to repair critically low health sectors.
- The contract count shown in onboarding will update more quickly as it now includes pending contracts.
- The contracts table now includes a column for state that shows: pending, active, complete, or failed.
- The contract list now updates after a contract is deleted.