### PR TITLE
Merge alert dismiss routes

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -245,10 +245,9 @@ func (b *bus) Handler() http.Handler {
 		"POST   /account/:id/requiressync": b.accountsRequiresSyncHandlerPOST,
 		"POST   /account/:id/resetdrift":   b.accountsResetDriftHandlerPOST,
 
-		"GET    /alerts":            b.handleGETAlerts,
-		"POST   /alerts/dismiss":    b.handlePOSTAlertsDismiss,
-		"POST   /alerts/dismissall": b.handlePOSTAlertsDismissAll,
-		"POST   /alerts/register":   b.handlePOSTAlertsRegister,
+		"GET    /alerts":          b.handleGETAlerts,
+		"POST   /alerts/dismiss":  b.handlePOSTAlertsDismiss,
+		"POST   /alerts/register": b.handlePOSTAlertsRegister,
 
 		"GET    /autopilots":    b.autopilotsListHandlerGET,
 		"GET    /autopilot/:id": b.autopilotsHandlerGET,
@@ -1730,15 +1729,18 @@ func (b *bus) handleGETAlerts(jc jape.Context) {
 }
 
 func (b *bus) handlePOSTAlertsDismiss(jc jape.Context) {
+	var all bool
+	if jc.DecodeForm("all", &all) != nil {
+		return
+	} else if all {
+		jc.Check("failed to dismiss all alerts", b.alertMgr.DismissAllAlerts(jc.Request.Context()))
+		return
+	}
 	var ids []types.Hash256
 	if jc.Decode(&ids) != nil {
 		return
 	}
 	jc.Check("failed to dismiss alerts", b.alertMgr.DismissAlerts(jc.Request.Context(), ids...))
-}
-
-func (b *bus) handlePOSTAlertsDismissAll(jc jape.Context) {
-	jc.Check("failed to dismiss alerts", b.alertMgr.DismissAllAlerts(jc.Request.Context()))
 }
 
 func (b *bus) handlePOSTAlertsRegister(jc jape.Context) {

--- a/bus/client/alerts.go
+++ b/bus/client/alerts.go
@@ -22,14 +22,22 @@ func (c *Client) Alerts(opts alerts.AlertsOpts) (alerts []alerts.Alert, err erro
 	return
 }
 
-// DismissAllAlerts dimisses all alerts.
-func (c *Client) DismissAllAlerts(ctx context.Context) error {
-	return c.c.WithContext(ctx).POST("/alerts/dismissall", nil, nil)
-}
-
 // DismissAlerts dimisses the alerts with the given IDs.
 func (c *Client) DismissAlerts(ctx context.Context, ids ...types.Hash256) error {
-	return c.c.WithContext(ctx).POST("/alerts/dismiss", ids, nil)
+	return c.dismissAlerts(ctx, false, ids...)
+}
+
+// DismissAllAlerts dimisses all registered alerts.
+func (c *Client) DismissAllAlerts(ctx context.Context) error {
+	return c.dismissAlerts(ctx, true)
+}
+
+func (c *Client) dismissAlerts(ctx context.Context, all bool, ids ...types.Hash256) error {
+	values := url.Values{}
+	if all {
+		values.Set("all", fmt.Sprint(true))
+	}
+	return c.c.WithContext(ctx).POST("/alerts/dismiss?"+values.Encode(), ids, nil)
 }
 
 // RegisterAlert registers the given alert.

--- a/worker/downloader_test.go
+++ b/worker/downloader_test.go
@@ -16,7 +16,7 @@ func TestDownloaderStopped(t *testing.T) {
 
 	req := sectorDownloadReq{
 		resps: &sectorResponses{
-			c: make(chan struct{}),
+			c: make(chan struct{}, 1),
 		},
 	}
 	dl.enqueue(&req)


### PR DESCRIPTION
When writing the docs I had a slight change of heart. This PR merges the dismiss routes and makes "all" a query param.