### PR TITLE
Worker Cleanup

### DIFF
--- a/worker/contract_lock.go
+++ b/worker/contract_lock.go
@@ -51,7 +51,7 @@ func newContractLock(fcid types.FileContractID, lockID uint64, d time.Duration, 
 	return cl
 }
 
-func (w *worker) acquireContractLock(ctx context.Context, fcid types.FileContractID, priority int) (_ revisionUnlocker, err error) {
+func (w *worker) acquireContractLock(ctx context.Context, fcid types.FileContractID, priority int) (_ *contractLock, err error) {
 	lockID, err := w.bus.AcquireContract(ctx, fcid, priority, w.contractLockingDuration)
 	if err != nil {
 		return nil, err

--- a/worker/download.go
+++ b/worker/download.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,10 +41,9 @@ type (
 	id [8]byte
 
 	downloadManager struct {
+		hm     HostManager
 		mm     MemoryManager
-		hp     hostProvider
-		pss    partialSlabStore
-		slm    sectorLostMarker
+		os     ObjectStore
 		logger *zap.SugaredLogger
 
 		maxOverdrive     uint64
@@ -52,7 +52,7 @@ type (
 		statsOverdrivePct                *stats.DataPoints
 		statsSlabDownloadSpeedBytesPerMS *stats.DataPoints
 
-		stopChan chan struct{}
+		shutdownCtx context.Context
 
 		mu            sync.Mutex
 		downloaders   map[types.PublicKey]*downloader
@@ -60,18 +60,18 @@ type (
 	}
 
 	downloader struct {
-		host hostV3
+		host Host
 
 		statsDownloadSpeedBytesPerMS    *stats.DataPoints // keep track of this separately for stats (no decay is applied)
 		statsSectorDownloadEstimateInMS *stats.DataPoints
 
 		signalWorkChan chan struct{}
-		stopChan       chan struct{}
+		shutdownCtx    context.Context
 
 		mu                  sync.Mutex
 		consecutiveFailures uint64
-		queue               []*sectorDownloadReq
 		numDownloads        uint64
+		queue               []*sectorDownloadReq
 	}
 
 	downloaderStats struct {
@@ -80,13 +80,8 @@ type (
 		numDownloads uint64
 	}
 
-	sectorLostMarker interface {
-		DeleteHostSector(ctx context.Context, hk types.PublicKey, root types.Hash256) error
-	}
-
 	slabDownload struct {
 		mgr *downloadManager
-		slm sectorLostMarker
 
 		minShards int
 		offset    uint32
@@ -113,7 +108,7 @@ type (
 	}
 
 	slabDownloadResponse struct {
-		mem              *acquiredMemory
+		mem              Memory
 		surchargeApplied bool
 		shards           [][]byte
 		index            int
@@ -165,15 +160,14 @@ func (w *worker) initDownloadManager(maxMemory, maxOverdrive uint64, overdriveTi
 	}
 
 	mm := newMemoryManager(logger, maxMemory)
-	w.downloadManager = newDownloadManager(w, w, mm, w.bus, maxOverdrive, overdriveTimeout, logger)
+	w.downloadManager = newDownloadManager(w.shutdownCtx, w, mm, w.bus, maxOverdrive, overdriveTimeout, logger)
 }
 
-func newDownloadManager(hp hostProvider, pss partialSlabStore, mm MemoryManager, slm sectorLostMarker, maxOverdrive uint64, overdriveTimeout time.Duration, logger *zap.SugaredLogger) *downloadManager {
+func newDownloadManager(ctx context.Context, hm HostManager, mm MemoryManager, os ObjectStore, maxOverdrive uint64, overdriveTimeout time.Duration, logger *zap.SugaredLogger) *downloadManager {
 	return &downloadManager{
-		hp:     hp,
+		hm:     hm,
 		mm:     mm,
-		pss:    pss,
-		slm:    slm,
+		os:     os,
 		logger: logger,
 
 		maxOverdrive:     maxOverdrive,
@@ -182,13 +176,13 @@ func newDownloadManager(hp hostProvider, pss partialSlabStore, mm MemoryManager,
 		statsOverdrivePct:                stats.NoDecay(),
 		statsSlabDownloadSpeedBytesPerMS: stats.NoDecay(),
 
-		stopChan: make(chan struct{}),
+		shutdownCtx: ctx,
 
 		downloaders: make(map[types.PublicKey]*downloader),
 	}
 }
 
-func newDownloader(host hostV3) *downloader {
+func newDownloader(ctx context.Context, host Host) *downloader {
 	return &downloader{
 		host: host,
 
@@ -196,7 +190,7 @@ func newDownloader(host hostV3) *downloader {
 		statsDownloadSpeedBytesPerMS:    stats.NoDecay(),
 
 		signalWorkChan: make(chan struct{}, 1),
-		stopChan:       make(chan struct{}),
+		shutdownCtx:    ctx,
 
 		queue: make([]*sectorDownloadReq, 0),
 	}
@@ -231,7 +225,7 @@ func (mgr *downloadManager) DownloadObject(ctx context.Context, w io.Writer, o o
 		if !slabs[i].PartialSlab {
 			continue
 		}
-		data, slab, err := mgr.pss.PartialSlab(ctx, slabs[i].SlabSlice.Key, slabs[i].SlabSlice.Offset, slabs[i].SlabSlice.Length)
+		data, slab, err := mgr.fetchPartialSlab(ctx, slabs[i].SlabSlice.Key, slabs[i].SlabSlice.Offset, slabs[i].SlabSlice.Length)
 		if err != nil {
 			return fmt.Errorf("failed to fetch partial slab data: %w", err)
 		}
@@ -294,7 +288,7 @@ func (mgr *downloadManager) DownloadObject(ctx context.Context, w io.Writer, o o
 			select {
 			case <-ctx.Done():
 				return
-			case <-mgr.stopChan:
+			case <-mgr.shutdownCtx.Done():
 				return
 			case concurrentSlabsChan <- struct{}{}:
 			}
@@ -351,7 +345,7 @@ outer:
 	for {
 		var resp *slabDownloadResponse
 		select {
-		case <-mgr.stopChan:
+		case <-mgr.shutdownCtx.Done():
 			return errDownloadManagerStopped
 		case <-ctx.Done():
 			return errors.New("download timed out")
@@ -495,9 +489,8 @@ func (mgr *downloadManager) Stats() downloadManagerStats {
 func (mgr *downloadManager) Stop() {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
-	close(mgr.stopChan)
 	for _, d := range mgr.downloaders {
-		close(d.stopChan)
+		d.Stop()
 	}
 }
 
@@ -521,6 +514,24 @@ func (mgr *downloadManager) numDownloaders() int {
 	return len(mgr.downloaders)
 }
 
+// fetchPartialSlab fetches the data of a partial slab from the bus. It will
+// fall back to ask the bus for the slab metadata in case the slab wasn't found
+// in the partial slab buffer.
+func (mgr *downloadManager) fetchPartialSlab(ctx context.Context, key object.EncryptionKey, offset, length uint32) ([]byte, *object.Slab, error) {
+	data, err := mgr.os.FetchPartialSlab(ctx, key, offset, length)
+	if err != nil && strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
+		// Check if slab was already uploaded.
+		slab, err := mgr.os.Slab(ctx, key)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to fetch uploaded partial slab: %v", err)
+		}
+		return nil, &slab, nil
+	} else if err != nil {
+		return nil, nil, err
+	}
+	return data, nil, nil
+}
+
 func (mgr *downloadManager) refreshDownloaders(contracts []api.ContractMetadata) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
@@ -535,7 +546,7 @@ func (mgr *downloadManager) refreshDownloaders(contracts []api.ContractMetadata)
 	for hk := range mgr.downloaders {
 		_, wanted := want[hk]
 		if !wanted {
-			close(mgr.downloaders[hk].stopChan)
+			mgr.downloaders[hk].Stop()
 			delete(mgr.downloaders, hk)
 			continue
 		}
@@ -546,10 +557,10 @@ func (mgr *downloadManager) refreshDownloaders(contracts []api.ContractMetadata)
 	// update downloaders
 	for _, c := range want {
 		// create a host
-		host := mgr.hp.newHostV3(c.ID, c.HostKey, c.SiamuxAddr)
-		downloader := newDownloader(host)
+		host := mgr.hm.Host(c.HostKey, c.ID, c.SiamuxAddr)
+		downloader := newDownloader(mgr.shutdownCtx, host)
 		mgr.downloaders[c.HostKey] = downloader
-		go downloader.processQueue(mgr.hp)
+		go downloader.processQueue(mgr.hm)
 	}
 }
 
@@ -566,7 +577,6 @@ func (mgr *downloadManager) newSlabDownload(ctx context.Context, dID id, slice o
 	// create slab download
 	return &slabDownload{
 		mgr: mgr,
-		slm: mgr.slm,
 
 		minShards: int(slice.MinShards),
 		offset:    offset,
@@ -595,6 +605,18 @@ func (mgr *downloadManager) downloadSlab(ctx context.Context, dID id, slice obje
 	return slab.download(ctx)
 }
 
+func (d *downloader) Stop() {
+	for {
+		download := d.pop()
+		if download == nil {
+			break
+		}
+		if !download.done() {
+			download.fail(errors.New("downloader stopped"))
+		}
+	}
+}
+
 func (d *downloader) stats() downloaderStats {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -603,15 +625,6 @@ func (d *downloader) stats() downloaderStats {
 		healthy:      d.consecutiveFailures == 0,
 		numDownloads: d.numDownloads,
 	}
-}
-
-func (d *downloader) isStopped() bool {
-	select {
-	case <-d.stopChan:
-		return true
-	default:
-	}
-	return false
 }
 
 func (d *downloader) fillBatch() (batch []*sectorDownloadReq) {
@@ -651,8 +664,11 @@ func (d *downloader) processBatch(batch []*sectorDownloadReq) chan struct{} {
 	reqsChan := make(chan *sectorDownloadReq)
 	workerFn := func() {
 		for req := range reqsChan {
-			if d.isStopped() {
+			// check if we need to abort
+			select {
+			case <-d.shutdownCtx.Done():
 				break
+			default:
 			}
 
 			// update state
@@ -714,13 +730,13 @@ func (d *downloader) processBatch(batch []*sectorDownloadReq) chan struct{} {
 	return doneChan
 }
 
-func (d *downloader) processQueue(hp hostProvider) {
+func (d *downloader) processQueue(hp HostManager) {
 outer:
 	for {
 		// wait for work
 		select {
 		case <-d.signalWorkChan:
-		case <-d.stopChan:
+		case <-d.shutdownCtx.Done():
 			return
 		}
 
@@ -735,7 +751,7 @@ outer:
 			doneChan := d.processBatch(batch)
 			for {
 				select {
-				case <-d.stopChan:
+				case <-d.shutdownCtx.Done():
 					return
 				case <-doneChan:
 					continue outer
@@ -1027,7 +1043,7 @@ func (s *slabDownload) download(ctx context.Context) ([][]byte, bool, error) {
 loop:
 	for s.inflight() > 0 && !done {
 		select {
-		case <-s.mgr.stopChan:
+		case <-s.mgr.shutdownCtx.Done():
 			return nil, false, errors.New("download stopped")
 		case <-ctx.Done():
 			return nil, false, ctx.Err()
@@ -1061,7 +1077,7 @@ loop:
 
 				// handle lost sectors
 				if isSectorNotFound(resp.err) {
-					if err := s.slm.DeleteHostSector(ctx, resp.req.hk, resp.req.root); err != nil {
+					if err := s.mgr.os.DeleteHostSector(ctx, resp.req.hk, resp.req.root); err != nil {
 						s.mgr.logger.Errorw("failed to mark sector as lost", "hk", resp.req.hk, "root", resp.req.root, "err", err)
 					} else {
 						s.mgr.logger.Infow("successfully marked sector as lost", "hk", resp.req.hk, "root", resp.req.root)

--- a/worker/host.go
+++ b/worker/host.go
@@ -53,6 +53,7 @@ var _ Host = (*host)(nil)
 
 func (w *worker) Host(hk types.PublicKey, fcid types.FileContractID, siamuxAddr string) Host {
 	return &host{
+		hk:                       hk,
 		acc:                      w.accounts.ForHost(hk),
 		bus:                      w.bus,
 		contractSpendingRecorder: w.contractSpendingRecorder,

--- a/worker/host.go
+++ b/worker/host.go
@@ -1,0 +1,206 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"time"
+
+	rhpv2 "go.sia.tech/core/rhp/v2"
+	rhpv3 "go.sia.tech/core/rhp/v3"
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/hostdb"
+	"go.uber.org/zap"
+)
+
+type (
+	Host interface {
+		DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint32, overpay bool) error
+		FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error)
+		FetchRevision(ctx context.Context, fetchTimeout time.Duration, blockHeight uint64) (types.FileContractRevision, error)
+		FundAccount(ctx context.Context, balance types.Currency, rev *types.FileContractRevision) error
+		RenewContract(ctx context.Context, rrr api.RHPRenewRequest) (_ rhpv2.ContractRevision, _ []types.Transaction, err error)
+		SyncAccount(ctx context.Context, rev *types.FileContractRevision) error
+		UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte, rev types.FileContractRevision) (types.Hash256, error)
+	}
+
+	HostManager interface {
+		Host(types.PublicKey, types.FileContractID, string) Host
+	}
+)
+
+type (
+	host struct {
+		hk         types.PublicKey
+		renterKey  types.PrivateKey
+		accountKey types.PrivateKey
+		fcid       types.FileContractID
+		siamuxAddr string
+
+		acc                      *account
+		bus                      Bus
+		contractSpendingRecorder *contractSpendingRecorder
+		logger                   *zap.SugaredLogger
+		transportPool            *transportPoolV3
+		priceTables              *priceTables
+	}
+)
+
+var _ Host = (*host)(nil)
+
+func (w *worker) Host(hk types.PublicKey, fcid types.FileContractID, siamuxAddr string) Host {
+	return &host{
+		acc:                      w.accounts.ForHost(hk),
+		bus:                      w.bus,
+		contractSpendingRecorder: w.contractSpendingRecorder,
+		logger:                   w.logger.Named(hk.String()[:4]),
+		fcid:                     fcid,
+		siamuxAddr:               siamuxAddr,
+		renterKey:                w.deriveRenterKey(hk),
+		accountKey:               w.accounts.deriveAccountKey(hk),
+		transportPool:            w.transportPoolV3,
+		priceTables:              w.priceTables,
+	}
+}
+
+func (h *host) DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint32, overpay bool) (err error) {
+	pt, err := h.priceTables.fetch(ctx, h.hk, nil)
+	if err != nil {
+		return err
+	}
+	hpt := pt.HostPriceTable
+
+	// check for download gouging specifically
+	gc, err := GougingCheckerFromContext(ctx, overpay)
+	if err != nil {
+		return err
+	}
+	if breakdown := gc.Check(nil, &hpt); breakdown.DownloadGouging() {
+		return fmt.Errorf("%w: %v", errPriceTableGouging, breakdown)
+	}
+
+	// return errBalanceInsufficient if balance insufficient
+	defer func() {
+		if isBalanceInsufficient(err) {
+			err = fmt.Errorf("%w %v, err: %v", errBalanceInsufficient, h.hk, err)
+		}
+	}()
+
+	return h.acc.WithWithdrawal(ctx, func() (amount types.Currency, err error) {
+		err = h.transportPool.withTransportV3(ctx, h.hk, h.siamuxAddr, func(ctx context.Context, t *transportV3) error {
+			cost, err := readSectorCost(hpt, uint64(length))
+			if err != nil {
+				return err
+			}
+
+			var refund types.Currency
+			payment := rhpv3.PayByEphemeralAccount(h.acc.id, cost, pt.HostBlockHeight+defaultWithdrawalExpiryBlocks, h.accountKey)
+			cost, refund, err = RPCReadSector(ctx, t, w, hpt, &payment, offset, length, root)
+			amount = cost.Sub(refund)
+			return err
+		})
+		return
+	})
+}
+
+// UploadSector uploads a sector to the host.
+func (h *host) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte, rev types.FileContractRevision) (root types.Hash256, err error) {
+	// fetch price table
+	pt, err := h.priceTable(ctx, nil)
+	if err != nil {
+		return types.Hash256{}, err
+	}
+
+	// prepare payment
+	//
+	// TODO: change to account payments once we have the means to check for an
+	// insufficient balance error
+	expectedCost, _, _, err := uploadSectorCost(pt, rev.WindowEnd)
+	if err != nil {
+		return types.Hash256{}, err
+	}
+	if rev.RevisionNumber == math.MaxUint64 {
+		return types.Hash256{}, fmt.Errorf("revision number has reached max, fcid %v", rev.ParentID)
+	}
+	payment, ok := rhpv3.PayByContract(&rev, expectedCost, h.acc.id, h.renterKey)
+	if !ok {
+		return types.Hash256{}, errors.New("failed to create payment")
+	}
+
+	var cost types.Currency
+	err = h.transportPool.withTransportV3(ctx, h.hk, h.siamuxAddr, func(ctx context.Context, t *transportV3) error {
+		root, cost, err = RPCAppendSector(ctx, t, h.renterKey, pt, &rev, &payment, sector)
+		return err
+	})
+	if err != nil {
+		return types.Hash256{}, err
+	}
+
+	// record spending
+	h.contractSpendingRecorder.Record(rev, api.ContractSpending{Uploads: cost})
+	return root, nil
+}
+
+// Renew renews a contract with a host. To avoid an edge case where the contract
+// is drained and can therefore not be used to pay for the revision, we simply
+// don't pay for it.
+func (h *host) RenewContract(ctx context.Context, rrr api.RHPRenewRequest) (_ rhpv2.ContractRevision, _ []types.Transaction, err error) {
+	// Try to get a valid pricetable.
+	ptCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	var pt *rhpv3.HostPriceTable
+	hpt, err := h.priceTables.fetch(ptCtx, h.hk, nil)
+	if err == nil {
+		pt = &hpt.HostPriceTable
+	} else {
+		h.logger.Debugf("unable to fetch price table for renew: %v", err)
+	}
+
+	var rev rhpv2.ContractRevision
+	var txnSet []types.Transaction
+	var renewErr error
+	err = h.transportPool.withTransportV3(ctx, h.hk, h.siamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
+		_, err = RPCLatestRevision(ctx, t, h.fcid, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
+			// Renew contract.
+			rev, txnSet, renewErr = RPCRenew(ctx, rrr, h.bus, t, pt, *revision, h.renterKey, h.logger)
+			return rhpv3.HostPriceTable{}, nil, nil
+		})
+		return err
+	})
+	if err != nil {
+		return rhpv2.ContractRevision{}, nil, err
+	}
+	return rev, txnSet, renewErr
+}
+
+func (h *host) FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error) {
+	// fetchPT is a helper function that performs the RPC given a payment function
+	fetchPT := func(paymentFn PriceTablePaymentFunc) (hpt hostdb.HostPriceTable, err error) {
+		err = h.transportPool.withTransportV3(ctx, h.hk, h.siamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
+			hpt, err = RPCPriceTable(ctx, t, paymentFn)
+			InteractionRecorderFromContext(ctx).RecordPriceTableUpdate(hostdb.PriceTableUpdate{
+				HostKey:    h.hk,
+				Success:    isSuccessfulInteraction(err),
+				Timestamp:  time.Now(),
+				PriceTable: hpt,
+			})
+			return
+		})
+		return
+	}
+
+	// pay by contract if a revision is given
+	if rev != nil {
+		return fetchPT(h.preparePriceTableContractPayment(rev))
+	}
+
+	// pay by account
+	cs, err := h.bus.ConsensusState(ctx)
+	if err != nil {
+		return hostdb.HostPriceTable{}, err
+	}
+	return fetchPT(h.preparePriceTableAccountPayment(cs.BlockHeight))
+}

--- a/worker/memory.go
+++ b/worker/memory.go
@@ -13,7 +13,12 @@ type (
 	// uploads and downloads.
 	MemoryManager interface {
 		Status() api.MemoryStatus
-		AcquireMemory(ctx context.Context, amt uint64) *acquiredMemory
+		AcquireMemory(ctx context.Context, amt uint64) Memory
+	}
+
+	Memory interface {
+		Release()
+		ReleaseSome(amt uint64)
 	}
 
 	memoryManager struct {
@@ -53,7 +58,7 @@ func (mm *memoryManager) Status() api.MemoryStatus {
 	}
 }
 
-func (mm *memoryManager) AcquireMemory(ctx context.Context, amt uint64) *acquiredMemory {
+func (mm *memoryManager) AcquireMemory(ctx context.Context, amt uint64) Memory {
 	if amt == 0 {
 		mm.logger.Fatal("cannot acquire 0 memory")
 	} else if mm.totalAvailable < amt {

--- a/worker/net.go
+++ b/worker/net.go
@@ -1,0 +1,42 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+var privateSubnets []*net.IPNet
+
+func init() {
+	for _, subnet := range []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"100.64.0.0/10",
+	} {
+		_, subnet, err := net.ParseCIDR(subnet)
+		if err != nil {
+			panic(fmt.Sprintf("failed to parse subnet: %v", err))
+		}
+		privateSubnets = append(privateSubnets, subnet)
+	}
+}
+
+func isPrivateIP(addr net.IP) bool {
+	if addr.IsLoopback() || addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() {
+		return true
+	}
+
+	for _, block := range privateSubnets {
+		if block.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func dial(ctx context.Context, hostIP string) (net.Conn, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", hostIP)
+	return conn, err
+}

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -252,7 +252,7 @@ func (h *host) FetchRevision(ctx context.Context, fetchTimeout time.Duration, bl
 	// Try to fetch the revision with an account first.
 	ctx, cancel := timeoutCtx()
 	defer cancel()
-	rev, err := h.fetchRevisionWithAccount(ctx, h.HostKey(), h.siamuxAddr, blockHeight, h.fcid)
+	rev, err := h.fetchRevisionWithAccount(ctx, h.hk, h.siamuxAddr, blockHeight, h.fcid)
 	if err != nil && !(isBalanceInsufficient(err) || isWithdrawalsInactive(err) || isClosedStream(err)) { // TODO: checking for a closed stream here can be removed once the withdrawal timeout on the host side is removed
 		return types.FileContractRevision{}, fmt.Errorf("unable to fetch revision with account: %v", err)
 	} else if err == nil {
@@ -262,7 +262,7 @@ func (h *host) FetchRevision(ctx context.Context, fetchTimeout time.Duration, bl
 	// Fall back to using the contract to pay for the revision.
 	ctx, cancel = timeoutCtx()
 	defer cancel()
-	rev, err = h.fetchRevisionWithContract(ctx, h.HostKey(), h.siamuxAddr, h.fcid)
+	rev, err = h.fetchRevisionWithContract(ctx, h.hk, h.siamuxAddr, h.fcid)
 	if err != nil && !isInsufficientFunds(err) {
 		return types.FileContractRevision{}, fmt.Errorf("unable to fetch revision with contract: %v", err)
 	} else if err == nil {
@@ -272,7 +272,7 @@ func (h *host) FetchRevision(ctx context.Context, fetchTimeout time.Duration, bl
 	// If we don't have enough money in the contract, try again without paying.
 	ctx, cancel = timeoutCtx()
 	defer cancel()
-	rev, err = h.fetchRevisionNoPayment(ctx, h.HostKey(), h.siamuxAddr, h.fcid)
+	rev, err = h.fetchRevisionNoPayment(ctx, h.hk, h.siamuxAddr, h.fcid)
 	if err != nil {
 		return types.FileContractRevision{}, fmt.Errorf("unable to fetch revision without payment: %v", err)
 	}
@@ -362,7 +362,7 @@ func (h *host) FundAccount(ctx context.Context, balance types.Currency, rev *typ
 	}
 
 	return h.acc.WithDeposit(ctx, func() (types.Currency, error) {
-		return amount, h.transportPool.withTransportV3(ctx, h.HostKey(), h.siamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
+		return amount, h.transportPool.withTransportV3(ctx, h.hk, h.siamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
 			cost := amount.Add(pt.FundAccountCost)
 			payment, err := payByContract(rev, cost, rhpv3.Account{}, h.renterKey) // no account needed for funding
 			if err != nil {
@@ -386,7 +386,7 @@ func (h *host) SyncAccount(ctx context.Context, rev *types.FileContractRevision)
 
 	return h.acc.WithSync(ctx, func() (types.Currency, error) {
 		var balance types.Currency
-		err := h.transportPool.withTransportV3(ctx, h.HostKey(), h.siamuxAddr, func(ctx context.Context, t *transportV3) error {
+		err := h.transportPool.withTransportV3(ctx, h.hk, h.siamuxAddr, func(ctx context.Context, t *transportV3) error {
 			payment, err := payByContract(rev, pt.AccountBalanceCost, h.acc.id, h.renterKey)
 			if err != nil {
 				return err
@@ -413,19 +413,6 @@ type (
 		id   rhpv3.Account
 		key  types.PrivateKey
 		host types.PublicKey
-	}
-
-	host struct {
-		acc                      *account
-		bus                      Bus
-		contractSpendingRecorder *contractSpendingRecorder
-		fcid                     types.FileContractID
-		logger                   *zap.SugaredLogger
-		siamuxAddr               string
-		renterKey                types.PrivateKey
-		accountKey               types.PrivateKey
-		transportPool            *transportPoolV3
-		priceTables              *priceTables
 	}
 )
 
@@ -570,19 +557,11 @@ func (a *accounts) deriveAccountKey(hostKey types.PublicKey) types.PrivateKey {
 	return pk
 }
 
-func (r *host) Contract() types.FileContractID {
-	return r.fcid
-}
-
-func (r *host) HostKey() types.PublicKey {
-	return r.acc.host
-}
-
 // priceTable fetches a price table from the host. If a revision is provided, it
 // will be used to pay for the price table. The returned price table is
 // guaranteed to be safe to use.
 func (h *host) priceTable(ctx context.Context, rev *types.FileContractRevision) (rhpv3.HostPriceTable, error) {
-	pt, err := h.priceTables.fetch(ctx, h.HostKey(), rev)
+	pt, err := h.priceTables.fetch(ctx, h.hk, rev)
 	if err != nil {
 		return rhpv3.HostPriceTable{}, err
 	}
@@ -594,84 +573,6 @@ func (h *host) priceTable(ctx context.Context, rev *types.FileContractRevision) 
 		return rhpv3.HostPriceTable{}, fmt.Errorf("%w: %v", errPriceTableGouging, breakdown)
 	}
 	return pt.HostPriceTable, nil
-}
-
-func (h *host) DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint32, overpay bool) (err error) {
-	pt, err := h.priceTables.fetch(ctx, h.HostKey(), nil)
-	if err != nil {
-		return err
-	}
-	hpt := pt.HostPriceTable
-
-	// check for download gouging specifically
-	gc, err := GougingCheckerFromContext(ctx, overpay)
-	if err != nil {
-		return err
-	}
-	if breakdown := gc.Check(nil, &hpt); breakdown.DownloadGouging() {
-		return fmt.Errorf("%w: %v", errPriceTableGouging, breakdown)
-	}
-
-	// return errBalanceInsufficient if balance insufficient
-	defer func() {
-		if isBalanceInsufficient(err) {
-			err = fmt.Errorf("%w %v, err: %v", errBalanceInsufficient, h.HostKey(), err)
-		}
-	}()
-
-	return h.acc.WithWithdrawal(ctx, func() (amount types.Currency, err error) {
-		err = h.transportPool.withTransportV3(ctx, h.HostKey(), h.siamuxAddr, func(ctx context.Context, t *transportV3) error {
-			cost, err := readSectorCost(hpt, uint64(length))
-			if err != nil {
-				return err
-			}
-
-			var refund types.Currency
-			payment := rhpv3.PayByEphemeralAccount(h.acc.id, cost, pt.HostBlockHeight+defaultWithdrawalExpiryBlocks, h.accountKey)
-			cost, refund, err = RPCReadSector(ctx, t, w, hpt, &payment, offset, length, root)
-			amount = cost.Sub(refund)
-			return err
-		})
-		return
-	})
-}
-
-// UploadSector uploads a sector to the host.
-func (h *host) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte, rev types.FileContractRevision) (root types.Hash256, err error) {
-	// fetch price table
-	pt, err := h.priceTable(ctx, nil)
-	if err != nil {
-		return types.Hash256{}, err
-	}
-
-	// prepare payment
-	//
-	// TODO: change to account payments once we have the means to check for an
-	// insufficient balance error
-	expectedCost, _, _, err := uploadSectorCost(pt, rev.WindowEnd)
-	if err != nil {
-		return types.Hash256{}, err
-	}
-	if rev.RevisionNumber == math.MaxUint64 {
-		return types.Hash256{}, fmt.Errorf("revision number has reached max, fcid %v", rev.ParentID)
-	}
-	payment, ok := rhpv3.PayByContract(&rev, expectedCost, h.acc.id, h.renterKey)
-	if !ok {
-		return types.Hash256{}, errors.New("failed to create payment")
-	}
-
-	var cost types.Currency
-	err = h.transportPool.withTransportV3(ctx, h.HostKey(), h.siamuxAddr, func(ctx context.Context, t *transportV3) error {
-		root, cost, err = RPCAppendSector(ctx, t, h.renterKey, pt, &rev, &payment, sector)
-		return err
-	})
-	if err != nil {
-		return types.Hash256{}, err
-	}
-
-	// record spending
-	h.contractSpendingRecorder.Record(rev, api.ContractSpending{Uploads: cost})
-	return root, nil
 }
 
 // padBandwitdh pads the bandwidth to the next multiple of 1460 bytes.  1460
@@ -919,67 +820,6 @@ func processPayment(s *streamV3, payment rhpv3.PaymentMethod) error {
 // create a payment for that table and return it. It can also be used to perform
 // gouging checks before paying for the table.
 type PriceTablePaymentFunc func(pt rhpv3.HostPriceTable) (rhpv3.PaymentMethod, error)
-
-// Renew renews a contract with a host. To avoid an edge case where the contract
-// is drained and can therefore not be used to pay for the revision, we simply
-// don't pay for it.
-func (h *host) Renew(ctx context.Context, rrr api.RHPRenewRequest) (_ rhpv2.ContractRevision, _ []types.Transaction, err error) {
-	// Try to get a valid pricetable.
-	ptCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	var pt *rhpv3.HostPriceTable
-	hpt, err := h.priceTables.fetch(ptCtx, h.HostKey(), nil)
-	if err == nil {
-		pt = &hpt.HostPriceTable
-	} else {
-		h.logger.Debugf("unable to fetch price table for renew: %v", err)
-	}
-
-	var rev rhpv2.ContractRevision
-	var txnSet []types.Transaction
-	var renewErr error
-	err = h.transportPool.withTransportV3(ctx, h.HostKey(), h.siamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
-		_, err = RPCLatestRevision(ctx, t, h.fcid, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
-			// Renew contract.
-			rev, txnSet, renewErr = RPCRenew(ctx, rrr, h.bus, t, pt, *revision, h.renterKey, h.logger)
-			return rhpv3.HostPriceTable{}, nil, nil
-		})
-		return err
-	})
-	if err != nil {
-		return rhpv2.ContractRevision{}, nil, err
-	}
-	return rev, txnSet, renewErr
-}
-
-func (h *host) FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error) {
-	// fetchPT is a helper function that performs the RPC given a payment function
-	fetchPT := func(paymentFn PriceTablePaymentFunc) (hpt hostdb.HostPriceTable, err error) {
-		err = h.transportPool.withTransportV3(ctx, h.HostKey(), h.siamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
-			hpt, err = RPCPriceTable(ctx, t, paymentFn)
-			InteractionRecorderFromContext(ctx).RecordPriceTableUpdate(hostdb.PriceTableUpdate{
-				HostKey:    h.HostKey(),
-				Success:    isSuccessfulInteraction(err),
-				Timestamp:  time.Now(),
-				PriceTable: hpt,
-			})
-			return
-		})
-		return
-	}
-
-	// pay by contract if a revision is given
-	if rev != nil {
-		return fetchPT(h.preparePriceTableContractPayment(rev))
-	}
-
-	// pay by account
-	cs, err := h.bus.ConsensusState(ctx)
-	if err != nil {
-		return hostdb.HostPriceTable{}, err
-	}
-	return fetchPT(h.preparePriceTableAccountPayment(cs.BlockHeight))
-}
 
 // RPCPriceTable calls the UpdatePriceTable RPC.
 func RPCPriceTable(ctx context.Context, t *transportV3, paymentFunc PriceTablePaymentFunc) (_ hostdb.HostPriceTable, err error) {

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -38,18 +38,19 @@ var (
 
 type (
 	uploadManager struct {
-		b           Bus
-		hp          hostProvider
-		rl          revisionLocker
-		mm          MemoryManager
-		logger      *zap.SugaredLogger
-		shutdownCtx context.Context
+		hm     HostManager
+		mm     MemoryManager
+		os     ObjectStore
+		rl     revisionLocker // TODO: host should implement revisionLocker, would allow us to remove it here
+		logger *zap.SugaredLogger
 
 		maxOverdrive     uint64
 		overdriveTimeout time.Duration
 
 		statsOverdrivePct              *stats.DataPoints
 		statsSlabUploadSpeedBytesPerMS *stats.DataPoints
+
+		shutdownCtx context.Context
 
 		mu        sync.Mutex
 		uploaders []*uploader
@@ -73,7 +74,7 @@ type (
 
 	slabUpload struct {
 		uploadID     api.UploadID
-		mem          *acquiredMemory
+		mem          Memory
 		lockPriority int
 
 		maxOverdrive  uint64
@@ -137,7 +138,7 @@ func (w *worker) initUploadManager(maxMemory, maxOverdrive uint64, overdriveTime
 	}
 
 	mm := newMemoryManager(logger, maxMemory)
-	w.uploadManager = newUploadManager(w.bus, w, w, mm, maxOverdrive, overdriveTimeout, w.shutdownCtx, logger)
+	w.uploadManager = newUploadManager(w.shutdownCtx, w, mm, w.bus, w, maxOverdrive, overdriveTimeout, logger)
 }
 
 func (w *worker) upload(ctx context.Context, r io.Reader, contracts []api.ContractMetadata, up uploadParameters, opts ...UploadOption) (_ string, err error) {
@@ -274,7 +275,7 @@ func (w *worker) uploadPackedSlabs(ctx context.Context, lockingDuration time.Dur
 	return
 }
 
-func (w *worker) uploadPackedSlab(ctx context.Context, ps api.PackedSlab, rs api.RedundancySettings, contractSet string, lockPriority int, mem *acquiredMemory) error {
+func (w *worker) uploadPackedSlab(ctx context.Context, ps api.PackedSlab, rs api.RedundancySettings, contractSet string, lockPriority int, mem Memory) error {
 	// create a context with sane timeout
 	ctx, cancel := context.WithTimeout(ctx, defaultPackedSlabsUploadTimeout)
 	defer cancel()
@@ -303,13 +304,13 @@ func (w *worker) uploadPackedSlab(ctx context.Context, ps api.PackedSlab, rs api
 	return nil
 }
 
-func newUploadManager(b Bus, hp hostProvider, rl revisionLocker, mm MemoryManager, maxOverdrive uint64, overdriveTimeout time.Duration, shutdownCtx context.Context, logger *zap.SugaredLogger) *uploadManager {
+func newUploadManager(ctx context.Context, hm HostManager, mm MemoryManager, os ObjectStore, rl revisionLocker, maxOverdrive uint64, overdriveTimeout time.Duration, logger *zap.SugaredLogger) *uploadManager {
 	return &uploadManager{
-		b:      b,
-		hp:     hp,
+		hm:     hm,
+		mm:     mm,
+		os:     os,
 		rl:     rl,
 		logger: logger,
-		mm:     mm,
 
 		maxOverdrive:     maxOverdrive,
 		overdriveTimeout: overdriveTimeout,
@@ -317,15 +318,15 @@ func newUploadManager(b Bus, hp hostProvider, rl revisionLocker, mm MemoryManage
 		statsOverdrivePct:              stats.NoDecay(),
 		statsSlabUploadSpeedBytesPerMS: stats.NoDecay(),
 
-		shutdownCtx: shutdownCtx,
+		shutdownCtx: ctx,
 
 		uploaders: make([]*uploader, 0),
 	}
 }
 
-func (mgr *uploadManager) newUploader(b Bus, hp hostProvider, c api.ContractMetadata, bh uint64) *uploader {
+func (mgr *uploadManager) newUploader(os ObjectStore, h Host, c api.ContractMetadata, bh uint64) *uploader {
 	return &uploader{
-		b: b,
+		os: os,
 
 		// static
 		hk:              c.HostKey,
@@ -338,7 +339,7 @@ func (mgr *uploadManager) newUploader(b Bus, hp hostProvider, c api.ContractMeta
 		statsSectorUploadSpeedBytesPerMS: stats.NoDecay(),
 
 		// covered by mutex
-		host:      hp.newHostV3(c.ID, c.HostKey, c.SiamuxAddr),
+		host:      h,
 		bh:        bh,
 		fcid:      c.ID,
 		endHeight: c.WindowEnd,
@@ -346,7 +347,7 @@ func (mgr *uploadManager) newUploader(b Bus, hp hostProvider, c api.ContractMeta
 	}
 }
 
-func (mgr *uploadManager) MigrateShards(ctx context.Context, s *object.Slab, shardIndices []int, shards [][]byte, contractSet string, contracts []api.ContractMetadata, bh uint64, lockPriority int, mem *acquiredMemory) (err error) {
+func (mgr *uploadManager) MigrateShards(ctx context.Context, s *object.Slab, shardIndices []int, shards [][]byte, contractSet string, contracts []api.ContractMetadata, bh uint64, lockPriority int, mem Memory) (err error) {
 	// cancel all in-flight requests when the upload is done
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -365,14 +366,14 @@ func (mgr *uploadManager) MigrateShards(ctx context.Context, s *object.Slab, sha
 	}
 
 	// track the upload in the bus
-	if err := mgr.b.TrackUpload(ctx, upload.id); err != nil {
+	if err := mgr.os.TrackUpload(ctx, upload.id); err != nil {
 		return fmt.Errorf("failed to track upload '%v', err: %w", upload.id, err)
 	}
 
 	// defer a function that finishes the upload
 	defer func() {
 		ctx, cancel := context.WithTimeout(mgr.shutdownCtx, time.Minute)
-		if err := mgr.b.FinishUpload(ctx, upload.id); err != nil {
+		if err := mgr.os.FinishUpload(ctx, upload.id); err != nil {
 			mgr.logger.Errorf("failed to mark upload %v as finished: %v", upload.id, err)
 		}
 		cancel()
@@ -411,7 +412,7 @@ func (mgr *uploadManager) MigrateShards(ctx context.Context, s *object.Slab, sha
 	}
 
 	// update the slab
-	return mgr.b.UpdateSlab(ctx, *s, contractSet)
+	return mgr.os.UpdateSlab(ctx, *s, contractSet)
 }
 
 func (mgr *uploadManager) Stats() uploadManagerStats {
@@ -476,14 +477,14 @@ func (mgr *uploadManager) Upload(ctx context.Context, r io.Reader, contracts []a
 	}
 
 	// track the upload in the bus
-	if err := mgr.b.TrackUpload(ctx, upload.id); err != nil {
+	if err := mgr.os.TrackUpload(ctx, upload.id); err != nil {
 		return false, "", fmt.Errorf("failed to track upload '%v', err: %w", upload.id, err)
 	}
 
 	// defer a function that finishes the upload
 	defer func() {
 		ctx, cancel := context.WithTimeout(mgr.shutdownCtx, time.Minute)
-		if err := mgr.b.FinishUpload(ctx, upload.id); err != nil {
+		if err := mgr.os.FinishUpload(ctx, upload.id); err != nil {
 			mgr.logger.Errorf("failed to mark upload %v as finished: %v", upload.id, err)
 		}
 		cancel()
@@ -595,7 +596,7 @@ func (mgr *uploadManager) Upload(ctx context.Context, r io.Reader, contracts []a
 	// add partial slabs
 	if len(partialSlab) > 0 {
 		var pss []object.SlabSlice
-		pss, bufferSizeLimitReached, err = mgr.b.AddPartialSlab(ctx, partialSlab, uint8(up.rs.MinShards), uint8(up.rs.TotalShards), up.contractSet)
+		pss, bufferSizeLimitReached, err = mgr.os.AddPartialSlab(ctx, partialSlab, uint8(up.rs.MinShards), uint8(up.rs.TotalShards), up.contractSet)
 		if err != nil {
 			return false, "", err
 		}
@@ -604,13 +605,13 @@ func (mgr *uploadManager) Upload(ctx context.Context, r io.Reader, contracts []a
 
 	if up.multipart {
 		// persist the part
-		err = mgr.b.AddMultipartPart(ctx, up.bucket, up.path, up.contractSet, eTag, up.uploadID, up.partNumber, o.Slabs)
+		err = mgr.os.AddMultipartPart(ctx, up.bucket, up.path, up.contractSet, eTag, up.uploadID, up.partNumber, o.Slabs)
 		if err != nil {
 			return bufferSizeLimitReached, "", fmt.Errorf("couldn't add multi part: %w", err)
 		}
 	} else {
 		// persist the object
-		err = mgr.b.AddObject(ctx, up.bucket, up.path, up.contractSet, o, api.AddObjectOptions{MimeType: up.mimeType, ETag: eTag})
+		err = mgr.os.AddObject(ctx, up.bucket, up.path, up.contractSet, o, api.AddObjectOptions{MimeType: up.mimeType, ETag: eTag})
 		if err != nil {
 			return bufferSizeLimitReached, "", fmt.Errorf("couldn't add object: %w", err)
 		}
@@ -619,7 +620,7 @@ func (mgr *uploadManager) Upload(ctx context.Context, r io.Reader, contracts []a
 	return
 }
 
-func (mgr *uploadManager) UploadPackedSlab(ctx context.Context, rs api.RedundancySettings, ps api.PackedSlab, contracts []api.ContractMetadata, bh uint64, lockPriority int, mem *acquiredMemory) (err error) {
+func (mgr *uploadManager) UploadPackedSlab(ctx context.Context, rs api.RedundancySettings, ps api.PackedSlab, contracts []api.ContractMetadata, bh uint64, lockPriority int, mem Memory) (err error) {
 	// cancel all in-flight requests when the upload is done
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -641,14 +642,14 @@ func (mgr *uploadManager) UploadPackedSlab(ctx context.Context, rs api.Redundanc
 	}
 
 	// track the upload in the bus
-	if err := mgr.b.TrackUpload(ctx, upload.id); err != nil {
+	if err := mgr.os.TrackUpload(ctx, upload.id); err != nil {
 		return fmt.Errorf("failed to track upload '%v', err: %w", upload.id, err)
 	}
 
 	// defer a function that finishes the upload
 	defer func() {
 		ctx, cancel := context.WithTimeout(mgr.shutdownCtx, time.Minute)
-		if err := mgr.b.FinishUpload(ctx, upload.id); err != nil {
+		if err := mgr.os.FinishUpload(ctx, upload.id); err != nil {
 			mgr.logger.Errorf("failed to mark upload %v as finished: %v", upload.id, err)
 		}
 		cancel()
@@ -666,7 +667,7 @@ func (mgr *uploadManager) UploadPackedSlab(ctx context.Context, rs api.Redundanc
 
 	// mark packed slab as uploaded
 	slab := api.UploadedPackedSlab{BufferID: ps.BufferID, Shards: sectors}
-	err = mgr.b.MarkPackedSlabsUploaded(ctx, []api.UploadedPackedSlab{slab})
+	err = mgr.os.MarkPackedSlabsUploaded(ctx, []api.UploadedPackedSlab{slab})
 	if err != nil {
 		return fmt.Errorf("couldn't mark packed slabs uploaded, err: %v", err)
 	}
@@ -743,7 +744,8 @@ func (mgr *uploadManager) refreshUploaders(contracts []api.ContractMetadata, bh 
 
 		// renew uploaders that got renewed
 		if renewed {
-			uploader.Renew(mgr.hp, renewal, bh)
+			host := mgr.hm.Host(renewal.HostKey, renewal.ID, renewal.SiamuxAddr)
+			uploader.Renew(host, renewal, bh)
 		}
 
 		// update uploader and add to the list
@@ -757,15 +759,16 @@ func (mgr *uploadManager) refreshUploaders(contracts []api.ContractMetadata, bh 
 
 	// add missing uploaders
 	for _, c := range wanted {
-		uploader := mgr.newUploader(mgr.b, mgr.hp, c, bh)
+		host := mgr.hm.Host(c.HostKey, c.ID, c.SiamuxAddr)
+		uploader := mgr.newUploader(mgr.os, host, c, bh)
 		refreshed = append(refreshed, uploader)
-		go uploader.Start(mgr.hp, mgr.rl)
+		go uploader.Start(mgr.hm, mgr.rl)
 	}
 
 	mgr.uploaders = refreshed
 }
 
-func (u *upload) newSlabUpload(ctx context.Context, shards [][]byte, uploaders []*uploader, mem *acquiredMemory, maxOverdrive uint64) (*slabUpload, chan sectorUploadResp) {
+func (u *upload) newSlabUpload(ctx context.Context, shards [][]byte, uploaders []*uploader, mem Memory, maxOverdrive uint64) (*slabUpload, chan sectorUploadResp) {
 	// prepare response channel
 	responseChan := make(chan sectorUploadResp)
 
@@ -811,7 +814,7 @@ func (u *upload) newSlabUpload(ctx context.Context, shards [][]byte, uploaders [
 	}, responseChan
 }
 
-func (u *upload) uploadSlab(ctx context.Context, rs api.RedundancySettings, data []byte, length, index int, respChan chan slabUploadResponse, candidates []*uploader, mem *acquiredMemory, maxOverdrive uint64, overdriveTimeout time.Duration) (uploadSpeed int64, overdrivePct float64) {
+func (u *upload) uploadSlab(ctx context.Context, rs api.RedundancySettings, data []byte, length, index int, respChan chan slabUploadResponse, candidates []*uploader, mem Memory, maxOverdrive uint64, overdriveTimeout time.Duration) (uploadSpeed int64, overdrivePct float64) {
 	// add tracing
 	ctx, span := tracing.Tracer.Start(ctx, "uploadSlab")
 	defer span.End()
@@ -843,7 +846,7 @@ func (u *upload) uploadSlab(ctx context.Context, rs api.RedundancySettings, data
 	return
 }
 
-func (u *upload) uploadShards(ctx context.Context, shards [][]byte, candidates []*uploader, mem *acquiredMemory, maxOverdrive uint64, overdriveTimeout time.Duration) (sectors []object.Sector, uploadSpeed int64, overdrivePct float64, err error) {
+func (u *upload) uploadShards(ctx context.Context, shards [][]byte, candidates []*uploader, mem Memory, maxOverdrive uint64, overdriveTimeout time.Duration) (sectors []object.Sector, uploadSpeed int64, overdrivePct float64, err error) {
 	start := time.Now()
 
 	// add tracing


### PR DESCRIPTION
I decided to open this PR because I was at a point where I made a few small changes and everything still compiled... I figured I might as well get this merged already to have a nicer diff in consecutive PRs where I'll try and unit test the upload manager. 

The nice thing about these changes is that the upload and download managers are initialised in the same way, with all of their dependencies being nice clean interfaces. This PR adds a (temporary) interface called the `ObjectStore`. It's temporary because I might split it off into more granular interfaces down the road.

Next step is to mock the `Host`, `HostManager`, `MemoryManager` and `ObjectStore` which allow us to unit test both uploads and downloads.