### PR TITLE
Compute new collateral for renewals in worker instead of the autopilot

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -40,15 +40,16 @@ type (
 	// WalletPrepareRenewRequest is the request type for the /wallet/prepare/renew
 	// endpoint.
 	WalletPrepareRenewRequest struct {
-		Revision      types.FileContractRevision `json:"revision"`
-		EndHeight     uint64                     `json:"endHeight"`
-		HostAddress   types.Address              `json:"hostAddress"`
-		PriceTable    rhpv3.HostPriceTable       `json:"priceTable"`
-		NewCollateral types.Currency             `json:"newCollateral"`
-		RenterAddress types.Address              `json:"renterAddress"`
-		RenterFunds   types.Currency             `json:"renterFunds"`
-		RenterKey     types.PrivateKey           `json:"renterKey"`
-		WindowSize    uint64                     `json:"windowSize"`
+		Revision           types.FileContractRevision `json:"revision"`
+		EndHeight          uint64                     `json:"endHeight"`
+		ExpectedNewStorage uint64                     `json:"expectedNewStorage"`
+		HostAddress        types.Address              `json:"hostAddress"`
+		PriceTable         rhpv3.HostPriceTable       `json:"priceTable"`
+		MinNewCollateral   types.Currency             `json:"minNewCollateral"`
+		RenterAddress      types.Address              `json:"renterAddress"`
+		RenterFunds        types.Currency             `json:"renterFunds"`
+		RenterKey          types.PrivateKey           `json:"renterKey"`
+		WindowSize         uint64                     `json:"windowSize"`
 	}
 
 	// WalletPrepareRenewResponse is the response type for the /wallet/prepare/renew

--- a/api/worker.go
+++ b/api/worker.go
@@ -115,15 +115,16 @@ type (
 
 	// RHPRenewRequest is the request type for the /rhp/renew endpoint.
 	RHPRenewRequest struct {
-		ContractID    types.FileContractID `json:"contractID"`
-		EndHeight     uint64               `json:"endHeight"`
-		HostAddress   types.Address        `json:"hostAddress"`
-		HostKey       types.PublicKey      `json:"hostKey"`
-		SiamuxAddr    string               `json:"siamuxAddr"`
-		NewCollateral types.Currency       `json:"newCollateral"`
-		RenterAddress types.Address        `json:"renterAddress"`
-		RenterFunds   types.Currency       `json:"renterFunds"`
-		WindowSize    uint64               `json:"windowSize"`
+		ContractID       types.FileContractID `json:"contractID"`
+		EndHeight        uint64               `json:"endHeight"`
+		ExpectedStorage  uint64               `json:"expectedStorage"`
+		HostAddress      types.Address        `json:"hostAddress"`
+		HostKey          types.PublicKey      `json:"hostKey"`
+		MinNewCollateral types.Currency       `json:"minNewCollateral"`
+		SiamuxAddr       string               `json:"siamuxAddr"`
+		RenterAddress    types.Address        `json:"renterAddress"`
+		RenterFunds      types.Currency       `json:"renterFunds"`
+		WindowSize       uint64               `json:"windowSize"`
 	}
 
 	// RHPRenewResponse is the response type for the /rhp/renew endpoint.
@@ -131,6 +132,7 @@ type (
 		Error          string                 `json:"error"`
 		ContractID     types.FileContractID   `json:"contractID"`
 		Contract       rhpv2.ContractRevision `json:"contract"`
+		ContractPrice  types.Currency         `json:"contractPrice"`
 		TransactionSet []types.Transaction    `json:"transactionSet"`
 	}
 

--- a/api/worker.go
+++ b/api/worker.go
@@ -115,16 +115,16 @@ type (
 
 	// RHPRenewRequest is the request type for the /rhp/renew endpoint.
 	RHPRenewRequest struct {
-		ContractID       types.FileContractID `json:"contractID"`
-		EndHeight        uint64               `json:"endHeight"`
-		ExpectedStorage  uint64               `json:"expectedStorage"`
-		HostAddress      types.Address        `json:"hostAddress"`
-		HostKey          types.PublicKey      `json:"hostKey"`
-		MinNewCollateral types.Currency       `json:"minNewCollateral"`
-		SiamuxAddr       string               `json:"siamuxAddr"`
-		RenterAddress    types.Address        `json:"renterAddress"`
-		RenterFunds      types.Currency       `json:"renterFunds"`
-		WindowSize       uint64               `json:"windowSize"`
+		ContractID         types.FileContractID `json:"contractID"`
+		EndHeight          uint64               `json:"endHeight"`
+		ExpectedNewStorage uint64               `json:"expectedNewStorage"`
+		HostAddress        types.Address        `json:"hostAddress"`
+		HostKey            types.PublicKey      `json:"hostKey"`
+		MinNewCollateral   types.Currency       `json:"minNewCollateral"`
+		SiamuxAddr         string               `json:"siamuxAddr"`
+		RenterAddress      types.Address        `json:"renterAddress"`
+		RenterFunds        types.Currency       `json:"renterFunds"`
+		WindowSize         uint64               `json:"windowSize"`
 	}
 
 	// RHPRenewResponse is the response type for the /rhp/renew endpoint.

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1376,7 +1376,8 @@ func (c *contractor) renewContract(ctx context.Context, w Worker, ci contractInf
 	resp, err := w.RHPRenew(ctx, fcid, endHeight, hk, contract.SiamuxAddr, settings.Address, state.address, renterFunds, types.ZeroCurrency, expectedNewStorage, settings.WindowSize)
 	if err != nil {
 		c.logger.Errorw(
-			fmt.Sprintf("renewal failed, err: %v", err),
+			"renewal failed",
+			zap.Error(err),
 			"hk", hk,
 			"fcid", fcid,
 			"endHeight", endHeight,
@@ -1460,7 +1461,7 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 	// renew the contract
 	resp, err := w.RHPRenew(ctx, contract.ID, contract.EndHeight(), hk, contract.SiamuxAddr, settings.Address, state.address, renterFunds, minNewCollateral, expectedStorage, settings.WindowSize)
 	if err != nil {
-		c.logger.Errorw(fmt.Sprintf("refresh failed, err: %v", err), "hk", hk, "fcid", fcid)
+		c.logger.Errorw("refresh failed", zap.Error(err), "hk", hk, "fcid", fcid)
 		if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
 			return api.ContractMetadata{}, false, err
 		}
@@ -1474,7 +1475,7 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 	newCollateral := resp.Contract.Revision.MissedHostPayout().Sub(resp.ContractPrice)
 	refreshedContract, err := c.ap.bus.AddRenewedContract(ctx, resp.Contract, resp.ContractPrice, renterFunds, cs.BlockHeight, contract.ID, api.ContractStatePending)
 	if err != nil {
-		c.logger.Errorw(fmt.Sprintf("refresh failed, err: %v", err), "hk", hk, "fcid", fcid)
+		c.logger.Errorw("adding refreshed contract failed", zap.Error(err), "hk", hk, "fcid", fcid)
 		return api.ContractMetadata{}, false, err
 	}
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1394,13 +1394,13 @@ func (c *contractor) renewContract(ctx context.Context, w Worker, ci contractInf
 	*budget = budget.Sub(renterFunds)
 
 	// persist the contract
-	newCollateral := resp.Contract.Revision.MissedHostPayout().Sub(resp.ContractPrice)
 	renewedContract, err := c.ap.bus.AddRenewedContract(ctx, resp.Contract, resp.ContractPrice, renterFunds, cs.BlockHeight, fcid, api.ContractStatePending)
 	if err != nil {
 		c.logger.Errorw(fmt.Sprintf("renewal failed to persist, err: %v", err), "hk", hk, "fcid", fcid)
 		return api.ContractMetadata{}, false, err
 	}
 
+	newCollateral := resp.Contract.Revision.MissedHostPayout().Sub(resp.ContractPrice)
 	c.logger.Debugw(
 		"renewal succeeded",
 		"fcid", renewedContract.ID,
@@ -1472,7 +1472,6 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 	*budget = budget.Sub(renterFunds)
 
 	// persist the contract
-	newCollateral := resp.Contract.Revision.MissedHostPayout().Sub(resp.ContractPrice)
 	refreshedContract, err := c.ap.bus.AddRenewedContract(ctx, resp.Contract, resp.ContractPrice, renterFunds, cs.BlockHeight, contract.ID, api.ContractStatePending)
 	if err != nil {
 		c.logger.Errorw("adding refreshed contract failed", zap.Error(err), "hk", hk, "fcid", fcid)
@@ -1480,6 +1479,7 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 	}
 
 	// add to renewed set
+	newCollateral := resp.Contract.Revision.MissedHostPayout().Sub(resp.ContractPrice)
 	c.logger.Debugw("refresh succeeded",
 		"fcid", refreshedContract.ID,
 		"renewedFrom", contract.ID,

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1370,12 +1370,19 @@ func (c *contractor) renewContract(ctx context.Context, w Worker, ci contractInf
 	}
 
 	// calculate the host collateral
-	expectedStorage := renterFundsToExpectedStorage(renterFunds, endHeight-cs.BlockHeight, ci.priceTable)
+	expectedNewStorage := renterFundsToExpectedStorage(renterFunds, endHeight-cs.BlockHeight, ci.priceTable)
 
 	// renew the contract
-	resp, err := w.RHPRenew(ctx, fcid, endHeight, hk, contract.SiamuxAddr, settings.Address, state.address, renterFunds, types.ZeroCurrency, expectedStorage, settings.WindowSize)
+	resp, err := w.RHPRenew(ctx, fcid, endHeight, hk, contract.SiamuxAddr, settings.Address, state.address, renterFunds, types.ZeroCurrency, expectedNewStorage, settings.WindowSize)
 	if err != nil {
-		c.logger.Errorw(fmt.Sprintf("renewal failed, err: %v", err), "hk", hk, "fcid", fcid)
+		c.logger.Errorw(
+			fmt.Sprintf("renewal failed, err: %v", err),
+			"hk", hk,
+			"fcid", fcid,
+			"endHeight", endHeight,
+			"renterFunds", renterFunds,
+			"expectedNewStorage", expectedNewStorage,
+		)
 		if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
 			return api.ContractMetadata{}, false, err
 		}

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -312,7 +312,7 @@ func isOutOfCollateral(c api.Contract, s rhpv2.HostSettings, pt rhpv3.HostPriceT
 	if expectedStorage > s.RemainingStorage {
 		expectedStorage = s.RemainingStorage
 	}
-	newCollateral := worker.ContractRenewalCollateral(c.Revision.FileContract, expectedStorage, pt, blockHeight, c.EndHeight())
+	_, _, newCollateral := rhpv3.RenewalCosts(c.Revision.FileContract, pt, expectedStorage, c.EndHeight())
 	return isBelowCollateralThreshold(newCollateral, c.RemainingCollateral(s))
 }
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -24,8 +24,8 @@ const (
 	// into a contract upon renewing it. That means, we consider a contract
 	// worth renewing when that results in 10x the collateral of what it
 	// currently has remaining.
-	minContractCollateralThresholdNumerator   = 10
-	minContractCollateralThresholdDenominator = 100
+	minContractCollateralThresholdNumerator   = 1
+	minContractCollateralThresholdDenominator = 10
 
 	// contractConfirmationDeadline is the number of blocks since its start
 	// height we wait for a contract to appear on chain.
@@ -316,12 +316,12 @@ func isOutOfCollateral(c api.Contract, s rhpv2.HostSettings, pt rhpv3.HostPriceT
 	return isBelowCollateralThreshold(newCollateral, c.RemainingCollateral(s))
 }
 
-// isBelowCollateralThreshold returns true if the actualCollateral is below a
+// isBelowCollateralThreshold returns true if the remainingCollateral is below a
 // certain percentage of newCollateral. The newCollateral is the amount of
 // unallocated collateral in a contract after refreshing it and the
-// actualCollateral is the current amount of unallocated collateral in the
+// remainingCollateral is the current amount of unallocated collateral in the
 // contract.
-func isBelowCollateralThreshold(newCollateral, actualCollateral types.Currency) bool {
+func isBelowCollateralThreshold(newCollateral, remainingCollateral types.Currency) bool {
 	if newCollateral.IsZero() {
 		// Protect against division-by-zero. This can happen for 2 reasons.
 		// 1. the collateral is already at the host's max collateral so a
@@ -335,7 +335,7 @@ func isBelowCollateralThreshold(newCollateral, actualCollateral types.Currency) 
 		// contracts out eventually.
 		return false
 	}
-	return newCollateral.Cmp(minNewCollateral(actualCollateral)) < 0
+	return newCollateral.Cmp(minNewCollateral(remainingCollateral)) >= 0
 }
 
 // minNewCollateral returns the minimum amount of unallocated collateral that a

--- a/autopilot/hostfilter_test.go
+++ b/autopilot/hostfilter_test.go
@@ -1,0 +1,53 @@
+package autopilot
+
+import (
+	"testing"
+
+	"go.sia.tech/core/types"
+)
+
+func TestMinNewCollateral(t *testing.T) {
+	t.Parallel()
+
+	// The collateral threshold is 10% meaning that we expect 10 times the
+	// remaining collateral to be the minimum to trigger a renewal.
+	if min := minNewCollateral(types.Siacoins(1)); !min.Equals(types.Siacoins(10)) {
+		t.Fatalf("expected 10, got %v", min)
+	}
+}
+
+func TestIsBelowCollateralThreshold(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		newCollateral       types.Currency
+		remainingCollateral types.Currency
+		isBelow             bool
+	}{
+		{
+			remainingCollateral: types.NewCurrency64(1),
+			newCollateral:       types.NewCurrency64(10),
+			isBelow:             true,
+		},
+		{
+			remainingCollateral: types.NewCurrency64(1),
+			newCollateral:       types.NewCurrency64(9),
+			isBelow:             false,
+		},
+		{
+			remainingCollateral: types.NewCurrency64(1),
+			newCollateral:       types.NewCurrency64(11),
+			isBelow:             true,
+		},
+		{
+			remainingCollateral: types.NewCurrency64(1),
+			newCollateral:       types.ZeroCurrency,
+			isBelow:             false,
+		},
+	}
+	for i, test := range tests {
+		if isBelow := isBelowCollateralThreshold(test.newCollateral, test.remainingCollateral); isBelow != test.isBelow {
+			t.Fatalf("%v: expected %v, got %v", i+1, test.isBelow, isBelow)
+		}
+	}
+}

--- a/autopilot/workerpool.go
+++ b/autopilot/workerpool.go
@@ -25,7 +25,7 @@ type Worker interface {
 	RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP, siamuxAddr string, balance types.Currency) (err error)
 	RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (hostdb.HostPriceTable, error)
 	RHPPruneContract(ctx context.Context, fcid types.FileContractID, timeout time.Duration) (pruned, remaining uint64, err error)
-	RHPRenew(ctx context.Context, fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, hostAddress, renterAddress types.Address, renterFunds, newCollateral types.Currency, windowSize uint64) (rhpv2.ContractRevision, []types.Transaction, error)
+	RHPRenew(ctx context.Context, fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, hostAddress, renterAddress types.Address, renterFunds, minNewCollateral types.Currency, expectedStorage, windowSize uint64) (api.RHPRenewResponse, error)
 	RHPScan(ctx context.Context, hostKey types.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)
 	RHPSync(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP, siamuxAddr string) (err error)
 }

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -683,7 +683,10 @@ func (b *bus) walletPrepareRenewHandler(jc jape.Context) {
 	finalRevision.RevisionNumber = math.MaxUint64
 
 	// Prepare the new contract.
-	fc, basePrice := rhpv3.PrepareContractRenewal(wprr.Revision, wprr.HostAddress, wprr.RenterAddress, wprr.RenterFunds, wprr.NewCollateral, wprr.PriceTable, wprr.EndHeight)
+	fc, basePrice, err := rhpv3.PrepareContractRenewal(wprr.Revision, wprr.HostAddress, wprr.RenterAddress, wprr.RenterFunds, wprr.MinNewCollateral, wprr.PriceTable, wprr.ExpectedNewStorage, wprr.EndHeight)
+	if jc.Check("couldn't prepare contract renewal", err) != nil {
+		return
+	}
 
 	// Create the transaction containing both the final revision and new
 	// contract.

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -298,8 +298,8 @@ func (b *bus) Handler() http.Handler {
 		"GET    /host/:hostkey":                  b.hostsPubkeyHandlerGET,
 		"POST   /host/:hostkey/resetlostsectors": b.hostsResetLostSectorsPOST,
 
-		"PUT /metric/:key": b.metricsHandlerPUT,
-		"GET /metric/:key": b.metricsHandlerGET,
+		"PUT    /metric/:key": b.metricsHandlerPUT,
+		"GET    /metric/:key": b.metricsHandlerGET,
 
 		"POST   /multipart/create":      b.multipartHandlerCreatePOST,
 		"POST   /multipart/abort":       b.multipartHandlerAbortPOST,

--- a/bus/client/wallet.go
+++ b/bus/client/wallet.go
@@ -95,17 +95,18 @@ func (c *Client) WalletPrepareForm(ctx context.Context, renterAddress types.Addr
 }
 
 // WalletPrepareRenew funds and signs a contract renewal transaction.
-func (c *Client) WalletPrepareRenew(ctx context.Context, revision types.FileContractRevision, hostAddress, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, newCollateral types.Currency, pt rhpv3.HostPriceTable, endHeight, windowSize uint64) (api.WalletPrepareRenewResponse, error) {
+func (c *Client) WalletPrepareRenew(ctx context.Context, revision types.FileContractRevision, hostAddress, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, minNewCollateral types.Currency, pt rhpv3.HostPriceTable, endHeight, windowSize, expectedStorage uint64) (api.WalletPrepareRenewResponse, error) {
 	req := api.WalletPrepareRenewRequest{
-		Revision:      revision,
-		EndHeight:     endHeight,
-		HostAddress:   hostAddress,
-		PriceTable:    pt,
-		NewCollateral: newCollateral,
-		RenterAddress: renterAddress,
-		RenterFunds:   renterFunds,
-		RenterKey:     renterKey,
-		WindowSize:    windowSize,
+		Revision:           revision,
+		EndHeight:          endHeight,
+		ExpectedNewStorage: expectedStorage,
+		HostAddress:        hostAddress,
+		PriceTable:         pt,
+		MinNewCollateral:   minNewCollateral,
+		RenterAddress:      renterAddress,
+		RenterFunds:        renterFunds,
+		RenterKey:          renterKey,
+		WindowSize:         windowSize,
 	}
 	var resp api.WalletPrepareRenewResponse
 	err := c.c.WithContext(ctx).POST("/wallet/prepare/renew", req, &resp)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0
 	go.opentelemetry.io/otel/sdk v1.21.0
 	go.opentelemetry.io/otel/trace v1.21.0
-	go.sia.tech/core v0.1.12-0.20231011172826-6ca0ac7b3b6b
+	go.sia.tech/core v0.1.12-0.20231211155540-c255cc1e3282
 	go.sia.tech/gofakes3 v0.0.0-20231109151325-e0d47c10dce2
 	go.sia.tech/hostd v0.2.2
 	go.sia.tech/jape v0.11.1

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0
 	go.opentelemetry.io/otel/sdk v1.21.0
 	go.opentelemetry.io/otel/trace v1.21.0
-	go.sia.tech/core v0.1.12-0.20231211155540-c255cc1e3282
+	go.sia.tech/core v0.1.12-0.20231211182757-77190f04f90b
 	go.sia.tech/gofakes3 v0.0.0-20231109151325-e0d47c10dce2
 	go.sia.tech/hostd v0.2.2
 	go.sia.tech/jape v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ go.opentelemetry.io/otel/trace v1.21.0 h1:WD9i5gzvoUPuXIXH24ZNBudiarZDKuekPqi/E8
 go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+BaslueVtS/qQ=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
-go.sia.tech/core v0.1.12-0.20231211155540-c255cc1e3282 h1:5SYHarTm9AcIUQuSGco4YsaOJD0dxl6zDcoaE++o3oU=
-go.sia.tech/core v0.1.12-0.20231211155540-c255cc1e3282/go.mod h1:3EoY+rR78w1/uGoXXVqcYdwSjSJKuEMI5bL7WROA27Q=
+go.sia.tech/core v0.1.12-0.20231211182757-77190f04f90b h1:xJSxYN2kZD3NAijHIwjXhG5+7GoPyjDNIJPEoD3b72g=
+go.sia.tech/core v0.1.12-0.20231211182757-77190f04f90b/go.mod h1:3EoY+rR78w1/uGoXXVqcYdwSjSJKuEMI5bL7WROA27Q=
 go.sia.tech/gofakes3 v0.0.0-20231109151325-e0d47c10dce2 h1:ulzfJNjxN5DjXHClkW2pTiDk+eJ+0NQhX87lFDZ03t0=
 go.sia.tech/gofakes3 v0.0.0-20231109151325-e0d47c10dce2/go.mod h1:PlsiVCn6+wssrR7bsOIlZm0DahsVrDydrlbjY4F14sg=
 go.sia.tech/hostd v0.2.2 h1:HbXB4WripvVFUSpTrckEhC8DteL+QpXKZeonJHUpq3M=

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ go.opentelemetry.io/otel/trace v1.21.0 h1:WD9i5gzvoUPuXIXH24ZNBudiarZDKuekPqi/E8
 go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+BaslueVtS/qQ=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
-go.sia.tech/core v0.1.12-0.20231011172826-6ca0ac7b3b6b h1:gHnhRiY1SMWCEFu+1Xo0a967RVzHg+g+0grMbHNuLfE=
-go.sia.tech/core v0.1.12-0.20231011172826-6ca0ac7b3b6b/go.mod h1:3EoY+rR78w1/uGoXXVqcYdwSjSJKuEMI5bL7WROA27Q=
+go.sia.tech/core v0.1.12-0.20231211155540-c255cc1e3282 h1:5SYHarTm9AcIUQuSGco4YsaOJD0dxl6zDcoaE++o3oU=
+go.sia.tech/core v0.1.12-0.20231211155540-c255cc1e3282/go.mod h1:3EoY+rR78w1/uGoXXVqcYdwSjSJKuEMI5bL7WROA27Q=
 go.sia.tech/gofakes3 v0.0.0-20231109151325-e0d47c10dce2 h1:ulzfJNjxN5DjXHClkW2pTiDk+eJ+0NQhX87lFDZ03t0=
 go.sia.tech/gofakes3 v0.0.0-20231109151325-e0d47c10dce2/go.mod h1:PlsiVCn6+wssrR7bsOIlZm0DahsVrDydrlbjY4F14sg=
 go.sia.tech/hostd v0.2.2 h1:HbXB4WripvVFUSpTrckEhC8DteL+QpXKZeonJHUpq3M=

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -16,6 +16,7 @@ import (
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/object"
 	"go.sia.tech/siad/modules"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -1374,7 +1375,7 @@ func (s *SQLStore) RecordContractSpending(ctx context.Context, records []api.Con
 		}
 	}
 	if err := s.RecordContractMetric(ctx, metrics...); err != nil {
-		s.logger.Errorw("failed to record contract metrics", "err", err)
+		s.logger.Errorw("failed to record contract metrics", zap.Error(err))
 	}
 	return nil
 }

--- a/worker/client/rhp.go
+++ b/worker/client/rhp.go
@@ -82,16 +82,16 @@ func (c *Client) RHPPruneContract(ctx context.Context, contractID types.FileCont
 // RHPRenew renews an existing contract with a host.
 func (c *Client) RHPRenew(ctx context.Context, contractID types.FileContractID, endHeight uint64, hostKey types.PublicKey, siamuxAddr string, hostAddress, renterAddress types.Address, renterFunds, minNewCollateral types.Currency, expectedStorage, windowSize uint64) (resp api.RHPRenewResponse, err error) {
 	req := api.RHPRenewRequest{
-		ContractID:       contractID,
-		EndHeight:        endHeight,
-		ExpectedStorage:  expectedStorage,
-		HostAddress:      hostAddress,
-		HostKey:          hostKey,
-		MinNewCollateral: minNewCollateral,
-		RenterAddress:    renterAddress,
-		RenterFunds:      renterFunds,
-		SiamuxAddr:       siamuxAddr,
-		WindowSize:       windowSize,
+		ContractID:         contractID,
+		EndHeight:          endHeight,
+		ExpectedNewStorage: expectedStorage,
+		HostAddress:        hostAddress,
+		HostKey:            hostKey,
+		MinNewCollateral:   minNewCollateral,
+		RenterAddress:      renterAddress,
+		RenterFunds:        renterFunds,
+		SiamuxAddr:         siamuxAddr,
+		WindowSize:         windowSize,
 	}
 	err = c.c.WithContext(ctx).POST("/rhp/renew", req, &resp)
 	return

--- a/worker/client/rhp.go
+++ b/worker/client/rhp.go
@@ -80,22 +80,21 @@ func (c *Client) RHPPruneContract(ctx context.Context, contractID types.FileCont
 }
 
 // RHPRenew renews an existing contract with a host.
-func (c *Client) RHPRenew(ctx context.Context, contractID types.FileContractID, endHeight uint64, hostKey types.PublicKey, siamuxAddr string, hostAddress, renterAddress types.Address, renterFunds, newCollateral types.Currency, windowSize uint64) (rhpv2.ContractRevision, []types.Transaction, error) {
+func (c *Client) RHPRenew(ctx context.Context, contractID types.FileContractID, endHeight uint64, hostKey types.PublicKey, siamuxAddr string, hostAddress, renterAddress types.Address, renterFunds, minNewCollateral types.Currency, expectedStorage, windowSize uint64) (resp api.RHPRenewResponse, err error) {
 	req := api.RHPRenewRequest{
-		ContractID:    contractID,
-		EndHeight:     endHeight,
-		HostAddress:   hostAddress,
-		HostKey:       hostKey,
-		NewCollateral: newCollateral,
-		RenterAddress: renterAddress,
-		RenterFunds:   renterFunds,
-		SiamuxAddr:    siamuxAddr,
-		WindowSize:    windowSize,
+		ContractID:       contractID,
+		EndHeight:        endHeight,
+		ExpectedStorage:  expectedStorage,
+		HostAddress:      hostAddress,
+		HostKey:          hostKey,
+		MinNewCollateral: minNewCollateral,
+		RenterAddress:    renterAddress,
+		RenterFunds:      renterFunds,
+		SiamuxAddr:       siamuxAddr,
+		WindowSize:       windowSize,
 	}
-
-	var resp api.RHPRenewResponse
-	err := c.c.WithContext(ctx).POST("/rhp/renew", req, &resp)
-	return resp.Contract, resp.TransactionSet, err
+	err = c.c.WithContext(ctx).POST("/rhp/renew", req, &resp)
+	return
 }
 
 // RHPScan scans a host, returning its current settings.

--- a/worker/download.go
+++ b/worker/download.go
@@ -1061,7 +1061,7 @@ loop:
 				// handle lost sectors
 				if isSectorNotFound(resp.err) {
 					if err := s.slm.DeleteHostSector(ctx, resp.req.hk, resp.req.root); err != nil {
-						s.mgr.logger.Errorw("failed to mark sector as lost", "hk", resp.req.hk, "root", resp.req.root, "err", err)
+						s.mgr.logger.Errorw("failed to mark sector as lost", "hk", resp.req.hk, "root", resp.req.root, zap.Error(err))
 					} else {
 						s.mgr.logger.Infow("successfully marked sector as lost", "hk", resp.req.hk, "root", resp.req.root)
 					}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -167,7 +167,7 @@ type Bus interface {
 	WalletDiscard(ctx context.Context, txn types.Transaction) error
 	WalletFund(ctx context.Context, txn *types.Transaction, amount types.Currency, useUnconfirmedTxns bool) ([]types.Hash256, []types.Transaction, error)
 	WalletPrepareForm(ctx context.Context, renterAddress types.Address, renterKey types.PublicKey, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostSettings rhpv2.HostSettings, endHeight uint64) (txns []types.Transaction, err error)
-	WalletPrepareRenew(ctx context.Context, revision types.FileContractRevision, hostAddress, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, newCollateral types.Currency, pt rhpv3.HostPriceTable, endHeight, windowSize uint64) (api.WalletPrepareRenewResponse, error)
+	WalletPrepareRenew(ctx context.Context, revision types.FileContractRevision, hostAddress, renterAddress types.Address, renterKey types.PrivateKey, renterFunds, minNewCollateral types.Currency, pt rhpv3.HostPriceTable, endHeight, windowSize, expectedStorage uint64) (api.WalletPrepareRenewResponse, error)
 	WalletSign(ctx context.Context, txn *types.Transaction, toSign []types.Hash256, cf types.CoveredFields) error
 
 	Bucket(_ context.Context, bucket string) (api.Bucket, error)


### PR DESCRIPTION
That way we can do so after locking the contract to avoid exceeding the max collateral when uploading at the same time.
As a side - effect, since we only pass a pricetable to `RPCRenew`, we also use rhpv3 estimates now.