### PR TITLE
Change ResetConsensusSubscription to delete from tables instead of dropping them

### DIFF
--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -190,6 +190,10 @@ func TestConsensusReset(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Reopen the SQLStore.
+	ss = ss.Reopen()
+	defer ss.Close()
+
 	// Check tables.
 	var count int64
 	if err := ss.db.Model(&dbConsensusInfo{}).Count(&count).Error; err != nil || count != 1 {


### PR DESCRIPTION
This fixes an issue where startup would fail due to missing tables. Using `DELETE`, we make sure the reset operation is atomic.