### PR TITLE
Remove context value interaction recorder

### DIFF
--- a/worker/host.go
+++ b/worker/host.go
@@ -52,10 +52,10 @@ type (
 		acc                      *account
 		bus                      Bus
 		contractSpendingRecorder ContractSpendingRecorder
+		interactionRecorder      HostInteractionRecorder
 		logger                   *zap.SugaredLogger
 		transportPool            *transportPoolV3
 		priceTables              *priceTables
-		interactionRecorder      HostInteractionRecorder
 	}
 )
 
@@ -70,6 +70,7 @@ func (w *worker) Host(hk types.PublicKey, fcid types.FileContractID, siamuxAddr 
 		acc:                      w.accounts.ForHost(hk),
 		bus:                      w.bus,
 		contractSpendingRecorder: w.contractSpendingRecorder,
+		interactionRecorder:      w.hostInteractionRecorder,
 		logger:                   w.logger.Named(hk.String()[:4]),
 		fcid:                     fcid,
 		siamuxAddr:               siamuxAddr,
@@ -77,7 +78,6 @@ func (w *worker) Host(hk types.PublicKey, fcid types.FileContractID, siamuxAddr 
 		accountKey:               w.accounts.deriveAccountKey(hk),
 		transportPool:            w.transportPoolV3,
 		priceTables:              w.priceTables,
-		interactionRecorder:      w.hostInteractionRecorder,
 	}
 }
 

--- a/worker/host.go
+++ b/worker/host.go
@@ -55,6 +55,7 @@ type (
 		logger                   *zap.SugaredLogger
 		transportPool            *transportPoolV3
 		priceTables              *priceTables
+		interactionRecorder      HostInteractionRecorder
 	}
 )
 
@@ -76,6 +77,7 @@ func (w *worker) Host(hk types.PublicKey, fcid types.FileContractID, siamuxAddr 
 		accountKey:               w.accounts.deriveAccountKey(hk),
 		transportPool:            w.transportPoolV3,
 		priceTables:              w.priceTables,
+		interactionRecorder:      w.hostInteractionRecorder,
 	}
 }
 
