### PR TITLE
Scan twice before recording a failed scan

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1427,8 +1427,17 @@ func (w *worker) scanHost(ctx context.Context, hostKey types.PublicKey, hostIP s
 		}
 		settings, pt, duration, err = scan()
 		if err == nil {
-			w.logger.Infof("successfully scanned host %v after retry", hostKey)
+			w.logger.Debug("successfully scanned host %v after retry", hostKey)
 		}
+	}
+
+	// check if the scan failed due to a shutdown - shouldn't be necessary but
+	// just in case since recording a failed scan might have serious
+	// repercussions
+	select {
+	case <-w.shutdownCtx.Done():
+		return rhpv2.HostSettings{}, rhpv3.HostPriceTable{}, 0, w.shutdownCtx.Err()
+	default:
 	}
 
 	// record host scan

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1400,8 +1400,9 @@ func (w *worker) scanHost(ctx context.Context, hostKey types.PublicKey, hostIP s
 			}
 			return err
 		})
+		elapsed := time.Since(start)
 		if err != nil {
-			return settings, rhpv3.HostPriceTable{}, time.Since(start), errors.New("host is on a private network")
+			return settings, rhpv3.HostPriceTable{}, elapsed, err
 		}
 
 		// fetch the host pricetable
@@ -1414,7 +1415,7 @@ func (w *worker) scanHost(ctx context.Context, hostKey types.PublicKey, hostIP s
 				return nil
 			}
 		})
-		return settings, pt, time.Since(start), err
+		return settings, pt, elapsed, err
 	}
 
 	// scan: first try


### PR DESCRIPTION
I noticed that most of the churn on Arequipa comes from host being offline while other nodes report they are not. To rule out scans being fragile this PR scans twice if necessary.

Ran this on Arequipa and immediately after startup I'm seeing `renterd-arequipa  | 2024-02-09T13:49:43Z	INFO	worker.worker	worker/worker.go:1430	successfully scanned host ed25519:ec7389996f3cf39fe5073b82d98c65145936863082d6af16a307a6180b750cfc after retry` so it seems like it's making things a bit more robust.