### PR TITLE
Various `rclone` related fixes/improvements

### DIFF
--- a/api/object.go
+++ b/api/object.go
@@ -92,6 +92,7 @@ type (
 	// HeadObjectResponse is the response type for the HEAD /worker/object endpoint.
 	HeadObjectResponse struct {
 		ContentType  string             `json:"contentType"`
+		Etag         string             `json:"etag"`
 		LastModified string             `json:"lastModified"`
 		Range        *DownloadRange     `json:"range,omitempty"`
 		Size         int64              `json:"size"`
@@ -212,7 +213,8 @@ type (
 	}
 
 	HeadObjectOptions struct {
-		Range DownloadRange
+		IgnoreDelim bool
+		Range       DownloadRange
 	}
 
 	DownloadObjectOptions struct {
@@ -317,6 +319,9 @@ func (opts HeadObjectOptions) ApplyHeaders(h http.Header) {
 		} else {
 			h.Set("Range", fmt.Sprintf("bytes=%v-%v", opts.Range.Offset, opts.Range.Offset+opts.Range.Length-1))
 		}
+	}
+	if opts.IgnoreDelim {
+		h.Set("ignoreDelim", "true")
 	}
 }
 

--- a/api/object.go
+++ b/api/object.go
@@ -312,6 +312,12 @@ func (opts DeleteObjectOptions) Apply(values url.Values) {
 	}
 }
 
