### PR TITLE
Change response type for paginated alerts request

### DIFF
--- a/alerts/alerts.go
+++ b/alerts/alerts.go
@@ -37,7 +37,6 @@ type (
 	Alerter interface {
 		RegisterAlert(_ context.Context, a Alert) error
 		DismissAlerts(_ context.Context, ids ...types.Hash256) error
-		DismissAllAlerts(_ context.Context) error
 	}
 
 	// Severity indicates the severity of an alert.
@@ -142,17 +141,6 @@ func (m *Manager) RegisterAlert(ctx context.Context, alert Alert) error {
 	})
 }
 
-// DismissAllAlerts implements the Alerter interface.
-func (m *Manager) DismissAllAlerts(ctx context.Context) error {
-	m.mu.Lock()
-	toDismiss := make([]types.Hash256, 0, len(m.alerts))
-	for alertID := range m.alerts {
-		toDismiss = append(toDismiss, alertID)
-	}
-	m.mu.Unlock()
-	return m.DismissAlerts(ctx, toDismiss...)
-}
-
 // DismissAlerts implements the Alerter interface.
 func (m *Manager) DismissAlerts(ctx context.Context, ids ...types.Hash256) error {
 	var dismissed []types.Hash256
@@ -250,11 +238,6 @@ func (a *originAlerter) RegisterAlert(ctx context.Context, alert Alert) error {
 	}
 	alert.Data["origin"] = a.origin
 	return a.alerter.RegisterAlert(ctx, alert)
-}
-
-// DismissAllAlerts implements the Alerter interface.
-func (a *originAlerter) DismissAllAlerts(ctx context.Context) error {
-	return a.alerter.DismissAllAlerts(ctx)
 }
 
 // DismissAlerts implements the Alerter interface.

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1738,13 +1738,6 @@ func (b *bus) handleGETAlertsPaginated(jc jape.Context) {
 }
 
 func (b *bus) handlePOSTAlertsDismiss(jc jape.Context) {
-	var all bool
-	if jc.DecodeForm("all", &all) != nil {
-		return
-	} else if all {
-		jc.Check("failed to dismiss all alerts", b.alertMgr.DismissAllAlerts(jc.Request.Context()))
-		return
-	}
 	var ids []types.Hash256
 	if jc.Decode(&ids) != nil {
 		return

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1716,6 +1716,15 @@ func (b *bus) gougingParams(ctx context.Context) (api.GougingParams, error) {
 }
 
 func (b *bus) handleGETAlerts(jc jape.Context) {
+	if jc.Request.FormValue("offset") != "" || jc.Request.FormValue("limit") != "" {
+		b.handleGETAlertsPaginated(jc)
+		return
+	}
+	ar := b.alertMgr.Active(0, -1)
+	jc.Encode(ar.Alerts)
+}
+
+func (b *bus) handleGETAlertsPaginated(jc jape.Context) {
 	offset, limit := 0, -1
 	if jc.DecodeForm("offset", &offset) != nil {
 		return

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1715,16 +1715,16 @@ func (b *bus) gougingParams(ctx context.Context) (api.GougingParams, error) {
 	}, nil
 }
 
-func (b *bus) handleGETAlerts(jc jape.Context) {
-	if jc.Request.FormValue("offset") != "" || jc.Request.FormValue("limit") != "" {
-		b.handleGETAlertsPaginated(jc)
-		return
-	}
+func (b *bus) handleGETAlertsDeprecated(jc jape.Context) {
 	ar := b.alertMgr.Active(0, -1)
 	jc.Encode(ar.Alerts)
 }
 
-func (b *bus) handleGETAlertsPaginated(jc jape.Context) {
+func (b *bus) handleGETAlerts(jc jape.Context) {
+	if jc.Request.FormValue("offset") == "" && jc.Request.FormValue("limit") == "" {
+		b.handleGETAlertsDeprecated(jc)
+		return
+	}
 	offset, limit := 0, -1
 	if jc.DecodeForm("offset", &offset) != nil {
 		return

--- a/bus/client/alerts.go
+++ b/bus/client/alerts.go
@@ -25,11 +25,6 @@ func (c *Client) DismissAlerts(ctx context.Context, ids ...types.Hash256) error 
 	return c.dismissAlerts(ctx, false, ids...)
 }
 
-// DismissAllAlerts dimisses all registered alerts.
-func (c *Client) DismissAllAlerts(ctx context.Context) error {
-	return c.dismissAlerts(ctx, true)
-}
-
 func (c *Client) dismissAlerts(ctx context.Context, all bool, ids ...types.Hash256) error {
 	values := url.Values{}
 	if all {

--- a/bus/client/alerts.go
+++ b/bus/client/alerts.go
@@ -10,15 +10,13 @@ import (
 )
 
 // Alerts fetches the active alerts from the bus.
-func (c *Client) Alerts(opts alerts.AlertsOpts) (alerts []alerts.Alert, err error) {
+func (c *Client) Alerts(opts alerts.AlertsOpts) (resp alerts.AlertsResponse, err error) {
 	values := url.Values{}
-	if opts.Offset != 0 {
-		values.Set("offset", fmt.Sprint(opts.Offset))
-	}
+	values.Set("offset", fmt.Sprint(opts.Offset))
 	if opts.Limit != 0 {
 		values.Set("limit", fmt.Sprint(opts.Limit))
 	}
-	err = c.c.GET("/alerts?"+values.Encode(), &alerts)
+	err = c.c.GET("/alerts?"+values.Encode(), &resp)
 	return
 }
 

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1974,15 +1974,6 @@ func TestAlerts(t *testing.T) {
 	if len(foundAlerts) != 1 || foundAlerts[0].ID != alert2.ID {
 		t.Fatal("wrong alert")
 	}
-
-	// dismiss all
-	tt.OK(b.DismissAllAlerts(context.Background()))
-	ar, err = b.Alerts(alerts.AlertsOpts{})
-	foundAlerts = ar.Alerts
-	tt.OK(err)
-	if len(foundAlerts) != 0 {
-		t.Fatal("expected 0 alerts", len(foundAlerts))
-	}
 }
 
 func TestMultipartUploads(t *testing.T) {

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1923,9 +1923,9 @@ func TestAlerts(t *testing.T) {
 	tt.OK(b.RegisterAlert(context.Background(), alert))
 	findAlert := func(id types.Hash256) *alerts.Alert {
 		t.Helper()
-		alerts, err := b.Alerts(alerts.AlertsOpts{})
+		ar, err := b.Alerts(alerts.AlertsOpts{})
 		tt.OK(err)
-		for _, alert := range alerts {
+		for _, alert := range ar.Alerts {
 			if alert.ID == id {
 				return &alert
 			}
@@ -1960,14 +1960,16 @@ func TestAlerts(t *testing.T) {
 	}
 
 	// try to find with offset = 1
-	foundAlerts, err := b.Alerts(alerts.AlertsOpts{Offset: 1})
+	ar, err := b.Alerts(alerts.AlertsOpts{Offset: 1})
+	foundAlerts := ar.Alerts
 	tt.OK(err)
 	if len(foundAlerts) != 1 || foundAlerts[0].ID != alert.ID {
 		t.Fatal("wrong alert")
 	}
 
 	// try to find with limit = 1
-	foundAlerts, err = b.Alerts(alerts.AlertsOpts{Limit: 1})
+	ar, err = b.Alerts(alerts.AlertsOpts{Limit: 1})
+	foundAlerts = ar.Alerts
 	tt.OK(err)
 	if len(foundAlerts) != 1 || foundAlerts[0].ID != alert2.ID {
 		t.Fatal("wrong alert")
@@ -1975,7 +1977,8 @@ func TestAlerts(t *testing.T) {
 
 	// dismiss all
 	tt.OK(b.DismissAllAlerts(context.Background()))
-	foundAlerts, err = b.Alerts(alerts.AlertsOpts{})
+	ar, err = b.Alerts(alerts.AlertsOpts{})
+	foundAlerts = ar.Alerts
 	tt.OK(err)
 	if len(foundAlerts) != 0 {
 		t.Fatal("expected 0 alerts", len(foundAlerts))


### PR DESCRIPTION
This gets rid of dismiss "all" again to avoid a race condition where a user may dismiss alerts they haven't had a chance to read yet and adds pagination to get alerts endpoint.