### PR TITLE
Update refresh health query

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1991,42 +1991,16 @@ LIMIT ?
 			rowsAffected = res.RowsAffected
 
 			// Update the health of objects with outdated health.
-			var err error
-			if isSQLite(tx) {
-				err = tx.Exec(`
-			UPDATE objects
-			SET health = (
-				SELECT MIN(slabs.health)
-				FROM slabs
-				INNER JOIN slices ON slices.db_slab_id = slabs.id
-				INNER JOIN objects ON slices.db_object_id = objects.id
-			)
-			WHERE EXISTS (
-				SELECT 1 FROM slabs
-				INNER JOIN slices ON slices.db_slab_id = slabs.id
-				INNER JOIN objects ON slices.db_object_id = objects.id
-				WHERE slabs.health < objects.health
-			)	
-			`).Error
-			} else {
-				err = tx.Exec(`
-			UPDATE objects
-			JOIN (
-				SELECT slices.db_object_id, MIN(slabs.health) AS min_health
-				FROM slabs
-				INNER JOIN slices ON slices.db_slab_id = slabs.id
-				GROUP BY slices.db_object_id
-			) AS min_healths ON objects.id = min_healths.db_object_id
-			SET objects.health = min_healths.min_health
-			WHERE objects.health > (
-				SELECT MIN(slabs.health)
-				FROM slabs
-				INNER JOIN slices ON slices.db_slab_id = slabs.id
-				WHERE slices.db_object_id = objects.id
-			);
-				`).Error
-			}
-			return err
+			return tx.Exec(`
+UPDATE objects SET health = (
+	SELECT MIN(slabs.health)
+	FROM slabs
+	INNER JOIN slices ON slices.db_slab_id = slabs.id AND slices.db_object_id = objects.id
+) WHERE health != (
+	SELECT MIN(slabs.health)
+	FROM slabs
+	INNER JOIN slices ON slices.db_slab_id = slabs.id AND slices.db_object_id = objects.id
+)`).Error
 		})
 		if err != nil {
 			return err

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3911,11 +3911,10 @@ func TestRefreshHealth(t *testing.T) {
 
 	// add two test objects
 	o1 := t.Name() + "1"
-	s1 := object.GenerateEncryptionKey()
 	if added, err := ss.addTestObject(o1, object.Object{
 		Key: object.GenerateEncryptionKey(),
 		Slabs: []object.SlabSlice{{Slab: object.Slab{
-			Key: s1,
+			Key: object.GenerateEncryptionKey(),
 			Shards: []object.Sector{
 				newTestShard(hks[0], fcids[0], types.Hash256{0}),
 				newTestShard(hks[1], fcids[1], types.Hash256{1}),
@@ -3928,11 +3927,10 @@ func TestRefreshHealth(t *testing.T) {
 	}
 
 	o2 := t.Name() + "2"
-	s2 := object.GenerateEncryptionKey()
 	if added, err := ss.addTestObject(o2, object.Object{
 		Key: object.GenerateEncryptionKey(),
 		Slabs: []object.SlabSlice{{Slab: object.Slab{
-			Key: s2,
+			Key: object.GenerateEncryptionKey(),
 			Shards: []object.Sector{
 				newTestShard(hks[0], fcids[0], types.Hash256{2}),
 				newTestShard(hks[1], fcids[1], types.Hash256{3}),
@@ -3960,8 +3958,7 @@ func TestRefreshHealth(t *testing.T) {
 	}
 
 	// set the health of s1 to be lower than .5
-	s1b, _ := s1.MarshalBinary()
-	err = ss.db.Exec("UPDATE slabs SET health = 0.4 WHERE key = ?", secretKey(s1b)).Error
+	err = ss.overrideSlabHealth(o1, 0.4)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3978,8 +3975,7 @@ func TestRefreshHealth(t *testing.T) {
 	}
 
 	// set the health of s2 to be higher than .5
-	s2b, _ := s2.MarshalBinary()
-	err = ss.db.Exec("UPDATE slabs SET health = 0.6 WHERE key = ?", secretKey(s2b)).Error
+	err = ss.overrideSlabHealth(o2, 0.6)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I noticed on our integrity node an object wasn't properly getting its health refreshed. After digging in a bit I found we are currently setting the health of an object to be the `MIN` slab health across _all_ objects. Arequipa has a good example, currently all files are at 50% health... I have yet to performance test this change, I know the change that essentially broke the query was performance oriented, so perhaps we should/could deploy this on arequipa and see the effect it has there. I added a unit test for `RefreshHealth` too.