### PR TITLE
add SQL impl. for syncer.PeerStore

### DIFF
--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -64,6 +64,12 @@ func performMigrations(db *gorm.DB, logger *zap.SugaredLogger) error {
 				return err
 			},
 		},
+		{
+			ID: "00003_peer_store",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration(tx, "00003_peer_store", logger)
+			},
+		},
 	}
 
 	// Create migrator.

--- a/stores/migrations/mysql/main/migration_00003_peer_store.sql
+++ b/stores/migrations/mysql/main/migration_00003_peer_store.sql
@@ -8,7 +8,7 @@ CREATE TABLE `syncer_peers` (
   `synced_blocks` bigint,
   `sync_duration` bigint,
   PRIMARY KEY (`id`),
-  UNIQUE KEY (`address`)
+  UNIQUE KEY `idx_syncer_peers_address` (`address`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- dbSyncerBan
@@ -19,5 +19,6 @@ CREATE TABLE `syncer_bans` (
   `reason` longtext,
   `expiration` bigint NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY (`net_cidr`)
+  UNIQUE KEY `idx_syncer_bans_net_cidr` (`net_cidr`),
+  KEY `idx_syncer_bans_expiration` (`expiration`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/stores/migrations/mysql/main/migration_00003_peer_store.sql
+++ b/stores/migrations/mysql/main/migration_00003_peer_store.sql
@@ -1,0 +1,23 @@
+-- dbSyncerPeer
+CREATE TABLE `syncer_peers` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(3) DEFAULT NULL,
+  `address` varchar(191) NOT NULL,
+  `first_seen` bigint NOT NULL,
+  `last_connect` bigint,
+  `synced_blocks` bigint,
+  `sync_duration` bigint,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY (`address`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- dbSyncerBan
+CREATE TABLE `syncer_bans` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(3) DEFAULT NULL,
+  `net_cidr` varchar(191) NOT NULL,
+  `reason` longtext,
+  `expiration` bigint NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY (`net_cidr`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/stores/migrations/mysql/main/schema.sql
+++ b/stores/migrations/mysql/main/schema.sql
@@ -476,5 +476,5 @@ CREATE TABLE `syncer_bans` (
   `expiration` bigint NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_syncer_bans_net_cidr` (`net_cidr`),
-  KEY `idx_syncer_bans_expiration` (`expiration`),
+  KEY `idx_syncer_bans_expiration` (`expiration`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/stores/migrations/mysql/main/schema.sql
+++ b/stores/migrations/mysql/main/schema.sql
@@ -453,3 +453,28 @@ AND NOT EXISTS (
     FROM slices
     WHERE slices.db_slab_id = OLD.db_slab_id
 );
+
+-- dbSyncerPeer
+CREATE TABLE `syncer_peers` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(3) DEFAULT NULL,
+  `address` varchar(191) NOT NULL,
+  `first_seen` bigint NOT NULL,
+  `last_connect` bigint,
+  `synced_blocks` bigint,
+  `sync_duration` bigint,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_syncer_peers_address` (`address`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- dbSyncerBan
+CREATE TABLE `syncer_bans` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(3) DEFAULT NULL,
+  `net_cidr` varchar(191) NOT NULL,
+  `reason` longtext,
+  `expiration` bigint NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_syncer_bans_net_cidr` (`net_cidr`),
+  KEY `idx_syncer_bans_expiration` (`expiration`),
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/stores/migrations/sqlite/main/migration_00003_peer_store.sql
+++ b/stores/migrations/sqlite/main/migration_00003_peer_store.sql
@@ -1,0 +1,7 @@
+-- dbSyncerPeer
+CREATE TABLE `syncer_peers` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`address` text NOT NULL,`first_seen` BIGINT NOT NULL,`last_connect` BIGINT,`synced_blocks` BIGINT,`sync_duration` BIGINT);
+CREATE UNIQUE INDEX `idx_syncer_peers_address` ON `syncer_peers`(`address`);
+
+-- dbSyncerBan
+CREATE TABLE `syncer_bans` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`net_cidr` text  NOT NULL,`reason` text,`expiration` BIGINT NOT NULL);
+CREATE UNIQUE INDEX `idx_syncer_bans_net_cidr` ON `syncer_bans`(`net_cidr`);

--- a/stores/migrations/sqlite/main/schema.sql
+++ b/stores/migrations/sqlite/main/schema.sql
@@ -184,3 +184,12 @@ BEGIN
         WHERE slices.db_slab_id = OLD.db_slab_id
     );
 END;
+
+-- dbSyncerPeer
+CREATE TABLE `syncer_peers` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`address` text NOT NULL,`first_seen` BIGINT NOT NULL,`last_connect` BIGINT,`synced_blocks` BIGINT,`sync_duration` BIGINT);
+CREATE UNIQUE INDEX `idx_syncer_peers_address` ON `syncer_peers`(`address`);
+
+-- dbSyncerBan
+CREATE TABLE `syncer_bans` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`net_cidr` text  NOT NULL,`reason` text,`expiration` BIGINT NOT NULL);
+CREATE UNIQUE INDEX `idx_syncer_bans_net_cidr` ON `syncer_bans`(`net_cidr`);
+CREATE INDEX `idx_syncer_bans_expiration` ON `syncer_bans`(`expiration`);

--- a/stores/peers.go
+++ b/stores/peers.go
@@ -1,0 +1,221 @@
+package stores
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.sia.tech/coreutils/syncer"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type (
+	dbSyncerPeer struct {
+		Model
+
+		Address      string `gorm:"unique;index:idx_syncer_peers_address;NOT NULL"`
+		FirstSeen    unixTimeMS
+		LastConnect  unixTimeMS
+		SyncedBlocks unsigned64
+		SyncDuration unsigned64
+	}
+
+	dbSyncerBan struct {
+		Model
+
+		NetCidr    string     `gorm:"unique;index:idx_syncer_bans_net_cidr;NOT NULL"`
+		Expiration unixTimeMS `gorm:"index:idx_syncer_bans_expiration;NOT NULL"`
+		Reason     string
+	}
+)
+
+var (
+	// TODO: use syncer.ErrPeerNotFound when added
+	ErrPeerNotFound = errors.New("peer not found")
+)
+
+var (
+	_ syncer.PeerStore = (*SQLStore)(nil)
+)
+
+func (dbSyncerPeer) TableName() string {
+	return "syncer_peers"
+}
+
+func (dbSyncerBan) TableName() string {
+	return "syncer_bans"
+}
+
+func (p dbSyncerPeer) info() syncer.PeerInfo {
+	return syncer.PeerInfo{
+		Address:      p.Address,
+		FirstSeen:    time.Time(p.FirstSeen),
+		LastConnect:  time.Time(p.LastConnect),
+		SyncedBlocks: uint64(p.SyncedBlocks),
+		SyncDuration: time.Duration(p.SyncDuration),
+	}
+}
+
+// AddPeer adds a peer to the store. If the peer already exists, nil should
+// be returned.
+func (s *SQLStore) AddPeer(addr string) error {
+	return s.retryTransaction(func(tx *gorm.DB) error {
+		res := tx.
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "address"}},
+				DoNothing: true,
+			}).
+			Create(&dbSyncerPeer{Address: addr, FirstSeen: unixTimeMS(time.Now())})
+		return res.Error
+	})
+}
+
+// Peers returns the set of known peers.
+func (s *SQLStore) Peers() ([]syncer.PeerInfo, error) {
+	var peers []dbSyncerPeer
+	if err := s.db.Model(&dbSyncerPeer{}).Find(&peers).Error; err != nil {
+		return nil, err
+	}
+
+	infos := make([]syncer.PeerInfo, len(peers))
+	for i, peer := range peers {
+		infos[i] = peer.info()
+	}
+	return infos, nil
+}
+
+// UpdatePeerInfo updates the metadata for the specified peer. If the peer
+// is not found, the error should be ErrPeerNotFound.
+func (s *SQLStore) UpdatePeerInfo(addr string, fn func(*syncer.PeerInfo)) error {
+	return s.retryTransaction(func(tx *gorm.DB) error {
+		var peer dbSyncerPeer
+		err := tx.
+			Where("address = ?", addr).
+			Take(&peer).
+			Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrPeerNotFound
+		} else if err != nil {
+			return err
+		}
+
+		update := peer.info()
+		fn(&update)
+
+		return tx.Model(&peer).Updates(map[string]interface{}{
+			"last_connect":  unixTimeMS(update.LastConnect),
+			"synced_blocks": unsigned64(update.SyncedBlocks),
+			"sync_duration": unsigned64(update.SyncDuration),
+		}).Error
+	})
+}
+
+// Ban temporarily bans one or more IPs. The addr should either be a single
+// IP with port (e.g. 1.2.3.4:5678) or a CIDR subnet (e.g. 1.2.3.4/16).
+func (s *SQLStore) Ban(addr string, duration time.Duration, reason string) error {
+	cidr, err := normalizePeer(addr)
+	if err != nil {
+		return err
+	}
+
+	return s.retryTransaction(func(tx *gorm.DB) error {
+		res := tx.
+			Clauses(clause.OnConflict{
+				Columns: []clause.Column{{Name: "net_cidr"}},
+				DoUpdates: clause.Assignments(map[string]interface{}{
+					"expiration": unixTimeMS(time.Now().Add(duration)),
+					"reason":     reason,
+				}),
+			}).
+			Create(&dbSyncerBan{
+				NetCidr:    cidr,
+				Expiration: unixTimeMS(time.Now().Add(duration)),
+				Reason:     reason,
+			})
+		return res.Error
+	})
+
+}
+
+// Banned returns true, nil if the peer is banned.
+func (s *SQLStore) Banned(addr string) (bool, error) {
+	// normalize the address to a CIDR
+	netCIDR, err := normalizePeer(addr)
+	if err != nil {
+		return false, err
+	}
+
+	// parse the subnet
+	_, subnet, err := net.ParseCIDR(netCIDR)
+	if err != nil {
+		return false, err
+	}
+
+	// check all subnets from the given subnet to the max subnet length
+	var maxMaskLen int
+	if subnet.IP.To4() != nil {
+		maxMaskLen = 32
+	} else {
+		maxMaskLen = 128
+	}
+
+	checkSubnets := make([]string, 0, maxMaskLen)
+	for i := maxMaskLen; i > 0; i-- {
+		_, subnet, err := net.ParseCIDR(subnet.IP.String() + "/" + strconv.Itoa(i))
+		if err != nil {
+			return false, err
+		}
+		checkSubnets = append(checkSubnets, subnet.String())
+	}
+
+	var ban dbSyncerBan
+	if err := s.retryTransaction(func(tx *gorm.DB) error {
+		return tx.
+			Model(&dbSyncerBan{}).
+			Where("net_cidr IN ?", checkSubnets).
+			Order("expiration DESC").
+			First(&ban).
+			Error
+	}); err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, err
+	}
+
+	return time.Now().Before(time.Time(ban.Expiration)), nil
+}
+
+// normalizePeer normalizes a peer address to a CIDR subnet.
+func normalizePeer(peer string) (string, error) {
+	host, _, err := net.SplitHostPort(peer)
+	if err != nil {
+		host = peer
+	}
+	if strings.IndexByte(host, '/') != -1 {
+		_, subnet, err := net.ParseCIDR(host)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse CIDR: %w", err)
+		}
+		return subnet.String(), nil
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return "", errors.New("invalid IP address")
+	}
+
+	var maskLen int
+	if ip.To4() != nil {
+		maskLen = 32
+	} else {
+		maskLen = 128
+	}
+
+	_, normalized, err := net.ParseCIDR(fmt.Sprintf("%s/%d", ip.String(), maskLen))
+	if err != nil {
+		panic("failed to parse CIDR")
+	}
+	return normalized.String(), nil
+}

--- a/stores/peers.go
+++ b/stores/peers.go
@@ -138,7 +138,6 @@ func (s *SQLStore) Ban(addr string, duration time.Duration, reason string) error
 			})
 		return res.Error
 	})
-
 }
 
 // Banned returns true, nil if the peer is banned.

--- a/stores/peers_test.go
+++ b/stores/peers_test.go
@@ -1,0 +1,142 @@
+package stores
+
+import (
+	"testing"
+	"time"
+
+	"go.sia.tech/coreutils/syncer"
+)
+
+const (
+	testPeer = "1.2.3.4:9981"
+)
+
+func TestPeers(t *testing.T) {
+	ss := newTestSQLStore(t, defaultTestSQLStoreConfig)
+	defer ss.Close()
+
+	// assert ErrPeerNotFound before we add it
+	err := ss.UpdatePeerInfo(testPeer, func(info *syncer.PeerInfo) {})
+	if err != ErrPeerNotFound {
+		t.Fatal("expected peer not found")
+	}
+
+	// add peer
+	err = ss.AddPeer(testPeer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// fetch peers
+	var peer syncer.PeerInfo
+	peers, err := ss.Peers()
+	if err != nil {
+		t.Fatal(err)
+	} else if len(peers) != 1 {
+		t.Fatal("expected 1 peer")
+	} else {
+		peer = peers[0]
+	}
+
+	// assert peer info
+	if peer.Address != testPeer {
+		t.Fatal("unexpected address")
+	} else if peer.FirstSeen.IsZero() {
+		t.Fatal("unexpected first seen")
+	} else if !peer.LastConnect.IsZero() {
+		t.Fatal("unexpected last connect")
+	} else if peer.SyncedBlocks != 0 {
+		t.Fatal("unexpected synced blocks")
+	} else if peer.SyncDuration != 0 {
+		t.Fatal("unexpected sync duration")
+	}
+
+	// prepare peer update
+	lastConnect := time.Now().Truncate(time.Millisecond)
+	syncedBlocks := uint64(15)
+	syncDuration := 5 * time.Second
+
+	// update peer
+	err = ss.UpdatePeerInfo(testPeer, func(info *syncer.PeerInfo) {
+		info.LastConnect = lastConnect
+		info.SyncedBlocks = syncedBlocks
+		info.SyncDuration = syncDuration
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// refetch peer
+	peers, err = ss.Peers()
+	if err != nil {
+		t.Fatal(err)
+	} else if len(peers) != 1 {
+		t.Fatal("expected 1 peer")
+	} else {
+		peer = peers[0]
+	}
+
+	// assert peer info
+	if peer.Address != testPeer {
+		t.Fatal("unexpected address")
+	} else if peer.FirstSeen.IsZero() {
+		t.Fatal("unexpected first seen")
+	} else if !peer.LastConnect.Equal(lastConnect) {
+		t.Fatal("unexpected last connect")
+	} else if peer.SyncedBlocks != syncedBlocks {
+		t.Fatal("unexpected synced blocks")
+	} else if peer.SyncDuration != syncDuration {
+		t.Fatal("unexpected sync duration")
+	}
+
+	// ban peer
+	err = ss.Ban(testPeer, time.Hour, "too many hits")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert the peer was banned
+	banned, err := ss.Banned(testPeer)
+	if err != nil {
+		t.Fatal(err)
+	} else if !banned {
+		t.Fatal("expected banned")
+	}
+
+	// add another banned peer
+	bannedPeer := "1.2.3.4:9982"
+	err = ss.AddPeer(bannedPeer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// add another unbanned peer
+	unbannedPeer := "1.2.3.5:9981"
+	err = ss.AddPeer(unbannedPeer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert we have three peers
+	peers, err = ss.Peers()
+	if err != nil {
+		t.Fatal(err)
+	} else if len(peers) != 3 {
+		t.Fatalf("expected 3 peers, got %d", len(peers))
+	}
+
+	// assert the peers are properly banned
+	banned, err = ss.Banned(bannedPeer)
+	if err != nil {
+		t.Fatal(err)
+	} else if !banned {
+		t.Fatal("expected banned")
+	}
+
+	banned, err = ss.Banned(unbannedPeer)
+	if err != nil {
+		t.Fatal(err)
+	} else if banned {
+		t.Fatal("expected unbanned")
+	}
+}

--- a/stores/peers_test.go
+++ b/stores/peers_test.go
@@ -139,4 +139,26 @@ func TestPeers(t *testing.T) {
 	} else if banned {
 		t.Fatal("expected unbanned")
 	}
+
+	// ban by cidr
+	err = ss.Ban("192.168.1.0/30", time.Hour, "too many hits")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert address within subnet is banned
+	banned, err = ss.Banned("192.168.1.1")
+	if err != nil {
+		t.Fatal(err)
+	} else if !banned {
+		t.Fatal("expected banned")
+	}
+
+	// assert address outside subnet is not banned
+	banned, err = ss.Banned("192.168.1.4")
+	if err != nil {
+		t.Fatal(err)
+	} else if banned {
+		t.Fatal("expected unbanned")
+	}
 }

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -532,7 +532,8 @@ func retryTransaction(db *gorm.DB, logger *zap.SugaredLogger, fc func(tx *gorm.D
 			strings.Contains(err.Error(), "no such table") ||
 			strings.Contains(err.Error(), "Duplicate entry") ||
 			errors.Is(err, api.ErrPartNotFound) ||
-			errors.Is(err, api.ErrSlabNotFound) {
+			errors.Is(err, api.ErrSlabNotFound) ||
+			errors.Is(err, ErrPeerNotFound) {
 			return true
 		}
 		return false


### PR DESCRIPTION
This PR has our `SQLStore` implement the `syncer.PeerStore` in preparation of switching out our `SingleAddressWallet` for the one in `coreutils`. It has a unit test to cover SQLite and I ran the migration on a MySQL node, other than that it was not tested.