### PR TITLE
Download panic

### DIFF
--- a/worker/download.go
+++ b/worker/download.go
@@ -930,8 +930,14 @@ func (s *slabDownload) nextRequest(ctx context.Context, resps *sectorResponses, 
 			return nil
 		}
 
+		// select the fastest host
+		fastest := s.mgr.fastest(hosts)
+		if fastest == (types.PublicKey{}) {
+			return nil // can happen if downloader got stopped
+		}
+
 		// make the fastest host the current host
-		s.curr = s.mgr.fastest(hosts)
+		s.curr = fastest
 		s.used[s.curr] = struct{}{}
 	}
 


### PR DESCRIPTION
This PR fixes the following panic:

```
2023-12-18T20:15:19.113550941Z panic: runtime error: index out of range [0] with length 0
2023-12-18T20:15:19.113658636Z 
2023-12-18T20:15:19.113682316Z goroutine 11993312 [running]:
2023-12-18T20:15:19.113700056Z go.sia.tech/renterd/worker.(*slabDownload).nextRequest(0xc0090d40e0, {0x16e1860?, 0xc00cb00ff0}, 0xc01039a090, 0x1)
2023-12-18T20:15:19.113716001Z     /renterd/worker/download.go:939 +0x385
2023-12-18T20:15:19.113732441Z go.sia.tech/renterd/worker.(*slabDownload).overdrive.func5()
2023-12-18T20:15:19.113749406Z     /renterd/worker/download.go:896 +0x110
2023-12-18T20:15:19.113765726Z created by go.sia.tech/renterd/worker.(*slabDownload).overdrive in goroutine 11993056
2023-12-18T20:15:19.113796558Z     /renterd/worker/download.go:888 +0x1eb
```

Bit of an edge but it can happen if, during a download, a downloader is stopped/removed from the download manager and it's the only host left for overdriving a sector. In that case we trim down the hosts list to select the fastest host, only to find it's not available any longer. I didn't foresee this and assumed selecting the fastest host would always return a host.