### PR TITLE
Optimise Contract Sizes

### DIFF
--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3765,7 +3765,7 @@ func TestSlabHealthInvalidation(t *testing.T) {
 		}
 
 		// refresh health
-		now := time.Now().Round(time.Second)
+		now := time.Now()
 		if err := ss.RefreshHealth(context.Background()); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This prunable data query is rather slow because we have to `LEFT JOIN contract_sectors`. We need that because we want to include contracts without sectors too. I figured in this case it makes sense to split one query into two: one where we use `WHERE NOT EXISTS` to catch everything we would miss out on if we were to `INNER JOIN`.

In the contract size query (so fetching size details for a single contract) I kept the `LEFT JOIN` since it's bound by the `fcid` anyway. I considered getting rid of it all together because we only use it in the worker to escape early. We could also return a custom error and return a 400 when the user supplies a contract to prune but there's no sectors to prune. This would remove a `bus` route though (`/contract/:id/size`) and I wasn't sure whether that was a good or a bad thing.. might be usable at one point but otoh less routes less trouble... cc @ChrisSchinnerl wdyt.

`NOTE`: I didn't have to alter the tests because they broke when switching to an `INNER JOIN`