### PR TITLE
Prune slabs periodically

### DIFF
--- a/bus/client/client_test.go
+++ b/bus/client/client_test.go
@@ -72,12 +72,15 @@ func newTestClient(dir string) (*client.Client, func() error, func(context.Conte
 	client := client.New("http://"+l.Addr().String(), "test")
 	b, cleanup, err := node.NewBus(node.BusConfig{
 		Bus: config.Bus{
-			AnnouncementMaxAgeHours: 24 * 7 * 52, // 1 year
-			Bootstrap:               false,
-			GatewayAddr:             "127.0.0.1:0",
-			UsedUTXOExpiry:          time.Minute,
+			AnnouncementMaxAgeHours:       24 * 7 * 52, // 1 year
+			Bootstrap:                     false,
+			GatewayAddr:                   "127.0.0.1:0",
+			UsedUTXOExpiry:                time.Minute,
+			SlabBufferCompletionThreshold: 0,
 		},
-		Miner: node.NewMiner(client),
+		Miner:               node.NewMiner(client),
+		SlabPruningInterval: time.Minute,
+		SlabPruningCooldown: time.Minute,
 	}, filepath.Join(dir, "bus"), types.GeneratePrivateKey(), zap.New(zapcore.NewNopCore()))
 	if err != nil {
 		return nil, nil, nil, err

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -351,8 +351,10 @@ func main() {
 
 	network, _ := build.Network()
 	busCfg := node.BusConfig{
-		Bus:     cfg.Bus,
-		Network: network,
+		Bus:                 cfg.Bus,
+		Network:             network,
+		SlabPruningInterval: time.Hour,
+		SlabPruningCooldown: 30 * time.Second,
 	}
 	// Init db dialector
 	if cfg.Database.MySQL.URI != "" {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -108,7 +108,21 @@ func NewBus(cfg BusConfig, dir string, seed types.PrivateKey, l *zap.Logger) (ht
 	walletAddr := wallet.StandardAddress(seed.PublicKey())
 	sqlStoreDir := filepath.Join(dir, "partial_slabs")
 	announcementMaxAge := time.Duration(cfg.AnnouncementMaxAgeHours) * time.Hour
-	sqlStore, ccid, err := stores.NewSQLStore(dbConn, dbMetricsConn, alerts.WithOrigin(alertsMgr, "bus"), sqlStoreDir, true, announcementMaxAge, cfg.PersistInterval, walletAddr, cfg.SlabBufferCompletionThreshold, l.Sugar(), sqlLogger)
+	sqlStore, ccid, err := stores.NewSQLStore(stores.Config{
+		Conn:                          dbConn,
+		ConnMetrics:                   dbMetricsConn,
+		Alerts:                        alerts.WithOrigin(alertsMgr, "bus"),
+		PartialSlabDir:                sqlStoreDir,
+		Migrate:                       true,
+		AnnouncementMaxAge:            announcementMaxAge,
+		PersistInterval:               cfg.PersistInterval,
+		WalletAddress:                 walletAddr,
+		SlabBufferCompletionThreshold: cfg.SlabBufferCompletionThreshold,
+		Logger:                        l.Sugar(),
+		GormLogger:                    sqlLogger,
+		SlabPruningInterval:           time.Hour,
+		SlabPruningCooldown:           30 * time.Second,
+	})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -33,11 +33,13 @@ import (
 
 type BusConfig struct {
 	config.Bus
-	Network            *consensus.Network
-	Miner              *Miner
-	DBLoggerConfig     stores.LoggerConfig
-	DBDialector        gorm.Dialector
-	DBMetricsDialector gorm.Dialector
+	Network             *consensus.Network
+	Miner               *Miner
+	DBLoggerConfig      stores.LoggerConfig
+	DBDialector         gorm.Dialector
+	DBMetricsDialector  gorm.Dialector
+	SlabPruningInterval time.Duration
+	SlabPruningCooldown time.Duration
 }
 
 type AutopilotConfig struct {
@@ -120,8 +122,8 @@ func NewBus(cfg BusConfig, dir string, seed types.PrivateKey, l *zap.Logger) (ht
 		SlabBufferCompletionThreshold: cfg.SlabBufferCompletionThreshold,
 		Logger:                        l.Sugar(),
 		GormLogger:                    sqlLogger,
-		SlabPruningInterval:           time.Hour,
-		SlabPruningCooldown:           30 * time.Second,
+		SlabPruningInterval:           cfg.SlabPruningInterval,
+		SlabPruningCooldown:           cfg.SlabPruningCooldown,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -939,13 +939,16 @@ func testNetwork() *consensus.Network {
 func testBusCfg() node.BusConfig {
 	return node.BusConfig{
 		Bus: config.Bus{
-			AnnouncementMaxAgeHours: 24 * 7 * 52, // 1 year
-			Bootstrap:               false,
-			GatewayAddr:             "127.0.0.1:0",
-			PersistInterval:         testPersistInterval,
-			UsedUTXOExpiry:          time.Minute,
+			AnnouncementMaxAgeHours:       24 * 7 * 52, // 1 year
+			Bootstrap:                     false,
+			GatewayAddr:                   "127.0.0.1:0",
+			PersistInterval:               testPersistInterval,
+			UsedUTXOExpiry:                time.Minute,
+			SlabBufferCompletionThreshold: 0,
 		},
-		Network: testNetwork(),
+		Network:             testNetwork(),
+		SlabPruningInterval: time.Second,
+		SlabPruningCooldown: 10 * time.Millisecond,
 	}
 }
 

--- a/internal/testing/pruning_test.go
+++ b/internal/testing/pruning_test.go
@@ -201,11 +201,14 @@ func TestSectorPruning(t *testing.T) {
 	}
 
 	// assert amount of prunable data
-	res, err = b.PrunableData(context.Background())
-	tt.OK(err)
-	if res.TotalPrunable != uint64(math.Ceil(float64(numObjects)/2))*uint64(rs.TotalShards)*rhpv2.SectorSize {
-		t.Fatal("unexpected prunable data", n)
-	}
+	tt.Retry(100, 100*time.Millisecond, func() error {
+		res, err = b.PrunableData(context.Background())
+		tt.OK(err)
+		if res.TotalPrunable != uint64(math.Ceil(float64(numObjects)/2))*uint64(rs.TotalShards)*rhpv2.SectorSize {
+			return fmt.Errorf("unexpected prunable data %v", n)
+		}
+		return nil
+	})
 
 	// prune all contracts
 	for _, c := range contracts {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -2884,8 +2884,20 @@ func createOrUpdateSector(tx *gorm.DB, sector *dbSector) error {
 	err := tx.
 		Where(dbSector{Root: sector.Root[:]}).
 		Clauses(clause.OnConflict{
-			UpdateAll: true,
-			Columns:   []clause.Column{{Name: "root"}},
+			DoUpdates: clause.Set{
+				{
+					Column: clause.Column{Name: "db_slab_id"},
+					Value:  sector.DBSlabID,
+				},
+				{
+					Column: clause.Column{Name: "slab_index"},
+					Value:  sector.SlabIndex,
+				},
+				{
+					Column: clause.Column{Name: "latest_host"},
+					Value:  sector.LatestHost,
+				},
+			},
 		}).
 		Create(&sector).
 		Error

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -2884,20 +2884,8 @@ func createOrUpdateSector(tx *gorm.DB, sector *dbSector) error {
 	err := tx.
 		Where(dbSector{Root: sector.Root[:]}).
 		Clauses(clause.OnConflict{
-			DoUpdates: clause.Set{
-				{
-					Column: clause.Column{Name: "db_slab_id"},
-					Value:  sector.DBSlabID,
-				},
-				{
-					Column: clause.Column{Name: "slab_index"},
-					Value:  sector.SlabIndex,
-				},
-				{
-					Column: clause.Column{Name: "latest_host"},
-					Value:  sector.LatestHost,
-				},
-			},
+			UpdateAll: true,
+			Columns:   []clause.Column{{Name: "root"}},
 		}).
 		Create(&sector).
 		Error

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -614,7 +614,7 @@ func (s *SQLStore) DeleteBucket(ctx context.Context, bucket string) error {
 		if res.Error != nil {
 			return res.Error
 		}
-		return pruneSlabs(tx)
+		return nil
 	})
 }
 
@@ -1540,11 +1540,6 @@ func (s *SQLStore) RenameObjects(ctx context.Context, bucket, prefixOld, prefixN
 				Delete(&dbObject{})
 			if err := resp.Error; err != nil {
 				return err
-			}
-			if resp.RowsAffected > 0 {
-				if err := pruneSlabs(tx); err != nil {
-					return err
-				}
 			}
 		}
 		tx = tx.Exec("UPDATE objects SET object_id = "+sqlConcat(tx, "?", "SUBSTR(object_id, ?)")+" WHERE SUBSTR(object_id, 1, ?) = ? AND ?",
@@ -2495,9 +2490,6 @@ func deleteObject(tx *gorm.DB, bucket string, path string) (numDeleted int64, _ 
 	if numDeleted == 0 {
 		return 0, nil // nothing to prune if no object was deleted
 	}
-	if err := pruneSlabs(tx); err != nil {
-		return 0, err
-	}
 	return
 }
 
@@ -2508,9 +2500,6 @@ func deleteObjects(tx *gorm.DB, bucket string, path string) (numDeleted int64, _
 		return 0, tx.Error
 	}
 	numDeleted = tx.RowsAffected
-	if err := pruneSlabs(tx); err != nil {
-		return 0, err
-	}
 	return numDeleted, nil
 }
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -614,7 +614,8 @@ func (s *SQLStore) DeleteBucket(ctx context.Context, bucket string) error {
 		if res.Error != nil {
 			return res.Error
 		}
-		return pruneSlabs(tx)
+		s.scheduleSlabPruning()
+		return nil
 	})
 }
 
@@ -1472,9 +1473,18 @@ func (s *SQLStore) isKnownContract(fcid types.FileContractID) bool {
 	return found
 }
 
-func pruneSlabs(tx *gorm.DB) error {
-	if !isSQLite(tx) {
-		return tx.Exec(`
+func (s *SQLStore) scheduleSlabPruning() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.isSlabPruning {
+		s.slabPruningScheduled = true
+		return
+	}
+
+	prune := func() {
+		var err error
+		if !isSQLite(s.db) {
+			err = s.db.Exec(`
 			DELETE slabs
 			FROM slabs
 			LEFT JOIN slices ON slices.db_slab_id = slabs.id
@@ -1482,8 +1492,8 @@ func pruneSlabs(tx *gorm.DB) error {
 			AND slices.db_multipart_part_id IS NULL
 			AND slabs.db_buffered_slab_id IS NULL;
 		`).Error
-	} else {
-		return tx.Exec(`
+		} else {
+			err = s.db.Exec(`
 			DELETE FROM slabs
 				WHERE id IN (
 				SELECT slabs.id
@@ -1494,7 +1504,39 @@ func pruneSlabs(tx *gorm.DB) error {
 				AND slabs.db_buffered_slab_id IS NULL
 			);
 		`).Error
+		}
+		if err != nil {
+			s.logger.Errorw("failed to prune slabs", zap.Error(err))
+		}
 	}
+
+	go func() {
+		for {
+			// prune slabs
+			prune()
+
+			// wait for a bit to allow for more pruning to be scheduled for
+			// batching
+			select {
+			case <-s.shutdownCtx.Done():
+				return
+			case <-time.After(30 * time.Second):
+			}
+
+			// if no more pruning is scheduled we are done
+			s.mu.Lock()
+			if !s.slabPruningScheduled {
+				s.isSlabPruning = false
+				s.mu.Unlock()
+				return
+			}
+
+			// otherwise we set the flag to false and prune again
+			s.slabPruningScheduled = false
+			s.mu.Unlock()
+		}
+
+	}()
 }
 
 func fetchUsedContracts(tx *gorm.DB, usedContracts map[types.PublicKey]map[types.FileContractID]struct{}) (map[types.FileContractID]dbContract, error) {
@@ -1529,7 +1571,7 @@ func (s *SQLStore) RenameObject(ctx context.Context, bucket, keyOld, keyNew stri
 	return s.retryTransaction(func(tx *gorm.DB) error {
 		if force {
 			// delete potentially existing object at destination
-			if _, err := deleteObject(tx, bucket, keyNew); err != nil {
+			if _, err := s.deleteObject(tx, bucket, keyNew); err != nil {
 				return err
 			}
 		}
@@ -1561,9 +1603,7 @@ func (s *SQLStore) RenameObjects(ctx context.Context, bucket, prefixOld, prefixN
 				return err
 			}
 			if resp.RowsAffected > 0 {
-				if err := pruneSlabs(tx); err != nil {
-					return err
-				}
+				s.scheduleSlabPruning()
 			}
 		}
 		tx = tx.Exec("UPDATE objects SET object_id = "+sqlConcat(tx, "?", "SUBSTR(object_id, ?)")+" WHERE SUBSTR(object_id, 1, ?) = ? AND ?",
@@ -1622,7 +1662,7 @@ func (s *SQLStore) CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath
 			}
 			return tx.Save(&srcObj).Error
 		}
-		_, err = deleteObject(tx, dstBucket, dstPath)
+		_, err = s.deleteObject(tx, dstBucket, dstPath)
 		if err != nil {
 			return fmt.Errorf("failed to delete object: %w", err)
 		}
@@ -1770,7 +1810,7 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, 
 		// NOTE: please note that the object's created_at is currently used as
 		// its ModTime, if we ever stop recreating the object but update it
 		// instead we need to take this into account
-		_, err := deleteObject(tx, bucket, path)
+		_, err := s.deleteObject(tx, bucket, path)
 		if err != nil {
 			return fmt.Errorf("failed to delete object: %w", err)
 		}
@@ -1819,7 +1859,7 @@ func (s *SQLStore) RemoveObject(ctx context.Context, bucket, key string) error {
 	var rowsAffected int64
 	var err error
 	err = s.retryTransaction(func(tx *gorm.DB) error {
-		rowsAffected, err = deleteObject(tx, bucket, key)
+		rowsAffected, err = s.deleteObject(tx, bucket, key)
 		return err
 	})
 	if err != nil {
@@ -1835,7 +1875,7 @@ func (s *SQLStore) RemoveObjects(ctx context.Context, bucket, prefix string) err
 	var rowsAffected int64
 	var err error
 	err = s.retryTransaction(func(tx *gorm.DB) error {
-		rowsAffected, err = deleteObjects(tx, bucket, prefix)
+		rowsAffected, err = s.deleteObjects(tx, bucket, prefix)
 		return err
 	})
 	if err != nil {
@@ -2504,7 +2544,7 @@ func archiveContracts(ctx context.Context, tx *gorm.DB, contracts []dbContract, 
 // deleteObject deletes an object from the store and prunes all slabs which are
 // without an obect after the deletion. That means in case of packed uploads,
 // the slab is only deleted when no more objects point to it.
-func deleteObject(tx *gorm.DB, bucket string, path string) (numDeleted int64, _ error) {
+func (s *SQLStore) deleteObject(tx *gorm.DB, bucket string, path string) (numDeleted int64, _ error) {
 	tx = tx.Where("object_id = ? AND ?", path, sqlWhereBucket("objects", bucket)).
 		Delete(&dbObject{})
 	if tx.Error != nil {
@@ -2514,21 +2554,19 @@ func deleteObject(tx *gorm.DB, bucket string, path string) (numDeleted int64, _ 
 	if numDeleted == 0 {
 		return 0, nil // nothing to prune if no object was deleted
 	}
-	if err := pruneSlabs(tx); err != nil {
-		return 0, err
-	}
+	s.scheduleSlabPruning()
 	return
 }
 
-func deleteObjects(tx *gorm.DB, bucket string, path string) (numDeleted int64, _ error) {
+func (s *SQLStore) deleteObjects(tx *gorm.DB, bucket string, path string) (numDeleted int64, _ error) {
 	tx = tx.Exec("DELETE FROM objects WHERE SUBSTR(object_id, 1, ?) = ? AND ?",
 		utf8.RuneCountInString(path), path, sqlWhereBucket("objects", bucket))
 	if tx.Error != nil {
 		return 0, tx.Error
 	}
 	numDeleted = tx.RowsAffected
-	if err := pruneSlabs(tx); err != nil {
-		return 0, err
+	if numDeleted > 0 {
+		s.scheduleSlabPruning()
 	}
 	return numDeleted, nil
 }

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1017,9 +1017,9 @@ func TestSQLMetadataStore(t *testing.T) {
 	// incremented due to the object and slab being overwritten.
 	two := uint(2)
 	expectedObj.Slabs[0].DBObjectID = &two
-	expectedObj.Slabs[0].DBSlabID = 3
+	expectedObj.Slabs[0].DBSlabID = 1
 	expectedObj.Slabs[1].DBObjectID = &two
-	expectedObj.Slabs[1].DBSlabID = 4
+	expectedObj.Slabs[1].DBSlabID = 2
 	if !reflect.DeepEqual(obj, expectedObj) {
 		t.Fatal("object mismatch", cmp.Diff(obj, expectedObj))
 	}
@@ -1041,7 +1041,7 @@ func TestSQLMetadataStore(t *testing.T) {
 		TotalShards:     1,
 		Shards: []dbSector{
 			{
-				DBSlabID:   3,
+				DBSlabID:   1,
 				SlabIndex:  1,
 				Root:       obj1.Slabs[0].Shards[0].Root[:],
 				LatestHost: publicKey(obj1.Slabs[0].Shards[0].LatestHost),
@@ -1081,7 +1081,7 @@ func TestSQLMetadataStore(t *testing.T) {
 		TotalShards:     1,
 		Shards: []dbSector{
 			{
-				DBSlabID:   4,
+				DBSlabID:   2,
 				SlabIndex:  1,
 				Root:       obj1.Slabs[1].Shards[0].Root[:],
 				LatestHost: publicKey(obj1.Slabs[1].Shards[0].LatestHost),
@@ -1180,9 +1180,10 @@ func TestSQLMetadataStore(t *testing.T) {
 		}
 		return nil
 	}
-	if err := countCheck(1, 1, 1, 1); err != nil {
-		t.Fatal(err)
-	}
+	ss.scheduleSlabPruning()
+	ss.Retry(100, 100*time.Millisecond, func() error {
+		return countCheck(1, 1, 1, 1)
+	})
 
 	// Delete the object. Due to the cascade this should delete everything
 	// but the sectors.

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2910,27 +2910,39 @@ func TestContractSizes(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// prune slabs
+	ss.scheduleSlabPruning()
+
 	// assert there's one sector that can be pruned and assert it's from fcid 1
-	if n := prunableData(nil); n != rhpv2.SectorSize {
-		t.Fatal("unexpected amount of prunable data", n)
-	}
-	if n := prunableData(&fcids[1]); n != 0 {
-		t.Fatal("expected no prunable data", n)
-	}
+	ss.Retry(100, 100*time.Millisecond, func() error {
+		if n := prunableData(nil); n != rhpv2.SectorSize {
+			return fmt.Errorf("unexpected amount of prunable data %v", n)
+		}
+		if n := prunableData(&fcids[1]); n != 0 {
+			return fmt.Errorf("expected no prunable data %v", n)
+		}
+		return nil
+	})
 
 	// remove the second object
 	if err := ss.RemoveObject(context.Background(), api.DefaultBucketName, "obj_2"); err != nil {
 		t.Fatal(err)
 	}
 
+	// prune slabs
+	ss.scheduleSlabPruning()
+
 	// assert there's now two sectors that can be pruned
-	if n := prunableData(nil); n != rhpv2.SectorSize*2 {
-		t.Fatal("unexpected amount of prunable data", n)
-	} else if n := prunableData(&fcids[0]); n != rhpv2.SectorSize {
-		t.Fatal("unexpected amount of prunable data", n)
-	} else if n := prunableData(&fcids[1]); n != rhpv2.SectorSize {
-		t.Fatal("unexpected amount of prunable data", n)
-	}
+	ss.Retry(100, 100*time.Millisecond, func() error {
+		if n := prunableData(nil); n != rhpv2.SectorSize*2 {
+			return fmt.Errorf("unexpected amount of prunable data %v", n)
+		} else if n := prunableData(&fcids[0]); n != rhpv2.SectorSize {
+			return fmt.Errorf("unexpected amount of prunable data %v", n)
+		} else if n := prunableData(&fcids[1]); n != rhpv2.SectorSize {
+			return fmt.Errorf("unexpected amount of prunable data %v", n)
+		}
+		return nil
+	})
 
 	if size, err := ss.ContractSize(context.Background(), fcids[0]); err != nil {
 		t.Fatal("unexpected err", err)

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1190,9 +1190,10 @@ func TestSQLMetadataStore(t *testing.T) {
 	if err := ss.RemoveObject(ctx, api.DefaultBucketName, objID); err != nil {
 		t.Fatal(err)
 	}
-	if err := countCheck(0, 0, 0, 0); err != nil {
-		t.Fatal(err)
-	}
+	ss.scheduleSlabPruning()
+	ss.Retry(100, 100*time.Millisecond, func() error {
+		return countCheck(0, 0, 0, 0)
+	})
 }
 
 // TestObjectHealth verifies the object's health is returned correctly by all

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -287,7 +287,8 @@ func (s *SQLStore) AbortMultipartUpload(ctx context.Context, bucket, path string
 		if err != nil {
 			return fmt.Errorf("failed to delete multipart upload: %w", err)
 		}
-		return pruneSlabs(tx)
+		s.scheduleSlabPruning()
+		return nil
 	})
 }
 
@@ -326,7 +327,7 @@ func (s *SQLStore) CompleteMultipartUpload(ctx context.Context, bucket, path str
 		}
 
 		// Delete potentially existing object.
-		_, err := deleteObject(tx, bucket, path)
+		_, err := s.deleteObject(tx, bucket, path)
 		if err != nil {
 			return fmt.Errorf("failed to delete object: %w", err)
 		}

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -287,7 +287,7 @@ func (s *SQLStore) AbortMultipartUpload(ctx context.Context, bucket, path string
 		if err != nil {
 			return fmt.Errorf("failed to delete multipart upload: %w", err)
 		}
-		return nil
+		return pruneSlabs(tx)
 	})
 }
 

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -287,7 +287,7 @@ func (s *SQLStore) AbortMultipartUpload(ctx context.Context, bucket, path string
 		if err != nil {
 			return fmt.Errorf("failed to delete multipart upload: %w", err)
 		}
-		return pruneSlabs(tx)
+		return nil
 	})
 }
 

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -80,10 +80,12 @@ type (
 		shutdownCtx       context.Context
 		shutdownCtxCancel context.CancelFunc
 
-		mu           sync.Mutex
-		hasAllowlist bool
-		hasBlocklist bool
-		closed       bool
+		mu                   sync.Mutex
+		hasAllowlist         bool
+		hasBlocklist         bool
+		closed               bool
+		isSlabPruning        bool
+		slabPruningScheduled bool
 
 		knownContracts map[types.FileContractID]struct{}
 	}
@@ -266,6 +268,9 @@ func NewSQLStore(conn, connMetrics gorm.Dialector, alerts alerts.Alerter, partia
 	if err != nil {
 		return nil, modules.ConsensusChangeID{}, err
 	}
+
+	// Prune slabs on startup
+	ss.scheduleSlabPruning()
 
 	return ss, ccid, nil
 }

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -350,6 +350,7 @@ func tableCount(db *gorm.DB, model interface{}) (cnt int64, err error) {
 // Close closes the underlying database connection of the store.
 func (s *SQLStore) Close() error {
 	s.shutdownCtxCancel()
+	s.wg.Wait()
 
 	db, err := s.db.DB()
 	if err != nil {

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -47,7 +47,6 @@ type (
 		db        *gorm.DB
 		dbMetrics *gorm.DB
 		logger    *zap.SugaredLogger
-		wg        sync.WaitGroup
 
 		slabBufferMgr *SlabBufferManager
 
@@ -268,39 +267,7 @@ func NewSQLStore(conn, connMetrics gorm.Dialector, alerts alerts.Alerter, partia
 		return nil, modules.ConsensusChangeID{}, err
 	}
 
-	// Run maintenance once on startup.
-	ss.performMaintenance()
-
-	// Launch maintenance loop.
-	ss.wg.Add(1)
-	go func() {
-		ss.maintenanceLoop()
-		ss.wg.Done()
-	}()
-
 	return ss, ccid, nil
-}
-
-func (s *SQLStore) maintenanceLoop() {
-	t := time.NewTicker(time.Hour)
-	defer t.Stop()
-	for {
-		select {
-		case <-t.C:
-		case <-s.shutdownCtx.Done():
-			return
-		}
-		s.logger.Info("running database maintenance")
-		s.performMaintenance()
-		s.logger.Info("finished database maintenance")
-	}
-}
-
-func (s *SQLStore) performMaintenance() {
-	// prune slabs
-	if err := pruneSlabs(s.db); err != nil {
-		s.logger.Errorw("failed to prune slabs", zap.Error(err))
-	}
 }
 
 func isSQLite(db *gorm.DB) bool {
@@ -354,8 +321,6 @@ func tableCount(db *gorm.DB, model interface{}) (cnt int64, err error) {
 // Close closes the underlying database connection of the store.
 func (s *SQLStore) Close() error {
 	s.shutdownCtxCancel()
-
-	s.wg.Wait()
 
 	db, err := s.db.DB()
 	if err != nil {

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -76,7 +76,21 @@ func newTestSQLStore(t *testing.T, cfg testSQLStoreConfig) *testSQLStore {
 
 	walletAddrs := types.Address(frand.Entropy256())
 	alerts := alerts.WithOrigin(alerts.NewManager(), "test")
-	sqlStore, ccid, err := NewSQLStore(conn, connMetrics, alerts, dir, !cfg.skipMigrate, time.Hour, time.Second, walletAddrs, 0, zap.NewNop().Sugar(), newTestLogger())
+	sqlStore, ccid, err := NewSQLStore(Config{
+		Conn:                          conn,
+		ConnMetrics:                   connMetrics,
+		Alerts:                        alerts,
+		PartialSlabDir:                dir,
+		Migrate:                       !cfg.skipMigrate,
+		AnnouncementMaxAge:            time.Hour,
+		PersistInterval:               time.Second,
+		WalletAddress:                 walletAddrs,
+		SlabBufferCompletionThreshold: 0,
+		Logger:                        zap.NewNop().Sugar(),
+		GormLogger:                    newTestLogger(),
+		SlabPruningInterval:           time.Hour,
+		SlabPruningCooldown:           10 * time.Millisecond,
+	})
 	if err != nil {
 		t.Fatal("failed to create SQLStore", err)
 	}

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -117,6 +117,20 @@ func (s *testSQLStore) Reopen() *testSQLStore {
 	return newTestSQLStore(s.t, cfg)
 }
 
+func (s *testSQLStore) Retry(tries int, durationBetweenAttempts time.Duration, fn func() error) {
+	s.t.Helper()
+	for i := 1; i < tries; i++ {
+		err := fn()
+		if err == nil {
+			return
+		}
+		time.Sleep(durationBetweenAttempts)
+	}
+	if err := fn(); err != nil {
+		s.t.Fatal(err)
+	}
+}
+
 // newTestLogger creates a console logger used for testing.
 func newTestLogger() logger.Interface {
 	config := zap.NewProductionEncoderConfig()


### PR DESCRIPTION
Pruning slabs is quite a slow operation so this PR does 2 things.

1. Slightly improves the queries by reducing the nesting
2. Keep a background loop for pruning slabs which instead of pruning in a synchronous way is either triggered to prune or prunes every hour. It also comes with a 30s cooldown to better batch slab pruning

This is not a huge change but it makes quite the difference for nodes on slower disks with lots of files trying to override existing objects. When lots of objects are added at the same time I have seen my node spend a minute on a single query.