### PR TITLE
Add option to filter /contracts endpoint by contract set and return sets in contract metadata

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -66,6 +66,8 @@ type (
 		RenewedFrom   types.FileContractID `json:"renewedFrom"`
 		Spending      ContractSpending     `json:"spending"`
 		TotalCost     types.Currency       `json:"totalCost"`
+
+		Sets []string `json:"sets"`
 	}
 
 	// ContractPrunableData wraps a contract's size information with its id.
@@ -175,6 +177,10 @@ type (
 		Contracts     []ContractPrunableData `json:"contracts"`
 		TotalPrunable uint64                 `json:"totalPrunable"`
 		TotalSize     uint64                 `json:"totalSize"`
+	}
+
+	ContractsOpts struct {
+		ContractSet string `json:"contractset"`
 	}
 )
 

--- a/api/contract.go
+++ b/api/contract.go
@@ -67,7 +67,7 @@ type (
 		Spending      ContractSpending     `json:"spending"`
 		TotalCost     types.Currency       `json:"totalCost"`
 
-		Sets []string `json:"sets"`
+		ContractSets []string `json:"contractsets"`
 	}
 
 	// ContractPrunableData wraps a contract's size information with its id.

--- a/autopilot/accounts.go
+++ b/autopilot/accounts.go
@@ -41,8 +41,7 @@ type AccountStore interface {
 }
 
 type ContractStore interface {
-	Contracts(ctx context.Context) ([]api.ContractMetadata, error)
-	ContractSetContracts(ctx context.Context, set string) ([]api.ContractMetadata, error)
+	Contracts(ctx context.Context, opts api.ContractsOpts) ([]api.ContractMetadata, error)
 }
 
 func newAccounts(ap *Autopilot, a AccountStore, c ContractStore, w *workerPool, l *zap.SugaredLogger, refillInterval time.Duration) *accounts {
@@ -114,7 +113,7 @@ func (a *accounts) refillWorkerAccounts(ctx context.Context, w Worker) {
 	}
 
 	// fetch all contracts
-	contracts, err := a.c.Contracts(ctx)
+	contracts, err := a.c.Contracts(ctx, api.ContractsOpts{})
 	if err != nil {
 		a.l.Errorw(fmt.Sprintf("failed to fetch contracts for refill: %v", err))
 		return
@@ -123,7 +122,7 @@ func (a *accounts) refillWorkerAccounts(ctx context.Context, w Worker) {
 	}
 
 	// fetch all contract set contracts
-	contractSetContracts, err := a.c.ContractSetContracts(ctx, state.cfg.Contracts.Set)
+	contractSetContracts, err := a.c.Contracts(ctx, api.ContractsOpts{ContractSet: state.cfg.Contracts.Set})
 	if err != nil {
 		a.l.Errorw(fmt.Sprintf("failed to fetch contract set contracts: %v", err))
 		return

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -45,8 +45,7 @@ type Bus interface {
 	AncestorContracts(ctx context.Context, id types.FileContractID, minStartHeight uint64) ([]api.ArchivedContract, error)
 	ArchiveContracts(ctx context.Context, toArchive map[types.FileContractID]string) error
 	Contract(ctx context.Context, id types.FileContractID) (api.ContractMetadata, error)
-	Contracts(ctx context.Context) (contracts []api.ContractMetadata, err error)
-	ContractSetContracts(ctx context.Context, set string) ([]api.ContractMetadata, error)
+	Contracts(ctx context.Context, opts api.ContractsOpts) (contracts []api.ContractMetadata, err error)
 	FileContractTax(ctx context.Context, payout types.Currency) (types.Currency, error)
 	SetContractSet(ctx context.Context, set string, contracts []types.FileContractID) error
 	PrunableData(ctx context.Context) (prunableData api.ContractsPrunableDataResponse, err error)

--- a/autopilot/contract_pruning.go
+++ b/autopilot/contract_pruning.go
@@ -103,7 +103,7 @@ func (c *contractor) fetchPrunableContracts() (prunable []api.ContractPrunableDa
 	}
 
 	// fetch contract set contracts
-	csc, err := c.ap.bus.ContractSetContracts(ctx, c.ap.state.cfg.Contracts.Set)
+	csc, err := c.ap.bus.Contracts(ctx, api.ContractsOpts{ContractSet: c.ap.state.cfg.Contracts.Set})
 	if err != nil {
 		return nil, err
 	}

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -180,7 +180,7 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 	}
 
 	// fetch current contract set
-	currentSet, err := c.ap.bus.ContractSetContracts(ctx, state.cfg.Contracts.Set)
+	currentSet, err := c.ap.bus.Contracts(ctx, api.ContractsOpts{ContractSet: state.cfg.Contracts.Set})
 	if err != nil && !strings.Contains(err.Error(), api.ErrContractSetNotFound.Error()) {
 		return false, err
 	}

--- a/bus/client/contracts.go
+++ b/bus/client/contracts.go
@@ -102,8 +102,12 @@ func (c *Client) ContractSetContracts(ctx context.Context, set string) (contract
 }
 
 // Contracts returns all contracts in the metadata store.
-func (c *Client) Contracts(ctx context.Context) (contracts []api.ContractMetadata, err error) {
-	err = c.c.WithContext(ctx).GET("/contracts", &contracts)
+func (c *Client) Contracts(ctx context.Context, opts api.ContractsOpts) (contracts []api.ContractMetadata, err error) {
+	values := url.Values{}
+	if opts.ContractSet != "" {
+		values.Set("contractset", opts.ContractSet)
+	}
+	err = c.c.WithContext(ctx).GET("/contracts"+values.Encode(), &contracts)
 	return
 }
 

--- a/bus/client/contracts.go
+++ b/bus/client/contracts.go
@@ -101,7 +101,8 @@ func (c *Client) ContractSetContracts(ctx context.Context, set string) (contract
 	return
 }
 
-// Contracts returns all contracts in the metadata store.
+// Contracts retrieves contracts from the metadata store. If no filter is set,
+// all contracts are returned.
 func (c *Client) Contracts(ctx context.Context, opts api.ContractsOpts) (contracts []api.ContractMetadata, err error) {
 	values := url.Values{}
 	if opts.ContractSet != "" {

--- a/bus/client/contracts.go
+++ b/bus/client/contracts.go
@@ -107,7 +107,7 @@ func (c *Client) Contracts(ctx context.Context, opts api.ContractsOpts) (contrac
 	if opts.ContractSet != "" {
 		values.Set("contractset", opts.ContractSet)
 	}
-	err = c.c.WithContext(ctx).GET("/contracts"+values.Encode(), &contracts)
+	err = c.c.WithContext(ctx).GET("/contracts?"+values.Encode(), &contracts)
 	return
 }
 

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -881,7 +881,7 @@ func (c *TestCluster) WaitForContractSet(set string, n int) {
 func (c *TestCluster) waitForHostContracts(hosts map[types.PublicKey]struct{}) {
 	c.tt.Helper()
 	c.tt.Retry(300, 100*time.Millisecond, func() error {
-		contracts, err := c.Bus.Contracts(context.Background())
+		contracts, err := c.Bus.Contracts(context.Background(), api.ContractsOpts{})
 		if err != nil {
 			return err
 		}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -77,12 +77,25 @@ func TestNewTestCluster(t *testing.T) {
 		t.Fatal("TotalCost and ContractPrice shouldn't be zero")
 	}
 
+	// Make sure the contracts are part of the set.
+	busContracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range busContracts {
+		if len(c.Sets) != 1 {
+			t.Fatal("contract should be part of one set", len(c.Sets))
+		} else if c.Sets[0] != sets[0] {
+			t.Fatalf("contract should be part of set %v but was %v", sets[0], c.Sets[0])
+		}
+	}
+
 	// Mine blocks until contracts start renewing.
 	cluster.MineToRenewWindow()
 
 	// Wait for the contract to be renewed.
 	tt.Retry(100, 100*time.Millisecond, func() error {
-		contracts, err := cluster.Bus.Contracts(context.Background())
+		contracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 		if err != nil {
 			return err
 		}
@@ -120,7 +133,7 @@ func TestNewTestCluster(t *testing.T) {
 		cluster.MineBlocks(1)
 
 		// Fetch renewed contract and make sure we caught the proof and revision.
-		contracts, err := cluster.Bus.Contracts(context.Background())
+		contracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -567,7 +580,7 @@ func TestUploadDownloadBasic(t *testing.T) {
 	}
 
 	// fetch the contracts.
-	contracts, err := cluster.Bus.Contracts(context.Background())
+	contracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 	tt.OK(err)
 
 	// broadcast the revision for each contract and assert the revision height
@@ -585,7 +598,7 @@ func TestUploadDownloadBasic(t *testing.T) {
 	// check the revision height was updated.
 	tt.Retry(100, 100*time.Millisecond, func() error {
 		// fetch the contracts.
-		contracts, err := cluster.Bus.Contracts(context.Background())
+		contracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 		if err != nil {
 			return err
 		}
@@ -755,7 +768,7 @@ func TestUploadDownloadSpending(t *testing.T) {
 
 	// check that the funding was recorded
 	tt.Retry(100, testBusFlushInterval, func() error {
-		cms, err := cluster.Bus.Contracts(context.Background())
+		cms, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 		tt.OK(err)
 		if len(cms) == 0 {
 			t.Fatal("no contracts found")
@@ -849,7 +862,7 @@ func TestUploadDownloadSpending(t *testing.T) {
 	// wait for the contract to be renewed
 	tt.Retry(100, 100*time.Millisecond, func() error {
 		// fetch contracts
-		cms, err := cluster.Bus.Contracts(context.Background())
+		cms, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 		tt.OK(err)
 		if len(cms) == 0 {
 			t.Fatal("no contracts found")
@@ -880,7 +893,7 @@ func TestUploadDownloadSpending(t *testing.T) {
 
 	// check that the spending was recorded
 	tt.Retry(100, testBusFlushInterval, func() error {
-		cms, err := cluster.Bus.Contracts(context.Background())
+		cms, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1301,7 +1314,7 @@ func TestContractArchival(t *testing.T) {
 	tt := cluster.tt
 
 	// check that we have 1 contract
-	contracts, err := cluster.Bus.Contracts(context.Background())
+	contracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 	tt.OK(err)
 	if len(contracts) != 1 {
 		t.Fatal("expected 1 contract", len(contracts))
@@ -1318,7 +1331,7 @@ func TestContractArchival(t *testing.T) {
 
 	// check that we have 0 contracts
 	tt.Retry(100, 100*time.Millisecond, func() error {
-		contracts, err := cluster.Bus.Contracts(context.Background())
+		contracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 		if err != nil {
 			return err
 		}
@@ -1346,7 +1359,7 @@ func TestUnconfirmedContractArchival(t *testing.T) {
 	tt.OK(err)
 
 	// we should have a contract with the host
-	contracts, err := cluster.Bus.Contracts(context.Background())
+	contracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 	tt.OK(err)
 	if len(contracts) != 1 {
 		t.Fatalf("expected 1 contract, got %v", len(contracts))
@@ -1377,7 +1390,7 @@ func TestUnconfirmedContractArchival(t *testing.T) {
 	tt.OK(err)
 
 	// should have 2 contracts now
-	contracts, err = cluster.Bus.Contracts(context.Background())
+	contracts, err = cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 	tt.OK(err)
 	if len(contracts) != 2 {
 		t.Fatalf("expected 2 contracts, got %v", len(contracts))
@@ -1388,7 +1401,7 @@ func TestUnconfirmedContractArchival(t *testing.T) {
 	cluster.MineBlocks(20)
 
 	tt.Retry(100, 100*time.Millisecond, func() error {
-		contracts, err := cluster.Bus.Contracts(context.Background())
+		contracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
 		tt.OK(err)
 		if len(contracts) != 1 {
 			return fmt.Errorf("expected 1 contract, got %v", len(contracts))
@@ -2158,7 +2171,7 @@ func TestWalletFormUnconfirmed(t *testing.T) {
 	}
 
 	// There shouldn't be any contracts at this point.
-	contracts, err := b.Contracts(context.Background())
+	contracts, err := b.Contracts(context.Background(), api.ContractsOpts{})
 	tt.OK(err)
 	if len(contracts) != 0 {
 		t.Fatal("expected 0 contracts", len(contracts))

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -83,10 +83,10 @@ func TestNewTestCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, c := range busContracts {
-		if len(c.Sets) != 1 {
-			t.Fatal("contract should be part of one set", len(c.Sets))
-		} else if c.Sets[0] != sets[0] {
-			t.Fatalf("contract should be part of set %v but was %v", sets[0], c.Sets[0])
+		if len(c.ContractSets) != 1 {
+			t.Fatal("contract should be part of one set", len(c.ContractSets))
+		} else if c.ContractSets[0] != sets[0] {
+			t.Fatalf("contract should be part of set %v but was %v", sets[0], c.ContractSets[0])
 		}
 	}
 

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -160,7 +160,7 @@ func TestSectorPruning(t *testing.T) {
 	cluster.ShutdownAutopilot(context.Background())
 
 	// create a contracts dict
-	contracts, err := b.Contracts(context.Background())
+	contracts, err := b.Contracts(context.Background(), api.ContractsOpts{})
 	tt.OK(err)
 
 	// compare database against roots returned by the host

--- a/internal/testing/uploads_test.go
+++ b/internal/testing/uploads_test.go
@@ -78,7 +78,7 @@ func TestUploadingSectorsCache(t *testing.T) {
 	}
 
 	// fetch contracts
-	contracts, err := b.Contracts(context.Background())
+	contracts, err := b.Contracts(context.Background(), api.ContractsOpts{})
 	tt.OK(err)
 
 	// fetch pending roots for all contracts

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -788,6 +788,7 @@ func (s *SQLStore) Contracts(ctx context.Context, opts api.ContractsOpts) ([]api
 		Joins("Host").
 		Joins("LEFT JOIN contract_set_contracts csc ON csc.db_contract_id = contracts.id").
 		Joins("LEFT JOIN contract_sets cs ON cs.id = csc.db_contract_set_id").
+		Order("contracts.id ASC").
 		Scan(&dbContracts).
 		Error
 	if err != nil {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -779,13 +779,13 @@ func (s *SQLStore) Contracts(ctx context.Context, opts api.ContractsOpts) ([]api
 	// fetch all contracts, their hosts and the contract set name
 	var dbContracts []struct {
 		Contract dbContract `gorm:"embedded"`
-		Host     dbHost     `gorm:"embedded,embeddedPrefix:Host__"`
+		Host     dbHost     `gorm:"embedded"`
 		Name     string
 	}
 	err := s.db.
 		Model(&dbContract{}).
-		Select("contracts.*, Host.*, cs.name as Name").
-		Joins("Host").
+		Select("contracts.*, h.*, cs.name as Name").
+		Joins("INNER JOIN hosts h ON h.id = contracts.host_id").
 		Joins("LEFT JOIN contract_set_contracts csc ON csc.db_contract_id = contracts.id").
 		Joins("LEFT JOIN contract_sets cs ON cs.id = csc.db_contract_set_id").
 		Order("contracts.id ASC").

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -355,7 +355,7 @@ func (c dbContract) convert() api.ContractMetadata {
 		ProofHeight:    c.ProofHeight,
 		RevisionHeight: c.RevisionHeight,
 		RevisionNumber: revisionNumber,
-		Sets:           contractSets,
+		ContractSets:   contractSets,
 		Size:           c.Size,
 		StartHeight:    c.StartHeight,
 		State:          c.State.String(),

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -207,7 +207,7 @@ func TestSQLContractStore(t *testing.T) {
 	if !errors.Is(err, api.ErrContractNotFound) {
 		t.Fatal(err)
 	}
-	contracts, err := ss.Contracts(ctx)
+	contracts, err := ss.Contracts(ctx, api.ContractsOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,7 +253,7 @@ func TestSQLContractStore(t *testing.T) {
 	if !reflect.DeepEqual(fetched, expected) {
 		t.Fatal("contract mismatch")
 	}
-	contracts, err = ss.Contracts(ctx)
+	contracts, err = ss.Contracts(ctx, api.ContractsOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +304,7 @@ func TestSQLContractStore(t *testing.T) {
 	if !errors.Is(err, api.ErrContractNotFound) {
 		t.Fatal(err)
 	}
-	contracts, err = ss.Contracts(ctx)
+	contracts, err = ss.Contracts(ctx, api.ContractsOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -577,7 +577,7 @@ func TestRenewedContract(t *testing.T) {
 	}
 
 	// make sure the contract set was updated.
-	setContracts, err := ss.ContractSetContracts(context.Background(), "test")
+	setContracts, err := ss.Contracts(ctx, api.ContractsOpts{ContractSet: "test"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -770,7 +770,7 @@ func TestArchiveContracts(t *testing.T) {
 	}
 
 	// assert the first one is still active
-	active, err := ss.Contracts(context.Background())
+	active, err := ss.Contracts(context.Background(), api.ContractsOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -289,7 +289,7 @@ func (w *worker) uploadPackedSlab(ctx context.Context, rs api.RedundancySettings
 	defer cancel()
 
 	// fetch contracts
-	contracts, err := w.bus.ContractSetContracts(ctx, contractSet)
+	contracts, err := w.bus.Contracts(ctx, api.ContractsOpts{ContractSet: contractSet})
 	if err != nil {
 		return fmt.Errorf("couldn't fetch packed slabs from bus: %v", err)
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -78,8 +78,7 @@ type (
 		Contract(ctx context.Context, id types.FileContractID) (api.ContractMetadata, error)
 		ContractSize(ctx context.Context, id types.FileContractID) (api.ContractSize, error)
 		ContractRoots(ctx context.Context, id types.FileContractID) ([]types.Hash256, []types.Hash256, error)
-		Contracts(ctx context.Context) ([]api.ContractMetadata, error)
-		ContractSetContracts(ctx context.Context, set string) ([]api.ContractMetadata, error)
+		Contracts(ctx context.Context, opts api.ContractsOpts) ([]api.ContractMetadata, error)
 		RenewedContract(ctx context.Context, renewedFrom types.FileContractID) (api.ContractMetadata, error)
 
 		RecordHostScans(ctx context.Context, scans []hostdb.HostScan) error
@@ -766,13 +765,13 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 	ctx = WithGougingChecker(ctx, w.bus, up.GougingParams)
 
 	// fetch all contracts
-	dlContracts, err := w.bus.Contracts(ctx)
+	dlContracts, err := w.bus.Contracts(ctx, api.ContractsOpts{})
 	if jc.Check("couldn't fetch contracts from bus", err) != nil {
 		return
 	}
 
 	// fetch upload contracts
-	ulContracts, err := w.bus.ContractSetContracts(ctx, up.ContractSet)
+	ulContracts, err := w.bus.Contracts(ctx, api.ContractsOpts{ContractSet: up.ContractSet})
 	if jc.Check("couldn't fetch contracts from bus", err) != nil {
 		return
 	}
@@ -907,7 +906,7 @@ func (w *worker) objectsHandlerGET(jc jape.Context) {
 	}
 
 	// fetch all contracts
-	contracts, err := w.bus.Contracts(ctx)
+	contracts, err := w.bus.Contracts(ctx, api.ContractsOpts{})
 	if err != nil {
 		jc.Error(err, http.StatusInternalServerError)
 		return
@@ -1015,7 +1014,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	ctx = WithGougingChecker(ctx, w.bus, up.GougingParams)
 
 	// fetch contracts
-	contracts, err := w.bus.ContractSetContracts(ctx, up.ContractSet)
+	contracts, err := w.bus.Contracts(ctx, api.ContractsOpts{ContractSet: up.ContractSet})
 	if jc.Check("couldn't fetch contracts from bus", err) != nil {
 		return
 	}
@@ -1154,7 +1153,7 @@ func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {
 	ctx = WithGougingChecker(ctx, w.bus, up.GougingParams)
 
 	// fetch contracts
-	contracts, err := w.bus.ContractSetContracts(ctx, up.ContractSet)
+	contracts, err := w.bus.Contracts(ctx, api.ContractsOpts{ContractSet: up.ContractSet})
 	if jc.Check("couldn't fetch contracts from bus", err) != nil {
 		return
 	}
@@ -1197,7 +1196,7 @@ func (w *worker) rhpContractsHandlerGET(jc jape.Context) {
 	ctx := jc.Request.Context()
 
 	// fetch contracts
-	busContracts, err := w.bus.Contracts(ctx)
+	busContracts, err := w.bus.Contracts(ctx, api.ContractsOpts{})
 	if jc.Check("failed to fetch contracts from bus", err) != nil {
 		return
 	}


### PR DESCRIPTION
This also allows us to deprecate the existing endpoint for fetching all contracts of a set

Related to https://github.com/SiaFoundation/renterd/issues/716#issuecomment-1858244940