### PR TITLE
Use update instead of CreateInBatches in CompleteMultipartUpload

### DIFF
--- a/api/multipart.go
+++ b/api/multipart.go
@@ -60,14 +60,13 @@ type (
 	}
 
 	MultipartAddPartRequest struct {
-		Bucket       string               `json:"bucket"`
-		ETag         string               `json:"eTag"`
-		Path         string               `json:"path"`
-		ContractSet  string               `json:"contractSet"`
-		UploadID     string               `json:"uploadID"`
-		PartialSlabs []object.PartialSlab `json:"partialSlabs"`
-		PartNumber   int                  `json:"partNumber"`
-		Slices       []object.SlabSlice   `json:"slices"`
+		Bucket      string             `json:"bucket"`
+		ETag        string             `json:"eTag"`
+		Path        string             `json:"path"`
+		ContractSet string             `json:"contractSet"`
+		UploadID    string             `json:"uploadID"`
+		PartNumber  int                `json:"partNumber"`
+		Slices      []object.SlabSlice `json:"slices"`
 	}
 
 	MultipartCompleteResponse struct {

--- a/api/setting.go
+++ b/api/setting.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
 )
 
@@ -118,6 +119,11 @@ func (gs GougingSettings) Validate() error {
 // RedundancySettings.
 func (rs RedundancySettings) Redundancy() float64 {
 	return float64(rs.TotalShards) / float64(rs.MinShards)
+}
+
+// SlabSizeNoRedundancy returns the size of a slab without added redundancy.
+func (rs RedundancySettings) SlabSizeNoRedundancy() uint64 {
+	return uint64(rs.MinShards) * rhpv2.SectorSize
 }
 
 // Validate returns an error if the redundancy settings are not considered

--- a/api/slab.go
+++ b/api/slab.go
@@ -34,8 +34,8 @@ type (
 
 type (
 	AddPartialSlabResponse struct {
-		SlabBufferMaxSizeSoftReached bool                 `json:"slabBufferMaxSizeSoftReached"`
-		Slabs                        []object.PartialSlab `json:"slabs"`
+		SlabBufferMaxSizeSoftReached bool               `json:"slabBufferMaxSizeSoftReached"`
+		Slabs                        []object.SlabSlice `json:"slabs"`
 	}
 
 	// MigrationSlabsRequest is the request type for the /slabs/migration endpoint.

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -150,7 +150,7 @@ type (
 		UpdateObject(ctx context.Context, bucketName, path, contractSet, ETag, mimeType string, o object.Object) error
 
 		AbortMultipartUpload(ctx context.Context, bucketName, path string, uploadID string) (err error)
-		AddMultipartPart(ctx context.Context, bucketName, path, contractSet, eTag, uploadID string, partNumber int, slices []object.SlabSlice, partialSlab []object.PartialSlab) (err error)
+		AddMultipartPart(ctx context.Context, bucketName, path, contractSet, eTag, uploadID string, partNumber int, slices []object.SlabSlice) (err error)
 		CompleteMultipartUpload(ctx context.Context, bucketName, path, uploadID string, parts []api.MultipartCompletedPart) (_ api.MultipartCompleteResponse, err error)
 		CreateMultipartUpload(ctx context.Context, bucketName, path string, ec object.EncryptionKey, mimeType string) (api.MultipartCreateResponse, error)
 		MultipartUpload(ctx context.Context, uploadID string) (resp api.MultipartUpload, _ error)
@@ -161,7 +161,7 @@ type (
 		PackedSlabsForUpload(ctx context.Context, lockingDuration time.Duration, minShards, totalShards uint8, set string, limit int) ([]api.PackedSlab, error)
 		SlabBuffers(ctx context.Context) ([]api.SlabBuffer, error)
 
-		AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.PartialSlab, bufferSize int64, err error)
+		AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.SlabSlice, bufferSize int64, err error)
 		FetchPartialSlab(ctx context.Context, key object.EncryptionKey, offset, length uint32) ([]byte, error)
 		Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
 		RefreshHealth(ctx context.Context) error
@@ -2138,7 +2138,7 @@ func (b *bus) multipartHandlerUploadPartPUT(jc jape.Context) {
 		jc.Error(errors.New("upload_id must be non-empty"), http.StatusBadRequest)
 		return
 	}
-	err := b.ms.AddMultipartPart(jc.Request.Context(), req.Bucket, req.Path, req.ContractSet, req.ETag, req.UploadID, req.PartNumber, req.Slices, req.PartialSlabs)
+	err := b.ms.AddMultipartPart(jc.Request.Context(), req.Bucket, req.Path, req.ContractSet, req.ETag, req.UploadID, req.PartNumber, req.Slices)
 	if jc.Check("failed to upload part", err) != nil {
 		return
 	}

--- a/bus/client/multipart-upload.go
+++ b/bus/client/multipart-upload.go
@@ -19,16 +19,15 @@ func (c *Client) AbortMultipartUpload(ctx context.Context, bucket, path string, 
 }
 
 // AddMultipartPart adds a part to a multipart upload.
-func (c *Client) AddMultipartPart(ctx context.Context, bucket, path, contractSet, eTag, uploadID string, partNumber int, slices []object.SlabSlice, partialSlab []object.PartialSlab) (err error) {
+func (c *Client) AddMultipartPart(ctx context.Context, bucket, path, contractSet, eTag, uploadID string, partNumber int, slices []object.SlabSlice) (err error) {
 	err = c.c.WithContext(ctx).PUT("/multipart/part", api.MultipartAddPartRequest{
-		Bucket:       bucket,
-		ETag:         eTag,
-		Path:         path,
-		ContractSet:  contractSet,
-		UploadID:     uploadID,
-		PartNumber:   partNumber,
-		Slices:       slices,
-		PartialSlabs: partialSlab,
+		Bucket:      bucket,
+		ETag:        eTag,
+		Path:        path,
+		ContractSet: contractSet,
+		UploadID:    uploadID,
+		PartNumber:  partNumber,
+		Slices:      slices,
 	})
 	return
 }

--- a/bus/client/slabs.go
+++ b/bus/client/slabs.go
@@ -16,7 +16,7 @@ import (
 )
 
 // AddPartialSlab adds a partial slab to the bus.
-func (c *Client) AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.PartialSlab, slabBufferMaxSizeSoftReached bool, err error) {
+func (c *Client) AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.SlabSlice, slabBufferMaxSizeSoftReached bool, err error) {
 	c.c.Custom("POST", "/slabs/partial", nil, &api.AddPartialSlabResponse{})
 	values := url.Values{}
 	values.Set("minShards", fmt.Sprint(minShards))

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -2352,11 +2352,12 @@ func TestMultipartUploadWrappedByPartialSlabs(t *testing.T) {
 
 	// Download the object and verify its integrity.
 	dst := new(bytes.Buffer)
-	expectedData := append(part1Data, append(part2Data, part3Data...)...)
 	tt.OK(w.DownloadObject(context.Background(), dst, api.DefaultBucketName, objPath, api.DownloadObjectOptions{}))
-	if dst.Len() != len(expectedData) {
-		t.Fatalf("expected %v bytes, got %v", len(expectedData), dst.Len())
-	} else if !bytes.Equal(dst.Bytes(), expectedData) {
+	expectedData := append(part1Data, append(part2Data, part3Data...)...)
+	receivedData := dst.Bytes()
+	if len(receivedData) != len(expectedData) {
+		t.Fatalf("expected %v bytes, got %v", len(expectedData), len(receivedData))
+	} else if !bytes.Equal(receivedData, expectedData) {
 		t.Fatal("unexpected data")
 	}
 }

--- a/object/object.go
+++ b/object/object.go
@@ -111,9 +111,8 @@ func GenerateEncryptionKey() EncryptionKey {
 
 // An Object is a unit of data that has been stored on a host.
 type Object struct {
-	Key          EncryptionKey `json:"key"`
-	Slabs        []SlabSlice   `json:"slabs"`
-	PartialSlabs []PartialSlab `json:"partialSlab,omitempty"`
+	Key   EncryptionKey `json:"key"`
+	Slabs []SlabSlice   `json:"slabs"`
 }
 
 // NewObject returns a new Object with a random key.
@@ -145,9 +144,6 @@ func (o Object) TotalSize() int64 {
 	var n int64
 	for _, ss := range o.Slabs {
 		n += int64(ss.Length)
-	}
-	for _, partialSlab := range o.PartialSlabs {
-		n += int64(partialSlab.Length)
 	}
 	return n
 }

--- a/object/slab.go
+++ b/object/slab.go
@@ -24,14 +24,12 @@ type Sector struct {
 type Slab struct {
 	Health    float64       `json:"health"`
 	Key       EncryptionKey `json:"key"`
-	MinShards uint8         `json:"minShards"`
-	Shards    []Sector      `json:"shards"`
+	MinShards uint8         `json:"minShards,omitempty"`
+	Shards    []Sector      `json:"shards,omitempty"`
 }
 
-type PartialSlab struct {
-	Key    EncryptionKey `json:"key"`
-	Offset uint32        `json:"offset"`
-	Length uint32        `json:"length"`
+func (s Slab) IsPartial() bool {
+	return s.MinShards == 0 && len(s.Shards) == 0
 }
 
 // NewSlab returns a new slab for the shards.

--- a/object/slab.go
+++ b/object/slab.go
@@ -29,7 +29,7 @@ type Slab struct {
 }
 
 func (s Slab) IsPartial() bool {
-	return s.MinShards == 0 && len(s.Shards) == 0
+	return len(s.Shards) == 0
 }
 
 // NewSlab returns a new slab for the shards.

--- a/object/slab.go
+++ b/object/slab.go
@@ -40,6 +40,16 @@ func NewSlab(minShards uint8) Slab {
 	}
 }
 
+// NewPartialSlab returns a new partial slab.
+func NewPartialSlab(ec EncryptionKey, minShards uint8) Slab {
+	return Slab{
+		Health:    1,
+		Key:       ec,
+		MinShards: minShards,
+		Shards:    nil,
+	}
+}
+
 // ContractsFromShards is a helper to extract all contracts used by a set of
 // shards.
 func ContractsFromShards(shards []Sector) map[types.PublicKey]map[types.FileContractID]struct{} {

--- a/object/slab.go
+++ b/object/slab.go
@@ -24,7 +24,7 @@ type Sector struct {
 type Slab struct {
 	Health    float64       `json:"health"`
 	Key       EncryptionKey `json:"key"`
-	MinShards uint8         `json:"minShards,omitempty"`
+	MinShards uint8         `json:"minShards"`
 	Shards    []Sector      `json:"shards,omitempty"`
 }
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -442,6 +442,8 @@ func (raw rawObject) convert() (api.Object, error) {
 		for j, sector := range filtered {
 			if sector.ObjectIndex == 0 {
 				return api.Object{}, api.ErrObjectCorrupted
+			} else if sector.SectorIndex == 0 && !sector.SlabBuffered {
+				return api.Object{}, api.ErrObjectCorrupted
 			}
 			if sector.ObjectIndex != curr.ObjectIndex {
 				if err := addSlab(j); err != nil {

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3290,7 +3290,7 @@ func TestMarkSlabUploadedAfterRenew(t *testing.T) {
 
 	// create a full buffered slab.
 	completeSize := bufferedSlabSize(1)
-	ps, _, err := ss.AddPartialSlab(context.Background(), frand.Bytes(completeSize), 1, 1, testContractSet)
+	slabs, _, err := ss.AddPartialSlab(context.Background(), frand.Bytes(completeSize), 1, 1, testContractSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3298,7 +3298,7 @@ func TestMarkSlabUploadedAfterRenew(t *testing.T) {
 	// add it to an object to prevent it from getting pruned.
 	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "foo", testContractSet, "", "", object.Object{
 		Key:   object.GenerateEncryptionKey(),
-		Slabs: ps,
+		Slabs: slabs,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2561,8 +2561,8 @@ func TestPartialSlab(t *testing.T) {
 	assertBuffer(buffer1Name, 4, false, false)
 
 	// Use the added partial slab to create an object.
-	testObject := func(partialSlabs []object.PartialSlab) object.Object {
-		return object.Object{
+	testObject := func(partialSlabs []object.SlabSlice) object.Object {
+		obj := object.Object{
 			Key: object.GenerateEncryptionKey(),
 			Slabs: []object.SlabSlice{
 				{
@@ -2579,8 +2579,9 @@ func TestPartialSlab(t *testing.T) {
 					Length: rhpv2.SectorSize,
 				},
 			},
-			PartialSlabs: slabs,
 		}
+		obj.Slabs = append(obj.Slabs, partialSlabs...)
+		return obj
 	}
 	obj := testObject(slabs)
 	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "key", testContractSet, testETag, testMimeType, obj)
@@ -3296,9 +3297,8 @@ func TestMarkSlabUploadedAfterRenew(t *testing.T) {
 
 	// add it to an object to prevent it from getting pruned.
 	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "foo", testContractSet, "", "", object.Object{
-		Key:          object.GenerateEncryptionKey(),
-		Slabs:        nil,
-		PartialSlabs: ps,
+		Key:   object.GenerateEncryptionKey(),
+		Slabs: ps,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -85,7 +85,7 @@ func (s *SQLStore) CreateMultipartUpload(ctx context.Context, bucket, path strin
 	}, err
 }
 
-func (s *SQLStore) AddMultipartPart(ctx context.Context, bucket, path, contractSet, eTag, uploadID string, partNumber int, slices []object.SlabSlice, partialSlabs []object.PartialSlab) (err error) {
+func (s *SQLStore) AddMultipartPart(ctx context.Context, bucket, path, contractSet, eTag, uploadID string, partNumber int, slices []object.SlabSlice) (err error) {
 	// collect all used contracts
 	usedContracts := make(map[types.PublicKey]map[types.FileContractID]struct{})
 	for _, s := range slices {
@@ -131,9 +131,6 @@ func (s *SQLStore) AddMultipartPart(ctx context.Context, bucket, path, contractS
 		for _, slice := range slices {
 			size += uint64(slice.Length)
 		}
-		for _, ps := range partialSlabs {
-			size += uint64(ps.Length)
-		}
 		// Create a new part.
 		part := dbMultipartPart{
 			Etag:                eTag,
@@ -146,7 +143,7 @@ func (s *SQLStore) AddMultipartPart(ctx context.Context, bucket, path, contractS
 			return fmt.Errorf("failed to create part: %w", err)
 		}
 		// Create the slices.
-		err = s.createSlices(tx, nil, &part.ID, cs.ID, contracts, slices, partialSlabs)
+		err = s.createSlices(tx, nil, &part.ID, cs.ID, contracts, slices)
 		if err != nil {
 			return fmt.Errorf("failed to create slices: %w", err)
 		}

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -396,9 +396,9 @@ func (s *SQLStore) CompleteMultipartUpload(ctx context.Context, bucket, path str
 			return fmt.Errorf("failed to create object: %w", err)
 		}
 
-		// Assign the right object id and unassign the multipart upload.  Also
-		// clear the ID to make sure new slices are created with IDs in
-		// ascending order.
+		// Assign the right object id and unassign the multipart upload. Also
+		// set the right object_index to make sure the slices are sorted
+		// correctly when retrieving the object later.
 		for i := range slices {
 			err = tx.Model(&dbSlice{}).
 				Where("id", slices[i].ID).

--- a/stores/multipart_test.go
+++ b/stores/multipart_test.go
@@ -3,7 +3,6 @@ package stores
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
 	"testing"
 	"time"
 
@@ -132,7 +131,7 @@ func TestMultipartUploadWithUploadPackingRegression(t *testing.T) {
 		t.Fatalf("expected object size to be %v, got %v", totalSize, obj.Size)
 	} else if obj.TotalSize() != totalSize {
 		for _, f := range obj.Slabs {
-			fmt.Println("slice", f.Length, f.IsPartial())
+			t.Log("slice", f.Length, f.IsPartial())
 		}
 		t.Fatalf("expected object total size to be %v, got %v", totalSize, obj.TotalSize())
 	}

--- a/stores/multipart_test.go
+++ b/stores/multipart_test.go
@@ -58,7 +58,7 @@ func TestMultipartUploadWithUploadPackingRegression(t *testing.T) {
 			t.Fatal(err)
 		}
 		etag := hex.EncodeToString(frand.Bytes(16))
-		err = ss.AddMultipartPart(ctx, api.DefaultBucketName, objName, testContractSet, etag, resp.UploadID, i, []object.SlabSlice{}, partialSlabs)
+		err = ss.AddMultipartPart(ctx, api.DefaultBucketName, objName, testContractSet, etag, resp.UploadID, i, partialSlabs)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -132,10 +132,7 @@ func TestMultipartUploadWithUploadPackingRegression(t *testing.T) {
 		t.Fatalf("expected object size to be %v, got %v", totalSize, obj.Size)
 	} else if obj.TotalSize() != totalSize {
 		for _, f := range obj.Slabs {
-			fmt.Println("slice", f.Length)
-		}
-		for _, f := range obj.PartialSlabs {
-			fmt.Println("ps", f.Length)
+			fmt.Println("slice", f.Length, f.IsPartial())
 		}
 		t.Fatalf("expected object total size to be %v, got %v", totalSize, obj.TotalSize())
 	}

--- a/worker/download.go
+++ b/worker/download.go
@@ -213,20 +213,7 @@ func (mgr *downloadManager) DownloadObject(ctx context.Context, w io.Writer, o o
 	for _, s := range o.Slabs {
 		ss = append(ss, slabSlice{
 			SlabSlice:   s,
-			PartialSlab: false,
-		})
-	}
-	for _, ps := range o.PartialSlabs {
-		// add fake slab for partial slabs
-		ss = append(ss, slabSlice{
-			SlabSlice: object.SlabSlice{
-				Slab: object.Slab{
-					Key: ps.Key,
-				},
-				Offset: ps.Offset,
-				Length: ps.Length,
-			},
-			PartialSlab: true,
+			PartialSlab: s.IsPartial(),
 		})
 	}
 	slabs := slabsForDownload(ss, offset, length)
@@ -245,7 +232,7 @@ func (mgr *downloadManager) DownloadObject(ctx context.Context, w io.Writer, o o
 		}
 		if slab != nil {
 			slabs[i].SlabSlice.Slab = *slab
-			slabs[i].PartialSlab = false
+			slabs[i].PartialSlab = slab.IsPartial()
 		} else {
 			slabs[i].Data = data
 		}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -146,10 +146,10 @@ type Bus interface {
 	AddObject(ctx context.Context, bucket, path, contractSet string, o object.Object, opts api.AddObjectOptions) error
 	DeleteObject(ctx context.Context, bucket, path string, opts api.DeleteObjectOptions) error
 
-	AddMultipartPart(ctx context.Context, bucket, path, contractSet, ETag, uploadID string, partNumber int, slices []object.SlabSlice, partialSlabs []object.PartialSlab) (err error)
+	AddMultipartPart(ctx context.Context, bucket, path, contractSet, ETag, uploadID string, partNumber int, slices []object.SlabSlice) (err error)
 	MultipartUpload(ctx context.Context, uploadID string) (resp api.MultipartUpload, err error)
 
-	AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.PartialSlab, slabBufferMaxSizeSoftReached bool, err error)
+	AddPartialSlab(ctx context.Context, data []byte, minShards, totalShards uint8, contractSet string) (slabs []object.SlabSlice, slabBufferMaxSizeSoftReached bool, err error)
 	FetchPartialSlab(ctx context.Context, key object.EncryptionKey, offset, length uint32) ([]byte, error)
 	Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
 
@@ -1035,7 +1035,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 	}
 
 	// return early if the object is empty
-	if len(res.Object.Slabs) == 0 && len(res.Object.PartialSlabs) == 0 {
+	if len(res.Object.Slabs) == 0 {
 		return
 	}
 


### PR DESCRIPTION
This PR uses an update instead of create now when completing a multipart upload. 
That's possible now since we recently added the `object_index` to the slices and we no longer rely on the ID for the insertion order.

This also gets rid of the separate `PartialSlabs` field in the `object.Object` since workers won't be able to deduct the right download order. Instead partial slabs are now part of the regular slabs but without any slices.

Closes https://github.com/SiaFoundation/renterd/issues/769