### PR TITLE
Mod Time

### DIFF
--- a/api/object.go
+++ b/api/object.go
@@ -64,6 +64,7 @@ type (
 		ContractSet string        `json:"contractSet"`
 		Object      object.Object `json:"object"`
 		MimeType    string        `json:"mimeType"`
+		ModTime     TimeRFC3339   `json:"modTime"`
 		ETag        string        `json:"eTag"`
 	}
 
@@ -82,7 +83,8 @@ type (
 		DestinationBucket string `json:"destinationBucket"`
 		DestinationPath   string `json:"destinationPath"`
 
-		MimeType string `json:"mimeType"`
+		MimeType string      `json:"mimeType"`
+		ModTime  TimeRFC3339 `json:"modTime"`
 	}
 
 	// ObjectsDeleteRequest is the request type for the /bus/objects/list endpoint.
@@ -144,11 +146,13 @@ func (o ObjectMetadata) ContentType() string {
 
 type (
 	AddObjectOptions struct {
+		ModTime  TimeRFC3339
 		MimeType string
 		ETag     string
 	}
 
 	CopyObjectOptions struct {
+		ModTime  TimeRFC3339
 		MimeType string
 	}
 
@@ -195,6 +199,7 @@ type (
 		TotalShards                  int
 		ContractSet                  string
 		MimeType                     string
+		ModTime                      TimeRFC3339
 		DisablePreshardingEncryption bool
 		ContentLength                int64
 	}
@@ -221,6 +226,9 @@ func (opts UploadObjectOptions) Apply(values url.Values) {
 	}
 	if opts.MimeType != "" {
 		values.Set("mimetype", opts.MimeType)
+	}
+	if !opts.ModTime.IsZero() {
+		values.Set("modtime", opts.ModTime.String())
 	}
 	if opts.DisablePreshardingEncryption {
 		values.Set("disablepreshardingencryption", "true")

--- a/api/param.go
+++ b/api/param.go
@@ -105,7 +105,7 @@ func (t *TimeRFC3339) UnmarshalText(b []byte) error {
 
 // MarshalJSON implements json.Marshaler.
 func (t TimeRFC3339) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, (time.Time)(t).UTC().Format(time.RFC3339))), nil
+	return []byte(fmt.Sprintf(`"%s"`, (time.Time)(t).UTC().Format(time.RFC3339Nano))), nil
 }
 
 // String implements fmt.Stringer.

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -135,7 +135,7 @@ type (
 		ListBuckets(_ context.Context) ([]api.Bucket, error)
 		UpdateBucketPolicy(ctx context.Context, bucketName string, policy api.BucketPolicy) error
 
-		CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, dstPath, mimeType string) (api.ObjectMetadata, error)
+		CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, dstPath, mimeType string, modTime time.Time) (api.ObjectMetadata, error)
 		ListObjects(ctx context.Context, bucketName, prefix, sortBy, sortDir, marker string, limit int) (api.ObjectsListResponse, error)
 		Object(ctx context.Context, bucketName, path string) (api.Object, error)
 		ObjectEntries(ctx context.Context, bucketName, path, prefix, sortBy, sortDir, marker string, offset, limit int) ([]api.ObjectMetadata, bool, error)
