### PR TITLE
Add upload benchmark for uploader with mocked hosts

### DIFF
--- a/object/object.go
+++ b/object/object.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bytes"
 	"crypto/cipher"
+	"crypto/md5"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -140,6 +141,22 @@ func (o Object) Contracts() map[types.PublicKey]map[types.FileContractID]struct{
 		}
 	}
 	return usedContracts
+}
+
+func (o *Object) ComputeETag() string {
+	// calculate the eTag using the precomputed sector roots to avoid having to
+	// hash the entire object again.
+	h := md5.New()
+	b := make([]byte, 8)
+	for _, slab := range o.Slabs {
+		binary.LittleEndian.PutUint32(b[:4], slab.Offset)
+		binary.LittleEndian.PutUint32(b[4:], slab.Length)
+		h.Write(b)
+		for _, shard := range slab.Shards {
+			h.Write(shard.Root[:])
+		}
+	}
+	return string(hex.EncodeToString(h.Sum(nil)))
 }
 
 // TotalSize returns the total size of the object.

--- a/worker/bench_test.go
+++ b/worker/bench_test.go
@@ -1,0 +1,88 @@
+package worker
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	rhpv2 "go.sia.tech/core/rhp/v2"
+)
+
+// zeroReader is a reader that leaves the buffer unchanged and returns no error.
+// It's useful for benchmarks that need to produce data for uploading and should
+// be used together with a io.LimitReader.
+type zeroReader struct{}
+
+func (z *zeroReader) Read(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+// BenchmarkUploaderPacking benchmarks the Upload function with packing
+// disabled.
+func BenchmarkUploaderNoPacking(b *testing.B) {
+	w := newMockWorker()
+
+	minDataPieces := 10
+	totalDataPieces := 30
+
+	w.addHosts(totalDataPieces)
+
+	// create a reader that returns dev/null
+	data := io.LimitReader(&zeroReader{}, int64(b.N*rhpv2.SectorSize*minDataPieces))
+
+	up := testParameters(b.TempDir())
+	up.rs.MinShards = minDataPieces
+	up.rs.TotalShards = totalDataPieces
+	up.packing = false
+
+	b.ResetTimer()
+
+	_, _, err := w.ul.Upload(context.Background(), data, w.contracts(), up, lockingPriorityUpload)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(int64(rhpv2.SectorSize * minDataPieces))
+}
+
+// BenchmarkSectorRoot30Goroutines benchmarks the SectorRoot function with 30
+// goroutines processing roots in parallel to simulate sequential uploads of
+// slabs.
+func BenchmarkSectorRoot30Goroutines(b *testing.B) {
+	data := make([]byte, rhpv2.SectorSize)
+	b.SetBytes(int64(rhpv2.SectorSize))
+
+	// spin up workers
+	c := make(chan struct{})
+	work := func() {
+		for range c {
+			rhpv2.SectorRoot((*[rhpv2.SectorSize]byte)(data))
+		}
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func() {
+			work()
+			wg.Done()
+		}()
+	}
+	b.ResetTimer()
+
+	// run the benchmark
+	for i := 0; i < b.N; i++ {
+		c <- struct{}{}
+	}
+	close(c)
+	wg.Wait()
+}
+
+// BenchmarkSectorRootSingleGoroutine benchmarks the SectorRoot function.
+func BenchmarkSectorRootSingleGoroutine(b *testing.B) {
+	data := make([]byte, rhpv2.SectorSize)
+	b.SetBytes(rhpv2.SectorSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rhpv2.SectorRoot((*[rhpv2.SectorSize]byte)(data))
+	}
+}

--- a/worker/bench_test.go
+++ b/worker/bench_test.go
@@ -21,7 +21,7 @@ func (z *zeroReader) Read(p []byte) (n int, err error) {
 // BenchmarkUploaderSingleObject benchmarks uploading a single object.
 //
 // Speed       | CPU    | Commit
-// 232.97 MB/s | M2 Pro | 26d3119
+// 433.86 MB/s | M2 Pro | bae6e77
 func BenchmarkUploaderSingleObject(b *testing.B) {
 	w := newMockWorker()
 
@@ -46,7 +46,7 @@ func BenchmarkUploaderSingleObject(b *testing.B) {
 // BenchmarkUploaderSingleObject benchmarks uploading one object per slab.
 //
 // Speed       | CPU    | Commit
-// 185.10 MB/s | M2 Pro | 26d3119
+// 282.47 MB/s | M2 Pro | bae6e77
 func BenchmarkUploaderMultiObject(b *testing.B) {
 	w := newMockWorker()
 
@@ -75,7 +75,7 @@ func BenchmarkUploaderMultiObject(b *testing.B) {
 // slabs.
 //
 // Speed        | CPU    | Commit
-// 1668.87 MB/s | M2 Pro | 26d3119
+// 1658.49 MB/s | M2 Pro | bae6e77
 func BenchmarkSectorRoot30Goroutines(b *testing.B) {
 	data := make([]byte, rhpv2.SectorSize)
 	b.SetBytes(int64(rhpv2.SectorSize))
@@ -108,7 +108,7 @@ func BenchmarkSectorRoot30Goroutines(b *testing.B) {
 // BenchmarkSectorRootSingleGoroutine benchmarks the SectorRoot function.
 //
 // Speed       | CPU    | Commit
-// 176.91 MB/s | M2 Pro | 26d3119
+// 177.33 MB/s | M2 Pro | bae6e77
 func BenchmarkSectorRootSingleGoroutine(b *testing.B) {
 	data := make([]byte, rhpv2.SectorSize)
 	b.SetBytes(rhpv2.SectorSize)

--- a/worker/bench_test.go
+++ b/worker/bench_test.go
@@ -23,7 +23,7 @@ func (z *zeroReader) Read(p []byte) (n int, err error) {
 
 // BenchmarkDownlaoderSingleObject benchmarks downloading a single, slab-sized
 // object.
-// 485.48 MB/s | M2 Pro | bae6e77
+// 1036.74 MB/s | M2 Pro | c9dc1b6
 func BenchmarkDownloaderSingleObject(b *testing.B) {
 	w := newMockWorker()
 

--- a/worker/bench_test.go
+++ b/worker/bench_test.go
@@ -21,7 +21,7 @@ func (z *zeroReader) Read(p []byte) (n int, err error) {
 // BenchmarkUploaderSingleObject benchmarks uploading a single object.
 //
 // Speed       | CPU    | Commit
-// 217.35 MB/s | M2 Pro | afee1ac
+// 232.97 MB/s | M2 Pro | 26d3119
 func BenchmarkUploaderSingleObject(b *testing.B) {
 	w := newMockWorker()
 
@@ -46,7 +46,7 @@ func BenchmarkUploaderSingleObject(b *testing.B) {
 // BenchmarkUploaderSingleObject benchmarks uploading one object per slab.
 //
 // Speed       | CPU    | Commit
-// 139.74 MB/s | M2 Pro | afee1ac
+// 185.10 MB/s | M2 Pro | 26d3119
 func BenchmarkUploaderMultiObject(b *testing.B) {
 	w := newMockWorker()
 
@@ -75,7 +75,7 @@ func BenchmarkUploaderMultiObject(b *testing.B) {
 // slabs.
 //
 // Speed        | CPU    | Commit
-// 1611.98 MB/s | M2 Pro | afee1ac
+// 1668.87 MB/s | M2 Pro | 26d3119
 func BenchmarkSectorRoot30Goroutines(b *testing.B) {
 	data := make([]byte, rhpv2.SectorSize)
 	b.SetBytes(int64(rhpv2.SectorSize))
@@ -108,7 +108,7 @@ func BenchmarkSectorRoot30Goroutines(b *testing.B) {
 // BenchmarkSectorRootSingleGoroutine benchmarks the SectorRoot function.
 //
 // Speed       | CPU    | Commit
-// 174.71 MB/s | M2 Pro | afee1ac
+// 176.91 MB/s | M2 Pro | 26d3119
 func BenchmarkSectorRootSingleGoroutine(b *testing.B) {
 	data := make([]byte, rhpv2.SectorSize)
 	b.SetBytes(rhpv2.SectorSize)

--- a/worker/bench_test.go
+++ b/worker/bench_test.go
@@ -18,12 +18,11 @@ func (z *zeroReader) Read(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-// BenchmarkUploaderSingleObjectNoPacking benchmarks uploading a single object
-// without packing.
+// BenchmarkUploaderSingleObject benchmarks uploading a single object.
 //
 // Speed       | CPU    | Commit
 // 201.59 MB/s | M2 Pro | c31245f
-func BenchmarkUploaderSingleObjectNoPacking(b *testing.B) {
+func BenchmarkUploaderSingleObject(b *testing.B) {
 	w := newMockWorker()
 
 	up := testParameters(b.TempDir())
@@ -44,12 +43,11 @@ func BenchmarkUploaderSingleObjectNoPacking(b *testing.B) {
 	}
 }
 
-// BenchmarkUploaderSingleObjectNoPacking benchmarks uploading one object per
-// slab without packing.
+// BenchmarkUploaderSingleObject benchmarks uploading one object per slab.
 //
 // Speed       | CPU    | Commit
 // 116.40 MB/s | M2 Pro | c31245f
-func BenchmarkUploaderMultiObjectNoPacking(b *testing.B) {
+func BenchmarkUploaderMultiObject(b *testing.B) {
 	w := newMockWorker()
 
 	up := testParameters(b.TempDir())

--- a/worker/bench_test.go
+++ b/worker/bench_test.go
@@ -21,7 +21,7 @@ func (z *zeroReader) Read(p []byte) (n int, err error) {
 // BenchmarkUploaderSingleObject benchmarks uploading a single object.
 //
 // Speed       | CPU    | Commit
-// 201.59 MB/s | M2 Pro | c31245f
+// 217.35 MB/s | M2 Pro | afee1ac
 func BenchmarkUploaderSingleObject(b *testing.B) {
 	w := newMockWorker()
 
@@ -46,7 +46,7 @@ func BenchmarkUploaderSingleObject(b *testing.B) {
 // BenchmarkUploaderSingleObject benchmarks uploading one object per slab.
 //
 // Speed       | CPU    | Commit
-// 116.40 MB/s | M2 Pro | c31245f
+// 139.74 MB/s | M2 Pro | afee1ac
 func BenchmarkUploaderMultiObject(b *testing.B) {
 	w := newMockWorker()
 
@@ -75,7 +75,7 @@ func BenchmarkUploaderMultiObject(b *testing.B) {
 // slabs.
 //
 // Speed        | CPU    | Commit
-// 1671.26 MB/s | M2 Pro | c31245f
+// 1611.98 MB/s | M2 Pro | afee1ac
 func BenchmarkSectorRoot30Goroutines(b *testing.B) {
 	data := make([]byte, rhpv2.SectorSize)
 	b.SetBytes(int64(rhpv2.SectorSize))
@@ -108,7 +108,7 @@ func BenchmarkSectorRoot30Goroutines(b *testing.B) {
 // BenchmarkSectorRootSingleGoroutine benchmarks the SectorRoot function.
 //
 // Speed       | CPU    | Commit
-// 176.43 MB/s | M2 Pro | c31245f
+// 174.71 MB/s | M2 Pro | afee1ac
 func BenchmarkSectorRootSingleGoroutine(b *testing.B) {
 	data := make([]byte, rhpv2.SectorSize)
 	b.SetBytes(rhpv2.SectorSize)

--- a/worker/download.go
+++ b/worker/download.go
@@ -315,7 +315,7 @@ outer:
 					s := slabs[respIndex]
 					if s.PartialSlab {
 						// Partial slab.
-						_, err = cw.Write(s.Data)
+						_, err = bw.Write(s.Data)
 						if err != nil {
 							mgr.logger.Errorf("failed to send partial slab", respIndex, err)
 							return err

--- a/worker/host_test.go
+++ b/worker/host_test.go
@@ -16,11 +16,9 @@ func TestHost(t *testing.T) {
 	sector, root := newMockSector()
 
 	// upload the sector
-	uploaded, err := h.UploadSector(context.Background(), sector, types.FileContractRevision{})
+	err := h.UploadSector(context.Background(), rhpv2.SectorRoot(sector), sector, types.FileContractRevision{})
 	if err != nil {
 		t.Fatal(err)
-	} else if uploaded != root {
-		t.Fatal("root mismatch")
 	}
 
 	// download entire sector

--- a/worker/mocks_test.go
+++ b/worker/mocks_test.go
@@ -396,8 +396,9 @@ func (h *mockHost) DownloadSector(ctx context.Context, w io.Writer, root types.H
 	return err
 }
 
-func (h *mockHost) UploadSector(ctx context.Context, sector *[rhpv2.SectorSize]byte, rev types.FileContractRevision) (types.Hash256, error) {
-	return h.contract().addSector(sector), nil
+func (h *mockHost) UploadSector(ctx context.Context, sectorRoot types.Hash256, sector *[rhpv2.SectorSize]byte, rev types.FileContractRevision) error {
+	h.contract().addSector(sectorRoot, sector)
+	return nil
 }
 
 func (h *mockHost) FetchRevision(ctx context.Context, fetchTimeout time.Duration) (rev types.FileContractRevision, _ error) {
@@ -448,12 +449,10 @@ func newMockContract(hk types.PublicKey, fcid types.FileContractID) *mockContrac
 	}
 }
 
-func (c *mockContract) addSector(sector *[rhpv2.SectorSize]byte) (root types.Hash256) {
-	root = rhpv2.SectorRoot(sector)
+func (c *mockContract) addSector(sectorRoot types.Hash256, sector *[rhpv2.SectorSize]byte) {
 	c.mu.Lock()
-	c.sectors[root] = sector
+	c.sectors[sectorRoot] = sector
 	c.mu.Unlock()
-	return
 }
 
 func (c *mockContract) sector(root types.Hash256) (sector *[rhpv2.SectorSize]byte, found bool) {

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -789,17 +789,17 @@ func RPCReadSector(ctx context.Context, t *transportV3, w io.Writer, pt rhpv3.Ho
 	return
 }
 
-func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.PrivateKey, pt rhpv3.HostPriceTable, rev *types.FileContractRevision, payment rhpv3.PaymentMethod, sector *[rhpv2.SectorSize]byte) (sectorRoot types.Hash256, cost types.Currency, err error) {
+func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.PrivateKey, pt rhpv3.HostPriceTable, rev *types.FileContractRevision, payment rhpv3.PaymentMethod, sectorRoot types.Hash256, sector *[rhpv2.SectorSize]byte) (cost types.Currency, err error) {
 	defer wrapErr(&err, "AppendSector")
 
 	// sanity check revision first
 	if rev.RevisionNumber == math.MaxUint64 {
-		return types.Hash256{}, types.ZeroCurrency, errMaxRevisionReached
+		return types.ZeroCurrency, errMaxRevisionReached
 	}
 
 	s, err := t.DialStream(ctx)
 	if err != nil {
-		return types.Hash256{}, types.ZeroCurrency, err
+		return types.ZeroCurrency, err
 	}
 	defer s.Close()
 
@@ -829,7 +829,7 @@ func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.Privat
 	// compute expected collateral and refund
 	expectedCost, expectedCollateral, expectedRefund, err := uploadSectorCost(pt, rev.WindowEnd)
 	if err != nil {
-		return types.Hash256{}, types.ZeroCurrency, err
+		return types.ZeroCurrency, err
 	}
 
 	// apply leeways.
@@ -840,13 +840,13 @@ func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.Privat
 
 	// check if the cost, collateral and refund match our expectation.
 	if executeResp.TotalCost.Cmp(expectedCost) > 0 {
-		return types.Hash256{}, types.ZeroCurrency, fmt.Errorf("cost exceeds expectation: %v > %v", executeResp.TotalCost.String(), expectedCost.String())
+		return types.ZeroCurrency, fmt.Errorf("cost exceeds expectation: %v > %v", executeResp.TotalCost.String(), expectedCost.String())
 	}
 	if executeResp.FailureRefund.Cmp(expectedRefund) < 0 {
-		return types.Hash256{}, types.ZeroCurrency, fmt.Errorf("insufficient refund: %v < %v", executeResp.FailureRefund.String(), expectedRefund.String())
+		return types.ZeroCurrency, fmt.Errorf("insufficient refund: %v < %v", executeResp.FailureRefund.String(), expectedRefund.String())
 	}
 	if executeResp.AdditionalCollateral.Cmp(expectedCollateral) < 0 {
-		return types.Hash256{}, types.ZeroCurrency, fmt.Errorf("insufficient collateral: %v < %v", executeResp.AdditionalCollateral.String(), expectedCollateral.String())
+		return types.ZeroCurrency, fmt.Errorf("insufficient collateral: %v < %v", executeResp.AdditionalCollateral.String(), expectedCollateral.String())
 	}
 
 	// set the cost and refund
@@ -870,18 +870,17 @@ func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.Privat
 	collateral := executeResp.AdditionalCollateral.Add(executeResp.FailureRefund)
 
 	// check proof
-	sectorRoot = rhpv2.SectorRoot(sector)
 	if rev.Filesize == 0 {
 		// For the first upload to a contract we don't get a proof. So we just
 		// assert that the new contract root matches the root of the sector.
 		if rev.Filesize == 0 && executeResp.NewMerkleRoot != sectorRoot {
-			return types.Hash256{}, types.ZeroCurrency, fmt.Errorf("merkle root doesn't match the sector root upon first upload to contract: %v != %v", executeResp.NewMerkleRoot, sectorRoot)
+			return types.ZeroCurrency, fmt.Errorf("merkle root doesn't match the sector root upon first upload to contract: %v != %v", executeResp.NewMerkleRoot, sectorRoot)
 		}
 	} else {
 		// Otherwise we make sure the proof was transmitted and verify it.
 		actions := []rhpv2.RPCWriteAction{{Type: rhpv2.RPCWriteActionAppend}} // TODO: change once rhpv3 support is available
 		if !rhpv2.VerifyDiffProof(actions, rev.Filesize/rhpv2.SectorSize, executeResp.Proof, []types.Hash256{}, rev.FileMerkleRoot, executeResp.NewMerkleRoot, []types.Hash256{sectorRoot}) {
-			return types.Hash256{}, types.ZeroCurrency, errors.New("proof verification failed")
+			return types.ZeroCurrency, errors.New("proof verification failed")
 		}
 	}
 
@@ -889,7 +888,7 @@ func RPCAppendSector(ctx context.Context, t *transportV3, renterKey types.Privat
 	newRevision := *rev
 	newValid, newMissed, err := updateRevisionOutputs(&newRevision, types.ZeroCurrency, collateral)
 	if err != nil {
-		return types.Hash256{}, types.ZeroCurrency, err
+		return types.ZeroCurrency, err
 	}
 	newRevision.Filesize += rhpv2.SectorSize
 	newRevision.RevisionNumber++

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -770,6 +770,12 @@ func (u *upload) newSlabUpload(ctx context.Context, shards [][]byte, uploaders [
 			sCtx, sCancel := context.WithCancel(ctx)
 
 			// create the sector
+			// NOTE: we are computing the sector root here and pass it all the
+			// way down to the RPC to avoid having to recompute it for the proof
+			// verification. This is necessary because we need it ahead of time
+			// for the call to AddUploadingSector in uploader.go
+			// Once we upload to temp storage we don't need AddUploadingSector
+			// anymore and can move it back to the RPC.
 			sectors[idx] = &sectorUpload{
 				data:   (*[rhpv2.SectorSize]byte)(shards[idx]),
 				index:  idx,

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -2,8 +2,6 @@ package worker
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -531,14 +529,8 @@ func (mgr *uploadManager) Upload(ctx context.Context, r io.Reader, contracts []a
 		o.Slabs = append(o.Slabs, resp.slab)
 	}
 
-	// calculate the eTag
-	h := md5.New()
-	for _, slab := range o.Slabs {
-		for _, shard := range slab.Shards {
-			h.Write(shard.Root[:])
-		}
-	}
-	eTag = string(hex.EncodeToString(h.Sum(nil)))
+	// compute etag
+	eTag = o.ComputeETag()
 
 	// add partial slabs
 	if len(partialSlab) > 0 {

--- a/worker/upload_utils.go
+++ b/worker/upload_utils.go
@@ -2,11 +2,9 @@ package worker
 
 import (
 	"bytes"
-	"encoding/hex"
 	"io"
 
 	"github.com/gabriel-vasile/mimetype"
-	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/object"
 )
 
@@ -27,29 +25,4 @@ func newMimeReader(r io.Reader) (mimeType string, recycled io.Reader, err error)
 	mtype, err := mimetype.DetectReader(io.TeeReader(r, buf))
 	recycled = io.MultiReader(buf, r)
 	return mtype.String(), recycled, err
-}
-
-type hashReader struct {
-	r io.Reader
-	h *types.Hasher
-}
-
-func newHashReader(r io.Reader) *hashReader {
-	return &hashReader{
-		r: r,
-		h: types.NewHasher(),
-	}
-}
-
-func (e *hashReader) Read(p []byte) (int, error) {
-	n, err := e.r.Read(p)
-	if _, wErr := e.h.E.Write(p[:n]); wErr != nil {
-		return 0, wErr
-	}
-	return n, err
-}
-
-func (e *hashReader) Hash() string {
-	sum := e.h.Sum()
-	return hex.EncodeToString(sum[:])
 }


### PR DESCRIPTION
This PR aims to identify the theoretical max throughput of an `uploader` that is not constraint by the network or memory.

It also applies a few changes to bottlenecks encountered during benchmarking.