@@ -196,7 +198,7 @@ func (h *host) FetchPriceTable(ctx context.Context, rev *types.FileContractRevis
 	fetchPT := func(paymentFn PriceTablePaymentFunc) (hpt hostdb.HostPriceTable, err error) {
 		err = h.transportPool.withTransportV3(ctx, h.hk, h.siamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
 			hpt, err = RPCPriceTable(ctx, t, paymentFn)
-			HostInteractionRecorderFromContext(ctx).RecordPriceTableUpdate(hostdb.PriceTableUpdate{
+			h.interactionRecorder.RecordPriceTableUpdate(hostdb.PriceTableUpdate{
 				HostKey:    h.hk,
 				Success:    isSuccessfulInteraction(err),
 				Timestamp:  time.Now(),

--- a/worker/interactions.go
+++ b/worker/interactions.go
@@ -42,14 +42,6 @@ var (
 	_ HostInteractionRecorder = (*hostInteractionRecorder)(nil)
 )
 
-func HostInteractionRecorderFromContext(ctx context.Context) HostInteractionRecorder {
-	ir, ok := ctx.Value(keyInteractionRecorder).(HostInteractionRecorder)
-	if !ok {
-		panic("no interaction recorder attached to the context") // developer error
-	}
-	return ir
-}
-
 func interactionMiddleware(ir HostInteractionRecorder, routes map[string]jape.Handler) map[string]jape.Handler {
 	for route, handler := range routes {
 		routes[route] = jape.Adapt(func(h http.Handler) http.Handler {

--- a/worker/interactions.go
+++ b/worker/interactions.go
@@ -3,11 +3,9 @@ package worker
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"sync"
 	"time"
 
-	"go.sia.tech/jape"
 	"go.sia.tech/renterd/hostdb"
 	"go.uber.org/zap"
 )
@@ -41,18 +39,6 @@ type (
 var (
 	_ HostInteractionRecorder = (*hostInteractionRecorder)(nil)
 )
-
-func interactionMiddleware(ir HostInteractionRecorder, routes map[string]jape.Handler) map[string]jape.Handler {
-	for route, handler := range routes {
-		routes[route] = jape.Adapt(func(h http.Handler) http.Handler {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				ctx := context.WithValue(r.Context(), keyInteractionRecorder, ir)
-				h.ServeHTTP(w, r.WithContext(ctx))
-			})
-		})(handler)
-	}
-	return routes
-}
 
 func (w *worker) initHostInteractionRecorder(flushInterval time.Duration) {
 	if w.hostInteractionRecorder != nil {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -342,7 +342,7 @@ func (w *worker) rhpPriceTableHandler(jc jape.Context) {
 	var err error
 	var hpt hostdb.HostPriceTable
 	defer func() {
-		HostInteractionRecorderFromContext(ctx).RecordPriceTableUpdate(hostdb.PriceTableUpdate{
+		w.hostInteractionRecorder.RecordPriceTableUpdate(hostdb.PriceTableUpdate{
 			HostKey:    rptr.HostKey,
 			Success:    isSuccessfulInteraction(err),
 			Timestamp:  time.Now(),
@@ -1442,7 +1442,7 @@ func (w *worker) scanHost(ctx context.Context, hostKey types.PublicKey, hostIP s
 	}
 
 	// record host scan
-	HostInteractionRecorderFromContext(ctx).RecordHostScan(hostdb.HostScan{
+	w.hostInteractionRecorder.RecordHostScan(hostdb.HostScan{
 		HostKey:    hostKey,
 		Success:    isSuccessfulInteraction(err),
 		Timestamp:  time.Now(),

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1323,7 +1323,7 @@ func New(masterKey [32]byte, id string, b Bus, contractLockingDuration, busFlush
 
 // Handler returns an HTTP handler that serves the worker API.
 func (w *worker) Handler() http.Handler {
-	return jape.Mux(interactionMiddleware(w.hostInteractionRecorder, map[string]jape.Handler{
+	return jape.Mux(map[string]jape.Handler{
 		"GET    /account/:hostkey": w.accountHandlerGET,
 		"GET    /id":               w.idHandlerGET,
 
@@ -1351,7 +1351,7 @@ func (w *worker) Handler() http.Handler {
 		"PUT    /multipart/*path": w.multipartUploadHandlerPUT,
 
 		"GET    /state": w.stateHandlerGET,
-	}))
+	})
 }
 
 // Shutdown shuts down the worker.


### PR DESCRIPTION
```go
2024-02-13T21:48:42.216288715Z panic: no interaction recorder attached to the context
2024-02-13T21:48:42.216340814Z 
2024-02-13T21:48:42.216344851Z goroutine 2280 [running]:
2024-02-13T21:48:42.216348238Z go.sia.tech/renterd/worker.HostInteractionRecorderFromContext(...)
2024-02-13T21:48:42.216351103Z     /renterd/worker/interactions.go:48
2024-02-13T21:48:42.216354429Z go.sia.tech/renterd/worker.(*host).FetchPriceTable.func1.1({0x1a408e8, 0xc003dbec40}, 0xc20ff046e0?)
2024-02-13T21:48:42.216357465Z     /renterd/worker/host.go:199 +0x305
2024-02-13T21:48:42.216360621Z go.sia.tech/renterd/worker.(*transportPoolV3).withTransportV3(0xc000a7f2f0, {0x1a408e8, 0xc003dbec40}, {0x3c, 0x51, 0x24, 0x5a, 0x69, 0xb4, 0x87, ...}, ...)
2024-02-13T21:48:42.216363567Z     /renterd/worker/rhpv3.go:225 +0x175
2024-02-13T21:48:42.216366472Z go.sia.tech/renterd/worker.(*host).FetchPriceTable.func1(_)
2024-02-13T21:48:42.216369237Z     /renterd/worker/host.go:197 +0xca
2024-02-13T21:48:42.216372303Z go.sia.tech/renterd/worker.(*host).FetchPriceTable(_, {_, _}, _)
2024-02-13T21:48:42.216376090Z     /renterd/worker/host.go:216 +0x1ed
2024-02-13T21:48:42.216379467Z go.sia.tech/renterd/worker.(*priceTable).fetch(_, {_, _}, _)
2024-02-13T21:48:42.216383334Z     /renterd/worker/pricetables.go:160 +0x717
2024-02-13T21:48:42.216386630Z go.sia.tech/renterd/worker.(*priceTables).fetch(_, {_, _}, {0x3c, 0x51, 0x24, 0x5a, 0x69, 0xb4, 0x87, ...}, ...)
2024-02-13T21:48:42.216390517Z     /renterd/worker/pricetables.go:86 +0x213
2024-02-13T21:48:42.216394605Z go.sia.tech/renterd/worker.(*host).priceTable(_, {_, _}, _)
2024-02-13T21:48:42.216398242Z     /renterd/worker/rhpv3.go:517 +0xf7
2024-02-13T21:48:42.216402250Z go.sia.tech/renterd/worker.(*host).fetchRevisionWithAccount.func1.1.1(_)
2024-02-13T21:48:42.216407860Z     /renterd/worker/rhpv3.go:286 +0x65
2024-02-13T21:48:42.216413040Z go.sia.tech/renterd/worker.RPCLatestRevision({_, _}, _, {0x56, 0xc5, 0xd5, 0x3d, 0x49, 0xb6, 0xc5, ...}, ...)
2024-02-13T21:48:42.216441123Z     /renterd/worker/rhpv3.go:716 +0x228
2024-02-13T21:48:42.216444249Z go.sia.tech/renterd/worker.(*host).fetchRevisionWithAccount.func1.1({0x1a408e8?, 0xc003dbec40?}, 0xc0043e9860?)
2024-02-13T21:48:42.216447725Z     /renterd/worker/rhpv3.go:285 +0xdb
2024-02-13T21:48:42.216452204Z go.sia.tech/renterd/worker.(*transportPoolV3).withTransportV3(0xc000a7f2f0, {0x1a408e8, 0xc003dbec40}, {0x3c, 0x51, 0x24, 0x5a, 0x69, 0xb4, 0x87, ...}, ...)
2024-02-13T21:48:42.216455450Z     /renterd/worker/rhpv3.go:225 +0x175
2024-02-13T21:48:42.216458145Z go.sia.tech/renterd/worker.(*host).fetchRevisionWithAccount.func1()
2024-02-13T21:48:42.216461151Z     /renterd/worker/rhpv3.go:284 +0xb3
2024-02-13T21:48:42.216463826Z go.sia.tech/renterd/worker.(*account).WithWithdrawal(0xc005643400, {0x1a408e8?, 0xc003dbec40?}, 0xc016617400)
2024-02-13T21:48:42.216467943Z     /renterd/worker/rhpv3.go:446 +0x2b6
2024-02-13T21:48:42.216470749Z go.sia.tech/renterd/worker.(*host).fetchRevisionWithAccount(_, {_, _}, {0x3c, 0x51, 0x24, 0x5a, 0x69, 0xb4, 0x87, ...}, ...)
2024-02-13T21:48:42.216474786Z     /renterd/worker/rhpv3.go:282 +0xf9
2024-02-13T21:48:42.216477511Z go.sia.tech/renterd/worker.(*host).FetchRevision(0xc005657080, {_, _}, _)
2024-02-13T21:48:42.216480237Z     /renterd/worker/rhpv3.go:254 +0x1a6
2024-02-13T21:48:42.216483423Z go.sia.tech/renterd/worker.(*uploader).execute(0xc00565afc0, 0xc05ae45f10)
2024-02-13T21:48:42.216491137Z     /renterd/worker/uploader.go:205 +0x305
2024-02-13T21:48:42.216500174Z go.sia.tech/renterd/worker.(*uploader).Start(0xc00565afc0)
2024-02-13T21:48:42.216503440Z     /renterd/worker/uploader.go:112 +0x165
2024-02-13T21:48:42.216507057Z created by go.sia.tech/renterd/worker.(*uploadManager).refreshUploaders in goroutine 119
2024-02-13T21:48:42.216510864Z     /renterd/worker/upload.go:756 +0x6ea
```

If the only option for an unset interaction recorder is to panic, that seems like a bad fit for `context.Value`