### PR TITLE
Accumulate churn information into single alert instead of registering multiple

### DIFF
--- a/autopilot/churn.go
+++ b/autopilot/churn.go
@@ -1,0 +1,63 @@
+package autopilot
+
+import (
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/alerts"
+)
+
+type (
+	accumulatedChurn struct {
+		additions map[types.FileContractID][]contractSetAddition
+		removals  map[types.FileContractID][]contractSetRemoval
+	}
+)
+
+func newAccumulatedChurn() *accumulatedChurn {
+	return &accumulatedChurn{
+		additions: make(map[types.FileContractID][]contractSetAddition),
+		removals:  make(map[types.FileContractID][]contractSetRemoval),
+	}
+}
+
+func (c *accumulatedChurn) Alert(name string) alerts.Alert {
+	var hint string
+	if len(c.removals) > 0 {
+		hint = "A high churn rate can lead to a lot of unnecessary migrations, it might be necessary to tweak your configuration depending on the reason hosts are being discarded from the set."
+	}
+
+	removedReasons := make(map[string][]string, len(c.removals))
+	for fcid, contractRemovals := range c.removals {
+		for _, removal := range contractRemovals {
+			removedReasons[fcid.String()] = append(removedReasons[fcid.String()], removal.Reason)
+		}
+	}
+
+	return alerts.Alert{
+		ID:       alertChurnID,
+		Severity: alerts.SeverityInfo,
+		Message:  "Contract set changed",
+		Data: map[string]any{
+			"name":          name,
+			"set_additions": c.additions,
+			"set_removals":  c.removals,
+			"hint":          hint,
+		},
+		Timestamp: time.Now(),
+	}
+}
+
+func (c *accumulatedChurn) Apply(additions map[types.FileContractID]contractSetAddition, removals map[types.FileContractID]contractSetRemoval) {
+	for fcid, addition := range additions {
+		c.additions[fcid] = append(c.additions[fcid], addition)
+	}
+	for fcid, removal := range removals {
+		c.removals[fcid] = append(c.removals[fcid], removal)
+	}
+}
+
+func (c *accumulatedChurn) Reset() {
+	c.additions = make(map[types.FileContractID][]contractSetAddition)
+	c.removals = make(map[types.FileContractID][]contractSetRemoval)
+}

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -123,15 +123,25 @@ type (
 		recoverable bool
 	}
 
