### PR TITLE
Fix Struct Without JSON Tags

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -93,8 +93,8 @@ func ExplicitCoveredFields(txn types.Transaction) (cf types.CoveredFields) {
 // A SiacoinElement is a SiacoinOutput along with its ID.
 type SiacoinElement struct {
 	types.SiacoinOutput
-	ID             types.Hash256
-	MaturityHeight uint64
+	ID             types.Hash256 `json:"id"`
+	MaturityHeight uint64        `json:"maturityHeight"`
 }
 
 // A Transaction is an on-chain transaction relevant to a particular wallet,


### PR DESCRIPTION
wallet.SiacoinElement values are returned by some endpoints but the type did not have struct tags.  This fixes that so the encoded output conforms to our standards.  I searched the code for other instances of structs with an ID field having no tags and the only other instance I found was AutopilotConfig in internal/node/node.go, but this doesn't matter because that type isn't marshaled/unmarshaled anywhere.
