### PR TITLE
Stop using the worker's shutdown context for unlocking accounts

### DIFF
--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -392,7 +392,7 @@ func withAccountLock(ctx context.Context, as AccountStore, id rhpv3.Account, hk 
 	_ = as.UnlockAccount(ctx, acc.ID, lockID) // ignore error
 	cancel()
 
-	return nil
+	return err
 }
 
 // Balance returns the account balance.


### PR DESCRIPTION
This PR gets rid of `shutdownCtx` usage in the accounts and adds a `withAccountLock` helper. 
(Just pulling this out of #882  to try and get that merged.)