### PR TITLE
Fix "folder health misinterpreted"

### DIFF
--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3990,6 +3990,34 @@ func TestRefreshHealth(t *testing.T) {
 	} else if health(o2) != .6 {
 		t.Fatal("expected health to be .6, got", health(o2))
 	}
+
+	// add another object that is empty
+	o3 := t.Name() + "3"
+	if added, err := ss.addTestObject(o3, object.Object{
+		Key: object.GenerateEncryptionKey(),
+	}); err != nil {
+		t.Fatal(err)
+	} else if added.Health != 1 {
+		t.Fatal("expected health to be 1, got", added.Health)
+	}
+
+	// update its health to .1
+	if err := ss.db.
+		Model(&dbObject{}).
+		Where("object_id", o3).
+		Update("health", 0.1).
+		Error; err != nil {
+		t.Fatal(err)
+	} else if health(o3) != .1 {
+		t.Fatalf("expected health to be .1, got %v", health(o3))
+	}
+
+	// a refresh should not update its health
+	if err := ss.RefreshHealth(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if health(o3) != .1 {
+		t.Fatalf("expected health to be .1, got %v", health(o3))
+	}
 }
 
 func TestSlabCleanupTrigger(t *testing.T) {

--- a/stores/migrations.go
+++ b/stores/migrations.go
@@ -50,6 +50,12 @@ func performMigrations(db *gorm.DB, logger *zap.SugaredLogger) error {
 				return performMigration(tx, dbIdentifier, "00004_prune_slabs_cascade", logger)
 			},
 		},
+		{
+			ID: "00005_zero_size_object_health",
+			Migrate: func(tx *gorm.DB) error {
+				return performMigration(tx, dbIdentifier, "00005_zero_size_object_health", logger)
+			},
+		},
 	}
 
 	// Create migrator.

--- a/stores/migrations/mysql/main/migration_00005_zero_size_object_health.sql
+++ b/stores/migrations/mysql/main/migration_00005_zero_size_object_health.sql
@@ -1,0 +1,1 @@
+UPDATE objects SET health = 1 WHERE size = 0;

--- a/stores/migrations/sqlite/main/migration_00005_zero_size_object_health.sql
+++ b/stores/migrations/sqlite/main/migration_00005_zero_size_object_health.sql
@@ -1,0 +1,1 @@
+UPDATE objects SET health = 1 WHERE size = 0;


### PR DESCRIPTION
Closes https://github.com/SiaFoundation/renterd/issues/1036

Due to a bug in `refreshHealth` which is fixed now, 0-byte objects which were created by the UI as folders had a health != 1.

This PR fixes that and extends testing to make sure `RefreshHealth` doesn't update 0-byte files anymore.