### PR TITLE
Increase scanner min timeout to 10s

### DIFF
--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	scannerTimeoutInterval   = 10 * time.Minute
-	scannerTimeoutMinTimeout = time.Second * 5
+	scannerTimeoutMinTimeout = 10 * time.Second
 
 	trackerMinDataPoints     = 25
 	trackerNumDataPoints     = 1000


### PR DESCRIPTION
I noticed that I got a few hosts that are considered offline because they take ~6 seconds to respond when scanning. I think that should still be enough to be considered 'online'. Otherwise we might end up with unnecessary contract churn just because a host is temporarily slow.