### PR TITLE
Sanity check VerifySectorRangeProof input to avoid a panic

### DIFF
--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -598,8 +598,10 @@ func (w *worker) fetchContractRoots(t *rhpv2.Transport, rev *rhpv2.ContractRevis
 		rev.Signatures[1].Signature = rootsResp.Signature[:]
 
 		// verify the proof
-		if !rhpv2.VerifySectorRangeProof(rootsResp.MerkleProof, rootsResp.SectorRoots, offset, offset+n, numsectors, rev.Revision.FileMerkleRoot) {
-			return nil, fmt.Errorf("could verify roots proof, host %v, version %v; %w", rev.HostKey(), settings.Version, ErrInvalidMerkleProof)
+		if uint64(len(rootsResp.SectorRoots)) != n {
+			return nil, fmt.Errorf("couldn't verify contract roots proof, host %v, version %v, err: number of roots does not match range %d != %d", rev.HostKey(), settings.Version, len(rootsResp.SectorRoots), n)
+		} else if !rhpv2.VerifySectorRangeProof(rootsResp.MerkleProof, rootsResp.SectorRoots, offset, offset+n, numsectors, rev.Revision.FileMerkleRoot) {
+			return nil, fmt.Errorf("couldn't verify contract roots proof, host %v, version %v; %w", rev.HostKey(), settings.Version, ErrInvalidMerkleProof)
 		}
 
 		// append roots

--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -599,7 +599,7 @@ func (w *worker) fetchContractRoots(t *rhpv2.Transport, rev *rhpv2.ContractRevis
 
 		// verify the proof
 		if uint64(len(rootsResp.SectorRoots)) != n {
-			return nil, fmt.Errorf("couldn't verify contract roots proof, host %v, version %v, err: number of roots does not match range %d != %d", rev.HostKey(), settings.Version, len(rootsResp.SectorRoots), n)
+			return nil, fmt.Errorf("couldn't verify contract roots proof, host %v, version %v, err: number of roots does not match range %d != %d (num sectors: %d offset: %d)", rev.HostKey(), settings.Version, len(rootsResp.SectorRoots), n, numsectors, offset)
 		} else if !rhpv2.VerifySectorRangeProof(rootsResp.MerkleProof, rootsResp.SectorRoots, offset, offset+n, numsectors, rev.Revision.FileMerkleRoot) {
 			return nil, fmt.Errorf("couldn't verify contract roots proof, host %v, version %v; %w", rev.HostKey(), settings.Version, ErrInvalidMerkleProof)
 		}

--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -599,7 +599,7 @@ func (w *worker) fetchContractRoots(t *rhpv2.Transport, rev *rhpv2.ContractRevis
 
 		// verify the proof
 		if uint64(len(rootsResp.SectorRoots)) != n {
-			return nil, fmt.Errorf("couldn't verify contract roots proof, host %v, version %v, err: number of roots does not match range %d != %d (num sectors: %d offset: %d)", rev.HostKey(), settings.Version, len(rootsResp.SectorRoots), n, numsectors, offset)
+			return nil, fmt.Errorf("couldn't verify contract roots proof, host %v, version %v, err: number of roots does not match range %d != %d (num sectors: %d rev size: %d offset: %d)", rev.HostKey(), settings.Version, len(rootsResp.SectorRoots), n, numsectors, rev.Revision.Filesize, offset)
 		} else if !rhpv2.VerifySectorRangeProof(rootsResp.MerkleProof, rootsResp.SectorRoots, offset, offset+n, numsectors, rev.Revision.FileMerkleRoot) {
 			return nil, fmt.Errorf("couldn't verify contract roots proof, host %v, version %v; %w", rev.HostKey(), settings.Version, ErrInvalidMerkleProof)
 		}


### PR DESCRIPTION
This gets rid of the panic but I'm not sure when the returned proof is off. I added some extra context to the error.

Fixes #897 