### PR TITLE
Fix migration 35 failing due to foreign key constraint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/go/pkg/mod \
     CGO_ENABLED=1 go build -ldflags="-s -w" -tags="${BUILD_TAGS}" ./cmd/renterd
 
 # Build image that will be used to run renterd.
-FROM debian:bookworm-slim
+FROM alpine:3
 LABEL maintainer="The Sia Foundation <info@sia.tech>" \
       org.opencontainers.image.description.vendor="The Sia Foundation" \
       org.opencontainers.image.description="A renterd container - next-generation Sia renter" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN if [ "$BUILD_RUN_GO_GENERATE" = "true" ] ; then go generate ./... ; fi
 # Build renterd.
 RUN --mount=type=cache,target=/root/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=1 go build -ldflags="-s -w" -tags="${BUILD_TAGS}" ./cmd/renterd
+    CGO_ENABLED=1 go build -ldflags='-s -w -linkmode external -extldflags "-static"' -tags="${BUILD_TAGS}" ./cmd/renterd
 
 # Build image that will be used to run renterd.
 FROM alpine:3

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [[ "$BUILD_TAGS" == *'testnet'* ]]; then
     exec renterd -http=':9880' -s3.address=':7070' "$@"

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -1392,6 +1392,14 @@ func performMigration00034_objectHealth(txn *gorm.DB, logger *zap.SugaredLogger)
 
 func performMigration00035_bufferedSlabsDropSizeAndComplete(txn *gorm.DB, logger *zap.SugaredLogger) error {
 	logger.Info("performing migration 00035_bufferedSlabsDropSizeAndComplete")
+
+	// Disable foreign keys in SQLite to avoid issues with updating constraints.
+	if isSQLite(txn) {
+		if err := txn.Exec(`PRAGMA foreign_keys = 0`).Error; err != nil {
+			return err
+		}
+	}
+
 	if txn.Migrator().HasColumn(&dbBufferedSlab{}, "size") {
 		if err := txn.Migrator().DropColumn(&dbBufferedSlab{}, "size"); err != nil {
 			return err
@@ -1399,6 +1407,16 @@ func performMigration00035_bufferedSlabsDropSizeAndComplete(txn *gorm.DB, logger
 	}
 	if txn.Migrator().HasColumn(&dbBufferedSlab{}, "complete") {
 		if err := txn.Migrator().DropColumn(&dbBufferedSlab{}, "complete"); err != nil {
+			return err
+		}
+	}
+
+	// Enable foreign keys again.
+	if isSQLite(txn) {
+		if err := txn.Exec(`PRAGMA foreign_keys = 1`).Error; err != nil {
+			return err
+		}
+		if err := txn.Exec(`PRAGMA foreign_key_check(buffered_slabs)`).Error; err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Seems like Debian ships with an old version of SQLite which didn't have `ALTER TABLE foo DROP COLUMN` yet.
So it's trying to copy the table and drop it. This PR fixes that.

It's also migrating our image to alpine to get a more recent version of sqlite.