### PR TITLE
Remove Registry Endpoints

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -166,15 +166,6 @@ type (
 		AccountKey types.PrivateKey `json:"accountKey"`
 	}
 
-	// RHPRegistryReadRequest is the request type for the /rhp/registry/read
-	// endpoint.
-	RHPRegistryReadRequest struct {
-		HostKey     types.PublicKey                    `json:"hostKey"`
-		SiamuxAddr  string                             `json:"siamuxAddr"`
-		RegistryKey rhpv3.RegistryKey                  `json:"registryKey"`
-		Payment     rhpv3.PayByEphemeralAccountRequest `json:"payment"`
-	}
-
 	// RHPRegistryUpdateRequest is the request type for the /rhp/registry/update
 	// endpoint.
 	RHPRegistryUpdateRequest struct {

--- a/worker/client/rhp.go
+++ b/worker/client/rhp.go
@@ -10,7 +10,6 @@ import (
 	"go.sia.tech/renterd/hostdb"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
-	rhpv3 "go.sia.tech/core/rhp/v3"
 )
 
 // RHPBroadcast broadcasts the latest revision for a contract.
@@ -74,18 +73,6 @@ func (c *Client) RHPPruneContract(ctx context.Context, contractID types.FileCont
 	return
 }
 
-// RHPReadRegistry reads a registry value.
-func (c *Client) RHPReadRegistry(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, key rhpv3.RegistryKey, payment rhpv3.PayByEphemeralAccountRequest) (resp rhpv3.RegistryValue, err error) {
-	req := api.RHPRegistryReadRequest{
-		HostKey:     hostKey,
-		SiamuxAddr:  siamuxAddr,
-		RegistryKey: key,
-		Payment:     payment,
-	}
-	err = c.c.WithContext(ctx).POST("/rhp/registry/read", req, &resp)
-	return
-}
-
 // RHPRenew renews an existing contract with a host.
 func (c *Client) RHPRenew(ctx context.Context, contractID types.FileContractID, endHeight uint64, hostKey types.PublicKey, siamuxAddr string, hostAddress, renterAddress types.Address, renterFunds, newCollateral types.Currency, windowSize uint64) (rhpv2.ContractRevision, []types.Transaction, error) {
 	req := api.RHPRenewRequest{
@@ -123,16 +110,5 @@ func (c *Client) RHPSync(ctx context.Context, contractID types.FileContractID, h
 		SiamuxAddr: siamuxAddr,
 	}
 	err = c.c.WithContext(ctx).POST("/rhp/sync", req, nil)
-	return
-}
-
-// RHPUpdateRegistry updates a registry value.
-func (c *Client) RHPUpdateRegistry(ctx context.Context, hostKey types.PublicKey, key rhpv3.RegistryKey, value rhpv3.RegistryValue) (err error) {
-	req := api.RHPRegistryUpdateRequest{
-		HostKey:       hostKey,
-		RegistryKey:   key,
-		RegistryValue: value,
-	}
-	err = c.c.WithContext(ctx).POST("/rhp/registry/update", req, nil)
 	return
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -799,40 +799,6 @@ func (w *worker) rhpFundHandler(jc jape.Context) {
 	}))
 }
 
-func (w *worker) rhpRegistryReadHandler(jc jape.Context) {
-	var rrrr api.RHPRegistryReadRequest
-	if jc.Decode(&rrrr) != nil {
-		return
-	}
-	var value rhpv3.RegistryValue
-	err := w.transportPoolV3.withTransportV3(jc.Request.Context(), rrrr.HostKey, rrrr.SiamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
-		value, err = RPCReadRegistry(ctx, t, &rrrr.Payment, rrrr.RegistryKey)
-		return
-	})
-	if jc.Check("couldn't read registry", err) != nil {
-		return
-	}
-	jc.Encode(value)
-}
-
-func (w *worker) rhpRegistryUpdateHandler(jc jape.Context) {
-	var rrur api.RHPRegistryUpdateRequest
-	if jc.Decode(&rrur) != nil {
-		return
-	}
-	var pt rhpv3.HostPriceTable   // TODO
-	rc := pt.UpdateRegistryCost() // TODO: handle refund
-	cost, _ := rc.Total()
-	// TODO: refactor to a w.RegistryUpdate method that calls host.RegistryUpdate.
-	payment := preparePayment(w.accounts.deriveAccountKey(rrur.HostKey), cost, pt.HostBlockHeight)
-	err := w.transportPoolV3.withTransportV3(jc.Request.Context(), rrur.HostKey, rrur.SiamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
-		return RPCUpdateRegistry(ctx, t, &payment, rrur.RegistryKey, rrur.RegistryValue)
-	})
-	if jc.Check("couldn't update registry", err) != nil {
-		return
-	}
-}
-
 func (w *worker) rhpSyncHandler(jc jape.Context) {
 	ctx := jc.Request.Context()
 
@@ -1468,8 +1434,6 @@ func (w *worker) Handler() http.Handler {
 		"POST   /rhp/fund":                   w.rhpFundHandler,
 		"POST   /rhp/sync":                   w.rhpSyncHandler,
 		"POST   /rhp/pricetable":             w.rhpPriceTableHandler,
-		"POST   /rhp/registry/read":          w.rhpRegistryReadHandler,
-		"POST   /rhp/registry/update":        w.rhpRegistryUpdateHandler,
 
 		"GET    /stats/downloads": w.downloadsStatsHandlerGET,
 		"GET    /stats/uploads":   w.uploadsStatsHandlerGET,


### PR DESCRIPTION
With 1.0 coming we should probably just get rid of these routes to avoid having to mark them as deprecated in 1.1. 