### PR TITLE
More verbose usage information for CLI

### DIFF
--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -180,6 +180,16 @@ func tryLoadConfig() {
 
 	// If the config file doesn't exist, don't try to load it.
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		// create an empty config file if it doesn't exist
+		f, err := os.Create(configPath)
+		if err != nil {
+			log.Fatal("failed to create config file:", err)
+		}
+		defer f.Close()
+		f.WriteString(`
+# Renterd config file
+# Any values set here will be overwritten by CLI flags and environment variables
+`)
 		return
 	}
 

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -46,6 +46,31 @@ const (
 	// minutes. That's why we assume 10 seconds to be more than frequent enough
 	// to refill an account when it's due for another refill.
 	defaultAccountRefillInterval = 10 * time.Second
+
+	// emptyConfigFile is the default config file that will be created on disk
+	// if no config file exists.
+	emptyConfigFile = `# Renterd config file
+# Any values set here will be overwritten by CLI flags and environment variables if set
+`
+
+	// usageHeader is the header for the CLI usage text.
+	usageHeader = `
+Renterd is the official Sia renter daemon. It provides a REST API for forming
+contracts with hosts, uploading data to them and downloading data from them.
+
+There are 3 ways to configure renterd:
+  - CLI flags
+  - Environment variables
+  - A YAML config file called 'renterd.yaml' in 'renterd's data directory
+
+An empty config file will be created if it doesn't exist when 'renterd' runs for
+the first time. So if you are reading this, the file should already exist.
+
+See the documentation (https://docs.sia.tech/) for more information and examples
+on how to configure and use renterd.
+
+Usage:
+`
 )
 
 var (
@@ -188,9 +213,7 @@ func tryLoadConfig() {
 			log.Fatal("failed to create config file:", err)
 		}
 		defer f.Close()
-		f.WriteString(`# Renterd config file
-# Any values set here will be overwritten by CLI flags and environment variables if set
-`)
+		f.WriteString(emptyConfigFile)
 		return
 	}
 
@@ -297,23 +320,7 @@ func main() {
 
 	// custom usage
 	flag.Usage = func() {
-		log.Print(`
-Renterd is the official Sia renter daemon. It provides a REST API for forming
-contracts with hosts, uploading data to them and downloading data from them.
-
-There are 3 ways to configure renterd:
-  - CLI flags
-  - Environment variables
-  - A YAML config file called 'renterd.yaml' in 'renterd's data directory
-
-An empty config file will be created if it doesn't exist when 'renterd' runs for
-the first time. So if you are reading this, the file should already exist.
-
-See the documentation (https://docs.sia.tech/) for more information and examples
-on how to configure and use renterd.
-
-Usage:
-`)
+		log.Print(usageHeader)
 		flag.PrintDefaults()
 	}
 

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -3,10 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"net/http"
@@ -47,12 +45,6 @@ const (
 	// to refill an account when it's due for another refill.
 	defaultAccountRefillInterval = 10 * time.Second
 
-	// emptyConfigFile is the default config file that will be created on disk
-	// if no config file exists.
-	emptyConfigFile = `# Renterd config file
-# Any values set here will be overwritten by CLI flags and environment variables if set
-`
-
 	// usageHeader is the header for the CLI usage text.
 	usageHeader = `
 Renterd is the official Sia renter daemon. It provides a REST API for forming
@@ -61,10 +53,7 @@ contracts with hosts, uploading data to them and downloading data from them.
 There are 3 ways to configure renterd:
   - CLI flags
   - Environment variables
-  - A YAML config file called 'renterd.yaml' in 'renterd's data directory
-
-An empty config file will be created if it doesn't exist when 'renterd' runs for
-the first time. So if you are reading this, the file should already exist.
+  - A YAML config file
 
 See the documentation (https://docs.sia.tech/) for more information and examples
 on how to configure and use renterd.
@@ -207,13 +196,6 @@ func tryLoadConfig() {
 
 	// If the config file doesn't exist, don't try to load it.
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		// create an empty config file if it doesn't exist
-		f, err := os.Create(configPath)
-		if err != nil {
-			log.Fatal("failed to create config file:", err)
-		}
-		defer f.Close()
-		f.WriteString(emptyConfigFile)
 		return
 	}
 
@@ -226,7 +208,7 @@ func tryLoadConfig() {
 	dec := yaml.NewDecoder(f)
 	dec.KnownFields(true)
 
-	if err := dec.Decode(&cfg); err != nil && !errors.Is(err, io.EOF) {
+	if err := dec.Decode(&cfg); err != nil {
 		log.Fatal("failed to decode config file:", err)
 	}
 }

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -50,10 +50,10 @@ const (
 Renterd is the official Sia renter daemon. It provides a REST API for forming
 contracts with hosts, uploading data to them and downloading data from them.
 
-There are 3 ways to configure renterd:
+There are 3 ways to configure renterd (sorted from lowest to highest precedence):
+  - A YAML config file
   - CLI flags
   - Environment variables
-  - A YAML config file
 
 See the documentation (https://docs.sia.tech/) for more information and examples
 on how to configure and use renterd.


### PR DESCRIPTION
For a first time user it might not be obvious that configuring `renterd` via a config file is possible. This PR updates the usage info of `renterd` to inform users about that option and makes sure a config file is always created for the user to modify instead of relying on them creating it.