### PR TITLE
Redistribute wallet in batches

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -87,7 +87,7 @@ type Bus interface {
 	WalletDiscard(ctx context.Context, txn types.Transaction) error
 	WalletOutputs(ctx context.Context) (resp []wallet.SiacoinElement, err error)
 	WalletPending(ctx context.Context) (resp []types.Transaction, err error)
-	WalletRedistribute(ctx context.Context, outputs int, amount types.Currency) (id types.TransactionID, err error)
+	WalletRedistribute(ctx context.Context, outputs int, amount types.Currency) (ids []types.TransactionID, err error)
 }
 
 type Autopilot struct {

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -83,8 +83,8 @@ type (
 		Balance() (spendable, confirmed, unconfirmed types.Currency, _ error)
 		FundTransaction(cs consensus.State, txn *types.Transaction, amount types.Currency, useUnconfirmedTxns bool) ([]types.Hash256, error)
 		Height() uint64
-		Redistribute(cs consensus.State, outputs int, amount, feePerByte types.Currency, pool []types.Transaction) (types.Transaction, []types.Hash256, error)
-		ReleaseInputs(txn types.Transaction)
+		Redistribute(cs consensus.State, outputs int, amount, feePerByte types.Currency, pool []types.Transaction) ([]types.Transaction, []types.Hash256, error)
+		ReleaseInputs(txn ...types.Transaction)
 		SignTransaction(cs consensus.State, txn *types.Transaction, toSign []types.Hash256, cf types.CoveredFields) error
 		Transactions(before, since time.Time, offset, limit int) ([]wallet.Transaction, error)
 		UnspentOutputs() ([]wallet.SiacoinElement, error)
@@ -602,22 +602,27 @@ func (b *bus) walletRedistributeHandler(jc jape.Context) {
 	}
 
 	cs := b.cm.TipState()
-	txn, toSign, err := b.w.Redistribute(cs, wfr.Outputs, wfr.Amount, b.tp.RecommendedFee(), b.tp.Transactions())
+	txns, toSign, err := b.w.Redistribute(cs, wfr.Outputs, wfr.Amount, b.tp.RecommendedFee(), b.tp.Transactions())
 	if jc.Check("couldn't redistribute money in the wallet into the desired outputs", err) != nil {
 		return
 	}
 
-	err = b.w.SignTransaction(cs, &txn, toSign, types.CoveredFields{WholeTransaction: true})
-	if jc.Check("couldn't sign the transaction", err) != nil {
+	var ids []types.TransactionID
+	for i := 0; i < len(txns); i++ {
+		err = b.w.SignTransaction(cs, &txns[i], toSign, types.CoveredFields{WholeTransaction: true})
+		if jc.Check("couldn't sign the transaction", err) != nil {
+			b.w.ReleaseInputs(txns...)
+			return
+		}
+		ids = append(ids, txns[i].ID())
+	}
+
+	if jc.Check("couldn't broadcast the transaction", b.tp.AcceptTransactionSet(txns)) != nil {
+		b.w.ReleaseInputs(txns...)
 		return
 	}
 
-	if jc.Check("couldn't broadcast the transaction", b.tp.AcceptTransactionSet([]types.Transaction{txn})) != nil {
-		b.w.ReleaseInputs(txn)
-		return
-	}
-
-	jc.Encode(txn.ID())
+	jc.Encode(ids)
 }
 
 func (b *bus) walletDiscardHandler(jc jape.Context) {

--- a/bus/client/wallet.go
+++ b/bus/client/wallet.go
@@ -116,13 +116,13 @@ func (c *Client) WalletPrepareRenew(ctx context.Context, revision types.FileCont
 // WalletRedistribute broadcasts a transaction that redistributes the money in
 // the wallet in the desired number of outputs of given amount. If the
 // transaction was successfully broadcasted it will return the transaction ID.
-func (c *Client) WalletRedistribute(ctx context.Context, outputs int, amount types.Currency) (id types.TransactionID, err error) {
+func (c *Client) WalletRedistribute(ctx context.Context, outputs int, amount types.Currency) (ids []types.TransactionID, err error) {
 	req := api.WalletRedistributeRequest{
 		Amount:  amount,
 		Outputs: outputs,
 	}
 
-	err = c.c.WithContext(ctx).POST("/wallet/redistribute", req, &id)
+	err = c.c.WithContext(ctx).POST("/wallet/redistribute", req, &ids)
 	return
 }
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -366,7 +366,7 @@ func (w *SingleAddressWallet) Redistribute(cs consensus.State, outputs int, amou
 
 	for outputs > 0 {
 		var txn types.Transaction
-		for i := 0; outputs > 0 && i < redistributeBatchSize; i++ {
+		for i := 0; i < outputs && i < redistributeBatchSize; i++ {
 			txn.SiacoinOutputs = append(txn.SiacoinOutputs, types.SiacoinOutput{
 				Value:   amount,
 				Address: w.Address(),
@@ -434,6 +434,7 @@ func (w *SingleAddressWallet) Redistribute(cs consensus.State, outputs int, amou
 			w.lastUsed[sce.ID] = time.Now()
 		}
 
+		outputs -= len(txn.SiacoinOutputs)
 		txns = append(txns, txn)
 	}
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -91,10 +91,12 @@ func TestWalletRedistribute(t *testing.T) {
 
 	// split into 3 outputs of 6SC each
 	amount := oneSC.Mul64(6)
-	if txn, _, err := w.Redistribute(cs, 3, amount, types.NewCurrency64(1), nil); err != nil {
+	if txns, _, err := w.Redistribute(cs, 3, amount, types.NewCurrency64(1), nil); err != nil {
 		t.Fatal(err)
+	} else if len(txns) != 1 {
+		t.Fatalf("unexpected number of txns, %v != 1", len(txns))
 	} else {
-		applyTxn(txn)
+		applyTxn(txns[0])
 	}
 
 	// assert number of outputs
@@ -117,10 +119,12 @@ func TestWalletRedistribute(t *testing.T) {
 
 	// split into 2 outputs of 9SC
 	amount = oneSC.Mul64(9)
-	if txn, _, err := w.Redistribute(cs, 2, amount, types.NewCurrency64(1), nil); err != nil {
+	if txns, _, err := w.Redistribute(cs, 2, amount, types.NewCurrency64(1), nil); err != nil {
 		t.Fatal(err)
+	} else if len(txns) != 1 {
+		t.Fatalf("unexpected number of txns, %v != 1", len(txns))
 	} else {
-		applyTxn(txn)
+		applyTxn(txns[0])
 	}
 
 	// assert number of outputs
@@ -137,10 +141,12 @@ func TestWalletRedistribute(t *testing.T) {
 
 	// split into 5 outputs of 3SC
 	amount = oneSC.Mul64(3)
-	if txn, _, err := w.Redistribute(cs, 5, amount, types.NewCurrency64(1), nil); err != nil {
+	if txns, _, err := w.Redistribute(cs, 5, amount, types.NewCurrency64(1), nil); err != nil {
 		t.Fatal(err)
+	} else if len(txns) != 1 {
+		t.Fatalf("unexpected number of txns, %v != 1", len(txns))
 	} else {
-		applyTxn(txn)
+		applyTxn(txns[0])
 	}
 
 	// assert number of outputs that hold 3SC
@@ -154,10 +160,12 @@ func TestWalletRedistribute(t *testing.T) {
 	}
 
 	// split into 6 outputs of 3SC
-	if txn, _, err := w.Redistribute(cs, 6, amount, types.NewCurrency64(1), nil); err != nil {
+	if txns, _, err := w.Redistribute(cs, 6, amount, types.NewCurrency64(1), nil); err != nil {
 		t.Fatal(err)
+	} else if len(txns) != 1 {
+		t.Fatalf("unexpected number of txns, %v != 1", len(txns))
 	} else {
-		applyTxn(txn)
+		applyTxn(txns[0])
 	}
 
 	// assert number of outputs that hold 3SC


### PR DESCRIPTION
This PR changes 2 things.

1. funding a transaction will use the largest outputs first
2. redistribution happens in batches to avoid creating huge transactions