### PR TITLE
Add memory manager for downloads

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -52,7 +52,8 @@ type (
 	}
 
 	MemoryResponse struct {
-		Upload MemoryStatus `json:"upload"`
+		Download MemoryStatus `json:"download"`
+		Upload   MemoryStatus `json:"upload"`
 	}
 
 	MemoryStatus struct {

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -94,6 +94,7 @@ var (
 			DownloadMaxOverdrive:     5,
 			DownloadOverdriveTimeout: 3 * time.Second,
 
+			DownloadMaxMemory:      1 << 30, // 1 GiB
 			UploadMaxMemory:        1 << 30, // 1 GiB
 			UploadMaxOverdrive:     5,
 			UploadOverdriveTimeout: 3 * time.Second,

--- a/config/config.go
+++ b/config/config.go
@@ -98,6 +98,7 @@ type (
 		DownloadOverdriveTimeout      time.Duration  `yaml:"downloadOverdriveTimeout"`
 		UploadOverdriveTimeout        time.Duration  `yaml:"uploadOverdriveTimeout"`
 		DownloadMaxOverdrive          uint64         `yaml:"downloadMaxOverdrive"`
+		DownloadMaxMemory             uint64         `yaml:"downloadMaxMemory"`
 		UploadMaxMemory               uint64         `yaml:"uploadMaxMemory"`
 		UploadMaxOverdrive            uint64         `yaml:"uploadMaxOverdrive"`
 		AllowUnauthenticatedDownloads bool           `yaml:"allowUnauthenticatedDownloads"`

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -179,7 +179,7 @@ func NewBus(cfg BusConfig, dir string, seed types.PrivateKey, l *zap.Logger) (ht
 
 func NewWorker(cfg config.Worker, b worker.Bus, seed types.PrivateKey, l *zap.Logger) (http.Handler, ShutdownFn, error) {
 	workerKey := blake2b.Sum256(append([]byte("worker"), seed...))
-	w, err := worker.New(workerKey, cfg.ID, b, cfg.ContractLockTimeout, cfg.BusFlushInterval, cfg.DownloadOverdriveTimeout, cfg.UploadOverdriveTimeout, cfg.DownloadMaxOverdrive, cfg.UploadMaxMemory, cfg.UploadMaxOverdrive, cfg.AllowPrivateIPs, l)
+	w, err := worker.New(workerKey, cfg.ID, b, cfg.ContractLockTimeout, cfg.BusFlushInterval, cfg.DownloadOverdriveTimeout, cfg.UploadOverdriveTimeout, cfg.DownloadMaxOverdrive, cfg.DownloadMaxMemory, cfg.UploadMaxMemory, cfg.UploadMaxOverdrive, cfg.AllowPrivateIPs, l)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -952,6 +952,7 @@ func testWorkerCfg() config.Worker {
 		BusFlushInterval:         testBusFlushInterval,
 		DownloadOverdriveTimeout: 500 * time.Millisecond,
 		UploadOverdriveTimeout:   500 * time.Millisecond,
+		DownloadMaxMemory:        1 << 28, // 256 MiB
 		UploadMaxMemory:          1 << 28, // 256 MiB
 		UploadMaxOverdrive:       5,
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1342,7 +1342,8 @@ func (w *worker) idHandlerGET(jc jape.Context) {
 
 func (w *worker) memoryGET(jc jape.Context) {
 	jc.Encode(api.MemoryResponse{
-		Upload: w.uploadManager.mm.Status(),
+		Download: w.downloadManager.mm.Status(),
+		Upload:   w.uploadManager.mm.Status(),
 	})
 }
 
@@ -1370,7 +1371,7 @@ func (w *worker) stateHandlerGET(jc jape.Context) {
 }
 
 // New returns an HTTP handler that serves the worker API.
-func New(masterKey [32]byte, id string, b Bus, contractLockingDuration, busFlushInterval, downloadOverdriveTimeout, uploadOverdriveTimeout time.Duration, downloadMaxOverdrive, uploadMaxMemory, uploadMaxOverdrive uint64, allowPrivateIPs bool, l *zap.Logger) (*worker, error) {
+func New(masterKey [32]byte, id string, b Bus, contractLockingDuration, busFlushInterval, downloadOverdriveTimeout, uploadOverdriveTimeout time.Duration, downloadMaxOverdrive, downloadMaxMemory, uploadMaxMemory, uploadMaxOverdrive uint64, allowPrivateIPs bool, l *zap.Logger) (*worker, error) {
 	if contractLockingDuration == 0 {
 		return nil, errors.New("contract lock duration must be positive")
 	}
@@ -1400,12 +1401,16 @@ func New(masterKey [32]byte, id string, b Bus, contractLockingDuration, busFlush
 	w.initAccounts(b)
 	w.initContractSpendingRecorder()
 	w.initPriceTables()
-	w.initDownloadManager(downloadMaxOverdrive, downloadOverdriveTimeout, l.Sugar().Named("downloadmanager"))
-	mm, err := newMemoryManager(w.logger, uploadMaxMemory)
+	dmm, err := newMemoryManager(w.logger, downloadMaxMemory)
 	if err != nil {
 		return nil, err
 	}
-	w.initUploadManager(mm, uploadMaxOverdrive, uploadOverdriveTimeout, l.Sugar().Named("uploadmanager"))
+	w.initDownloadManager(dmm, downloadMaxOverdrive, downloadOverdriveTimeout, l.Sugar().Named("downloadmanager"))
+	umm, err := newMemoryManager(w.logger, uploadMaxMemory)
+	if err != nil {
+		return nil, err
+	}
+	w.initUploadManager(umm, uploadMaxOverdrive, uploadOverdriveTimeout, l.Sugar().Named("uploadmanager"))
 	return w, nil
 }
 


### PR DESCRIPTION
This PR adds a memory manager to downloads similar to the one we have for uploads with 1GB of default memory