### PR TITLE
Remove unused registry code

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -166,15 +166,6 @@ type (
 		AccountKey types.PrivateKey `json:"accountKey"`
 	}
 
-	// RHPRegistryUpdateRequest is the request type for the /rhp/registry/update
-	// endpoint.
-	RHPRegistryUpdateRequest struct {
-		HostKey       types.PublicKey     `json:"hostKey"`
-		SiamuxAddr    string              `json:"siamuxAddr"`
-		RegistryKey   rhpv3.RegistryKey   `json:"registryKey"`
-		RegistryValue rhpv3.RegistryValue `json:"registryValue"`
-	}
-
 	// DownloadStatsResponse is the response type for the /stats/downloads endpoint.
 	DownloadStatsResponse struct {
 		AvgDownloadSpeedMBPS float64           `json:"avgDownloadSpeedMbps"`

--- a/internal/testing/cluster.go
+++ b/internal/testing/cluster.go
@@ -580,13 +580,12 @@ func addStorageFolderToHost(ctx context.Context, hosts []*Host) error {
 	return nil
 }
 
-// announceHosts adds storage and a registry to each host and announces them to
+// announceHosts configures hosts with default settings and announces them to
 // the group
 func announceHosts(hosts []*Host) error {
 	for _, host := range hosts {
 		settings := defaultHostSettings
 		settings.NetAddress = host.RHPv2Addr()
-		settings.MaxRegistryEntries = 1 << 18
 		if err := host.settings.UpdateSettings(settings); err != nil {
 			return err
 		}

--- a/internal/testing/host.go
+++ b/internal/testing/host.go
@@ -88,9 +88,8 @@ var defaultHostSettings = settings.Settings{
 
 	PriceTableValidity: 10 * time.Second,
 
-	AccountExpiry:      30 * 24 * time.Hour, // 1 month
-	MaxAccountBalance:  types.Siacoins(10),
-	MaxRegistryEntries: 1e3,
+	AccountExpiry:     30 * 24 * time.Hour, // 1 month
+	MaxAccountBalance: types.Siacoins(10),
 }
 
 // Close shutsdown the host


### PR DESCRIPTION
stumbled into `RPCReadRegistry` while reading and figured we might as well remove the last remaining (unused) code revolving the registry