### PR TITLE
Improve `findAggregateContractMetric` performance and introduce 30 second granularity for contract metrics

### DIFF
--- a/stores/metrics.go
+++ b/stores/metrics.go
@@ -251,7 +251,7 @@ func (s *SQLStore) RecordContractMetric(ctx context.Context, metrics ...api.Cont
 	}
 	return s.dbMetrics.Transaction(func(tx *gorm.DB) error {
 		// delete any existing metric for the same contract that has happened
-		// within the same 30 seconds window by diving the timestamp by 30 seconds and use integer division.
+		// within the same 5' window by diving the timestamp by 5' and use integer division.
 		for _, metric := range metrics {
 			intervalStart := metric.Timestamp.Std().Truncate(contractMetricGranularity)
 			intervalEnd := intervalStart.Add(contractMetricGranularity)

--- a/stores/migrations/mysql/metrics/migration_00001_idx_contracts_fcid_timestamp.sql
+++ b/stores/migrations/mysql/metrics/migration_00001_idx_contracts_fcid_timestamp.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `idx_contracts_fcid_timestamp` ON `contracts`(`fcid`,`timestamp`);

--- a/stores/migrations/mysql/metrics/schema.sql
+++ b/stores/migrations/mysql/metrics/schema.sql
@@ -82,7 +82,7 @@ CREATE TABLE `contracts` (
   KEY `idx_contracts_timestamp` (`timestamp`),
   KEY `idx_remaining_funds` (`remaining_funds_lo`,`remaining_funds_hi`),
   KEY `idx_delete_spending` (`delete_spending_lo`,`delete_spending_hi`),
-  KEY `idx_list_spending` (`list_spending_lo`,`list_spending_hi`)
+  KEY `idx_list_spending` (`list_spending_lo`,`list_spending_hi`),
   KEY `idx_contracts_fcid_timestamp` (`fcid`,`timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 

--- a/stores/migrations/mysql/metrics/schema.sql
+++ b/stores/migrations/mysql/metrics/schema.sql
@@ -83,6 +83,7 @@ CREATE TABLE `contracts` (
   KEY `idx_remaining_funds` (`remaining_funds_lo`,`remaining_funds_hi`),
   KEY `idx_delete_spending` (`delete_spending_lo`,`delete_spending_hi`),
   KEY `idx_list_spending` (`list_spending_lo`,`list_spending_hi`)
+  KEY `idx_contracts_fcid_timestamp` (`fcid`,`timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- dbPerformanceMetric

--- a/stores/migrations/sqlite/metrics/migration_00001_idx_contracts_fcid_timestamp.sql
+++ b/stores/migrations/sqlite/metrics/migration_00001_idx_contracts_fcid_timestamp.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `idx_contracts_fcid_timestamp` ON `contracts`(`fcid`,`timestamp`);

--- a/stores/migrations/sqlite/metrics/schema.sql
+++ b/stores/migrations/sqlite/metrics/schema.sql
@@ -11,6 +11,7 @@ CREATE INDEX `idx_download_spending` ON `contracts`(`download_spending_lo`,`down
 CREATE INDEX `idx_upload_spending` ON `contracts`(`upload_spending_lo`,`upload_spending_hi`);
 CREATE INDEX `idx_contracts_revision_number` ON `contracts`(`revision_number`);
 CREATE INDEX `idx_remaining_funds` ON `contracts`(`remaining_funds_lo`,`remaining_funds_hi`);
+CREATE INDEX `idx_contracts_fcid_timestamp` ON `contracts`(`fcid`,`timestamp`);
 
 -- dbContractPruneMetric
 CREATE TABLE `contract_prunes` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`timestamp` BIGINT NOT NULL,`fcid` blob NOT NULL,`host` blob NOT NULL,`host_version` text,`pruned` BIGINT NOT NULL,`remaining` BIGINT NOT NULL,`duration` integer NOT NULL);

--- a/stores/migrations_metrics.go
+++ b/stores/migrations_metrics.go
@@ -8,20 +8,26 @@ import (
 	"gorm.io/gorm"
 )
 
-func performMetricsMigrations(tx *gorm.DB, logger *zap.SugaredLogger) error {
+func performMetricsMigrations(db *gorm.DB, logger *zap.SugaredLogger) error {
 	dbIdentifier := "metrics"
 	migrations := []*gormigrate.Migration{
 		{
 			ID:      "00001_init",
 			Migrate: func(tx *gorm.DB) error { return errRunV072 },
 		},
+		{
+			ID: "00001_idx_contracts_fcid_timestamp",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration(tx, dbIdentifier, "00001_idx_contracts_fcid_timestamp", logger)
+			},
+		},
 	}
 
 	// Create migrator.
-	m := gormigrate.New(tx, gormigrate.DefaultOptions, migrations)
+	m := gormigrate.New(db, gormigrate.DefaultOptions, migrations)
 
 	// Set init function.
-	m.InitSchema(initSchema(tx, dbIdentifier, logger))
+	m.InitSchema(initSchema(db, dbIdentifier, logger))
 
 	// Perform migrations.
 	if err := m.Migrate(); err != nil {


### PR DESCRIPTION
After doing some manual testing on Arequipa with about 34 million recorded contract metrics, I noticed that using multiple simpler queries (one select per contract per period) is a lot faster when combined with a composite index than a single more complex query.

This PR reduces the time it takes to display the contracts graph from about 25s down to <1s on the current set of data.

Combined with the granularity change of only recording one metric per contract every 5 minutes, a large host like Arequipa should only produce around 30 million rows a year.

