### PR TITLE
Defrag wallet implicitly and reduce wallet maintenance to 10 outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,6 @@ formed.
 
 ```json
 {
-	"wallet": {
-		"defragThreshold": 1000
-	},
 	"hosts": {
 		"allowRedundantIPs": false,
 		"maxDowntimeHours": 1440,

--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -39,7 +39,6 @@ type (
 	AutopilotConfig struct {
 		Contracts ContractsConfig `json:"contracts"`
 		Hosts     HostsConfig     `json:"hosts"`
-		Wallet    WalletConfig    `json:"wallet"`
 	}
 
 	// ContractsConfig contains all contract settings used in the autopilot.
@@ -61,11 +60,6 @@ type (
 		MaxDowntimeHours      uint64                      `json:"maxDowntimeHours"`
 		MinRecentScanFailures uint64                      `json:"minRecentScanFailures"`
 		ScoreOverrides        map[types.PublicKey]float64 `json:"scoreOverrides"`
-	}
-
-	// WalletConfig contains all wallet settings used in the autopilot.
-	WalletConfig struct {
-		DefragThreshold uint64 `json:"defragThreshold"`
 	}
 )
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -578,31 +578,26 @@ func (c *contractor) performWalletMaintenance(ctx context.Context) error {
 		}
 	}
 
+	wantedNumOutputs := 10
+
 	// enough outputs - nothing to do
 	available, err := b.WalletOutputs(ctx)
 	if err != nil {
 		return err
 	}
-	if uint64(len(available)) >= cfg.Contracts.Amount {
-		l.Debugf("no wallet maintenance needed, plenty of outputs available (%v>=%v)", len(available), cfg.Contracts.Amount)
+	if uint64(len(available)) >= uint64(wantedNumOutputs) {
+		l.Debugf("no wallet maintenance needed, plenty of outputs available (%v>=%v)", len(available), uint64(wantedNumOutputs))
 		return nil
 	}
+	wantedNumOutputs -= len(available)
 
-	// not enough balance to redistribute outputs - nothing to do
-	amount := cfg.Contracts.Allowance.Div64(cfg.Contracts.Amount)
-	outputs := balance.Div(amount).Big().Uint64()
-	if outputs < 2 {
-		l.Warnf("wallet maintenance skipped, wallet has insufficient balance %v", balance)
-		return err
-	}
-	if outputs > cfg.Contracts.Amount {
-		outputs = cfg.Contracts.Amount
-	}
+	// figure out the amount per output
+	amount := cfg.Contracts.Allowance.Div64(uint64(wantedNumOutputs))
 
 	// redistribute outputs
-	ids, err := b.WalletRedistribute(ctx, int(outputs), amount)
+	ids, err := b.WalletRedistribute(ctx, wantedNumOutputs, amount)
 	if err != nil {
-		return fmt.Errorf("failed to redistribute wallet into %d outputs of amount %v, balance %v, err %v", outputs, amount, balance, err)
+		return fmt.Errorf("failed to redistribute wallet into %d outputs of amount %v, balance %v, err %v", wantedNumOutputs, amount, balance, err)
 	}
 
 	l.Debugf("wallet maintenance succeeded, txns %v", ids)

--- a/autopilot/hostscore_test.go
+++ b/autopilot/hostscore_test.go
@@ -29,9 +29,6 @@ var cfg = api.AutopilotConfig{
 		MaxDowntimeHours:      24 * 7 * 2,
 		MinRecentScanFailures: 10,
 	},
-	Wallet: api.WalletConfig{
-		DefragThreshold: 1000,
-	},
 }
 
 func TestHostScore(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	gitlab.com/NebulousLabs/encoding v0.0.0-20200604091946-456c3dc907fe
 	go.sia.tech/core v0.1.12-0.20231211182757-77190f04f90b
 	go.sia.tech/gofakes3 v0.0.0-20231109151325-e0d47c10dce2
-	go.sia.tech/hostd v0.2.2
+	go.sia.tech/hostd v0.3.0-beta.1
 	go.sia.tech/jape v0.11.1
 	go.sia.tech/mux v1.2.0
 	go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ go.sia.tech/core v0.1.12-0.20231211182757-77190f04f90b h1:xJSxYN2kZD3NAijHIwjXhG
 go.sia.tech/core v0.1.12-0.20231211182757-77190f04f90b/go.mod h1:3EoY+rR78w1/uGoXXVqcYdwSjSJKuEMI5bL7WROA27Q=
 go.sia.tech/gofakes3 v0.0.0-20231109151325-e0d47c10dce2 h1:ulzfJNjxN5DjXHClkW2pTiDk+eJ+0NQhX87lFDZ03t0=
 go.sia.tech/gofakes3 v0.0.0-20231109151325-e0d47c10dce2/go.mod h1:PlsiVCn6+wssrR7bsOIlZm0DahsVrDydrlbjY4F14sg=
-go.sia.tech/hostd v0.2.2 h1:HbXB4WripvVFUSpTrckEhC8DteL+QpXKZeonJHUpq3M=
-go.sia.tech/hostd v0.2.2/go.mod h1:t1hzcQUFyNnP1mW1AxdFiAya2uyUz5lGLuCVehSkXkg=
+go.sia.tech/hostd v0.3.0-beta.1 h1:A2RL4wkW18eb28+fJtdyK9OYNiiwpCDO8FO3cyT9r7A=
+go.sia.tech/hostd v0.3.0-beta.1/go.mod h1:gVtU631RkbtOEHJKb8qghudhWcYIL8w3phjvV2/bz0A=
 go.sia.tech/jape v0.11.1 h1:M7IP+byXL7xOqzxcHUQuXW+q3sYMkYzmMlMw+q8ZZw0=
 go.sia.tech/jape v0.11.1/go.mod h1:4QqmBB+t3W7cNplXPj++ZqpoUb2PeiS66RLpXmEGap4=
 go.sia.tech/mux v1.2.0 h1:ofa1Us9mdymBbGMY2XH/lSpY8itFsKIo/Aq8zwe+GHU=

--- a/stores/autopilot_test.go
+++ b/stores/autopilot_test.go
@@ -41,9 +41,6 @@ func TestAutopilotStore(t *testing.T) {
 			MinRecentScanFailures: 10,
 			AllowRedundantIPs:     true, // allow for integration tests by default
 		},
-		Wallet: api.WalletConfig{
-			DefragThreshold: 1234,
-		},
 	}
 
 	// add an autopilot with that config


### PR DESCRIPTION
So far we've created 1 output per contract we want to form as part of the contract maintenance. That works but is not optimal since a large node with 200 outputs will frequently run into transactions which are too large for the transaction pool when trying to send a greater amount of Siacoins. 

Now that we spend unconfirmed outputs when forming contracts, we can get away with fewer outputs. So this PR sets that number to 10 outputs and allows the wallet to grow up to 30 before starting to defrag the outputs the same way `hostd` defragments outputs.