### PR TITLE
Add Tag Linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,6 +84,12 @@ linters-settings:
       - name: package-comments
         disabled: true
 
+  tagliatelle:
+    case:
+      rules:
+        json: goCamel
+        yaml: goCamel
+
 linters:
   disable-all: true
   fast: false
@@ -95,6 +101,7 @@ linters:
     - misspell
     - typecheck
     - whitespace
+    - tagliatelle
 
 issues:
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.

--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -92,7 +92,7 @@ type (
 		PruningLastStart   TimeRFC3339 `json:"pruningLastStart"`
 		Scanning           bool        `json:"scanning"`
 		ScanningLastStart  TimeRFC3339 `json:"scanningLastStart"`
-		UptimeMS           DurationMS  `json:"uptimeMS"`
+		UptimeMS           DurationMS  `json:"uptimeMs"`
 
 		StartTime TimeRFC3339 `json:"startTime"`
 		BuildState

--- a/api/state.go
+++ b/api/state.go
@@ -6,7 +6,7 @@ type (
 		Network   string      `json:"network"`
 		Version   string      `json:"version"`
 		Commit    string      `json:"commit"`
-		OS        string      `json:"OS"`
+		OS        string      `json:"os"`
 		BuildTime TimeRFC3339 `json:"buildTime"`
 	}
 )

--- a/api/worker.go
+++ b/api/worker.go
@@ -176,21 +176,21 @@ type (
 
 	// DownloadStatsResponse is the response type for the /stats/downloads endpoint.
 	DownloadStatsResponse struct {
-		AvgDownloadSpeedMBPS float64           `json:"avgDownloadSpeedMBPS"`
+		AvgDownloadSpeedMBPS float64           `json:"avgDownloadSpeedMbps"`
 		AvgOverdrivePct      float64           `json:"avgOverdrivePct"`
 		HealthyDownloaders   uint64            `json:"healthyDownloaders"`
 		NumDownloaders       uint64            `json:"numDownloaders"`
 		DownloadersStats     []DownloaderStats `json:"downloadersStats"`
 	}
 	DownloaderStats struct {
-		AvgSectorDownloadSpeedMBPS float64         `json:"avgSectorDownloadSpeedMBPS"`
+		AvgSectorDownloadSpeedMBPS float64         `json:"avgSectorDownloadSpeedMbps"`
 		HostKey                    types.PublicKey `json:"hostKey"`
 		NumDownloads               uint64          `json:"numDownloads"`
 	}
 
 	// UploadStatsResponse is the response type for the /stats/uploads endpoint.
 	UploadStatsResponse struct {
-		AvgSlabUploadSpeedMBPS float64         `json:"avgSlabUploadSpeedMBPS"`
+		AvgSlabUploadSpeedMBPS float64         `json:"avgSlabUploadSpeedMbps"`
 		AvgOverdrivePct        float64         `json:"avgOverdrivePct"`
 		HealthyUploaders       uint64          `json:"healthyUploaders"`
 		NumUploaders           uint64          `json:"numUploaders"`
@@ -198,7 +198,7 @@ type (
 	}
 	UploaderStats struct {
 		HostKey                  types.PublicKey `json:"hostKey"`
-		AvgSectorUploadSpeedMBPS float64         `json:"avgSectorUploadSpeedMBPS"`
+		AvgSectorUploadSpeedMBPS float64         `json:"avgSectorUploadSpeedMbps"`
 	}
 
 	// WorkerStateResponse is the response type for the /worker/state endpoint.

--- a/build/meta.go
+++ b/build/meta.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	commit = "?"
-	version = "?"
+	commit    = "?"
+	version   = "?"
 	buildTime = 0
 )
 

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -643,6 +643,7 @@ func runCompatMigrateAutopilotJSONToStore(bc *bus.Client, id, dir string) (err e
 
 	// read the json config
 	log.Println("migration: reading autopilot.json")
+	//nolint:tagliatelle
 	var cfg struct {
 		Config api.AutopilotConfig `json:"Config"`
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ type (
 		RemoteAddr                    string        `yaml:"remoteAddr"`
 		RemotePassword                string        `yaml:"remotePassword"`
 		PersistInterval               time.Duration `yaml:"persistInterval"`
-		UsedUTXOExpiry                time.Duration `yaml:"usedUTXOExpiry"`
+		UsedUTXOExpiry                time.Duration `yaml:"usedUtxoExpiry"`
 		SlabBufferCompletionThreshold int64         `yaml:"slabBufferCompleionThreshold"`
 	}
 
@@ -67,7 +67,7 @@ type (
 
 	// MySQL contains the configuration for an optional MySQL database.
 	MySQL struct {
-		URI             string `yaml:"URI"`
+		URI             string `yaml:"uri"`
 		User            string `yaml:"user"`
 		Password        string `yaml:"password"`
 		Database        string `yaml:"database"`
@@ -90,7 +90,7 @@ type (
 	// Worker contains the configuration for a worker.
 	Worker struct {
 		Enabled                       bool           `yaml:"enabled"`
-		ID                            string         `yaml:"ID"`
+		ID                            string         `yaml:"id"`
 		Remotes                       []RemoteWorker `yaml:"remotes"`
 		AllowPrivateIPs               bool           `yaml:"allowPrivateIPs"`
 		BusFlushInterval              time.Duration  `yaml:"busFlushInterval"`


### PR DESCRIPTION
Add tagliatelle linter to the golangci-lint configuration to make sure our struct tags follow the goCamel naming convention.