### PR TITLE
Improve logging for failed host scans

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -112,6 +112,6 @@ func (opts HostsForScanningOptions) Apply(values url.Values) {
 		values.Set("limit", fmt.Sprint(opts.Limit))
 	}
 	if !opts.MaxLastScan.IsZero() {
-		values.Set("maxLastScan", fmt.Sprint(TimeRFC3339(opts.MaxLastScan)))
+		values.Set("lastScan", fmt.Sprint(TimeRFC3339(opts.MaxLastScan)))
 	}
 }

--- a/api/worker.go
+++ b/api/worker.go
@@ -19,6 +19,10 @@ var (
 	// ErrContractSetNotSpecified is returned by the worker API by endpoints that
 	// need a contract set to be able to upload data.
 	ErrContractSetNotSpecified = errors.New("contract set is not specified")
+
+	// ErrHostOnPrivateNetwork is returned by the worker API when a host can't
+	// be scanned since it is on a private network.
+	ErrHostOnPrivateNetwork = errors.New("host is on a private network")
 )
 
 type (

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -752,11 +752,14 @@ func (c *contractor) runContractChecks(ctx context.Context, w Worker, contracts 
 			continue
 		}
 
-		// if the host doesn't have a valid pricetable, update it
-		var invalidPT bool
-		if err := refreshPriceTable(ctx, w, &host.Host); err != nil {
-			c.logger.Errorf("could not fetch price table for host %v: %v", host.PublicKey, err)
-			invalidPT = true
+		// if the host doesn't have a valid pricetable, update it if we were
+		// able to obtain a revision
+		invalidPT := contract.Revision == nil
+		if contract.Revision != nil {
+			if err := refreshPriceTable(ctx, w, &host.Host); err != nil {
+				c.logger.Errorf("could not fetch price table for host %v: %v", host.PublicKey, err)
+				invalidPT = true
+			}
 		}
 
 		// refresh the consensus state

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -154,6 +154,7 @@ type testClusterOptions struct {
 	logger               *zap.Logger
 	uploadPacking        bool
 	skipSettingAutopilot bool
+	skipRunningAutopilot bool
 	walletKey            *types.PrivateKey
 
 	autopilotCfg      *node.AutopilotConfig
@@ -393,11 +394,13 @@ func newTestCluster(t *testing.T, opts testClusterOptions) *TestCluster {
 		_ = autopilotServer.Serve(autopilotListener)
 		cluster.wg.Done()
 	}()
-	cluster.wg.Add(1)
-	go func() {
-		_ = aStartFn()
-		cluster.wg.Done()
-	}()
+	if !opts.skipRunningAutopilot {
+		cluster.wg.Add(1)
+		go func() {
+			_ = aStartFn()
+			cluster.wg.Done()
+		}()
+	}
 
 	// Set the test contract set to make sure we can add objects at the
 	// beginning of a test right away.

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -2527,17 +2527,20 @@ func TestHostScan(t *testing.T) {
 
 	// fetch hosts for scanning with maxLastScan set to now which should return
 	// all hosts
-	toScan, err := b.HostsForScanning(context.Background(), api.HostsForScanningOptions{
-		MaxLastScan: api.TimeRFC3339(time.Now()),
+	tt.Retry(100, 100*time.Millisecond, func() error {
+		toScan, err := b.HostsForScanning(context.Background(), api.HostsForScanningOptions{
+			MaxLastScan: api.TimeRFC3339(time.Now()),
+		})
+		tt.OK(err)
+		if len(toScan) != 2 {
+			return fmt.Errorf("expected 2 hosts, got %v", len(toScan))
+		}
+		return nil
 	})
-	tt.OK(err)
-	if len(toScan) != 2 {
-		t.Fatalf("expected 2 hosts, got %v", len(toScan))
-	}
 
 	// fetch hosts again with the unix epoch timestamp which should only return
 	// 1 host since that one hasn't been scanned yet
-	toScan, err = b.HostsForScanning(context.Background(), api.HostsForScanningOptions{
+	toScan, err := b.HostsForScanning(context.Background(), api.HostsForScanningOptions{
 		MaxLastScan: api.TimeRFC3339(time.Unix(0, 1)),
 	})
 	tt.OK(err)

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -2460,7 +2460,8 @@ func TestHostScan(t *testing.T) {
 	w := cluster.Worker
 	tt := cluster.tt
 
-	// Add a host.
+	// add 2 hosts to the cluster, 1 to scan and 1 to make sure we always have 1
+	// peer and consider ourselves connected to the internet
 	hosts := cluster.AddHosts(2)
 	host := hosts[0]
 

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -2491,6 +2491,10 @@ func TestHostScan(t *testing.T) {
 	}
 
 	scanHost := func() error {
+		// timing on the CI can be weird, wait a bit to make sure time passes
+		// between scans
+		time.Sleep(time.Millisecond)
+
 		resp, err := w.RHPScan(context.Background(), hk, hostIP, 10*time.Second)
 		tt.OK(err)
 		if resp.ScanError != "" {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1386,7 +1386,6 @@ func (w *worker) Shutdown(ctx context.Context) error {
 
 func (w *worker) scanHost(ctx context.Context, timeout time.Duration, hostKey types.PublicKey, hostIP string) (rhpv2.HostSettings, rhpv3.HostPriceTable, time.Duration, error) {
 	logger := w.logger.With("host", hostKey).With("hostIP", hostIP).With("timeout", timeout)
-
 	// prepare a helper for scanning
 	scan := func() (rhpv2.HostSettings, rhpv3.HostPriceTable, time.Duration, error) {
 		// apply timeout


### PR DESCRIPTION
Previously we didn't log failed host scans but this PR changes it so that we ignore certain errors but log the remaining ones. That should reveal any unexpected errors. 

e.g. quite a few scans fail due to the key handshake failing which seems to be mostly related to hosts reannouncing themselves with a new key as part of upgrading from `siad` to `hostd`.

This PR also adds a minor functional changes which is moving the `timeout` into the `scanHost` method to reapply the full timeout on the second scan.