### PR TITLE
Discard full txnSet and not just last txn

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -11,6 +11,12 @@ import (
 )
 
 type (
+	// WalletDiscardRequest is the request type for the /wallet/discard
+	// endpoint.
+	WalletDiscardRequest struct {
+		TransactionSet []types.Transaction `json:"transactionSet"`
+	}
+
 	// WalletFundRequest is the request type for the /wallet/fund endpoint.
 	WalletFundRequest struct {
 		Transaction        types.Transaction `json:"transaction"`

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -84,7 +84,7 @@ type Bus interface {
 
 	// wallet
 	Wallet(ctx context.Context) (api.WalletResponse, error)
-	WalletDiscard(ctx context.Context, txn types.Transaction) error
+	WalletDiscard(ctx context.Context, txnSet ...types.Transaction) error
 	WalletOutputs(ctx context.Context) (resp []wallet.SiacoinElement, err error)
 	WalletPending(ctx context.Context) (resp []types.Transaction, err error)
 	WalletRedistribute(ctx context.Context, outputs int, amount types.Currency) (id types.TransactionID, err error)

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -85,10 +85,6 @@ const (
 	timeoutPruneContract = 10 * time.Minute
 )
 
-var (
-	errLargeTransaction = errors.New("transaction is too large for this transaction pool")
-)
-
 type (
 	contractor struct {
 		ap       *Autopilot
@@ -1388,9 +1384,7 @@ func (c *contractor) renewContract(ctx context.Context, w Worker, ci contractInf
 			"renterFunds", renterFunds,
 			"expectedNewStorage", expectedNewStorage,
 		)
-		if strings.Contains(err.Error(), errLargeTransaction.Error()) {
-			return api.ContractMetadata{}, true, err
-		} else if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
+		if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
 			return api.ContractMetadata{}, false, err
 		}
 		return api.ContractMetadata{}, true, err
@@ -1468,9 +1462,7 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 	resp, err := w.RHPRenew(ctx, contract.ID, contract.EndHeight(), hk, contract.SiamuxAddr, settings.Address, state.address, renterFunds, minNewCollateral, expectedStorage, settings.WindowSize)
 	if err != nil {
 		c.logger.Errorw("refresh failed", zap.Error(err), "hk", hk, "fcid", fcid)
-		if strings.Contains(err.Error(), errLargeTransaction.Error()) {
-			return api.ContractMetadata{}, true, err
-		} else if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
+		if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
 			return api.ContractMetadata{}, false, err
 		}
 		return api.ContractMetadata{}, true, err
@@ -1543,9 +1535,7 @@ func (c *contractor) formContract(ctx context.Context, w Worker, host hostdb.Hos
 	if err != nil {
 		// TODO: keep track of consecutive failures and break at some point
 		c.logger.Errorw(fmt.Sprintf("contract formation failed, err: %v", err), "hk", hk)
-		if strings.Contains(err.Error(), errLargeTransaction.Error()) {
-			return api.ContractMetadata{}, true, err
-		} else if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
+		if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
 			return api.ContractMetadata{}, false, err
 		}
 		return api.ContractMetadata{}, true, err

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -85,6 +85,10 @@ const (
 	timeoutPruneContract = 10 * time.Minute
 )
 
+var (
+	errLargeTransaction = errors.New("transaction is too large for this transaction pool")
+)
+
 type (
 	contractor struct {
 		ap       *Autopilot
@@ -1384,7 +1388,9 @@ func (c *contractor) renewContract(ctx context.Context, w Worker, ci contractInf
 			"renterFunds", renterFunds,
 			"expectedNewStorage", expectedNewStorage,
 		)
-		if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
+		if strings.Contains(err.Error(), errLargeTransaction.Error()) {
+			return api.ContractMetadata{}, true, err
+		} else if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
 			return api.ContractMetadata{}, false, err
 		}
 		return api.ContractMetadata{}, true, err
@@ -1462,7 +1468,9 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 	resp, err := w.RHPRenew(ctx, contract.ID, contract.EndHeight(), hk, contract.SiamuxAddr, settings.Address, state.address, renterFunds, minNewCollateral, expectedStorage, settings.WindowSize)
 	if err != nil {
 		c.logger.Errorw("refresh failed", zap.Error(err), "hk", hk, "fcid", fcid)
-		if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
+		if strings.Contains(err.Error(), errLargeTransaction.Error()) {
+			return api.ContractMetadata{}, true, err
+		} else if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
 			return api.ContractMetadata{}, false, err
 		}
 		return api.ContractMetadata{}, true, err
@@ -1535,7 +1543,9 @@ func (c *contractor) formContract(ctx context.Context, w Worker, host hostdb.Hos
 	if err != nil {
 		// TODO: keep track of consecutive failures and break at some point
 		c.logger.Errorw(fmt.Sprintf("contract formation failed, err: %v", err), "hk", hk)
-		if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
+		if strings.Contains(err.Error(), errLargeTransaction.Error()) {
+			return api.ContractMetadata{}, true, err
+		} else if strings.Contains(err.Error(), wallet.ErrInsufficientBalance.Error()) {
 			return api.ContractMetadata{}, false, err
 		}
 		return api.ContractMetadata{}, true, err

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -84,7 +84,7 @@ type (
 		FundTransaction(cs consensus.State, txn *types.Transaction, amount types.Currency, useUnconfirmedTxns bool) ([]types.Hash256, error)
 		Height() uint64
 		Redistribute(cs consensus.State, outputs int, amount, feePerByte types.Currency, pool []types.Transaction) (types.Transaction, []types.Hash256, error)
-		ReleaseInputs(txnSete ...types.Transaction)
+		ReleaseInputs(txnSet ...types.Transaction)
 		SignTransaction(cs consensus.State, txn *types.Transaction, toSign []types.Hash256, cf types.CoveredFields) error
 		Transactions(before, since time.Time, offset, limit int) ([]wallet.Transaction, error)
 		UnspentOutputs() ([]wallet.SiacoinElement, error)

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -84,7 +84,7 @@ type (
 		FundTransaction(cs consensus.State, txn *types.Transaction, amount types.Currency, useUnconfirmedTxns bool) ([]types.Hash256, error)
 		Height() uint64
 		Redistribute(cs consensus.State, outputs int, amount, feePerByte types.Currency, pool []types.Transaction) (types.Transaction, []types.Hash256, error)
-		ReleaseInputs(txn types.Transaction)
+		ReleaseInputs(txnSete ...types.Transaction)
 		SignTransaction(cs consensus.State, txn *types.Transaction, toSign []types.Hash256, cf types.CoveredFields) error
 		Transactions(before, since time.Time, offset, limit int) ([]wallet.Transaction, error)
 		UnspentOutputs() ([]wallet.SiacoinElement, error)
@@ -621,9 +621,9 @@ func (b *bus) walletRedistributeHandler(jc jape.Context) {
 }
 
 func (b *bus) walletDiscardHandler(jc jape.Context) {
-	var txn types.Transaction
-	if jc.Decode(&txn) == nil {
-		b.w.ReleaseInputs(txn)
+	var wdr api.WalletDiscardRequest
+	if jc.Decode(&wdr) == nil {
+		b.w.ReleaseInputs(wdr.TransactionSet...)
 	}
 }
 

--- a/bus/client/wallet.go
+++ b/bus/client/wallet.go
@@ -32,7 +32,7 @@ func (c *Client) SendSiacoins(ctx context.Context, scos []types.SiacoinOutput, u
 			_ = c.WalletDiscard(ctx, txnSet...)
 		}
 	}()
-	err = c.WalletSign(ctx, &txn, toSign, types.CoveredFields{WholeTransaction: true})
+	err = c.WalletSign(ctx, &txnSet[len(txnSet)-1], toSign, types.CoveredFields{WholeTransaction: true})
 	if err != nil {
 		return err
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -270,9 +270,11 @@ func (w *SingleAddressWallet) FundTransaction(cs consensus.State, txn *types.Tra
 // ReleaseInputs is a helper function that releases the inputs of txn for use in
 // other transactions. It should only be called on transactions that are invalid
 // or will never be broadcast.
-func (w *SingleAddressWallet) ReleaseInputs(txn types.Transaction) {
-	for _, in := range txn.SiacoinInputs {
-		delete(w.lastUsed, types.Hash256(in.ParentID))
+func (w *SingleAddressWallet) ReleaseInputs(txnSet ...types.Transaction) {
+	for _, txn := range txnSet {
+		for _, in := range txn.SiacoinInputs {
+			delete(w.lastUsed, types.Hash256(in.ParentID))
+		}
 	}
 }
 

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -1234,7 +1234,7 @@ func RPCRenew(ctx context.Context, rrr api.RHPRenewRequest, bus Bus, t *transpor
 	}
 
 	// Starting from here, we need to make sure to release the txn on error.
-	defer discardTxnOnErr(ctx, bus, l, wprr.TransactionSet[len(wprr.TransactionSet)-1], "RPCRenew", &err)
+	defer discardTxnSetOnErr(ctx, bus, l, wprr.TransactionSet, "RPCRenew", &err)
 
 	txnSet := wprr.TransactionSet
 	parents, txn := txnSet[:len(txnSet)-1], txnSet[len(txnSet)-1]


### PR DESCRIPTION
When funding transactions we need to release not just the funded transaction but also the parents since we now also use unconfirmed txns as inputs. Otherwise we can't reuse them.