+	contractSetAdditions struct {
+		HostKey   types.PublicKey       `json:"hostKey"`
+		Additions []contractSetAddition `json:"additions"`
+	}
+
 	contractSetAddition struct {
-		Size    uint64          `json:"size"`
-		HostKey types.PublicKey `json:"hostKey"`
+		Size uint64          `json:"size"`
+		Time api.TimeRFC3339 `json:"time"`
+	}
+
+	contractSetRemovals struct {
+		HostKey  types.PublicKey      `json:"hostKey"`
+		Removals []contractSetRemoval `json:"removals"`
 	}
 
 	contractSetRemoval struct {
-		Size    uint64          `json:"size"`
-		HostKey types.PublicKey `json:"hostKey"`
-		Reason  string          `json:"reasons"`
+		Size   uint64          `json:"size"`
+		Reason string          `json:"reasons"`
+		Time   api.TimeRFC3339 `json:"time"`
 	}
 
 	renewal struct {
@@ -455,8 +465,9 @@ func (c *contractor) computeContractSetChanged(ctx context.Context, name string,
 	}
 
 	// log added and removed contracts
-	setAdditions := make(map[types.FileContractID]contractSetAddition)
-	setRemovals := make(map[types.FileContractID]contractSetRemoval)
+	setAdditions := make(map[types.FileContractID]contractSetAdditions)
+	setRemovals := make(map[types.FileContractID]contractSetRemovals)
+	now := api.TimeNow()
 	for _, contract := range oldSet {
 		_, exists := inNewSet[contract.ID]
 		_, renewed := inNewSet[renewalsFromTo[contract.ID]]
@@ -466,11 +477,18 @@ func (c *contractor) computeContractSetChanged(ctx context.Context, name string,
 				reason = "unknown"
 			}
 
-			setRemovals[contract.ID] = contractSetRemoval{
-				Size:    contractData[contract.ID],
-				HostKey: contract.HostKey,
-				Reason:  reason,
+			if _, exists := setRemovals[contract.ID]; !exists {
+				setRemovals[contract.ID] = contractSetRemovals{
+					HostKey: contract.HostKey,
+				}
 			}
+			removals := setRemovals[contract.ID]
+			removals.Removals = append(removals.Removals, contractSetRemoval{
+				Size:   contractData[contract.ID],
+				Reason: reason,
+				Time:   now,
+			})
+			setRemovals[contract.ID] = removals
 			c.logger.Debugf("contract %v was removed from the contract set, size: %v, reason: %v", contract.ID, contractData[contract.ID], reason)
 		}
 	}
@@ -478,10 +496,17 @@ func (c *contractor) computeContractSetChanged(ctx context.Context, name string,
 		_, existed := inOldSet[contract.ID]
 		_, renewed := renewalsToFrom[contract.ID]
 		if !existed && !renewed {
-			setAdditions[contract.ID] = contractSetAddition{
-				Size:    contractData[contract.ID],
-				HostKey: contract.HostKey,
+			if _, exists := setAdditions[contract.ID]; !exists {
+				setAdditions[contract.ID] = contractSetAdditions{
+					HostKey: contract.HostKey,
+				}
 			}
+			additions := setAdditions[contract.ID]
+			additions.Additions = append(additions.Additions, contractSetAddition{
+				Size: contractData[contract.ID],
+				Time: now,
+			})
+			setAdditions[contract.ID] = additions
 			c.logger.Debugf("contract %v was added to the contract set, size: %v", contract.ID, contractData[contract.ID])
 		}
 	}
@@ -501,7 +526,6 @@ func (c *contractor) computeContractSetChanged(ctx context.Context, name string,
 	}
 
 	// record churn metrics
-	now := api.TimeNow()
 	var metrics []api.ContractSetChurnMetric
 	for fcid := range setAdditions {
 		metrics = append(metrics, api.ContractSetChurnMetric{
@@ -516,7 +540,7 @@ func (c *contractor) computeContractSetChanged(ctx context.Context, name string,
 			Name:       c.ap.state.cfg.Contracts.Set,
 			ContractID: fcid,
 			Direction:  api.ChurnDirRemoved,
-			Reason:     removal.Reason,
+			Reason:     removal.Removals[0].Reason,
 			Timestamp:  now,
 		})
 	}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1726,7 +1726,10 @@ func (b *bus) gougingParams(ctx context.Context) (api.GougingParams, error) {
 }
 
 func (b *bus) handleGETAlertsDeprecated(jc jape.Context) {
-	ar := b.alertMgr.Active(0, -1)
+	ar, err := b.alertMgr.Alerts(jc.Request.Context(), alerts.AlertsOpts{Offset: 0, Limit: -1})
+	if jc.Check("failed to fetch alerts", err) != nil {
+		return
+	}
 	jc.Encode(ar.Alerts)
 }
 
@@ -1744,7 +1747,11 @@ func (b *bus) handleGETAlerts(jc jape.Context) {
 		jc.Error(errors.New("offset must be non-negative"), http.StatusBadRequest)
 		return
 	}
-	jc.Encode(b.alertMgr.Active(offset, limit))
+	ar, err := b.alertMgr.Alerts(jc.Request.Context(), alerts.AlertsOpts{Offset: offset, Limit: limit})
+	if jc.Check("failed to fetch alerts", err) != nil {
+		return
+	}
+	jc.Encode(ar)
 }
 
 func (b *bus) handlePOSTAlertsDismiss(jc jape.Context) {

--- a/bus/client/alerts.go
+++ b/bus/client/alerts.go
@@ -10,13 +10,13 @@ import (
 )
 
 // Alerts fetches the active alerts from the bus.
-func (c *Client) Alerts(opts alerts.AlertsOpts) (resp alerts.AlertsResponse, err error) {
+func (c *Client) Alerts(ctx context.Context, opts alerts.AlertsOpts) (resp alerts.AlertsResponse, err error) {
 	values := url.Values{}
 	values.Set("offset", fmt.Sprint(opts.Offset))
 	if opts.Limit != 0 {
 		values.Set("limit", fmt.Sprint(opts.Limit))
 	}
-	err = c.c.GET("/alerts?"+values.Encode(), &resp)
+	err = c.c.WithContext(ctx).GET("/alerts?"+values.Encode(), &resp)
 	return
 }
 

--- a/internal/testing/cluster_test.go
+++ b/internal/testing/cluster_test.go
@@ -1923,7 +1923,7 @@ func TestAlerts(t *testing.T) {
 	tt.OK(b.RegisterAlert(context.Background(), alert))
 	findAlert := func(id types.Hash256) *alerts.Alert {
 		t.Helper()
-		ar, err := b.Alerts(alerts.AlertsOpts{})
+		ar, err := b.Alerts(context.Background(), alerts.AlertsOpts{})
 		tt.OK(err)
 		for _, alert := range ar.Alerts {
 			if alert.ID == id {
@@ -1960,7 +1960,7 @@ func TestAlerts(t *testing.T) {
 	}
 
 	// try to find with offset = 1
-	ar, err := b.Alerts(alerts.AlertsOpts{Offset: 1})
+	ar, err := b.Alerts(context.Background(), alerts.AlertsOpts{Offset: 1})
 	foundAlerts := ar.Alerts
 	tt.OK(err)
 	if len(foundAlerts) != 1 || foundAlerts[0].ID != alert.ID {
@@ -1968,7 +1968,7 @@ func TestAlerts(t *testing.T) {
 	}
 
 	// try to find with limit = 1
-	ar, err = b.Alerts(alerts.AlertsOpts{Limit: 1})
+	ar, err = b.Alerts(context.Background(), alerts.AlertsOpts{Limit: 1})
 	foundAlerts = ar.Alerts
 	tt.OK(err)
 	if len(foundAlerts) != 1 || foundAlerts[0].ID != alert2.ID {


### PR DESCRIPTION
This is done by introducing an accumulator which is reset every time the alert was dismissed by the user.

Depends on https://github.com/SiaFoundation/renterd/pull/987