### PR TITLE
Fix panic on refresh and minCollateral calculation

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -206,9 +206,9 @@ func (c Contract) RenterFunds() types.Currency {
 }
 
 // RemainingCollateral returns the remaining collateral in the contract.
-func (c Contract) RemainingCollateral(s rhpv2.HostSettings) types.Currency {
-	if c.Revision.MissedHostPayout().Cmp(s.ContractPrice) < 0 {
+func (c Contract) RemainingCollateral() types.Currency {
+	if c.Revision.MissedHostPayout().Cmp(c.ContractPrice) < 0 {
 		return types.ZeroCurrency
 	}
-	return c.Revision.MissedHostPayout().Sub(s.ContractPrice)
+	return c.Revision.MissedHostPayout().Sub(c.ContractPrice)
 }

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -1458,7 +1458,6 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 		return api.ContractMetadata{}, false, fmt.Errorf("insufficient budget: %s < %s", budget.String(), renterFunds.String())
 	}
 
-	// calculate the new collateral
 	expectedStorage := renterFundsToExpectedStorage(renterFunds, contract.EndHeight()-cs.BlockHeight, ci.priceTable)
 	unallocatedCollateral := rev.MissedHostPayout().Sub(contract.ContractPrice)
 

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -313,7 +313,7 @@ func isOutOfCollateral(c api.Contract, s rhpv2.HostSettings, pt rhpv3.HostPriceT
 		expectedStorage = s.RemainingStorage
 	}
 	_, _, newCollateral := rhpv3.RenewalCosts(c.Revision.FileContract, pt, expectedStorage, c.EndHeight())
-	return isBelowCollateralThreshold(newCollateral, c.RemainingCollateral(s))
+	return isBelowCollateralThreshold(newCollateral, c.RemainingCollateral())
 }
 
 // isBelowCollateralThreshold returns true if the remainingCollateral is below a

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -296,7 +296,7 @@ func main() {
 
 	flag.Parse()
 
-	log.Println("renterd v0.6.0")
+	log.Println("renterd v0.7.1")
 	log.Println("Network", build.NetworkName())
 	if flag.Arg(0) == "version" {
 		log.Println("Commit:", githash)

--- a/worker/host.go
+++ b/worker/host.go
@@ -167,8 +167,7 @@ func (h *host) RenewContract(ctx context.Context, rrr api.RHPRenewRequest) (_ rh
 	err = h.transportPool.withTransportV3(ctx, h.hk, h.siamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
 		_, err = RPCLatestRevision(ctx, t, h.fcid, func(revision *types.FileContractRevision) (rhpv3.HostPriceTable, rhpv3.PaymentMethod, error) {
 			// Renew contract.
-			contractPrice = pt.ContractPrice
-			rev, txnSet, renewErr = RPCRenew(ctx, rrr, h.bus, t, pt, *revision, h.renterKey, h.logger)
+			rev, txnSet, contractPrice, renewErr = RPCRenew(ctx, rrr, h.bus, t, pt, *revision, h.renterKey, h.logger)
 			return rhpv3.HostPriceTable{}, nil, nil
 		})
 		return err

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -1214,9 +1214,6 @@ func RPCRenew(ctx context.Context, rrr api.RHPRenewRequest, bus Bus, t *transpor
 		}
 	}
 
-	// Remember contract price.
-	contractPrice := pt.ContractPrice
-
 	// Perform gouging checks.
 	gc, err := GougingCheckerFromContext(ctx, false)
 	if err != nil {
@@ -1331,7 +1328,7 @@ func RPCRenew(ctx context.Context, rrr api.RHPRenewRequest, bus Bus, t *transpor
 	return rhpv2.ContractRevision{
 		Revision:   noOpRevision,
 		Signatures: [2]types.TransactionSignature{renterNoOpRevisionSignature, hostSigs.RevisionSignature},
-	}, txnSet, contractPrice, nil
+	}, txnSet, pt.ContractPrice, nil
 }
 
 // initialRevision returns the first revision of a file contract formation


### PR DESCRIPTION
When refreshing a contract that is not below the collateral threshold we no longer enforce a minimum new collateral. 
Also when refreshing a contract that isn't out of funds, we don't increase the funds we put in the refreshed contract.

Also fixes a panic when we renew/refresh without a valid price table