### PR TITLE
Increase withdrawal expiry

### DIFF
--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -38,7 +38,7 @@ const (
 	// defaultWithdrawalExpiryBlocks is the number of blocks we add to the
 	// current blockheight when we define an expiry block height for withdrawal
 	// messages.
-	defaultWithdrawalExpiryBlocks = 6
+	defaultWithdrawalExpiryBlocks = 12
 
 	// maxPriceTableSize defines the maximum size of a price table
 	maxPriceTableSize = 16 * 1024

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -79,6 +79,10 @@ var (
 	// errWithdrawalsInactive occurs when the host is (perhaps temporarily)
 	// unsynced and has disabled its account manager.
 	errWithdrawalsInactive = errors.New("ephemeral account withdrawals are inactive because the host is not synced")
+
+	// errWithdrawalExpired is returned by the host when the withdrawal request
+	// has an expiry block height that is in the past.
+	errWithdrawalExpired = errors.New("withdrawal request expired")
 )
 
 func isBalanceInsufficient(err error) bool { return isError(err, errBalanceInsufficient) }
@@ -94,6 +98,7 @@ func isSectorNotFound(err error) bool {
 	return isError(err, errSectorNotFound) || isError(err, errSectorNotFoundOld)
 }
 func isWithdrawalsInactive(err error) bool { return isError(err, errWithdrawalsInactive) }
+func isWithdrawalExpired(err error) bool   { return isError(err, errWithdrawalExpired) }
 
 func isError(err error, target error) bool {
 	if err == nil {
@@ -250,7 +255,7 @@ func (h *host) FetchRevision(ctx context.Context, fetchTimeout time.Duration, bl
 	ctx, cancel := timeoutCtx()
 	defer cancel()
 	rev, err := h.fetchRevisionWithAccount(ctx, h.hk, h.siamuxAddr, blockHeight, h.fcid)
-	if err != nil && !(isBalanceInsufficient(err) || isWithdrawalsInactive(err) || isClosedStream(err)) { // TODO: checking for a closed stream here can be removed once the withdrawal timeout on the host side is removed
+	if err != nil && !(isBalanceInsufficient(err) || isWithdrawalsInactive(err) || isWithdrawalExpired(err) || isClosedStream(err)) { // TODO: checking for a closed stream here can be removed once the withdrawal timeout on the host side is removed
 		return types.FileContractRevision{}, fmt.Errorf("unable to fetch revision with account: %v", err)
 	} else if err == nil {
 		return rev, nil


### PR DESCRIPTION
Cerlancism reported the following errors. These can only by caused if the renter thinks its synced, but in reality it's not. This happens on the testnet sometimes when a lot of blocks are mined in short succession. We already have an "ignore-list" for errors after which we try contract payment, so I figured we best add this one too. I also increased the withdrawal expiry since we really don't use that for anything. The withdrawal message just has to have a sane expiry.

```
075c746d: unable to fetch revision with account: LatestRevision: failed to fetch pricetable, err: PriceTable: couldn't read RPCPriceTableResponse: ReadResponse: failed to process payment: failed to process account payment: withdrawal request expired
84956180: unable to fetch revision with account: LatestRevision: failed to fetch pricetable, err: PriceTable: couldn't read RPCPriceTableResponse: ReadResponse: failed to process payment: failed to process account payment: withdrawal request expired
```