### PR TITLE
Add `generateKey` flag to multipart create endpoint

### DIFF
--- a/api/multipart.go
+++ b/api/multipart.go
@@ -47,7 +47,7 @@ type (
 
 	CreateMultipartOptions struct {
 		GenerateKey bool
-		Key         object.EncryptionKey
+		Key         *object.EncryptionKey
 		MimeType    string
 		Metadata    ObjectUserMetadata
 	}
@@ -82,11 +82,11 @@ type (
 	}
 
 	MultipartCreateRequest struct {
-		Bucket   string               `json:"bucket"`
-		Path     string               `json:"path"`
-		Key      object.EncryptionKey `json:"key"`
-		MimeType string               `json:"mimeType"`
-		Metadata ObjectUserMetadata   `json:"metadata"`
+		Bucket   string                `json:"bucket"`
+		Path     string                `json:"path"`
+		Key      *object.EncryptionKey `json:"key"`
+		MimeType string                `json:"mimeType"`
+		Metadata ObjectUserMetadata    `json:"metadata"`
 
 		// TODO: The next major version change should invert this to create a
 		// key by default

--- a/api/multipart.go
+++ b/api/multipart.go
@@ -46,9 +46,10 @@ type (
 	}
 
 	CreateMultipartOptions struct {
-		Key      object.EncryptionKey
-		MimeType string
-		Metadata ObjectUserMetadata
+		GenerateKey bool
+		Key         object.EncryptionKey
+		MimeType    string
+		Metadata    ObjectUserMetadata
 	}
 )
 
@@ -86,6 +87,10 @@ type (
 		Key      object.EncryptionKey `json:"key"`
 		MimeType string               `json:"mimeType"`
 		Metadata ObjectUserMetadata   `json:"metadata"`
+
+		// TODO: The next major version change should invert this to create a
+		// key by default
+		GenerateKey bool `json:"generateKey"`
 	}
 
 	MultipartCreateResponse struct {

--- a/api/object.go
+++ b/api/object.go
@@ -235,20 +235,18 @@ type (
 
 	// UploadObjectOptions is the options type for the worker client.
 	UploadObjectOptions struct {
-		Offset                       int
-		MinShards                    int
-		TotalShards                  int
-		ContractSet                  string
-		DisablePreshardingEncryption bool
-		ContentLength                int64
-		MimeType                     string
-		Metadata                     ObjectUserMetadata
+		Offset        int
+		MinShards     int
+		TotalShards   int
+		ContractSet   string
+		ContentLength int64
+		MimeType      string
+		Metadata      ObjectUserMetadata
 	}
 
 	UploadMultipartUploadPartOptions struct {
-		DisablePreshardingEncryption bool
-		EncryptionOffset             int
-		ContentLength                int64
+		EncryptionOffset *int
+		ContentLength    int64
 	}
 )
 
@@ -268,9 +266,6 @@ func (opts UploadObjectOptions) ApplyValues(values url.Values) {
 	if opts.MimeType != "" {
 		values.Set("mimetype", opts.MimeType)
 	}
-	if opts.DisablePreshardingEncryption {
-		values.Set("disablepreshardingencryption", "true")
-	}
 }
 
 func (opts UploadObjectOptions) ApplyHeaders(h http.Header) {
@@ -280,11 +275,8 @@ func (opts UploadObjectOptions) ApplyHeaders(h http.Header) {
 }
 
 func (opts UploadMultipartUploadPartOptions) Apply(values url.Values) {
-	if opts.DisablePreshardingEncryption {
-		values.Set("disablepreshardingencryption", "true")
-	}
-	if !opts.DisablePreshardingEncryption || opts.EncryptionOffset != 0 {
-		values.Set("offset", fmt.Sprint(opts.EncryptionOffset))
+	if opts.EncryptionOffset != nil {
+		values.Set("offset", fmt.Sprint(*opts.EncryptionOffset))
 	}
 }
 

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -2178,7 +2178,9 @@ func (b *bus) multipartHandlerCreatePOST(jc jape.Context) {
 	}
 
 	key := req.Key
-	if key == (object.EncryptionKey{}) {
+	if req.GenerateKey {
+		key = object.GenerateEncryptionKey()
+	} else if key == (object.EncryptionKey{}) {
 		key = object.NoOpKey
 	}
 

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -2177,11 +2177,13 @@ func (b *bus) multipartHandlerCreatePOST(jc jape.Context) {
 		return
 	}
 
-	key := req.Key
+	var key object.EncryptionKey
 	if req.GenerateKey {
 		key = object.GenerateEncryptionKey()
-	} else if key == (object.EncryptionKey{}) {
+	} else if req.Key == nil {
 		key = object.NoOpKey
+	} else {
+		key = *req.Key
 	}
 
 	resp, err := b.ms.CreateMultipartUpload(jc.Request.Context(), req.Bucket, req.Path, key, req.MimeType, req.Metadata)

--- a/bus/client/multipart-upload.go
+++ b/bus/client/multipart-upload.go
@@ -46,11 +46,12 @@ func (c *Client) CompleteMultipartUpload(ctx context.Context, bucket, path, uplo
 // CreateMultipartUpload creates a new multipart upload.
 func (c *Client) CreateMultipartUpload(ctx context.Context, bucket, path string, opts api.CreateMultipartOptions) (resp api.MultipartCreateResponse, err error) {
 	err = c.c.WithContext(ctx).POST("/multipart/create", api.MultipartCreateRequest{
-		Bucket:   bucket,
-		Path:     path,
-		Key:      opts.Key,
-		MimeType: opts.MimeType,
-		Metadata: opts.Metadata,
+		Bucket:      bucket,
+		GenerateKey: opts.GenerateKey,
+		Path:        path,
+		Key:         opts.Key,
+		MimeType:    opts.MimeType,
+		Metadata:    opts.Metadata,
 	}, &resp)
 	return
 }

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -2015,7 +2015,7 @@ func TestMultipartUploads(t *testing.T) {
 	// correctly.
 	putPart := func(partNum int, offset int, data []byte) string {
 		t.Helper()
-		res, err := w.UploadMultipartUploadPart(context.Background(), bytes.NewReader(data), api.DefaultBucketName, objPath, mpr.UploadID, partNum, api.UploadMultipartUploadPartOptions{EncryptionOffset: offset})
+		res, err := w.UploadMultipartUploadPart(context.Background(), bytes.NewReader(data), api.DefaultBucketName, objPath, mpr.UploadID, partNum, api.UploadMultipartUploadPartOptions{EncryptionOffset: &offset})
 		tt.OK(err)
 		if res.ETag == "" {
 			t.Fatal("expected non-empty ETag")
@@ -2362,22 +2362,25 @@ func TestMultipartUploadWrappedByPartialSlabs(t *testing.T) {
 
 	// upload a part that is a partial slab
 	part3Data := bytes.Repeat([]byte{3}, int(slabSize)/4)
+	offset := int(slabSize + slabSize/4)
 	resp3, err := w.UploadMultipartUploadPart(context.Background(), bytes.NewReader(part3Data), api.DefaultBucketName, objPath, mpr.UploadID, 3, api.UploadMultipartUploadPartOptions{
-		EncryptionOffset: int(slabSize + slabSize/4),
+		EncryptionOffset: &offset,
 	})
 	tt.OK(err)
 
 	// upload a part that is exactly a full slab
 	part2Data := bytes.Repeat([]byte{2}, int(slabSize))
+	offset = int(slabSize / 4)
 	resp2, err := w.UploadMultipartUploadPart(context.Background(), bytes.NewReader(part2Data), api.DefaultBucketName, objPath, mpr.UploadID, 2, api.UploadMultipartUploadPartOptions{
-		EncryptionOffset: int(slabSize / 4),
+		EncryptionOffset: &offset,
 	})
 	tt.OK(err)
 
 	// upload another part the same size as the first one
 	part1Data := bytes.Repeat([]byte{1}, int(slabSize)/4)
+	offset = 0
 	resp1, err := w.UploadMultipartUploadPart(context.Background(), bytes.NewReader(part1Data), api.DefaultBucketName, objPath, mpr.UploadID, 1, api.UploadMultipartUploadPartOptions{
-		EncryptionOffset: 0,
+		EncryptionOffset: &offset,
 	})
 	tt.OK(err)
 

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1996,7 +1996,7 @@ func TestMultipartUploads(t *testing.T) {
 
 	// Start a new multipart upload.
 	objPath := "/foo"
-	mpr, err := b.CreateMultipartUpload(context.Background(), api.DefaultBucketName, objPath, api.CreateMultipartOptions{Key: object.GenerateEncryptionKey()})
+	mpr, err := b.CreateMultipartUpload(context.Background(), api.DefaultBucketName, objPath, api.CreateMultipartOptions{GenerateKey: true})
 	tt.OK(err)
 	if mpr.UploadID == "" {
 		t.Fatal("expected non-empty upload ID")

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -2354,7 +2354,8 @@ func TestMultipartUploadWrappedByPartialSlabs(t *testing.T) {
 
 	// start a new multipart upload. We upload the parts in reverse order
 	objPath := "/foo"
-	mpr, err := b.CreateMultipartUpload(context.Background(), api.DefaultBucketName, objPath, api.CreateMultipartOptions{Key: object.GenerateEncryptionKey()})
+	key := object.GenerateEncryptionKey()
+	mpr, err := b.CreateMultipartUpload(context.Background(), api.DefaultBucketName, objPath, api.CreateMultipartOptions{Key: &key})
 	tt.OK(err)
 	if mpr.UploadID == "" {
 		t.Fatal("expected non-empty upload ID")

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -405,7 +405,7 @@ func (s *s3) CopyObject(ctx context.Context, srcBucket, srcKey, dstBucket, dstKe
 func (s *s3) CreateMultipartUpload(ctx context.Context, bucket, key string, meta map[string]string) (gofakes3.UploadID, error) {
 	convertToSiaMetadataHeaders(meta)
 	resp, err := s.b.CreateMultipartUpload(ctx, bucket, "/"+key, api.CreateMultipartOptions{
-		Key:      object.NoOpKey,
+		Key:      &object.NoOpKey,
 		MimeType: meta["Content-Type"],
 		Metadata: api.ExtractObjectUserMetadataFrom(meta),
 	})

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -418,8 +418,7 @@ func (s *s3) CreateMultipartUpload(ctx context.Context, bucket, key string, meta
 
 func (s *s3) UploadPart(ctx context.Context, bucket, object string, id gofakes3.UploadID, partNumber int, contentLength int64, input io.Reader) (*gofakes3.UploadPartResult, error) {
 	res, err := s.w.UploadMultipartUploadPart(ctx, input, bucket, object, string(id), partNumber, api.UploadMultipartUploadPartOptions{
-		DisablePreshardingEncryption: true,
-		ContentLength:                contentLength,
+		ContentLength: contentLength,
 	})
 	if err != nil {
 		return nil, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1155,7 +1155,7 @@ func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {
 
 	// make sure only one of the following is set
 	if encryptionEnabled := !upload.Key.IsNoopKey(); encryptionEnabled && jc.Request.FormValue("offset") == "" {
-		jc.Error(errors.New("if presharding encryption isn't disabled, the offset needs to be set"), http.StatusBadRequest)
+		jc.Error(errors.New("if object encryption (pre-erasure coding) wasn't disabled by creating the multipart upload with the no-op key, the offset needs to be set"), http.StatusBadRequest)
 		return
 	} else if encryptionEnabled {
 		opts = append(opts, WithCustomEncryptionOffset(uint64(offset)))

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1154,7 +1154,7 @@ func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {
 	}
 
 	// make sure only one of the following is set
-	if encryptionEnabled := upload.Key != object.NoOpKey; encryptionEnabled && jc.Request.FormValue("offset") == "" {
+	if encryptionEnabled := !upload.Key.IsNoopKey(); encryptionEnabled && jc.Request.FormValue("offset") == "" {
 		jc.Error(errors.New("if presharding encryption isn't disabled, the offset needs to be set"), http.StatusBadRequest)
 		return
 	} else if encryptionEnabled {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1126,20 +1126,21 @@ func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {
 		return
 	}
 
-	// make sure only one of the following is set
-	var disablePreshardingEncryption bool
-	if jc.DecodeForm("disablepreshardingencryption", &disablePreshardingEncryption) != nil {
-		return
-	}
-	if !disablePreshardingEncryption && jc.Request.FormValue("offset") == "" {
-		jc.Error(errors.New("if presharding encryption isn't disabled, the offset needs to be set"), http.StatusBadRequest)
-		return
-	}
+	// get the offset
 	var offset int
 	if jc.DecodeForm("offset", &offset) != nil {
 		return
 	} else if offset < 0 {
 		jc.Error(errors.New("offset must be positive"), http.StatusBadRequest)
+		return
+	}
+
+	// fetch upload from bus
+	upload, err := w.bus.MultipartUpload(ctx, uploadID)
+	if isError(err, api.ErrMultipartUploadNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if jc.Check("failed to fetch multipart upload", err) != nil {
 		return
 	}
 
@@ -1149,17 +1150,15 @@ func (w *worker) multipartUploadHandlerPUT(jc jape.Context) {
 		WithContractSet(up.ContractSet),
 		WithPacking(up.UploadPacking),
 		WithRedundancySettings(up.RedundancySettings),
+		WithCustomKey(upload.Key),
 	}
-	if disablePreshardingEncryption {
-		opts = append(opts, WithCustomKey(object.NoOpKey))
-	} else {
-		upload, err := w.bus.MultipartUpload(ctx, uploadID)
-		if err != nil {
-			jc.Error(err, http.StatusBadRequest)
-			return
-		}
+
+	// make sure only one of the following is set
+	if encryptionEnabled := upload.Key != object.NoOpKey; encryptionEnabled && jc.Request.FormValue("offset") == "" {
+		jc.Error(errors.New("if presharding encryption isn't disabled, the offset needs to be set"), http.StatusBadRequest)
+		return
+	} else if encryptionEnabled {
 		opts = append(opts, WithCustomEncryptionOffset(uint64(offset)))
-		opts = append(opts, WithCustomKey(upload.Key))
 	}
 
 	// attach gouging checker to the context


### PR DESCRIPTION
That way a client doesn't need to generate a key themselves. 

This PR also gets rid of the `disablePreshardingEncryption` flag and instead looks at the encryption key to determine whether encryption is enabled and an offset is necessary. This should offer better protection against misusing the multipart upload API. For everyone already using it correctly, this change is backwards compatible. 