### PR TITLE
Remove spendingMu, interactionsMu and objectsMu

### DIFF
--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -699,10 +699,6 @@ func (ss *SQLStore) RecordHostScans(ctx context.Context, scans []hostdb.HostScan
 		return nil // nothing to do
 	}
 
-	// Only allow for applying one batch of interactions at a time.
-	ss.interactionsMu.Lock()
-	defer ss.interactionsMu.Unlock()
-
 	// Get keys from input.
 	keyMap := make(map[publicKey]struct{})
 	var hks []publicKey
@@ -823,10 +819,6 @@ func (ss *SQLStore) RecordPriceTables(ctx context.Context, priceTableUpdate []ho
 	if len(priceTableUpdate) == 0 {
 		return nil // nothing to do
 	}
-
-	// Only allow for applying one batch of interactions at a time.
-	ss.interactionsMu.Lock()
-	defer ss.interactionsMu.Unlock()
 
 	// Get keys from input.
 	keyMap := make(map[publicKey]struct{})

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1300,10 +1300,6 @@ func (s *SQLStore) RecordContractSpending(ctx context.Context, records []api.Con
 		return nil // nothing to do
 	}
 
-	// Only allow for applying one batch of spending records at a time.
-	s.spendingMu.Lock()
-	defer s.spendingMu.Unlock()
-
 	squashedRecords := make(map[types.FileContractID]api.ContractSpending)
 	latestValues := make(map[types.FileContractID]struct {
 		revision          uint64
@@ -1650,9 +1646,6 @@ func (s *SQLStore) DeleteHostSector(ctx context.Context, hk types.PublicKey, roo
 }
 
 func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, eTag, mimeType string, o object.Object) error {
-	s.objectsMu.Lock()
-	defer s.objectsMu.Unlock()
-
 	// Sanity check input.
 	for _, s := range o.Slabs {
 		for i, shard := range s.Shards {
@@ -1773,9 +1766,6 @@ func (s *SQLStore) Slab(ctx context.Context, key object.EncryptionKey) (object.S
 }
 
 func (ss *SQLStore) UpdateSlab(ctx context.Context, s object.Slab, contractSet string) error {
-	ss.objectsMu.Lock()
-	defer ss.objectsMu.Unlock()
-
 	// sanity check the shards don't contain an empty root
 	for _, s := range s.Shards {
 		if s.Root == (types.Hash256{}) {
@@ -1925,9 +1915,6 @@ LIMIT ?
 `, now.Unix(), refreshHealthBatchSize)
 		var rowsAffected int64
 		err := s.retryTransaction(func(tx *gorm.DB) error {
-			s.objectsMu.Lock()
-			defer s.objectsMu.Unlock()
-
 			// create temp table from the health query since we will reuse it
 			if err := tx.Exec("DROP TABLE IF EXISTS src").Error; err != nil {
 				return err

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -81,10 +81,6 @@ type (
 		closed       bool
 
 		knownContracts map[types.FileContractID]struct{}
-
-		spendingMu     sync.Mutex
-		interactionsMu sync.Mutex
-		objectsMu      sync.Mutex
 	}
 
 	revisionUpdate struct {


### PR DESCRIPTION
We introduced these mutexes to avoid locking issues in the database but have since improved our queries and overall db architecture enough to remove them again. Especially MySQL deployments might see significant performance improvements due to the more granular locking MySQL will use. 