@@ -146,7 +146,7 @@ type (
 		RenameObject(ctx context.Context, bucketName, from, to string, force bool) error
 		RenameObjects(ctx context.Context, bucketName, from, to string, force bool) error
 		SearchObjects(ctx context.Context, bucketName, substring string, offset, limit int) ([]api.ObjectMetadata, error)
-		UpdateObject(ctx context.Context, bucketName, path, contractSet, ETag, mimeType string, o object.Object) error
+		UpdateObject(ctx context.Context, bucketName, path, contractSet, ETag, mimeType string, modTime time.Time, o object.Object) error
 
 		AbortMultipartUpload(ctx context.Context, bucketName, path string, uploadID string) (err error)
 		AddMultipartPart(ctx context.Context, bucketName, path, contractSet, eTag, uploadID string, partNumber int, slices []object.SlabSlice) (err error)
@@ -1257,7 +1257,7 @@ func (b *bus) objectsHandlerPUT(jc jape.Context) {
 	} else if aor.Bucket == "" {
 		aor.Bucket = api.DefaultBucketName
 	}
-	jc.Check("couldn't store object", b.ms.UpdateObject(jc.Request.Context(), aor.Bucket, jc.PathParam("path"), aor.ContractSet, aor.ETag, aor.MimeType, aor.Object))
+	jc.Check("couldn't store object", b.ms.UpdateObject(jc.Request.Context(), aor.Bucket, jc.PathParam("path"), aor.ContractSet, aor.ETag, aor.MimeType, aor.ModTime.Std(), aor.Object))
 }
 
 func (b *bus) objectsCopyHandlerPOST(jc jape.Context) {
@@ -1266,7 +1266,7 @@ func (b *bus) objectsCopyHandlerPOST(jc jape.Context) {
 		return
 	}
 
-	om, err := b.ms.CopyObject(jc.Request.Context(), orr.SourceBucket, orr.DestinationBucket, orr.SourcePath, orr.DestinationPath, orr.MimeType)
+	om, err := b.ms.CopyObject(jc.Request.Context(), orr.SourceBucket, orr.DestinationBucket, orr.SourcePath, orr.DestinationPath, orr.MimeType, orr.ModTime.Std())
 	if jc.Check("couldn't copy object", err) != nil {
 		return
 	}

--- a/bus/client/objects.go
+++ b/bus/client/objects.go
@@ -17,6 +17,7 @@ func (c *Client) AddObject(ctx context.Context, bucket, path, contractSet string
 		ContractSet: contractSet,
 		Object:      o,
 		MimeType:    opts.MimeType,
+		ModTime:     opts.ModTime,
 		ETag:        opts.ETag,
 	})
 	return
@@ -32,6 +33,7 @@ func (c *Client) CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, 
 		DestinationPath:   dstPath,
 
 		MimeType: opts.MimeType,
