### PR TITLE
Add onlymetadata flag to objects endpoint

### DIFF
--- a/api/object.go
+++ b/api/object.go
@@ -54,7 +54,7 @@ type (
 	Object struct {
 		Metadata ObjectUserMetadata `json:"metadata,omitempty"`
 		ObjectMetadata
-		object.Object
+		object.Object `json:"omitempty"`
 	}
 
 	// ObjectMetadata contains various metadata about an object.
@@ -212,13 +212,14 @@ type (
 	}
 
 	GetObjectOptions struct {
-		Prefix      string
-		Offset      int
-		Limit       int
-		IgnoreDelim bool
-		Marker      string
-		SortBy      string
-		SortDir     string
+		Prefix       string
+		Offset       int
+		Limit        int
+		IgnoreDelim  bool
+		Marker       string
+		OnlyMetadata bool
+		SortBy       string
+		SortDir      string
 	}
 
 	ListObjectOptions struct {
@@ -323,6 +324,9 @@ func (opts GetObjectOptions) Apply(values url.Values) {
 	}
 	if opts.Marker != "" {
 		values.Set("marker", opts.Marker)
+	}
+	if opts.OnlyMetadata {
+		values.Set("onlymetadata", "true")
 	}
 	if opts.SortBy != "" {
 		values.Set("sortBy", opts.SortBy)

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -137,6 +137,7 @@ type (
 		CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, dstPath, mimeType string, metadata api.ObjectUserMetadata) (api.ObjectMetadata, error)
 		ListObjects(ctx context.Context, bucketName, prefix, sortBy, sortDir, marker string, limit int) (api.ObjectsListResponse, error)
 		Object(ctx context.Context, bucketName, path string) (api.Object, error)
+		ObjectMetadata(ctx context.Context, bucketName, path string) (api.Object, error)
 		ObjectEntries(ctx context.Context, bucketName, path, prefix, sortBy, sortDir, marker string, offset, limit int) ([]api.ObjectMetadata, bool, error)
 		ObjectsBySlabKey(ctx context.Context, bucketName string, slabKey object.EncryptionKey) ([]api.ObjectMetadata, error)
 		ObjectsStats(ctx context.Context, opts api.ObjectsStatsOpts) (api.ObjectsStatsResponse, error)
@@ -1192,13 +1193,22 @@ func (b *bus) objectsHandlerGET(jc jape.Context) {
 	if jc.DecodeForm("bucket", &bucket) != nil {
 		return
 	}
+	var onlymetadata bool
+	if jc.DecodeForm("onlymetadata", &onlymetadata) != nil {
+		return
+	}
 
-	o, err := b.ms.Object(jc.Request.Context(), bucket, path)
+	var o api.Object
+	var err error
+	if onlymetadata {
+		o, err = b.ms.ObjectMetadata(jc.Request.Context(), bucket, path)
+	} else {
+		o, err = b.ms.Object(jc.Request.Context(), bucket, path)
+	}
 	if errors.Is(err, api.ErrObjectNotFound) {
 		jc.Error(err, http.StatusNotFound)
 		return
-	}
-	if jc.Check("couldn't load object", err) != nil {
+	} else if jc.Check("couldn't load object", err) != nil {
 		return
 	}
 	jc.Encode(api.ObjectsResponse{Object: &o})

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -287,7 +287,10 @@ func (s *s3) GetObject(ctx context.Context, bucketName, objectName string, range
 // HeadObject should return a NotFound() error if the object does not
 // exist.
 func (s *s3) HeadObject(ctx context.Context, bucketName, objectName string) (*gofakes3.Object, error) {
-	res, err := s.b.Object(ctx, bucketName, objectName, api.GetObjectOptions{IgnoreDelim: true})
+	res, err := s.b.Object(ctx, bucketName, objectName, api.GetObjectOptions{
+		IgnoreDelim:  true,
+		OnlyMetadata: true,
+	})
 	if err != nil && strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
 		return nil, gofakes3.KeyNotFound(objectName)
 	} else if err != nil {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -410,14 +410,14 @@ func (s dbSlab) convert() (slab object.Slab, err error) {
 }
 
 func (raw rawObjectMetadata) convert() api.ObjectMetadata {
-	return api.ObjectMetadata{
-		ETag:     raw.ETag,
-		Health:   raw.Health,
-		MimeType: raw.MimeType,
-		ModTime:  api.TimeRFC3339(time.Time(raw.ModTime).UTC()),
-		Name:     raw.Name,
-		Size:     raw.Size,
-	}
+	return newObjectMetadata(
+		raw.Name,
+		raw.ETag,
+		raw.MimeType,
+		raw.Health,
+		time.Time(raw.ModTime),
+		raw.Size,
+	)
 }
 
 func (raw rawObject) toSlabSlice() (slice object.SlabSlice, _ error) {
@@ -1556,13 +1556,14 @@ func (s *SQLStore) CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath
 			// No copying is happening. We just update the metadata on the src
 			// object.
 			srcObj.MimeType = mimeType
-			om = api.ObjectMetadata{
-				Health:   srcObj.Health,
-				MimeType: srcObj.MimeType,
-				ModTime:  api.TimeRFC3339(srcObj.CreatedAt.UTC()),
-				Name:     srcObj.ObjectID,
-				Size:     srcObj.Size,
-			}
+			om = newObjectMetadata(
+				srcObj.ObjectID,
+				srcObj.Etag,
+				srcObj.MimeType,
+				srcObj.Health,
+				srcObj.CreatedAt,
+				srcObj.Size,
+			)
 			if err := s.updateUserMetadata(tx, srcObj.ID, metadata); err != nil {
 				return fmt.Errorf("failed to update user metadata: %w", err)
 			}
@@ -1610,14 +1611,14 @@ func (s *SQLStore) CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath
 			return fmt.Errorf("failed to create object metadata: %w", err)
 		}
 
-		om = api.ObjectMetadata{
-			MimeType: dstObj.MimeType,
-			ETag:     dstObj.Etag,
-			Health:   srcObj.Health,
-			ModTime:  api.TimeRFC3339(dstObj.CreatedAt.UTC()),
-			Name:     dstObj.ObjectID,
-			Size:     dstObj.Size,
-		}
+		om = newObjectMetadata(
+			dstObj.ObjectID,
+			dstObj.Etag,
+			dstObj.MimeType,
+			dstObj.Health,
+			dstObj.CreatedAt,
+			dstObj.Size,
+		)
 		return nil
 	})
 	return
@@ -2320,19 +2321,55 @@ func (s *SQLStore) objectHydrate(ctx context.Context, tx *gorm.DB, bucket, path 
 	// return object
 	return api.Object{
 		Metadata: metadata,
-		ObjectMetadata: api.ObjectMetadata{
-			ETag:     obj[0].ObjectETag,
-			Health:   obj[0].ObjectHealth,
-			MimeType: obj[0].ObjectMimeType,
-			ModTime:  api.TimeRFC3339(obj[0].ObjectModTime.UTC()),
-			Name:     obj[0].ObjectName,
-			Size:     obj[0].ObjectSize,
-		},
+		ObjectMetadata: newObjectMetadata(
+			obj[0].ObjectName,
+			obj[0].ObjectETag,
+			obj[0].ObjectMimeType,
+			obj[0].ObjectHealth,
+			obj[0].ObjectModTime,
+			obj[0].ObjectSize,
+		),
 		Object: object.Object{
 			Key:   key,
 			Slabs: slabs,
 		},
 	}, nil
+}
+
+// ObjectMetadata returns an object's metadata
+func (s *SQLStore) ObjectMetadata(ctx context.Context, bucket, path string) (api.Object, error) {
+	var resp api.Object
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		var obj dbObject
+		err := tx.Model(&dbObject{}).
+			Joins("INNER JOIN buckets b ON objects.db_bucket_id = b.id").
+			Where("b.name", bucket).
+			Where("object_id", path).
+			Take(&obj).
+			Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return api.ErrObjectNotFound
+		} else if err != nil {
+			return err
+		}
+		oum, err := s.objectMetadata(ctx, tx, bucket, path)
+		if err != nil {
+			return err
+		}
+		resp = api.Object{
+			ObjectMetadata: newObjectMetadata(
+				obj.ObjectID,
+				obj.Etag,
+				obj.MimeType,
+				obj.Health,
+				obj.CreatedAt,
+				obj.Size,
+			),
+			Metadata: oum,
+		}
+		return nil
+	})
+	return resp, err
 }
 
 func (s *SQLStore) objectMetadata(ctx context.Context, tx *gorm.DB, bucket, path string) (api.ObjectUserMetadata, error) {
@@ -2353,6 +2390,17 @@ func (s *SQLStore) objectMetadata(ctx context.Context, tx *gorm.DB, bucket, path
 		metadata[row.Key] = row.Value
 	}
 	return metadata, nil
+}
+
+func newObjectMetadata(name, etag, mimeType string, health float64, modTime time.Time, size int64) api.ObjectMetadata {
+	return api.ObjectMetadata{
+		ETag:     etag,
+		Health:   health,
+		ModTime:  api.TimeRFC3339(modTime.UTC()),
+		Name:     name,
+		Size:     size,
+		MimeType: mimeType,
+	}
 }
 
 func (s *SQLStore) objectRaw(ctx context.Context, txn *gorm.DB, bucket string, path string) (rows rawObject, err error) {


### PR DESCRIPTION
Adds a flag to the objects endpoint to allow fetching an object's metadata without the slice information or key and make use of that flag in `HeadObject`.

