### PR TITLE
Extend contract set change alerts with host info

### DIFF
--- a/autopilot/alerts.go
+++ b/autopilot/alerts.go
@@ -137,7 +137,7 @@ func newContractPruningFailedAlert(hk types.PublicKey, version string, fcid type
 	}
 }
 
-func newContractSetChangeAlert(name string, set map[types.FileContractID]types.PublicKey, additions map[types.FileContractID]contractSetAddition, removals map[types.FileContractID]contractSetRemoval) alerts.Alert {
+func newContractSetChangeAlert(name string, additions map[types.FileContractID]contractSetAddition, removals map[types.FileContractID]contractSetRemoval) alerts.Alert {
 	var hint string
 	if len(removals) > 0 {
 		hint = "A high churn rate can lead to a lot of unnecessary migrations, it might be necessary to tweak your configuration depending on the reason hosts are being discarded from the set."
@@ -154,7 +154,6 @@ func newContractSetChangeAlert(name string, set map[types.FileContractID]types.P
 		Message:  "Contract set changed",
 		Data: map[string]any{
 			"name":          name,
-			"set":           set,
 			"set_additions": additions,
 			"set_removals":  removals,
 			"hint":          hint,

--- a/autopilot/alerts.go
+++ b/autopilot/alerts.go
@@ -137,10 +137,15 @@ func newContractPruningFailedAlert(hk types.PublicKey, version string, fcid type
 	}
 }
 
-func newContractSetChangeAlert(name string, added, removed int, removedReasons map[string]string) alerts.Alert {
+func newContractSetChangeAlert(name string, set map[types.FileContractID]types.PublicKey, additions map[types.FileContractID]contractSetAddition, removals map[types.FileContractID]contractSetRemoval) alerts.Alert {
 	var hint string
-	if removed > 0 {
+	if len(removals) > 0 {
 		hint = "A high churn rate can lead to a lot of unnecessary migrations, it might be necessary to tweak your configuration depending on the reason hosts are being discarded from the set."
+	}
+
+	removedReasons := make(map[string]string, len(removals))
+	for k, v := range removals {
+		removedReasons[k.String()] = v.Reason
 	}
 
 	return alerts.Alert{
@@ -148,11 +153,17 @@ func newContractSetChangeAlert(name string, added, removed int, removedReasons m
 		Severity: alerts.SeverityInfo,
 		Message:  "Contract set changed",
 		Data: map[string]any{
-			"name":     name,
-			"added":    added,
-			"removed":  removed,
+			"name":          name,
+			"set":           set,
+			"set_additions": additions,
+			"set_removals":  removals,
+			"hint":          hint,
+
+			// TODO: these fields can be removed on the next major release, they
+			// contain redundant information
+			"added":    len(additions),
+			"removed":  len(removals),
 			"removals": removedReasons,
-			"hint":     hint,
 		},
 		Timestamp: time.Now(),
 	}

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -447,7 +447,6 @@ func (c *contractor) computeContractSetChanged(ctx context.Context, name string,
 	}
 
 	// log added and removed contracts
-	set := make(map[types.FileContractID]types.PublicKey)
 	setAdditions := make(map[types.FileContractID]contractSetAddition)
 	setRemovals := make(map[types.FileContractID]contractSetRemoval)
 	for _, contract := range oldSet {
@@ -477,7 +476,6 @@ func (c *contractor) computeContractSetChanged(ctx context.Context, name string,
 			}
 			c.logger.Debugf("contract %v was added to the contract set, size: %v", contract.ID, contractData[contract.ID])
 		}
-		set[contract.ID] = contract.HostKey
 	}
 
 	// log renewed contracts that did not make it into the contract set
@@ -532,7 +530,7 @@ func (c *contractor) computeContractSetChanged(ctx context.Context, name string,
 	)
 	hasChanged := len(setAdditions)+len(setRemovals) > 0
 	if hasChanged {
-		c.ap.RegisterAlert(ctx, newContractSetChangeAlert(name, set, setAdditions, setRemovals))
+		c.ap.RegisterAlert(ctx, newContractSetChangeAlert(name, setAdditions, setRemovals))
 	}
 	return hasChanged
 }


### PR DESCRIPTION
This PR adds host info to the contract set change alert, as requested in #963

**REQUIRES UI CHANGE**
This PR requires an accompanying UI change to ensure the alert is displayed properly. I'm wondering whether we should create a list of alerts + properties in the frontend, and only display those keys and alerts. That way we could always maintain backwards compatibility in the backend, but tweak or add alerts. We can merge that separately from the frontend and then when the frontend made the required changes we can get rid of the redundant/old compat code we had to add. Downside would be that every new alert or added property would need a UI update to get displayed.


**Example screenshot:**
<img width="637" alt="Screenshot 2024-02-15 at 09 33 08" src="https://github.com/SiaFoundation/renterd/assets/684818/417ec89a-adea-4528-84d7-182e88da5c7b">


**Example JSON:**
```json
{
		"id": "h:f27b88af9f84c7b51121b902d91c7ec5b0d557470f6f9a9b871c333101b1bace",
		"severity": "info",
		"message": "Contract set changed",
		"data": {
			"added": 2,
			"hint": "A high churn rate can lead to a lot of unnecessary migrations, it might be necessary to tweak your configuration depending on the reason hosts are being discarded from the set.",
			"name": "autopilot",
			"origin": "autopilot.autopilot",
			"removals": {
				"fcid:0d3e929712f5787f50088f407628e53c821afa6eb2168488f42b680a40dfb528": "truncated",
				"fcid:dbfdbf6889bc164af52111639cce4eb2a36195dea4ed0df64d25dc67f107a185": "truncated"
			},
			"removed": 2,
			"set": {
				"fcid:1e47af48a39193a2daa5b3353d69d11ec8461de0a8046c3a4ee4d6962e3d6e30": "ed25519:87e90594ac909076f6473fbebfe278fa6794fe0bb7b3b093b0792e5a5b734239",
				"fcid:483e0596f9a4c838be9eb3510db47f9e8dc3a694cc6533a495ea407c5521f50a": "ed25519:b078bef7e2ea7a9e1d0594658b75ad4f40fc2abd3f2ab86048a0ac54747c2b9e",
				"fcid:7f16d77da8e4cb061e03ba3c763344545f11edd8b53a55c1f119870091a754dd": "ed25519:96bf3099f428f3affe45dcb30b904e5f4f3f33da368d9316d32b4fe0e4bec223",
				"fcid:85401e621970d3d1b1a272214bb80aaf6cc86dc2e2e004a658ecd42a7221e20f": "ed25519:80878e4094555a7af2fd7155903e3fc149dcff650d01544c9685ad6cb799a620",
				"fcid:96e7d7ddc60b16fca0c7aeff991bc05fbbd2f3e497364348a82f73226c9fd8cb": "ed25519:95770d3b9bf02e025bb7f76715cccf943974e73c480d81e1d9b480845bca1989",
				"fcid:985087e5c165fb0e76112b456744e4a424dc111b6faabbc2d63fceb57e6ad236": "ed25519:075c746dd0e85eea7aeb05a5c4f37c2af35e4a8c48493fccec285ead4dbe5c49",
				"fcid:b0ffea63cf1509b1a98a9e7e78d182e2664b5ddeb6167d50508f2819ab393a3c": "ed25519:a3aef7db34413e0f1d33140c3cab0a0113317d55b99df6c77a38fbc7a11d2ae1",
				"fcid:c40207017ccce23cef4cdfacf1d40e793c61d73b7108d1e05188131a9c29f60c": "ed25519:66aa6e0a08073250d01cadf997fa568b02646a873d0b319e6a6308fd12ba07ef",
				"fcid:c7a18551ef3e802333e1bed810efafa3ae66d053d4e01e11f1d2d725d1d6ccf5": "ed25519:22eecdbd45e8a445adea8584934aeaa74d54898bb111439556a0a2cb9bdce13d",
				"fcid:ce9f9509da2e632f371861d85a4ff0218dcd4070e9e109187be0b953adc4182f": "ed25519:9d0dc5d8a28332254debcf81c83ba429283293cc9647f96cd1071dad34717aab",
				"fcid:de83db92f43de9dad4f17b93bc0c674921fb75af6d5817b7cce504fc289db3e9": "ed25519:c101ca41273de728bd51c76c003c2d9ff93cba713c2c57850c5e50a66a7a8791",
				"fcid:e5918ca79f78206be0c9adb0ceabc0d1ed21f6c026286d41102f2a7e43132d02": "ed25519:707d189dfd08469efebf1a51338b3d73eed4ac1b56213a0ed6521179f60a7b71"
			},
			"set_additions": {
				"fcid:1e47af48a39193a2daa5b3353d69d11ec8461de0a8046c3a4ee4d6962e3d6e30": {
					"hostKey": "ed25519:87e90594ac909076f6473fbebfe278fa6794fe0bb7b3b093b0792e5a5b734239",
					"size": 0
				},
				"fcid:985087e5c165fb0e76112b456744e4a424dc111b6faabbc2d63fceb57e6ad236": {
					"hostKey": "ed25519:075c746dd0e85eea7aeb05a5c4f37c2af35e4a8c48493fccec285ead4dbe5c49",
					"size": 0
				}
			},
			"set_removals": {
				"fcid:0d3e929712f5787f50088f407628e53c821afa6eb2168488f42b680a40dfb528": {
					"hostKey": "ed25519:09a5972a8fe871f765a52729fab15a78a2e0a7d85a8b614de3f4295f2a87292b",
					"reason": "truncated",
					"size": 0
				},
				"fcid:dbfdbf6889bc164af52111639cce4eb2a36195dea4ed0df64d25dc67f107a185": {
					"hostKey": "ed25519:34d5b8b744c61689df3a67120975109495abf2306dd8228275a8378f97649cb1",
					"reason": "truncated",
					"size": 0
				}
			}
		},
		"timestamp": "2024-02-15T09:29:23.06047+01:00"
	}
```