+		ModTime:  opts.ModTime,
 	}, &om)
 	return
 }

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -185,16 +185,15 @@ type (
 	// rawObjectRow contains all necessary information to reconstruct the object.
 	rawObjectSector struct {
 		// object
-		ObjectID        uint
-		ObjectIndex     uint64
-		ObjectKey       []byte
-		ObjectName      string
-		ObjectSize      int64
-		ObjectModTime   datetime
-		ObjectCreatedAt datetime
-		ObjectMimeType  string
-		ObjectHealth    float64
-		ObjectETag      string
+		ObjectID       uint
+		ObjectIndex    uint64
+		ObjectKey      []byte
+		ObjectName     string
+		ObjectSize     int64
+		ObjectModTime  datetime
+		ObjectMimeType string
+		ObjectHealth   float64
+		ObjectETag     string
 
 		// slice
 		SliceOffset uint32
@@ -458,19 +457,13 @@ func (raw rawObject) convert() (api.Object, error) {
 		}
 	}
 
-	// use mod time if it's not zero
-	mt := time.Time(raw[0].ObjectModTime)
-	if mt.Unix() == 0 {
-		mt = time.Time(raw[0].ObjectCreatedAt)
-	}
-
 	// return object
 	return api.Object{
 		ObjectMetadata: api.ObjectMetadata{
 			ETag:     raw[0].ObjectETag,
 			Health:   raw[0].ObjectHealth,
 			MimeType: raw[0].ObjectMimeType,
-			ModTime:  api.TimeRFC3339(mt),
+			ModTime:  api.TimeRFC3339(raw[0].ObjectModTime),
 			Name:     raw[0].ObjectName,
 			Size:     raw[0].ObjectSize,
 		},

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -2168,7 +2168,7 @@ func (s *SQLStore) ObjectsBySlabKey(ctx context.Context, bucket string, slabKey 
 	}
 
 	err = s.db.Raw(`
-SELECT DISTINCT obj.object_id as Name, obj.size as Size, obj.mime_type as MimeType, objects.mod_time AS ModTime, sla.health as Health,
+SELECT DISTINCT obj.object_id as Name, obj.size as Size, obj.mime_type as MimeType, obj.mod_time AS ModTime, sla.health as Health
 FROM slabs sla
 INNER JOIN slices sli ON sli.db_slab_id = sla.id
 INNER JOIN objects obj ON sli.db_object_id = obj.id

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -83,7 +83,7 @@ func TestObjectBasic(t *testing.T) {
 	}
 
 	// add the object
-	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, t.Name(), testContractSet, testETag, testMimeType, want); err != nil {
+	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, t.Name(), testContractSet, testETag, testMimeType, testModTime, want); err != nil {
 		t.Fatal(err)
 	}
 
@@ -119,7 +119,7 @@ func TestObjectBasic(t *testing.T) {
 	}
 
 	// add the object
-	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, t.Name(), testContractSet, testETag, testMimeType, want2); err != nil {
+	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, t.Name(), testContractSet, testETag, testMimeType, testModTime, want2); err != nil {
 		t.Fatal(err)
 	}
 
@@ -409,7 +409,7 @@ func TestContractRoots(t *testing.T) {
 	}
 
 	// add the object.
-	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, t.Name(), testContractSet, testETag, testMimeType, obj); err != nil {
+	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, t.Name(), testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 		t.Fatal(err)
 	}
 
@@ -511,7 +511,7 @@ func TestRenewedContract(t *testing.T) {
 	}
 
 	// add the object.
-	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, obj); err != nil {
+	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 		t.Fatal(err)
 	}
 
@@ -933,7 +933,7 @@ func TestSQLMetadataStore(t *testing.T) {
 	// Store it.
 	ctx := context.Background()
 	objID := "key1"
-	if err := ss.UpdateObject(ctx, api.DefaultBucketName, objID, testContractSet, testETag, testMimeType, obj1); err != nil {
+	if err := ss.UpdateObject(ctx, api.DefaultBucketName, objID, testContractSet, testETag, testMimeType, testModTime, obj1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -987,6 +987,7 @@ func TestSQLMetadataStore(t *testing.T) {
 				Length:      200,
 			},
 		},
+		ModTime:  obj.ModTime, // ignore ModTime
 		MimeType: testMimeType,
 		Etag:     testETag,
 	}
@@ -995,7 +996,7 @@ func TestSQLMetadataStore(t *testing.T) {
 	}
 
 	// Try to store it again. Should work.
-	if err := ss.UpdateObject(ctx, api.DefaultBucketName, objID, testContractSet, testETag, testMimeType, obj1); err != nil {
+	if err := ss.UpdateObject(ctx, api.DefaultBucketName, objID, testContractSet, testETag, testMimeType, testModTime, obj1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1016,6 +1017,7 @@ func TestSQLMetadataStore(t *testing.T) {
 	// The expected object is the same except for some ids which were
 	// incremented due to the object and slab being overwritten.
 	two := uint(2)
+	expectedObj.ModTime = obj.ModTime
 	expectedObj.Slabs[0].DBObjectID = &two
 	expectedObj.Slabs[0].DBSlabID = 3
 	expectedObj.Slabs[1].DBObjectID = &two
@@ -1138,7 +1140,7 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	// Remove the first slab of the object.
 	obj1.Slabs = obj1.Slabs[1:]
-	if err := ss.UpdateObject(ctx, api.DefaultBucketName, objID, testContractSet, testETag, testMimeType, obj1); err != nil {
+	if err := ss.UpdateObject(ctx, api.DefaultBucketName, objID, testContractSet, testETag, testMimeType, testModTime, obj1); err != nil {
 		t.Fatal(err)
 	}
 	fullObj, err = ss.Object(ctx, api.DefaultBucketName, objID)
@@ -1247,7 +1249,7 @@ func TestObjectHealth(t *testing.T) {
 		},
 	}
 
-	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, "/foo", testContractSet, testETag, testMimeType, add); err != nil {
+	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, "/foo", testContractSet, testETag, testMimeType, testModTime, add); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1341,7 +1343,7 @@ func TestObjectHealth(t *testing.T) {
 		Key:   object.GenerateEncryptionKey(),
 		Slabs: nil,
 	}
-	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, "/bar", testContractSet, testETag, testMimeType, add); err != nil {
+	if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, "/bar", testContractSet, testETag, testMimeType, testModTime, add); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1380,7 +1382,7 @@ func TestObjectEntries(t *testing.T) {
 		obj := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		err := ss.UpdateObject(ctx, api.DefaultBucketName, o.path, testContractSet, testETag, testMimeType, obj)
+		err := ss.UpdateObject(ctx, api.DefaultBucketName, o.path, testContractSet, testETag, testMimeType, testModTime, obj)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1518,7 +1520,7 @@ func TestSearchObjects(t *testing.T) {
 		obj := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		if err := ss.UpdateObject(ctx, api.DefaultBucketName, o.path, testContractSet, testETag, testMimeType, obj); err != nil {
+		if err := ss.UpdateObject(ctx, api.DefaultBucketName, o.path, testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1657,7 +1659,7 @@ func TestUnhealthySlabs(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, obj); err != nil {
+	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1757,7 +1759,7 @@ func TestUnhealthySlabsNegHealth(t *testing.T) {
 
 	// add the object
 	ctx := context.Background()
-	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, obj); err != nil {
+	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1814,7 +1816,7 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 
 	// add the object
 	ctx := context.Background()
-	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, obj); err != nil {
+	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1906,7 +1908,7 @@ func TestUnhealthySlabsNoRedundancy(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, obj); err != nil {
+	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1965,7 +1967,7 @@ func TestContractSectors(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, obj); err != nil {
+	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1991,7 +1993,7 @@ func TestContractSectors(t *testing.T) {
 	}
 
 	// Add the object again.
-	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, obj); err != nil {
+	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2048,7 +2050,7 @@ func TestUpdateSlab(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, obj); err != nil {
+	if err := ss.UpdateObject(ctx, api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2319,7 +2321,7 @@ func TestRenameObjects(t *testing.T) {
 	ctx := context.Background()
 	for _, path := range objects {
 		obj := newTestObject(1)
-		if err := ss.UpdateObject(ctx, api.DefaultBucketName, path, testContractSet, testETag, testMimeType, obj); err != nil {
+		if err := ss.UpdateObject(ctx, api.DefaultBucketName, path, testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -2437,7 +2439,7 @@ func TestObjectsStats(t *testing.T) {
 		}
 
 		key := hex.EncodeToString(frand.Bytes(32))
-		err := ss.UpdateObject(context.Background(), api.DefaultBucketName, key, testContractSet, testETag, testMimeType, obj)
+		err := ss.UpdateObject(context.Background(), api.DefaultBucketName, key, testContractSet, testETag, testMimeType, testModTime, obj)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2609,7 +2611,7 @@ func TestPartialSlab(t *testing.T) {
 		return obj
 	}
 	obj := testObject(slabs)
-	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "key", testContractSet, testETag, testMimeType, obj)
+	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "key", testContractSet, testETag, testMimeType, testModTime, obj)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2649,7 +2651,7 @@ func TestPartialSlab(t *testing.T) {
 
 	// Create an object again.
 	obj2 := testObject(slabs)
-	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "key2", testContractSet, testETag, testMimeType, obj2)
+	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "key2", testContractSet, testETag, testMimeType, testModTime, obj2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2701,7 +2703,7 @@ func TestPartialSlab(t *testing.T) {
 
 	// Create an object again.
 	obj3 := testObject(slabs)
-	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "key3", testContractSet, testETag, testMimeType, obj3)
+	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "key3", testContractSet, testETag, testMimeType, testModTime, obj3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2783,7 +2785,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 
 	// Associate them with an object.
-	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "foo", testContractSet, "", "", object.Object{
+	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "foo", testContractSet, "", "", testModTime, object.Object{
 		Key:   object.GenerateEncryptionKey(),
 		Slabs: append(slices1, slices2...),
 	})
@@ -2865,7 +2867,7 @@ func TestContractSizes(t *testing.T) {
 
 	// add an object to both contracts
 	for i := 0; i < 2; i++ {
-		if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, fmt.Sprintf("obj_%d", i+1), testContractSet, testETag, testMimeType, object.Object{
+		if err := ss.UpdateObject(context.Background(), api.DefaultBucketName, fmt.Sprintf("obj_%d", i+1), testContractSet, testETag, testMimeType, testModTime, object.Object{
 			Key: object.GenerateEncryptionKey(),
 			Slabs: []object.SlabSlice{
 				{
@@ -3023,7 +3025,7 @@ func TestObjectsBySlabKey(t *testing.T) {
 	}
 	for _, name := range []string{"obj1", "obj2", "obj3"} {
 		obj.Slabs[0].Length++
-		err = ss.UpdateObject(context.Background(), api.DefaultBucketName, name, testContractSet, testETag, testMimeType, obj)
+		err = ss.UpdateObject(context.Background(), api.DefaultBucketName, name, testContractSet, testETag, testMimeType, testModTime, obj)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3095,7 +3097,7 @@ func TestBucketObjects(t *testing.T) {
 
 	// Adding an object to a bucket that doesn't exist shouldn't work.
 	obj := newTestObject(1)
-	err := ss.UpdateObject(context.Background(), "unknown-bucket", "foo", testContractSet, testETag, testMimeType, obj)
+	err := ss.UpdateObject(context.Background(), "unknown-bucket", "foo", testContractSet, testETag, testMimeType, testModTime, obj)
 	if !errors.Is(err, api.ErrBucketNotFound) {
 		t.Fatal("expected ErrBucketNotFound", err)
 	}
@@ -3126,7 +3128,7 @@ func TestBucketObjects(t *testing.T) {
 		obj := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		err := ss.UpdateObject(ctx, o.bucket, o.path, testContractSet, testETag, testMimeType, obj)
+		err := ss.UpdateObject(ctx, o.bucket, o.path, testContractSet, testETag, testMimeType, testModTime, obj)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3273,13 +3275,13 @@ func TestCopyObject(t *testing.T) {
 
 	// Create one object.
 	obj := newTestObject(1)
-	err := ss.UpdateObject(ctx, "src", "/foo", testContractSet, testETag, testMimeType, obj)
+	err := ss.UpdateObject(ctx, "src", "/foo", testContractSet, testETag, testMimeType, testModTime, obj)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Copy it within the same bucket.
-	if om, err := ss.CopyObject(ctx, "src", "src", "/foo", "/bar", ""); err != nil {
+	if om, err := ss.CopyObject(ctx, "src", "src", "/foo", "/bar", "", testModTime); err != nil {
 		t.Fatal(err)
 	} else if entries, _, err := ss.ObjectEntries(ctx, "src", "/", "", "", "", "", 0, -1); err != nil {
 		t.Fatal(err)
@@ -3292,7 +3294,7 @@ func TestCopyObject(t *testing.T) {
 	}
 
 	// Copy it cross buckets.
-	if om, err := ss.CopyObject(ctx, "src", "dst", "/foo", "/bar", ""); err != nil {
+	if om, err := ss.CopyObject(ctx, "src", "dst", "/foo", "/bar", "", testModTime); err != nil {
 		t.Fatal(err)
 	} else if entries, _, err := ss.ObjectEntries(ctx, "dst", "/", "", "", "", "", 0, -1); err != nil {
 		t.Fatal(err)
@@ -3330,7 +3332,7 @@ func TestMarkSlabUploadedAfterRenew(t *testing.T) {
 	}
 
 	// add it to an object to prevent it from getting pruned.
-	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "foo", testContractSet, "", "", object.Object{
+	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "foo", testContractSet, "", "", testModTime, object.Object{
 		Key:   object.GenerateEncryptionKey(),
 		Slabs: slabs,
 	})
@@ -3414,7 +3416,7 @@ func TestListObjects(t *testing.T) {
 		obj := newTestObject(frand.Intn(9) + 1)
 		obj.Slabs = obj.Slabs[:1]
 		obj.Slabs[0].Length = uint32(o.size)
-		if err := ss.UpdateObject(ctx, api.DefaultBucketName, o.path, testContractSet, testETag, testMimeType, obj); err != nil {
+		if err := ss.UpdateObject(ctx, api.DefaultBucketName, o.path, testContractSet, testETag, testMimeType, testModTime, obj); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -3632,7 +3634,7 @@ func TestUpdateSlabSanityChecks(t *testing.T) {
 	}
 
 	// set slab.
-	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, object.Object{
+	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "foo", testContractSet, testETag, testMimeType, testModTime, object.Object{
 		Key:   object.GenerateEncryptionKey(),
 		Slabs: []object.SlabSlice{{Slab: slab}},
 	})
@@ -3718,7 +3720,7 @@ func TestSlabHealthInvalidation(t *testing.T) {
 
 	// prepare a slab with pieces on h1 and h2
 	s1 := object.GenerateEncryptionKey()
-	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "o1", testContractSet, testETag, testMimeType, object.Object{
+	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "o1", testContractSet, testETag, testMimeType, testModTime, object.Object{
 		Key: object.GenerateEncryptionKey(),
 		Slabs: []object.SlabSlice{{Slab: object.Slab{
 			Key: s1,
@@ -3734,7 +3736,7 @@ func TestSlabHealthInvalidation(t *testing.T) {
 
 	// prepare a slab with pieces on h3 and h4
 	s2 := object.GenerateEncryptionKey()
-	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "o2", testContractSet, testETag, testMimeType, object.Object{
+	err = ss.UpdateObject(context.Background(), api.DefaultBucketName, "o2", testContractSet, testETag, testMimeType, testModTime, object.Object{
 		Key: object.GenerateEncryptionKey(),
 		Slabs: []object.SlabSlice{{Slab: object.Slab{
 			Key: s2,

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"go.sia.tech/core/types"
@@ -390,6 +391,7 @@ func (s *SQLStore) CompleteMultipartUpload(ctx context.Context, bucket, path str
 			Key:        mu.Key,
 			Size:       int64(size),
 			MimeType:   mu.MimeType,
+			ModTime:    time.Now(), // TODO: PJ: CreateMultipartUpload docs have no mention of X-Amz-Meta-Mtime
 			Etag:       eTag,
 		}
 		if err := tx.Create(&obj).Error; err != nil {

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -28,6 +28,10 @@ const (
 	testETag            = "d34db33f"
 )
 
+var (
+	testModTime time.Time
+)
+
 type testSQLStore struct {
 	t *testing.T
 	*SQLStore

--- a/stores/types.go
+++ b/stores/types.go
@@ -266,7 +266,7 @@ func (dt *datetime) Scan(value interface{}) error {
 		}
 	}
 	if !ok {
-		return fmt.Errorf("failed to parse datetime value: %v", s)
+		return fmt.Errorf("failed to parse datetime value: '%v'", s)
 	}
 
 	*dt = datetime(t)

--- a/worker/contract_lock.go
+++ b/worker/contract_lock.go
@@ -31,8 +31,8 @@ type contractLock struct {
 	stopWG                 sync.WaitGroup
 }
 
-func newContractLock(ctx context.Context, fcid types.FileContractID, lockID uint64, d time.Duration, locker ContractLocker, logger *zap.SugaredLogger) *contractLock {
-	ctx, cancel := context.WithCancel(ctx)
+func newContractLock(fcid types.FileContractID, lockID uint64, d time.Duration, locker ContractLocker, logger *zap.SugaredLogger) *contractLock {
+	ctx, cancel := context.WithCancel(context.Background())
 	cl := &contractLock{
 		lockID: lockID,
 		fcid:   fcid,
@@ -56,7 +56,7 @@ func (w *worker) acquireContractLock(ctx context.Context, fcid types.FileContrac
 	if err != nil {
 		return nil, err
 	}
-	return newContractLock(w.shutdownCtx, fcid, lockID, w.contractLockingDuration, w.bus, w.logger), nil
+	return newContractLock(fcid, lockID, w.contractLockingDuration, w.bus, w.logger), nil
 }
 
 func (w *worker) withContractLock(ctx context.Context, fcid types.FileContractID, priority int, fn func() error) error {

--- a/worker/contract_lock.go
+++ b/worker/contract_lock.go
@@ -31,8 +31,8 @@ type contractLock struct {
 	stopWG                 sync.WaitGroup
 }
 
-func newContractLock(fcid types.FileContractID, lockID uint64, d time.Duration, locker ContractLocker, logger *zap.SugaredLogger) *contractLock {
-	ctx, cancel := context.WithCancel(context.Background())
+func newContractLock(ctx context.Context, fcid types.FileContractID, lockID uint64, d time.Duration, locker ContractLocker, logger *zap.SugaredLogger) *contractLock {
+	ctx, cancel := context.WithCancel(ctx)
 	cl := &contractLock{
 		lockID: lockID,
 		fcid:   fcid,
@@ -56,7 +56,7 @@ func (w *worker) acquireContractLock(ctx context.Context, fcid types.FileContrac
 	if err != nil {
 		return nil, err
 	}
-	return newContractLock(fcid, lockID, w.contractLockingDuration, w.bus, w.logger), nil
+	return newContractLock(w.shutdownCtx, fcid, lockID, w.contractLockingDuration, w.bus, w.logger), nil
 }
 
 func (w *worker) withContractLock(ctx context.Context, fcid types.FileContractID, priority int, fn func() error) error {

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -609,7 +609,7 @@ func (mgr *uploadManager) Upload(ctx context.Context, r io.Reader, contracts []a
 		}
 	} else {
 		// persist the object
-		err = mgr.os.AddObject(ctx, up.bucket, up.path, up.contractSet, o, api.AddObjectOptions{MimeType: up.mimeType, ETag: eTag})
+		err = mgr.os.AddObject(ctx, up.bucket, up.path, up.contractSet, o, api.AddObjectOptions{MimeType: up.mimeType, ETag: eTag, ModTime: api.TimeRFC3339(up.modTime)})
 		if err != nil {
 			return bufferSizeLimitReached, "", fmt.Errorf("couldn't add object: %w", err)
 		}

--- a/worker/upload_params.go
+++ b/worker/upload_params.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"time"
+
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/build"
 	"go.sia.tech/renterd/object"
@@ -22,6 +24,7 @@ type uploadParameters struct {
 	contractSet string
 	packing     bool
 	mimeType    string
+	modTime     time.Time
 }
 
 func defaultParameters(bucket, path string) uploadParameters {
@@ -81,6 +84,12 @@ func WithCustomEncryptionOffset(offset uint64) UploadOption {
 func WithMimeType(mimeType string) UploadOption {
 	return func(up *uploadParameters) {
 		up.mimeType = mimeType
+	}
+}
+
+func WithModTime(modTime time.Time) UploadOption {
+	return func(up *uploadParameters) {
+		up.modTime = modTime
 	}
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -964,6 +964,12 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 		return
 	}
 
+	// decode the modtime from the query string
+	var modTime time.Time
+	if jc.DecodeForm("modtime", (*api.TimeRFC3339)(&modTime)) != nil {
+		return
+	}
+
 	// decode the bucket from the query string
 	bucket := api.DefaultBucketName
 	if jc.DecodeForm("bucket", &bucket) != nil {
@@ -1007,6 +1013,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 		WithBlockHeight(up.CurrentHeight),
 		WithContractSet(up.ContractSet),
 		WithMimeType(mimeType),
+		WithModTime(modTime),
 		WithPacking(up.UploadPacking),
 		WithRedundancySettings(up.RedundancySettings),
 	}


### PR DESCRIPTION
This PR extends the objects with a `mod_time` field. That field used to be a "virtual field", we were just returning the object's `created_at` time stamp as the `mod_time`. This does not play well with `rclone` (among other things probably) so I added a column, used `created_at` as the default value for objects that already exist, and I start using the `X-Amz-Meta-Mtime` metadata that's passed by s3 clients.

This fixes the problem outlined in <https://github.com/SiaFoundation/renterd/issues/833> **but** not entirely. We have to use `rclone`'s `--modify-window 1s` parameter because otherwise it's complaining about ms differences in mod times. 

I've confirmed that mod times reach the database with nanosecond precision, however the s3 head object response returns the `Last-Modified` headers in the following format `Thu, 06 Jul 2023 12:10:06 GMT`.. so we're losing precision there. Still kind of confused as to how I'm expected to avoid losing the precision there.

```
2023/12/18 22:04:49 DEBUG : dl_baseline.txt: Size and modification time the same (differ by -545.765768ms, within tolerance 1s)
2023/12/18 22:04:49 DEBUG : dl_baseline.txt: Unchanged skipping
```
```
rclone lsl renterd:default
10156 2023-06-05 23:43:34.000000000 benchmark/dl_baseline.txt
```
```
select object_id, mod_time from objects where object_id LIKE "%baseline%";
object_id	mod_time
/benchmark/dl_baseline.txt	2023-06-05 23:43:34.546
```