### PR TITLE
Make use of go generated commit and version

### DIFF
--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -47,10 +47,6 @@ const (
 )
 
 var (
-	// to be supplied at build time
-	githash   = "?"
-	builddate = "?"
-
 	cfg = config.Config{
 		Directory: ".",
 		Seed:      os.Getenv("RENTERD_SEED"),
@@ -290,11 +286,9 @@ func main() {
 
 	flag.Parse()
 
-	log.Println("renterd v1.0.0")
-	log.Println("Network", build.NetworkName())
 	if flag.Arg(0) == "version" {
-		log.Println("Commit:", githash)
-		log.Println("Build Date:", builddate)
+		log.Println("Commit:", build.Commit())
+		log.Println("Build Date:", build.BuildTime())
 		return
 	} else if flag.Arg(0) == "seed" {
 		log.Println("Seed phrase:")
@@ -400,6 +394,8 @@ func main() {
 		log.Fatalln("failed to create logger:", err)
 	}
 	defer closeFn(context.Background())
+
+	logger.Info("renterd", zap.String("version", build.Version()), zap.String("network", build.NetworkName()), zap.String("commit", build.Commit()), zap.Time("buildDate", build.BuildTime()))
 
 	busCfg.DBLoggerConfig = stores.LoggerConfig{
 		LogLevel:                  level,


### PR DESCRIPTION
Updates main.go to match `hostd` by making use of the `build` package. The resulting logging looks like this 

```bash
2023-12-21T18:03:39+01:00	INFO	renterd/main.go:398	renterd	{"version": "v0.7.1-45-gf1febab2", "network": "Mainnet", "commit": "f1febab2", "buildDate": "2023-12-21T16:10:27+01:00"}
```

and

```bash
Commit: f1febab2
Build Date: 2023-12-21 16:10:27 +0100 CET
```