### PR TITLE
implement wallet.ApplyTx and wallet.RevertTx

### DIFF
--- a/stores/subscriber.go
+++ b/stores/subscriber.go
@@ -10,11 +10,16 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
+	"go.sia.tech/coreutils/wallet"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
-var _ chain.Subscriber = (*chainSubscriber)(nil)
+var (
+	_ chain.Subscriber = (*chainSubscriber)(nil)
+	_ wallet.ApplyTx   = (*chainSubscriber)(nil)
+	_ wallet.RevertTx  = (*chainSubscriber)(nil)
+)
 
 type (
 	chainSubscriber struct {
@@ -34,10 +39,12 @@ type (
 		persistTimer   *time.Timer
 
 		announcements []announcement
+		events        []eventChange
+
 		contractState map[types.Hash256]contractState
 		hosts         map[types.PublicKey]struct{}
 		mayCommit     bool
-		outputs       []outputChange
+		outputs       map[types.Hash256]outputChange
 		proofs        map[types.Hash256]uint64
 		revisions     map[types.Hash256]revisionUpdate
 		transactions  []txnChange
@@ -55,6 +62,7 @@ func NewChainSubscriber(db *gorm.DB, logger *zap.SugaredLogger, intvls []time.Du
 		persistInterval:    persistInterval,
 
 		contractState: make(map[types.Hash256]contractState),
+		outputs:       make(map[types.Hash256]outputChange),
 		hosts:         make(map[types.PublicKey]struct{}),
 		proofs:        make(map[types.Hash256]uint64),
 		revisions:     make(map[types.Hash256]revisionUpdate),
@@ -461,4 +469,115 @@ func (cs *chainSubscriber) processChainRevertUpdateContracts(cru *chain.RevertUp
 
 func (cs *chainSubscriber) retryTransaction(fc func(tx *gorm.DB) error, opts ...*sql.TxOptions) error {
 	return retryTransaction(cs.db, cs.logger, fc, cs.retryIntervals, opts...)
+}
+
+// AddEvents is called with all relevant events added in the update.
+func (cs *chainSubscriber) AddEvents(events []wallet.Event) error {
+	for _, event := range events {
+		cs.events = append(cs.events, eventChange{
+			addition: true,
+			event: dbWalletEvent{
+				EventID:        hash256(event.ID),
+				Inflow:         currency(event.Inflow),
+				Outflow:        currency(event.Outflow),
+				Transaction:    event.Transaction,
+				MaturityHeight: event.MaturityHeight,
+				Source:         string(event.Source),
+				Timestamp:      event.Timestamp.Unix(),
+				Height:         event.Index.Height,
+				BlockID:        hash256(event.Index.ID),
+			},
+		})
+	}
+	return nil
+}
+
+// AddSiacoinElements is called with all new siacoin elements in the
+// update. Ephemeral siacoin elements are not included.
+func (cs *chainSubscriber) AddSiacoinElements(elements []wallet.SiacoinElement) error {
+	for _, el := range elements {
+		if _, ok := cs.outputs[el.ID]; ok {
+			return fmt.Errorf("output %q already exists", el.ID)
+		}
+		cs.outputs[el.ID] = outputChange{
+			addition: true,
+			se: dbWalletOutput{
+				OutputID:       hash256(el.ID),
+				LeafIndex:      el.StateElement.LeafIndex,
+				MerkleProof:    el.StateElement.MerkleProof,
+				Value:          currency(el.SiacoinOutput.Value),
+				Address:        hash256(el.SiacoinOutput.Address),
+				MaturityHeight: el.MaturityHeight,
+				Height:         el.Index.Height,
+				BlockID:        hash256(el.Index.ID),
+			},
+		}
+	}
+
+	return nil
+}
+
+// RemoveSiacoinElements is called with all siacoin elements that were
+// spent in the update.
+func (cs *chainSubscriber) RemoveSiacoinElements(ids []types.SiacoinOutputID) error {
+	for _, id := range ids {
+		if _, ok := cs.outputs[types.Hash256(id)]; ok {
+			return fmt.Errorf("output %q not found", id)
+		}
+
+		cs.outputs[types.Hash256(id)] = outputChange{
+			addition: false,
+			se: dbWalletOutput{
+				OutputID: hash256(id),
+			},
+		}
+	}
+	return nil
+}
+
+// WalletStateElements returns all state elements in the database. It is used
+// to update the proofs of all state elements affected by the update.
+func (cs *chainSubscriber) WalletStateElements() (elements []types.StateElement, _ error) {
+	for id, el := range cs.outputs {
+		elements = append(elements, types.StateElement{
+			ID:          id,
+			LeafIndex:   el.se.LeafIndex,
+			MerkleProof: el.se.MerkleProof,
+		})
+	}
+	return
+}
+
+// UpdateStateElements updates the proofs of all state elements affected by the
+// update.
+func (cs *chainSubscriber) UpdateStateElements(elements []types.StateElement) error {
+	for _, se := range elements {
+		curr := cs.outputs[se.ID]
+		curr.se.MerkleProof = se.MerkleProof
+		curr.se.LeafIndex = se.LeafIndex
+		cs.outputs[se.ID] = curr
+	}
+	return nil
+}
+
+// RevertIndex is called with the chain index that is being reverted. Any events
+// and siacoin elements that were created by the index should be removed.
+func (cs *chainSubscriber) RevertIndex(index types.ChainIndex) error {
+	// remove any events that were added in the reverted block
+	filtered := cs.events[:0]
+	for i := range cs.events {
+		if cs.events[i].event.Index() != index {
+			filtered = append(filtered, cs.events[i])
+		}
+	}
+	cs.events = filtered
+
+	// remove any siacoin elements that were added in the reverted block
+	for id, el := range cs.outputs {
+		if el.se.Index() == index {
+			delete(cs.outputs, id)
+		}
+	}
+
+	return nil
 }

--- a/stores/types.go
+++ b/stores/types.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	proofHashSize = 32
 	secretKeySize = 32
 )
 
@@ -35,6 +36,7 @@ type (
 	balance        big.Int
 	unsigned64     uint64 // used for storing large uint64 values in sqlite
 	secretKey      []byte
+	merkleProof    []types.Hash256
 )
 
 // GormDataType implements gorm.GormDataTypeInterface.
@@ -339,6 +341,42 @@ func (u *unsigned64) Scan(value interface{}) error {
 // Value returns a datetime value, implements driver.Valuer interface.
 func (u unsigned64) Value() (driver.Value, error) {
 	return int64(u), nil
+}
+
+// GormDataType implements gorm.GormDataTypeInterface.
+func (mp *merkleProof) GormDataType() string {
+	return "bytes"
+}
+
+// Scan scans value into mp, implements sql.Scanner interface.
+func (mp *merkleProof) Scan(value interface{}) error {
+	bytes, ok := value.([]byte)
+	if !ok {
+		return errors.New(fmt.Sprint("failed to unmarshal merkleProof value:", value))
+	} else if len(bytes)%proofHashSize != 0 {
+		return fmt.Errorf("failed to unmarshal merkleProof value due to invalid number of bytes %v is not a multiple of %v: %v", len(bytes), proofHashSize, value)
+	} else if len(bytes) == 0 {
+		return errors.New("failed to unmarshal merkleProof value, no bytes found")
+	}
+
+	n := len(bytes) / proofHashSize
+	hashes := make([]types.Hash256, n)
+	for i := 0; i < n; i++ {
+		copy(hashes[i][:], bytes[:proofHashSize])
+		bytes = bytes[proofHashSize:]
+	}
+	*mp = hashes
+	return nil
+}
+
+// Value returns a merkle proof value, implements driver.Valuer interface.
+func (mp merkleProof) Value() (driver.Value, error) {
+	var i int
+	out := make([]byte, len(mp)*proofHashSize)
+	for _, ph := range mp {
+		i += copy(out[i:], ph[:])
+	}
+	return out, nil
 }
 
 func (bCurrency) GormDataType() string {

--- a/stores/wallet.go
+++ b/stores/wallet.go
@@ -36,16 +36,16 @@ type (
 		Model
 
 		// event
-		EventID        hash256 `gorm:"unique;index;NOT NULL;size:32"`
+		EventID        hash256 `gorm:"unique;index:idx_events_event_id;NOT NULL;size:32"`
 		Inflow         currency
 		Outflow        currency
 		Transaction    types.Transaction `gorm:"serializer:json"`
-		MaturityHeight uint64            `gorm:"index"`
-		Source         string            `gorm:"index:idx_events_source"`
-		Timestamp      int64             `gorm:"index:idx_events_timestamp"`
+		MaturityHeight uint64            `gorm:"index:idx_wallet_events_maturity_height"`
+		Source         string            `gorm:"index:idx_wallet_events_source"`
+		Timestamp      int64             `gorm:"index:idx_wallet_events_timestamp"`
 
 		// chain index
-		Height  uint64  `gorm:"index"`
+		Height  uint64  `gorm:"index:idx_wallet_events_height"`
 		BlockID hash256 `gorm:"size:32"`
 	}
 
@@ -59,15 +59,15 @@ type (
 		Model
 
 		// siacoin element
-		OutputID       hash256 `gorm:"unique;index;NOT NULL;size:32"`
+		OutputID       hash256 `gorm:"unique;index:idx_wallet_outputs_output_id;NOT NULL;size:32"`
 		LeafIndex      uint64
 		MerkleProof    merkleProof
 		Value          currency
 		Address        hash256 `gorm:"size:32"`
-		MaturityHeight uint64  `gorm:"index"`
+		MaturityHeight uint64  `gorm:"index:idx_wallet_outputs_maturity_height"`
 
 		// chain index
-		Height  uint64  `gorm:"index"`
+		Height  uint64  `gorm:"index:idx_wallet_outputs_height"`
 		BlockID hash256 `gorm:"size:32"`
 	}
 


### PR DESCRIPTION
This PR implements the interfaces necessary to process chain updates. I introduce the `db` types here, migrations come later.