+func (opts HeadObjectOptions) Apply(values url.Values) {
+	if opts.IgnoreDelim {
+		values.Set("ignoreDelim", "true")
+	}
+}
+
 func (opts HeadObjectOptions) ApplyHeaders(h http.Header) {
 	if opts.Range != (DownloadRange{}) {
 		if opts.Range.Length == -1 {
@@ -319,9 +325,6 @@ func (opts HeadObjectOptions) ApplyHeaders(h http.Header) {
 		} else {
 			h.Set("Range", fmt.Sprintf("bytes=%v-%v", opts.Range.Offset, opts.Range.Offset+opts.Range.Length-1))
 		}
-	}
-	if opts.IgnoreDelim {
-		h.Set("ignoreDelim", "true")
 	}
 }
 

--- a/api/object.go
+++ b/api/object.go
@@ -92,7 +92,7 @@ type (
 	// HeadObjectResponse is the response type for the HEAD /worker/object endpoint.
 	HeadObjectResponse struct {
 		ContentType  string             `json:"contentType"`
-		Etag         string             `json:"etag"`
+		Etag         string             `json:"eTag"`
 		LastModified string             `json:"lastModified"`
 		Range        *DownloadRange     `json:"range,omitempty"`
 		Size         int64              `json:"size"`

--- a/internal/test/e2e/metadata_test.go
+++ b/internal/test/e2e/metadata_test.go
@@ -55,6 +55,8 @@ func TestObjectMetadata(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gor.Metadata, opts.Metadata) {
 		t.Fatal("metadata mismatch", gor.Metadata)
+	} else if gor.Etag == "" {
+		t.Fatal("missing etag")
 	}
 
 	// perform a HEAD request and assert the headers are all present
@@ -63,6 +65,7 @@ func TestObjectMetadata(t *testing.T) {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(hor, &api.HeadObjectResponse{
 		ContentType:  or.Object.ContentType(),
+		Etag:         gor.Etag,
 		LastModified: or.Object.LastModified(),
 		Range:        &api.DownloadRange{Offset: 1, Length: 1, Size: int64(len(data))},
 		Size:         int64(len(data)),

--- a/internal/test/e2e/s3_test.go
+++ b/internal/test/e2e/s3_test.go
@@ -499,6 +499,13 @@ func TestS3List(t *testing.T) {
 		if !cmp.Equal(test.want, got) {
 			t.Errorf("test %d: unexpected response, want %v got %v", i, test.want, got)
 		}
+		for _, obj := range result.Contents {
+			if obj.ETag == "" {
+				t.Fatal("expected non-empty ETag")
+			} else if obj.LastModified.IsZero() {
+				t.Fatal("expected non-zero LastModified")
+			}
+		}
 	}
 }
 

--- a/object/object.go
+++ b/object/object.go
@@ -3,7 +3,6 @@ package object
 import (
 	"bytes"
 	"crypto/cipher"
-	"crypto/md5"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -144,22 +143,6 @@ func (o Object) Contracts() map[types.PublicKey]map[types.FileContractID]struct{
 		}
 	}
 	return usedContracts
-}
-
-func (o *Object) ComputeETag() string {
-	// calculate the eTag using the precomputed sector roots to avoid having to
-	// hash the entire object again.
-	h := md5.New()
-	b := make([]byte, 8)
-	for _, slab := range o.Slabs {
-		binary.LittleEndian.PutUint32(b[:4], slab.Offset)
-		binary.LittleEndian.PutUint32(b[4:], slab.Length)
-		h.Write(b)
-		for _, shard := range slab.Shards {
-			h.Write(shard.Root[:])
-		}
-	}
-	return string(hex.EncodeToString(h.Sum(nil)))
 }
 
 // TotalSize returns the total size of the object.

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -48,6 +48,7 @@ type bus interface {
 
 type worker interface {
 	GetObject(ctx context.Context, bucket, path string, opts api.DownloadObjectOptions) (*api.GetObjectResponse, error)
+	HeadObject(ctx context.Context, bucket, path string, opts api.HeadObjectOptions) (*api.HeadObjectResponse, error)
 	UploadObject(ctx context.Context, r io.Reader, bucket, path string, opts api.UploadObjectOptions) (*api.UploadObjectResponse, error)
 	UploadMultipartUploadPart(ctx context.Context, r io.Reader, bucket, path, uploadID string, partNumber int, opts api.UploadMultipartUploadPartOptions) (*api.UploadMultipartUploadPartResponse, error)
 }

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1747,6 +1747,11 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, 
 			return fmt.Errorf("failed to create object: %w", err)
 		}
 
+		// Fetch object id for the created or updated object.
+		if err := tx.Model(&dbObject{}).Select("id").Scan(&obj.ID).Error; err != nil {
+			return fmt.Errorf("failed to fetch object id: %w", err)
+		}
+
 		// Fetch contract set.
 		var cs dbContractSet
 		if err := tx.Take(&cs, "name = ?", contractSet).Error; err != nil {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -2894,7 +2894,7 @@ func (s *SQLStore) ListObjects(ctx context.Context, bucket, prefix, sortBy, sort
 	}
 	var rows []rawObjectMetadata
 	if err := s.db.
-		Select("o.object_id as Name, o.size as Size, o.health as Health, o.mime_type as mimeType, o.created_at as ModTime").
+		Select("o.object_id as Name, o.size as Size, o.health as Health, o.mime_type as MimeType, o.created_at as ModTime, o.etag as ETag").
 		Model(&dbObject{}).
 		Table("objects o").
 		Joins("INNER JOIN buckets b ON o.db_bucket_id = b.id").

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1773,16 +1773,16 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, 
 			return err
 		}
 
-		// Fetch the used contracts.
-		contracts, err := fetchUsedContracts(tx, usedContracts)
-		if err != nil {
-			return fmt.Errorf("failed to fetch used contracts: %w", err)
-		}
-
 		// Fetch contract set.
 		var cs dbContractSet
 		if err := tx.Take(&cs, "name = ?", contractSet).Error; err != nil {
 			return fmt.Errorf("contract set %v not found: %w", contractSet, err)
+		}
+
+		// Fetch the used contracts.
+		contracts, err := fetchUsedContracts(tx, usedContracts)
+		if err != nil {
+			return fmt.Errorf("failed to fetch used contracts: %w", err)
 		}
 
 		// Create all slices. This also creates any missing slabs or sectors.

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1739,6 +1739,7 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, 
 		}
 		err = tx.
 			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "db_bucket_id"}, {Name: "object_id"}},
 				UpdateAll: true,
 			}).
 			Create(&obj).Error

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1708,12 +1708,6 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, 
 
 	// UpdateObject is ACID.
 	return s.retryTransaction(func(tx *gorm.DB) error {
-		// Fetch contract set.
-		var cs dbContractSet
-		if err := tx.Take(&cs, "name = ?", contractSet).Error; err != nil {
-			return fmt.Errorf("contract set %v not found: %w", contractSet, err)
-		}
-
 		// Try to delete. We want to get rid of the object and its slices if it
 		// exists.
 		//
@@ -1727,6 +1721,12 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, 
 		_, err := s.deleteObject(tx, bucket, path)
 		if err != nil {
 			return fmt.Errorf("failed to delete object: %w", err)
+		}
+
+		// Fetch contract set.
+		var cs dbContractSet
+		if err := tx.Take(&cs, "name = ?", contractSet).Error; err != nil {
+			return fmt.Errorf("contract set %v not found: %w", contractSet, err)
 		}
 
 		// Insert a new object.

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1709,37 +1709,27 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, 
 	// collect all used contracts
 	usedContracts := o.Contracts()
 
+	// fetch bucket id
+	var bucketID uint
+	err := s.db.Table("(SELECT id from buckets WHERE buckets.name = ?) bucket_id", bucket).
+		Take(&bucketID).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return fmt.Errorf("bucket %v not found: %w", bucket, api.ErrBucketNotFound)
+	} else if err != nil {
+		return fmt.Errorf("failed to fetch bucket id: %w", err)
+	}
+
 	// UpdateObject is ACID.
 	return s.retryTransaction(func(tx *gorm.DB) error {
-		// Try to delete. We want to get rid of the object and its slices if it
-		// exists.
-		//
-		// NOTE: the object's created_at is currently used as its ModTime, if we
-		// ever stop recreating the object but update it instead we need to take
-		// this into account
-		//
-		// NOTE: the metadata is not deleted because this delete will cascade,
-		// if we stop recreating the object we have to make sure to delete the
-		// object's metadata before trying to recreate it
-		_, err := s.deleteObject(tx, bucket, path)
-		if err != nil {
-			return fmt.Errorf("UpdateObject: failed to delete object: %w", err)
-		}
-
-		// Insert a new object.
-		var bucketID uint
-		err = tx.Table("(SELECT id from buckets WHERE buckets.name = ?) bucket_id", bucket).
-			Take(&bucketID).Error
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("bucket %v not found: %w", bucket, api.ErrBucketNotFound)
-		} else if err != nil {
-			return fmt.Errorf("failed to fetch bucket id: %w", err)
-		}
+		// Insert a new object or update an existing one.
 		objKey, err := o.Key.MarshalBinary()
 		if err != nil {
 			return fmt.Errorf("failed to marshal object key: %w", err)
 		}
 		obj := dbObject{
+			Model: Model{
+				CreatedAt: time.Now(),
+			},
 			DBBucketID: bucketID,
 			ObjectID:   path,
 			Key:        objKey,
@@ -1747,7 +1737,11 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, 
 			MimeType:   mimeType,
 			Etag:       eTag,
 		}
-		err = tx.Create(&obj).Error
+		err = tx.
+			Clauses(clause.OnConflict{
+				UpdateAll: true,
+			}).
+			Create(&obj).Error
 		if err != nil {
 			return fmt.Errorf("failed to create object: %w", err)
 		}
@@ -1764,9 +1758,33 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, 
 			return fmt.Errorf("failed to fetch used contracts: %w", err)
 		}
 
+		// Delete any old slices.
+		var slices []dbSlice
+		if err := tx.Where("db_object_id = ?", obj.ID).Limit(1).Find(&slices).Error; err != nil {
+			return fmt.Errorf("failed to fetch slices: %w", err)
+		}
+		if len(slices) > 0 {
+			if err := tx.Where("db_object_id", obj.ID).Delete(&dbSlice{}).Error; err != nil {
+				return fmt.Errorf("failed to delete slices: %w", err)
+			} else if err := pruneSlabs(tx); err != nil {
+				return fmt.Errorf("failed to prune slabs: %w", err)
+			}
+		}
+
 		// Create all slices. This also creates any missing slabs or sectors.
 		if err := s.createSlices(tx, &obj.ID, nil, cs.ID, contracts, o.Slabs); err != nil {
 			return fmt.Errorf("failed to create slices: %w", err)
+		}
+
+		// Delete any old user metadata.
+		var oldMetadata []dbObjectUserMetadata
+		if err := tx.Where("db_object_id = ?", obj.ID).Limit(1).Find(&oldMetadata).Error; err != nil {
+			return fmt.Errorf("failed to fetch user metadata: %w", err)
+		}
+		if len(oldMetadata) > 0 {
+			if err := tx.Where("db_object_id", obj.ID).Delete(&dbObjectUserMetadata{}).Error; err != nil {
+				return fmt.Errorf("failed to delete user metadata: %w", err)
+			}
 		}
 
 		// Create all user metadata.

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1058,9 +1058,9 @@ func TestSQLMetadataStore(t *testing.T) {
 	// incremented due to the object and slab being overwritten.
 	two := uint(2)
 	expectedObj.Slabs[0].DBObjectID = &two
-	expectedObj.Slabs[0].DBSlabID = 3
+	expectedObj.Slabs[0].DBSlabID = 1
 	expectedObj.Slabs[1].DBObjectID = &two
-	expectedObj.Slabs[1].DBSlabID = 4
+	expectedObj.Slabs[1].DBSlabID = 2
 	if !reflect.DeepEqual(obj, expectedObj) {
 		t.Fatal("object mismatch", cmp.Diff(obj, expectedObj))
 	}
@@ -1082,7 +1082,7 @@ func TestSQLMetadataStore(t *testing.T) {
 		TotalShards:     1,
 		Shards: []dbSector{
 			{
-				DBSlabID:   3,
+				DBSlabID:   1,
 				SlabIndex:  1,
 				Root:       obj1.Slabs[0].Shards[0].Root[:],
 				LatestHost: publicKey(obj1.Slabs[0].Shards[0].LatestHost),
@@ -1122,7 +1122,7 @@ func TestSQLMetadataStore(t *testing.T) {
 		TotalShards:     1,
 		Shards: []dbSector{
 			{
-				DBSlabID:   4,
+				DBSlabID:   2,
 				SlabIndex:  1,
 				Root:       obj1.Slabs[1].Shards[0].Root[:],
 				LatestHost: publicKey(obj1.Slabs[1].Shards[0].LatestHost),

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1056,9 +1056,10 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	// The expected object is the same except for some ids which were
 	// incremented due to the object and slab being overwritten.
-	expectedObj.Slabs[0].DBObjectID = &one
+	two := uint(2)
+	expectedObj.Slabs[0].DBObjectID = &two
 	expectedObj.Slabs[0].DBSlabID = 3
-	expectedObj.Slabs[1].DBObjectID = &one
+	expectedObj.Slabs[1].DBObjectID = &two
 	expectedObj.Slabs[1].DBSlabID = 4
 	if !reflect.DeepEqual(obj, expectedObj) {
 		t.Fatal("object mismatch", cmp.Diff(obj, expectedObj))
@@ -4557,10 +4558,14 @@ func TestTypeCurrency(t *testing.T) {
 func TestUpdateObjectParallel(t *testing.T) {
 	cfg := defaultTestSQLStoreConfig
 
-	// check if we are running against mysql and only persist if we aren't
 	dbURI, _, _, _ := DBConfigFromEnv()
 	if dbURI == "" {
-		cfg.persistent = true
+		// it's pretty much impossile to optimise for both sqlite and mysql at
+		// the same time so we skip this test for SQLite for now
+		// TODO: once we moved away from gorm and implement separate interfaces
+		// for SQLite and MySQL, we have more control over the used queries and
+		// can revisit this
+		t.SkipNow()
 	}
 	ss := newTestSQLStore(t, cfg)
 	ss.retryTransactionIntervals = []time.Duration{0} // don't retry

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -4613,7 +4613,7 @@ func TestUpdateObjectParallel(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 4; i++ {
 		wg.Add(1)
 		go func() {
 			work()

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -4552,7 +4552,12 @@ func TestTypeCurrency(t *testing.T) {
 // threads won't cause deadlocks.
 func TestUpdateObjectParallel(t *testing.T) {
 	cfg := defaultTestSQLStoreConfig
-	cfg.persistent = true
+
+	// check if we are running against mysql and only persist if we aren't
+	dbURI, _, _, _ := DBConfigFromEnv()
+	if dbURI == "" {
+		cfg.persistent = true
+	}
 	ss := newTestSQLStore(t, cfg)
 	ss.retryTransactionIntervals = []time.Duration{0} // don't retry
 	defer ss.Close()

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -3492,6 +3492,13 @@ func TestListObjects(t *testing.T) {
 		{"/foo", "size", "ASC", "", []api.ObjectMetadata{{Name: "/foo/bar", Size: 1, Health: 1}, {Name: "/foo/bat", Size: 2, Health: 1}, {Name: "/foo/baz/quux", Size: 3, Health: .75}, {Name: "/foo/baz/quuz", Size: 4, Health: .5}}},
 		{"/foo", "size", "DESC", "", []api.ObjectMetadata{{Name: "/foo/baz/quuz", Size: 4, Health: .5}, {Name: "/foo/baz/quux", Size: 3, Health: .75}, {Name: "/foo/bat", Size: 2, Health: 1}, {Name: "/foo/bar", Size: 1, Health: 1}}},
 	}
+	// set common fields
+	for i := range tests {
+		for j := range tests[i].want {
+			tests[i].want[j].ETag = testETag
+			tests[i].want[j].MimeType = testMimeType
+		}
+	}
 	for _, test := range tests {
 		res, err := ss.ListObjects(ctx, api.DefaultBucketName, test.prefix, test.sortBy, test.sortDir, "", -1)
 		if err != nil {

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -4552,7 +4552,6 @@ func TestTypeCurrency(t *testing.T) {
 // threads won't cause deadlocks.
 func TestUpdateObjectParallel(t *testing.T) {
 	cfg := defaultTestSQLStoreConfig
-	cfg.dir = t.TempDir()
 	cfg.persistent = true
 	ss := newTestSQLStore(t, cfg)
 	ss.retryTransactionIntervals = []time.Duration{0} // don't retry

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1056,11 +1056,10 @@ func TestSQLMetadataStore(t *testing.T) {
 
 	// The expected object is the same except for some ids which were
 	// incremented due to the object and slab being overwritten.
-	two := uint(2)
-	expectedObj.Slabs[0].DBObjectID = &two
-	expectedObj.Slabs[0].DBSlabID = 1
-	expectedObj.Slabs[1].DBObjectID = &two
-	expectedObj.Slabs[1].DBSlabID = 2
+	expectedObj.Slabs[0].DBObjectID = &one
+	expectedObj.Slabs[0].DBSlabID = 3
+	expectedObj.Slabs[1].DBObjectID = &one
+	expectedObj.Slabs[1].DBSlabID = 4
 	if !reflect.DeepEqual(obj, expectedObj) {
 		t.Fatal("object mismatch", cmp.Diff(obj, expectedObj))
 	}
@@ -1082,7 +1081,7 @@ func TestSQLMetadataStore(t *testing.T) {
 		TotalShards:     1,
 		Shards: []dbSector{
 			{
-				DBSlabID:   1,
+				DBSlabID:   3,
 				SlabIndex:  1,
 				Root:       obj1.Slabs[0].Shards[0].Root[:],
 				LatestHost: publicKey(obj1.Slabs[0].Shards[0].LatestHost),
@@ -1122,7 +1121,7 @@ func TestSQLMetadataStore(t *testing.T) {
 		TotalShards:     1,
 		Shards: []dbSector{
 			{
-				DBSlabID:   2,
+				DBSlabID:   4,
 				SlabIndex:  1,
 				Root:       obj1.Slabs[1].Shards[0].Root[:],
 				LatestHost: publicKey(obj1.Slabs[1].Shards[0].LatestHost),

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -327,6 +327,12 @@ func (s *SQLStore) CompleteMultipartUpload(ctx context.Context, bucket, path str
 	}
 	var eTag string
 	err = s.retryTransaction(func(tx *gorm.DB) error {
+		// Delete potentially existing object.
+		_, err := s.deleteObject(tx, bucket, path)
+		if err != nil {
+			return fmt.Errorf("failed to delete object: %w", err)
+		}
+
 		// Find multipart upload.
 		var mu dbMultipartUpload
 		err = tx.Where("upload_id = ?", uploadID).
@@ -345,12 +351,6 @@ func (s *SQLStore) CompleteMultipartUpload(ctx context.Context, bucket, path str
 		// Check bucket name.
 		if mu.DBBucket.Name != bucket {
 			return fmt.Errorf("bucket name mismatch: %v != %v: %w", mu.DBBucket.Name, bucket, api.ErrBucketNotFound)
-		}
-
-		// Delete potentially existing object.
-		_, err := s.deleteObject(tx, bucket, path)
-		if err != nil {
-			return fmt.Errorf("failed to delete object: %w", err)
 		}
 
 		// Sort the parts.

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -107,8 +107,8 @@ func newTestSQLStore(t *testing.T, cfg testSQLStoreConfig) *testSQLStore {
 		conn = NewMySQLConnection(dbUser, dbPassword, dbURI, dbName)
 		connMetrics = NewMySQLConnection(dbUser, dbPassword, dbURI, dbMetricsName)
 	} else if cfg.persistent {
-		conn = NewSQLiteConnection(filepath.Join(cfg.dir, "db.sqlite"))
-		connMetrics = NewSQLiteConnection(filepath.Join(cfg.dir, "metrics.sqlite"))
+		conn = NewSQLiteConnection(filepath.Join(dir, "db.sqlite"))
+		connMetrics = NewSQLiteConnection(filepath.Join(dir, "metrics.sqlite"))
 	} else {
 		conn = NewEphemeralSQLiteConnection(dbName)
 		connMetrics = NewEphemeralSQLiteConnection(dbMetricsName)

--- a/worker/client/client.go
+++ b/worker/client/client.go
@@ -81,12 +81,9 @@ func (c *Client) DownloadStats() (resp api.DownloadStatsResponse, err error) {
 func (c *Client) HeadObject(ctx context.Context, bucket, path string, opts api.HeadObjectOptions) (*api.HeadObjectResponse, error) {
 	c.c.Custom("HEAD", fmt.Sprintf("/objects/%s", path), nil, nil)
 
-	if strings.HasSuffix(path, "/") {
-		return nil, errors.New("the given path is a directory, HEAD can only be performed on objects")
-	}
-
 	values := url.Values{}
 	values.Set("bucket", url.QueryEscape(bucket))
+	opts.Apply(values)
 	path = api.ObjectPathEscape(path)
 	path += "?" + values.Encode()
 

--- a/worker/client/client.go
+++ b/worker/client/client.go
@@ -87,6 +87,7 @@ func (c *Client) HeadObject(ctx context.Context, bucket, path string, opts api.H
 
 	values := url.Values{}
 	values.Set("bucket", url.QueryEscape(bucket))
+	path = api.ObjectPathEscape(path)
 	path += "?" + values.Encode()
 
 	// TODO: support HEAD in jape client
@@ -325,6 +326,7 @@ func parseObjectResponseHeaders(header http.Header) (api.HeadObjectResponse, err
 
 	return api.HeadObjectResponse{
 		ContentType:  header.Get("Content-Type"),
+		Etag:         trimEtag(header.Get("ETag")),
 		LastModified: header.Get("Last-Modified"),
 		Range:        r,
 		Size:         size,
@@ -346,4 +348,9 @@ func sizeFromSeeker(r io.Reader) (int64, error) {
 		return 0, err
 	}
 	return size, nil
+}
+
+func trimEtag(etag string) string {
+	etag = strings.TrimPrefix(etag, "\"")
+	return strings.TrimSuffix(etag, "\"")
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1098,7 +1098,7 @@ func (w *worker) objectsHandlerPUT(jc jape.Context) {
 	if err := jc.Check("couldn't upload object", err); err != nil {
 		if err != nil {
 			w.logger.Error(err)
-			if !errors.Is(err, ErrShuttingDown) && !errors.Is(err, errUploadInterrupted) {
+			if !errors.Is(err, ErrShuttingDown) && !errors.Is(err, errUploadInterrupted) && !errors.Is(err, context.Canceled) {
 				w.registerAlert(newUploadFailedAlert(bucket, path, up.ContractSet, mimeType, rs.MinShards, rs.TotalShards, len(contracts), up.UploadPacking, false, err))
 			}
 		}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -872,7 +872,7 @@ func (w *worker) objectsHandlerHEAD(jc jape.Context) {
 	res, err := w.bus.Object(jc.Request.Context(), bucket, path, api.GetObjectOptions{
 		OnlyMetadata: true,
 	})
-	if errors.Is(err, api.ErrObjectNotFound) {
+	if err != nil && strings.Contains(err.Error(), api.ErrObjectNotFound.Error()) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	} else if err != nil {


### PR DESCRIPTION
- refactor database code to reduce deadlocks + add test for triggering deadlocks
- turn ETag into md5 hash and set it on objects in `backend.go` 
- Fix ListObjects not returning etag or modtime
