### PR TITLE
Remove /bus/contracts/sets/:set endpoint

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -270,7 +270,6 @@ func (b *bus) Handler() http.Handler {
 		"GET    /contracts/prunable":     b.contractsPrunableDataHandlerGET,
 		"GET    /contracts/renewed/:id":  b.contractsRenewedIDHandlerGET,
 		"GET    /contracts/sets":         b.contractsSetsHandlerGET,
-		"GET    /contracts/set/:set":     b.contractsSetHandlerGET,
 		"PUT    /contracts/set/:set":     b.contractsSetHandlerPUT,
 		"DELETE /contracts/set/:set":     b.contractsSetHandlerDELETE,
 		"POST   /contracts/spending":     b.contractsSpendingHandlerPOST,
@@ -933,16 +932,6 @@ func (b *bus) contractsArchiveHandlerPOST(jc jape.Context) {
 	}
 
 	jc.Check("failed to archive contracts", b.ms.ArchiveContracts(jc.Request.Context(), toArchive))
-}
-
-func (b *bus) contractsSetHandlerGET(jc jape.Context) {
-	cs, err := b.ms.Contracts(jc.Request.Context(),
-		api.ContractsOpts{
-			ContractSet: jc.PathParam("set"),
-		})
-	if jc.Check("couldn't load contracts", err) == nil {
-		jc.Encode(cs)
-	}
 }
 
 func (b *bus) contractsSetsHandlerGET(jc jape.Context) {

--- a/bus/client/contracts.go
+++ b/bus/client/contracts.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -88,16 +87,6 @@ func (c *Client) ContractSets(ctx context.Context) (sets []string, err error) {
 // ContractSize returns the contract's size.
 func (c *Client) ContractSize(ctx context.Context, contractID types.FileContractID) (size api.ContractSize, err error) {
 	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/contract/%s/size", contractID), &size)
-	return
-}
-
-// ContractSetContracts returns the contracts for the given set from the
-// metadata store.
-func (c *Client) ContractSetContracts(ctx context.Context, set string) (contracts []api.ContractMetadata, err error) {
-	if set == "" {
-		return nil, errors.New("set cannot be empty")
-	}
-	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/contracts/set/%s", set), &contracts)
 	return
 }
 

--- a/internal/testing/blocklist_test.go
+++ b/internal/testing/blocklist_test.go
@@ -26,7 +26,7 @@ func TestBlocklist(t *testing.T) {
 	tt := cluster.tt
 
 	// fetch contracts
-	contracts, err := b.ContractSetContracts(ctx, testAutopilotConfig.Contracts.Set)
+	contracts, err := b.Contracts(ctx, api.ContractsOpts{ContractSet: testAutopilotConfig.Contracts.Set})
 	tt.OK(err)
 	if len(contracts) != 3 {
 		t.Fatalf("unexpected number of contracts, %v != 3", len(contracts))
@@ -40,7 +40,7 @@ func TestBlocklist(t *testing.T) {
 
 	// assert h3 is no longer in the contract set
 	tt.Retry(5, time.Second, func() error {
-		contracts, err := b.ContractSetContracts(ctx, testAutopilotConfig.Contracts.Set)
+		contracts, err := b.Contracts(ctx, api.ContractsOpts{ContractSet: testAutopilotConfig.Contracts.Set})
 		tt.OK(err)
 		if len(contracts) != 2 {
 			return fmt.Errorf("unexpected number of contracts, %v != 2", len(contracts))
@@ -60,7 +60,7 @@ func TestBlocklist(t *testing.T) {
 
 	// assert h1 is no longer in the contract set
 	tt.Retry(5, time.Second, func() error {
-		contracts, err := b.ContractSetContracts(ctx, testAutopilotConfig.Contracts.Set)
+		contracts, err := b.Contracts(ctx, api.ContractsOpts{ContractSet: testAutopilotConfig.Contracts.Set})
 		tt.OK(err)
 		if len(contracts) != 1 {
 			return fmt.Errorf("unexpected number of contracts, %v != 1", len(contracts))
@@ -77,7 +77,7 @@ func TestBlocklist(t *testing.T) {
 	tt.OK(b.UpdateHostAllowlist(ctx, nil, []types.PublicKey{hk1, hk2}, false))
 	tt.OK(b.UpdateHostBlocklist(ctx, nil, []string{h1.NetAddress}, false))
 	tt.Retry(5, time.Second, func() error {
-		contracts, err := b.ContractSetContracts(ctx, testAutopilotConfig.Contracts.Set)
+		contracts, err := b.Contracts(ctx, api.ContractsOpts{ContractSet: testAutopilotConfig.Contracts.Set})
 		tt.OK(err)
 		if len(contracts) != 3 {
 			return fmt.Errorf("unexpected number of contracts, %v != 3", len(contracts))

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -865,7 +865,7 @@ func (c *TestCluster) WaitForContractSet(set string, n int) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
-		contracts, err := c.Bus.ContractSetContracts(ctx, set)
+		contracts, err := c.Bus.Contracts(ctx, api.ContractsOpts{ContractSet: set})
 		if err != nil {
 			return err
 		}

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -725,7 +725,7 @@ func TestUploadDownloadExtended(t *testing.T) {
 	tt.OK(b.SetContractSet(context.Background(), t.Name(), nil))
 
 	// assert there are no contracts in the set
-	csc, err := b.ContractSetContracts(context.Background(), t.Name())
+	csc, err := b.Contracts(context.Background(), api.ContractsOpts{ContractSet: t.Name()})
 	tt.OK(err)
 	if len(csc) != 0 {
 		t.Fatalf("expected no contracts, got %v", len(csc))
@@ -869,7 +869,7 @@ func TestUploadDownloadSpending(t *testing.T) {
 		}
 
 		// fetch contract set contracts
-		contracts, err := cluster.Bus.ContractSetContracts(context.Background(), testAutopilotConfig.Contracts.Set)
+		contracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{ContractSet: testAutopilotConfig.Contracts.Set})
 		tt.OK(err)
 		currentSet := make(map[types.FileContractID]struct{})
 		for _, c := range contracts {

--- a/internal/testing/gouging_test.go
+++ b/internal/testing/gouging_test.go
@@ -53,7 +53,7 @@ func TestGouging(t *testing.T) {
 	}
 
 	// fetch current contract set
-	contracts, err := b.ContractSetContracts(context.Background(), cfg.Set)
+	contracts, err := b.Contracts(context.Background(), api.ContractsOpts{ContractSet: cfg.Set})
 	tt.OK(err)
 
 	// update the host settings so it's gouging

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -981,12 +981,6 @@ WHERE c.fcid = ?
 	return
 }
 
-func (s *SQLStore) ContractSetContracts(ctx context.Context, set string) ([]api.ContractMetadata, error) {
-	return s.Contracts(ctx, api.ContractsOpts{
-		ContractSet: set,
-	})
-}
-
 func (s *SQLStore) ContractSets(ctx context.Context) ([]string, error) {
 	var sets []string
 	err := s.db.Raw("SELECT name FROM contract_sets").

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -268,12 +268,12 @@ func TestSQLContractStore(t *testing.T) {
 	if err := ss.SetContractSet(ctx, "foo", []types.FileContractID{contracts[0].ID}); err != nil {
 		t.Fatal(err)
 	}
-	if contracts, err := ss.ContractSetContracts(ctx, "foo"); err != nil {
+	if contracts, err := ss.Contracts(ctx, api.ContractsOpts{ContractSet: "foo"}); err != nil {
 		t.Fatal(err)
 	} else if len(contracts) != 1 {
 		t.Fatalf("should have 1 contracts but got %v", len(contracts))
 	}
-	if _, err := ss.ContractSetContracts(ctx, "bar"); !errors.Is(err, api.ErrContractSetNotFound) {
+	if _, err := ss.Contracts(ctx, api.ContractsOpts{ContractSet: "bar"}); !errors.Is(err, api.ErrContractSetNotFound) {
 		t.Fatal(err)
 	}
 
@@ -3749,7 +3749,7 @@ func TestSlabHealthInvalidation(t *testing.T) {
 	}
 
 	// assert there are 0 contracts in the contract set
-	cscs, err := ss.ContractSetContracts(context.Background(), testContractSet)
+	cscs, err := ss.Contracts(context.Background(), api.ContractsOpts{ContractSet: testContractSet})
 	if err != nil {
 		t.Fatal(err)
 	} else if len(cscs) != 0 {
@@ -3777,7 +3777,7 @@ func TestSlabHealthInvalidation(t *testing.T) {
 	assertHealthValid(s2, false)
 
 	// assert there are 2 contracts in the contract set
-	cscs, err = ss.ContractSetContracts(context.Background(), testContractSet)
+	cscs, err = ss.Contracts(context.Background(), api.ContractsOpts{ContractSet: testContractSet})
 	if err != nil {
 		t.Fatal(err)
 	} else if len(cscs) != 2 {


### PR DESCRIPTION
Since it has a subset of the functionality of `/contracts`