### PR TITLE
Upload & Download Failure Alerts

### DIFF
--- a/worker/alerts.go
+++ b/worker/alerts.go
@@ -1,0 +1,59 @@
+package worker
+
+import (
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/alerts"
+	"lukechampine.com/frand"
+)
+
+func randomAlertID() types.Hash256 {
+	return frand.Entropy256()
+}
+
+func newDownloadFailedAlert(bucket, path, prefix, marker string, offset, length, contracts int64, err error) alerts.Alert {
+	return alerts.Alert{
+		ID:       randomAlertID(),
+		Severity: alerts.SeverityError,
+		Message:  "Download failed",
+		Data: map[string]any{
+			"bucket":    bucket,
+			"path":      path,
+			"prefix":    prefix,
+			"marker":    marker,
+			"offset":    offset,
+			"length":    length,
+			"contracts": contracts,
+			"err":       err,
+		},
+		Timestamp: time.Now(),
+	}
+}
+
+func newUploadFailedAlert(bucket, path, contractSet, mimeType string, minShards, totalShards, contracts int, packing, multipart bool, err error) alerts.Alert {
+	data := map[string]any{
+		"bucket":      bucket,
+		"path":        path,
+		"contractSet": contractSet,
+		"minShards":   minShards,
+		"totalShards": totalShards,
+		"packing":     packing,
+		"contracts":   contracts,
+		"err":         err,
+	}
+	if mimeType != "" {
+		data["mimeType"] = mimeType
+	}
+	if multipart {
+		data["multipart"] = true
+	}
+
+	return alerts.Alert{
+		ID:        randomAlertID(),
+		Severity:  alerts.SeverityError,
+		Message:   "Upload failed",
+		Data:      data,
+		Timestamp: time.Now(),
+	}
+}

--- a/worker/download.go
+++ b/worker/download.go
@@ -30,6 +30,10 @@ const (
 	maxConcurrentSlabsPerDownload  = 3
 )
 
+var (
+	errDownloadManagerStopped = errors.New("download manager stopped")
+)
+
 type (
 	// id is a unique identifier used for debugging
 	id [8]byte
@@ -323,7 +327,7 @@ outer:
 	for {
 		select {
 		case <-mgr.stopChan:
-			return errors.New("manager was stopped")
+			return errDownloadManagerStopped
 		case <-ctx.Done():
 			return errors.New("download timed out")
 		case resp := <-responseChan:


### PR DESCRIPTION
This PR adds alerts for both upload and download failures. 

An open question is how to handle migration related up - and download failures. I haven't added those yet since those errors already bubble up through migration failure alerts. What's unfortunate though is that we lose some context by having the autopilot register those.