### PR TITLE
Schedule Trigger When Funded

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -205,6 +205,12 @@ func (ap *Autopilot) Run() error {
 		return nil
 	}
 
+	// schedule a trigger when the wallet receives its first deposit
+	if err := ap.tryScheduleTriggerWhenFunded(); err != nil {
+		ap.logger.Error(err)
+		return nil
+	}
+
 	var forceScan bool
 	var launchAccountRefillsOnce sync.Once
 	for {
@@ -456,6 +462,51 @@ func (ap *Autopilot) blockUntilSynced(interrupt <-chan time.Time) (synced, block
 		}
 		return
 	}
+}
+
+func (ap *Autopilot) tryScheduleTriggerWhenFunded() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	wallet, err := ap.bus.Wallet(ctx)
+	cancel()
+
+	// no need to schedule a trigger if the wallet is already funded
+	if err != nil {
+		return err
+	} else if !wallet.Confirmed.Add(wallet.Unconfirmed).IsZero() {
+		return nil
+	}
+
+	// spin a goroutine that triggers the autopilot when we receive a deposit
+	ap.logger.Info("autopilot loop trigger is scheduled for when the wallet receives a deposit")
+	ap.wg.Add(1)
+	go func() {
+		defer ap.wg.Done()
+
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ap.stopChan:
+				return
+			case <-ticker.C:
+			}
+
+			// fetch wallet info
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			if wallet, err = ap.bus.Wallet(ctx); err != nil {
+				ap.logger.Errorf("failed to get wallet info, err: %v", err)
+			}
+			cancel()
+
+			// if we have received a deposit, trigger the autopilot
+			if !wallet.Confirmed.Add(wallet.Unconfirmed).IsZero() {
+				_ = ap.Trigger(false)
+				return
+			}
+		}
+	}()
+
+	return nil
 }
 
 func (ap *Autopilot) isRunning() bool {

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -500,8 +500,9 @@ func (ap *Autopilot) tryScheduleTriggerWhenFunded() error {
 
 			// if we have received a deposit, trigger the autopilot
 			if !wallet.Confirmed.Add(wallet.Unconfirmed).IsZero() {
-				_ = ap.Trigger(false)
-				return
+				if ap.Trigger(false) {
+					return
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
Scheduling a trigger when the wallet receives its first deposit makes things really smooth on first setup - so I vote we merge something like this. It essentially replaces `blockUntilFunded` which I had to remove because we can't block for other reasons (host infos). I should not have removed it but instead replaced it with a trigger. This PR does that.

edit: I don't think it's worth adding a test, it's very NDF prone, I verified it manually 