### PR TITLE
Ensure applying the MigrationSurchargeMultiplier never prevents a download

### DIFF
--- a/api/setting.go
+++ b/api/setting.go
@@ -112,6 +112,11 @@ func (gs GougingSettings) Validate() error {
 	if gs.MinPriceTableValidity < 10*time.Second {
 		return errors.New("MinPriceTableValidity must be at least 10 seconds")
 	}
+	_, overflow := gs.MaxDownloadPrice.Mul64WithOverflow(gs.MigrationSurchargeMultiplier)
+	if overflow {
+		maxMultiplier := types.MaxCurrency.Div(gs.MaxDownloadPrice).Big().Uint64()
+		return fmt.Errorf("MigrationSurchargeMultiplier must be less than %v, otherwise applying it to MaxDownloadPrice overflows the currency type", maxMultiplier)
+	}
 	return nil
 }
 

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -72,17 +72,16 @@ func WithGougingChecker(ctx context.Context, cs consensusState, gp api.GougingPa
 
 		// adjust the max download price if we are dealing with a critical
 		// migration that might be failing due to gouging checks
+		settings := gp.GougingSettings
 		if criticalMigration && gp.GougingSettings.MigrationSurchargeMultiplier > 0 {
-			if adjustedMaxDownloadPrice, overflow := gp.GougingSettings.MaxDownloadPrice.Mul64WithOverflow(gp.GougingSettings.MigrationSurchargeMultiplier); overflow {
-				return gougingChecker{}, errors.New("failed to apply the 'MigrationSurchargeMultiplier', overflow detected")
-			} else {
-				gp.GougingSettings.MaxDownloadPrice = adjustedMaxDownloadPrice
+			if adjustedMaxDownloadPrice, overflow := gp.GougingSettings.MaxDownloadPrice.Mul64WithOverflow(gp.GougingSettings.MigrationSurchargeMultiplier); !overflow {
+				settings.MaxDownloadPrice = adjustedMaxDownloadPrice
 			}
 		}
 
 		return gougingChecker{
 			consensusState: consensusState,
-			settings:       gp.GougingSettings,
+			settings:       settings,
 			txFee:          gp.TransactionFee,
 
 			// NOTE:


### PR DESCRIPTION
I discovered something quite nasty on my node, where I had a couple of critical downloads that were failing to migrate because we were applying the "MigrationSurchargeMultiplier" over and over again to the `MaxDownloadPrice`, eventually causing an overflow.

```
9e5bd369: failed to apply surcharge multiplier of 10 to 60.3 TS, overflow detected
DEBUG PJ: setting adjust max dl price 6.03 KS
DEBUG PJ: setting adjust max dl price 60.3 KS
...
DEBUG PJ: setting adjust max dl price 603 GS
DEBUG PJ: setting adjust max dl price 6.03 TS
DEBUG PJ: setting adjust max dl price 60.3 TS
```

Since that is the worst thing to happen to a critical migration I figured it'd be best to a) extend the gouging settings validation to ensure a user never enters a combination that overflows and b) stop preventing a potential overflow (which is now no longer possible) from actually executing the critical download

I'm on the fence whether we need to extend the bus checks on startup, we might be invalidating gouging settings in the wild, although I feel that's extremely unlikely... we could handle the error and revert only the multiplier to the default setting. If it were to happen, we currently revert the user's gouging settings to the default values.

