### PR TITLE
Reduce occurences of account refill alert

### DIFF
--- a/autopilot/accounts.go
+++ b/autopilot/accounts.go
@@ -146,12 +146,11 @@ func (a *accounts) refillWorkerAccounts(ctx context.Context, w Worker) {
 				defer cancel()
 				accountID, refilled, rerr := refillWorkerAccount(rCtx, a.a, w, workerID, contract)
 				if rerr != nil {
-					if inSet || rerr.Is(errMaxDriftExceeded) {
-						// register the alert on failure if the contract is in
-						// the set or the error is errMaxDriftExceeded
+					if rerr.Is(errMaxDriftExceeded) {
+						// register the alert if error is errMaxDriftExceeded
 						a.ap.RegisterAlert(ctx, newAccountRefillAlert(accountID, contract, *rerr))
-						a.l.Errorw(rerr.err.Error(), rerr.keysAndValues...)
 					}
+					a.l.Errorw(rerr.err.Error(), rerr.keysAndValues...)
 				} else {
 					// dismiss alerts on success
 					a.ap.DismissAlert(ctx, alertIDForAccount(alertAccountRefillID, accountID))

--- a/autopilot/accounts.go
+++ b/autopilot/accounts.go
@@ -136,12 +136,9 @@ func (a *accounts) refillWorkerAccounts(ctx context.Context, w Worker) {
 
 	// refill accounts in separate goroutines
 	for _, c := range contracts {
-		// add logging for contracts in the set
-		_, inSet := inContractSet[c.ID]
-
 		// launch refill if not already in progress
 		if a.markRefillInProgress(workerID, c.HostKey) {
-			go func(contract api.ContractMetadata, inSet bool) {
+			go func(contract api.ContractMetadata) {
 				rCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 				defer cancel()
 				accountID, refilled, rerr := refillWorkerAccount(rCtx, a.a, w, workerID, contract)
@@ -166,7 +163,7 @@ func (a *accounts) refillWorkerAccounts(ctx context.Context, w Worker) {
 				}
 
 				a.markRefillDone(workerID, contract.HostKey)
-			}(c, inSet)
+			}(c)
 		}
 	}
 }


### PR DESCRIPTION
The account refill alert is too spammy and most of the time doesn't require action by the renter. This reduces the alert frequency so that only actionable errors are alerted.

![Screenshot 2024-03-09 at 11 19 29 AM](https://github.com/SiaFoundation/renterd/assets/5544150/d0ab6477-8ce5-42a9-82d9-399eb7c33675)
