### PR TITLE
Only log lost sectors if sector was part of an active contract

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -126,7 +126,7 @@ type (
 		ContractSizes(ctx context.Context) (map[types.FileContractID]api.ContractSize, error)
 		ContractSize(ctx context.Context, id types.FileContractID) (api.ContractSize, error)
 
-		DeleteHostSector(ctx context.Context, hk types.PublicKey, root types.Hash256) error
+		DeleteHostSector(ctx context.Context, hk types.PublicKey, root types.Hash256) (int, error)
 
 		Bucket(_ context.Context, bucketName string) (api.Bucket, error)
 		CreateBucket(_ context.Context, bucketName string, policy api.BucketPolicy) error
@@ -1409,9 +1409,11 @@ func (b *bus) sectorsHostRootHandlerDELETE(jc jape.Context) {
 	} else if jc.DecodeParam("root", &root) != nil {
 		return
 	}
-	err := b.ms.DeleteHostSector(jc.Request.Context(), hk, root)
+	n, err := b.ms.DeleteHostSector(jc.Request.Context(), hk, root)
 	if jc.Check("failed to mark sector as lost", err) != nil {
 		return
+	} else if n > 0 {
+		b.logger.Infow("successfully marked sector as lost", "hk", hk, "root", root)
 	}
 }
 

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3582,8 +3582,10 @@ func TestDeleteHostSector(t *testing.T) {
 	}
 
 	// Prune the sector from hk1.
-	if err := ss.DeleteHostSector(context.Background(), hk1, root); err != nil {
+	if n, err := ss.DeleteHostSector(context.Background(), hk1, root); err != nil {
 		t.Fatal(err)
+	} else if n == 0 {
+		t.Fatal("no sectors were pruned")
 	}
 
 	// Make sure 2 contractSector entries exist.

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3584,8 +3584,8 @@ func TestDeleteHostSector(t *testing.T) {
 	// Prune the sector from hk1.
 	if n, err := ss.DeleteHostSector(context.Background(), hk1, root); err != nil {
 		t.Fatal(err)
-	} else if n == 0 {
-		t.Fatal("no sectors were pruned")
+	} else if n != 2 {
+		t.Fatal("no sectors were pruned", n)
 	}
 
 	// Make sure 2 contractSector entries exist.

--- a/worker/download.go
+++ b/worker/download.go
@@ -761,8 +761,6 @@ loop:
 				if isSectorNotFound(resp.err) {
 					if err := s.mgr.os.DeleteHostSector(ctx, resp.req.host.PublicKey(), resp.req.root); err != nil {
 						s.mgr.logger.Errorw("failed to mark sector as lost", "hk", resp.req.host.PublicKey(), "root", resp.req.root, zap.Error(err))
-					} else {
-						s.mgr.logger.Infow("successfully marked sector as lost", "hk", resp.req.host.PublicKey(), "root", resp.req.root)
 					}
 				} else if isPriceTableGouging(resp.err) && s.overpay && !resp.req.overpay {
 					resp.req.overpay = true // ensures we don't retry the same request over and over again


### PR DESCRIPTION
Right now we print a lot of "successfully marked sector as lost" regardless of whether the host was actually supposed to have that sector or not. e.g. a contract with a host might have expired and the host doesn't need to have a sector but we still log this message, confusing the operator of the node.

This PR moves the log line to the bus to make sure we only print it when there was actually an associated contract in the db for a given contract.