### PR TITLE
Copying 0-byte file, checking objectHealth in metadata.go

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -2107,7 +2107,7 @@ func (s *SQLStore) object(ctx context.Context, txn *gorm.DB, bucket string, path
 
 func (s *SQLStore) objectHealth(ctx context.Context, tx *gorm.DB, objectID uint) (health float64, err error) {
 	if err = tx.
-		Select("MIN(sla.health)").
+		Select("COALESCE(MIN(sla.health), 1)").
 		Model(&dbObject{}).
 		Table("objects o").
 		Joins("LEFT JOIN slices sli ON o.id = sli.`db_object_id`").


### PR DESCRIPTION
During uploading some backup files with rclone via S3 API, the following error occurred:

`ERROR    db    stores/metadata.go:1493    sql: Scan error on column index 0, name "MIN(sla.health)": converting NULL to float64 is unsupported    {"elapsed": "1.358ms", "rows": 1, "sql": "SELECT MIN(sla.health) FROM objects o LEFT JOIN slices sli ON o.id = sli.db_object_id LEFT JOIN slabs sla ON sli.db_slab_id = sla.id WHERE o.id = 4629"}`

To the recommendation by @ChrisSchinnerl I have fixed this issue by wrap the MIN() function with COALESCE().