### PR TITLE
Remove ObjectsBySlabKey

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -63,7 +63,6 @@ type Bus interface {
 	RecordContractPruneMetric(ctx context.Context, metrics ...api.ContractPruneMetric) error
 
 	// objects
-	ObjectsBySlabKey(ctx context.Context, bucket string, key object.EncryptionKey) (objects []api.ObjectMetadata, err error)
 	RefreshHealth(ctx context.Context) error
 	Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
 	SlabsForMigration(ctx context.Context, healthCutoff float64, set string, limit int) ([]api.UnhealthySlab, error)

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -139,7 +139,6 @@ type (
 		ListObjects(ctx context.Context, bucketName, prefix, sortBy, sortDir, marker string, limit int) (api.ObjectsListResponse, error)
 		Object(ctx context.Context, bucketName, path string) (api.Object, error)
 		ObjectEntries(ctx context.Context, bucketName, path, prefix, sortBy, sortDir, marker string, offset, limit int) ([]api.ObjectMetadata, bool, error)
-		ObjectsBySlabKey(ctx context.Context, bucketName string, slabKey object.EncryptionKey) ([]api.ObjectMetadata, error)
 		ObjectsStats(ctx context.Context) (api.ObjectsStatsResponse, error)
 		RemoveObject(ctx context.Context, bucketName, path string) error
 		RemoveObjects(ctx context.Context, bucketName, prefix string) error
@@ -339,7 +338,6 @@ func (b *bus) Handler() http.Handler {
 		"POST   /slabs/partial":       b.slabsPartialHandlerPOST,
 		"POST   /slabs/refreshhealth": b.slabsRefreshHealthHandlerPOST,
 		"GET    /slab/:key":           b.slabHandlerGET,
-		"GET    /slab/:key/objects":   b.slabObjectsHandlerGET,
 		"PUT    /slab":                b.slabHandlerPUT,
 
 		"GET    /state":         b.stateHandlerGET,
@@ -1403,22 +1401,6 @@ func (b *bus) sectorsHostRootHandlerDELETE(jc jape.Context) {
 	if jc.Check("failed to mark sector as lost", err) != nil {
 		return
 	}
-}
-
-func (b *bus) slabObjectsHandlerGET(jc jape.Context) {
-	var key object.EncryptionKey
-	if jc.DecodeParam("key", &key) != nil {
-		return
-	}
-	bucket := api.DefaultBucketName
-	if jc.DecodeForm("bucket", &bucket) != nil {
-		return
-	}
-	objects, err := b.ms.ObjectsBySlabKey(jc.Request.Context(), bucket, key)
-	if jc.Check("failed to retrieve objects by slab", err) != nil {
-		return
-	}
-	jc.Encode(objects)
 }
 
 func (b *bus) slabHandlerGET(jc jape.Context) {

--- a/bus/client/objects.go
+++ b/bus/client/objects.go
@@ -72,14 +72,6 @@ func (c *Client) Object(ctx context.Context, bucket, path string, opts api.GetOb
 	return
 }
 
-// ObjectsBySlabKey returns all objects that reference a given slab.
-func (c *Client) ObjectsBySlabKey(ctx context.Context, bucket string, key object.EncryptionKey) (objects []api.ObjectMetadata, err error) {
-	values := url.Values{}
-	values.Set("bucket", bucket)
-	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/slab/%v/objects?"+values.Encode(), key), &objects)
-	return
-}
-
 // ObjectsStats returns information about the number of objects and their size.
 func (c *Client) ObjectsStats() (osr api.ObjectsStatsResponse, err error) {
 	err = c.c.GET("/stats/objects", &osr)

--- a/object/object.go
+++ b/object/object.go
@@ -41,6 +41,11 @@ func (k *EncryptionKey) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
+// Equals implements the Equaler interface.
+func (k EncryptionKey) Equals(o EncryptionKey) bool {
+	return bytes.Equal(k.entropy[:], o.entropy[:])
+}
+
 // String implements fmt.Stringer.
 func (k EncryptionKey) String() string {
 	return "key:" + hex.EncodeToString(k.entropy[:])


### PR DESCRIPTION
This method is unused and uses `rawObjectMetadata`, the fewer usages of that raw object hydration the better so I removed it. I suspect it was used at one point in the autopilot but that is no longer the case. Already removed it from the docs.