### PR TITLE
Close pipeReader at the end of serveContent

### DIFF
--- a/worker/serve.go
+++ b/worker/serve.go
@@ -67,6 +67,7 @@ func serveContent(rw http.ResponseWriter, req *http.Request, obj api.Object, dow
 
 	// launch the download in a goroutine
 	pr, pw := io.Pipe()
+	defer pr.Close()
 	go func() {
 		if err := downloadFn(pw, offset, length); err != nil {
 			pw.CloseWithError(err)


### PR DESCRIPTION
We seem to be running into an edge case where `DownloadObject` is stuck forever since writing to the `io.PipeWriter` never finishes. 
Looking at `serveContent` we never seemed to close the corresponding reader in case `serveContent` exits without reading all the data from it.