### PR TITLE
Fail upload/download request if uploader/downloader was already stopped

### DIFF
--- a/worker/downloader.go
+++ b/worker/downloader.go
@@ -18,6 +18,10 @@ const (
 	maxConcurrentSectorsPerHost = 3
 )
 
+var (
+	errDownloaderStopped = errors.New("downloader was stopped")
+)
+
 type (
 	downloader struct {
 		host Host
@@ -65,7 +69,7 @@ func (d *downloader) Stop() {
 			break
 		}
 		if !download.done() {
-			download.fail(errors.New("downloader stopped"))
+			download.fail(errDownloaderStopped)
 		}
 	}
 }
@@ -88,7 +92,7 @@ func (d *downloader) enqueue(download *sectorDownloadReq) {
 	// check for stopped
 	if d.stopped {
 		d.mu.Unlock()
-		go download.fail(errors.New("downloader stopped")) // don't block the caller
+		go download.fail(errDownloaderStopped) // don't block the caller
 		return
 	}
 

--- a/worker/downloader_test.go
+++ b/worker/downloader_test.go
@@ -1,0 +1,32 @@
+package worker
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDownloaderStopped(t *testing.T) {
+	w := newMockWorker()
+	h := w.addHost()
+	w.dl.refreshDownloaders(w.contracts())
+
+	dl := w.dl.downloaders[h.PublicKey()]
+	dl.Stop()
+
+	req := sectorDownloadReq{
+		resps: &sectorResponses{
+			c: make(chan struct{}),
+		},
+	}
+	dl.enqueue(&req)
+
+	select {
+	case <-req.resps.c:
+		if err := req.resps.responses[0].err; !errors.Is(err, errDownloaderStopped) {
+			t.Fatal("unexpected error response", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no response")
+	}
+}

--- a/worker/downloader_test.go
+++ b/worker/downloader_test.go
@@ -26,7 +26,7 @@ func TestDownloaderStopped(t *testing.T) {
 		if err := req.resps.responses[0].err; !errors.Is(err, errDownloaderStopped) {
 			t.Fatal("unexpected error response", err)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("no response")
 	}
 }

--- a/worker/uploader.go
+++ b/worker/uploader.go
@@ -36,6 +36,7 @@ type (
 		fcid      types.FileContractID
 		host      Host
 		queue     []*sectorUploadReq
+		stopped   bool
 
 		// stats related field
 		consecutiveFailures uint64
@@ -136,6 +137,10 @@ outer:
 }
 
 func (u *uploader) Stop(err error) {
+	u.mu.Lock()
+	u.stopped = true
+	u.mu.Unlock()
+
 	for {
 		upload := u.pop()
 		if upload == nil {
@@ -148,12 +153,19 @@ func (u *uploader) Stop(err error) {
 }
 
 func (u *uploader) enqueue(req *sectorUploadReq) {
+	u.mu.Lock()
+	// check for stopped
+	if u.stopped {
+		u.mu.Unlock()
+		go req.fail(errors.New("uploader stopped")) // don't block the caller
+		return
+	}
+
 	// decorate the request
-	req.fcid = u.ContractID()
+	req.fcid = u.fcid
 	req.hk = u.hk
 
 	// enqueue the request
-	u.mu.Lock()
 	u.queue = append(u.queue, req)
 	u.mu.Unlock()
 

--- a/worker/uploader.go
+++ b/worker/uploader.go
@@ -19,6 +19,10 @@ const (
 	sectorUploadTimeout = 60 * time.Second
 )
 
+var (
+	errUploaderStopped = errors.New("uploader was stopped")
+)
+
 type (
 	uploader struct {
 		os     ObjectStore
@@ -157,7 +161,7 @@ func (u *uploader) enqueue(req *sectorUploadReq) {
 	// check for stopped
 	if u.stopped {
 		u.mu.Unlock()
-		go req.fail(errors.New("uploader stopped")) // don't block the caller
+		go req.fail(errUploaderStopped) // don't block the caller
 		return
 	}
 

--- a/worker/uploader_test.go
+++ b/worker/uploader_test.go
@@ -1,0 +1,32 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestUploaderStopped(t *testing.T) {
+	w := newMockWorker()
+	w.addHost()
+	w.ul.refreshUploaders(w.contracts(), 1)
+
+	ul := w.ul.uploaders[0]
+	ul.Stop(errors.New("test"))
+
+	req := sectorUploadReq{
+		responseChan: make(chan sectorUploadResp),
+		sector:       &sectorUpload{ctx: context.Background()},
+	}
+	ul.enqueue(&req)
+
+	select {
+	case res := <-req.responseChan:
+		if !errors.Is(res.err, errUploaderStopped) {
+			t.Fatal("expected error response")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no response")
+	}
+}

--- a/worker/uploader_test.go
+++ b/worker/uploader_test.go
@@ -26,7 +26,7 @@ func TestUploaderStopped(t *testing.T) {
 		if !errors.Is(res.err, errUploaderStopped) {
 			t.Fatal("expected error response")
 		}
-	case <-time.After(time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("no response")
 	}
 }


### PR DESCRIPTION
To avoid a potential deadlock where we never receive a response since the request gets queued but not processed