### PR TITLE
Extend /objects/stats response with `numUnfinishedObjects` and `totalUnfinishedObjectsSize`

### DIFF
--- a/api/object.go
+++ b/api/object.go
@@ -113,11 +113,13 @@ type (
 
 	// ObjectsStatsResponse is the response type for the /bus/stats/objects endpoint.
 	ObjectsStatsResponse struct {
-		NumObjects        uint64  `json:"numObjects"`        // number of objects
-		MinHealth         float64 `json:"minHealth"`         // minimum health of all objects
-		TotalObjectsSize  uint64  `json:"totalObjectsSize"`  // size of all objects
-		TotalSectorsSize  uint64  `json:"totalSectorsSize"`  // uploaded size of all objects
-		TotalUploadedSize uint64  `json:"totalUploadedSize"` // uploaded size of all objects including redundant sectors
+		NumObjects                 uint64  `json:"numObjects"`                 // number of objects
+		NumUnfinishedObjects       uint64  `json:"numUnfinishedObjects"`       // number of unfinished objects
+		MinHealth                  float64 `json:"minHealth"`                  // minimum health of all objects
+		TotalObjectsSize           uint64  `json:"totalObjectsSize"`           // size of all objects
+		TotalUnfinishedObjectsSize uint64  `json:"totalUnfinishedObjectsSize"` // size of all unfinished objects
+		TotalSectorsSize           uint64  `json:"totalSectorsSize"`           // uploaded size of all objects
+		TotalUploadedSize          uint64  `json:"totalUploadedSize"`          // uploaded size of all objects including redundant sectors
 	}
 )
 

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1978,6 +1978,19 @@ func TestMultipartUploads(t *testing.T) {
 		t.Fatal("unexpected part:", part3)
 	}
 
+	// Check objects stats.
+	os, err := b.ObjectsStats()
+	tt.OK(err)
+	if os.NumObjects != 0 {
+		t.Fatalf("expected 0 object, got %v", os.NumObjects)
+	} else if os.TotalObjectsSize != 0 {
+		t.Fatalf("expected object size of 0, got %v", os.TotalObjectsSize)
+	} else if os.NumUnfinishedObjects != 1 {
+		t.Fatalf("expected 1 unfinished object, got %v", os.NumUnfinishedObjects)
+	} else if os.TotalUnfinishedObjectsSize != uint64(size) {
+		t.Fatalf("expected unfinished object size of %v, got %v", size, os.TotalUnfinishedObjectsSize)
+	}
+
 	// Complete upload
 	ui, err := b.CompleteMultipartUpload(context.Background(), api.DefaultBucketName, objPath, mpr.UploadID, []api.MultipartCompletedPart{
 		{
@@ -2022,6 +2035,19 @@ func TestMultipartUploads(t *testing.T) {
 		t.Fatal(err)
 	} else if expectedData := data1[:1]; !bytes.Equal(data, expectedData) {
 		t.Fatal("unexpected data:", cmp.Diff(data, expectedData))
+	}
+
+	// Check objects stats.
+	os, err = b.ObjectsStats()
+	tt.OK(err)
+	if os.NumObjects != 1 {
+		t.Fatalf("expected 1 object, got %v", os.NumObjects)
+	} else if os.TotalObjectsSize != uint64(size) {
+		t.Fatalf("expected object size of %v, got %v", size, os.TotalObjectsSize)
+	} else if os.NumUnfinishedObjects != 0 {
+		t.Fatalf("expected 0 unfinished object, got %v", os.NumUnfinishedObjects)
+	} else if os.TotalUnfinishedObjectsSize != 0 {
+		t.Fatalf("expected unfinished object size of 0, got %v", os.TotalUnfinishedObjectsSize)
 	}
 }
 


### PR DESCRIPTION
Added due to https://github.com/SiaFoundation/renterd/issues/834

cc @alexfreska 