### PR TITLE
Prevent broadcast of empty txn set in WalletRedistribute

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -606,6 +606,11 @@ func (b *bus) walletRedistributeHandler(jc jape.Context) {
 	}
 
 	var ids []types.TransactionID
+	if len(txns) == 0 {
+		jc.Encode(ids)
+		return
+	}
+
 	for i := 0; i < len(txns); i++ {
 		err = b.w.SignTransaction(cs, &txns[i], toSign, types.CoveredFields{WholeTransaction: true})
 		if jc.Check("couldn't sign the transaction", err) != nil {

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -2488,7 +2488,7 @@ func TestWalletRedistribute(t *testing.T) {
 	_, err = cluster.Bus.WalletRedistribute(context.Background(), 3, types.Siacoins(10))
 	if err != nil {
 		t.Fatal(err)
-  }
+	}
 }
 
 func TestHostScan(t *testing.T) {


### PR DESCRIPTION
I encountered the following error on my node:

```
2024-03-06T08:46:30Z    ERROR   autopilot       autopilot/autopilot.go:266      wallet maintenance failed, err: failed to redistribute wallet into 3 outputs of amount ~3.333 KS, balance ~14.56 KS, err couldn't broadcast the transaction: transaction set is empty
```

It happens because we don't properly return early if there's nothing to be redistributed and instead go and broadcast an empty txn set.