### PR TITLE
Fix markers in S3 API

### DIFF
--- a/internal/test/e2e/s3_test.go
+++ b/internal/test/e2e/s3_test.go
@@ -507,6 +507,23 @@ func TestS3List(t *testing.T) {
 			}
 		}
 	}
+
+	// use pagination to loop over objects one-by-one
+	marker := ""
+	expectedOrder := []string{"a/", "a/a/a", "a/b", "ab", "b", "c/a", "d", "y/", "y/y/y/y"}
+	hasMore := true
+	for i := 0; hasMore; i++ {
+		result, err := core.ListObjectsV2("bucket", "", "", marker, "", 1)
+		if err != nil {
+			t.Fatal(err)
+		} else if len(result.Contents) != 1 {
+			t.Fatalf("unexpected number of objects, %d != 1", len(result.Contents))
+		} else if result.Contents[0].Key != expectedOrder[i] {
+			t.Errorf("unexpected object, %s != %s", result.Contents[0].Key, expectedOrder[i])
+		}
+		marker = result.NextContinuationToken
+		hasMore = result.IsTruncated
+	}
 }
 
 func TestS3MultipartUploads(t *testing.T) {

--- a/s3/backend.go
+++ b/s3/backend.go
@@ -88,6 +88,11 @@ func (s *s3) ListBucket(ctx context.Context, bucketName string, prefix *gofakes3
 		page.MaxKeys = maxKeysDefault
 	}
 
+	// Adjust marker
+	if page.HasMarker {
+		page.Marker = "/" + page.Marker
+	}
+
 	var objects []api.ObjectMetadata
 	var err error
 	response := gofakes3.NewObjectList()
@@ -141,6 +146,10 @@ func (s *s3) ListBucket(ctx context.Context, bucketName string, prefix *gofakes3
 	if err != nil {
 		return nil, gofakes3.ErrorMessage(gofakes3.ErrInternal, err.Error())
 	}
+
+	// Remove the leading slash from the marker since we also do that for the
+	// name of each object
+	response.NextMarker = strings.TrimPrefix(response.NextMarker, "/")
 
 	// Loop over the entries and add them to the response.
 	for _, object := range objects {


### PR DESCRIPTION
This PR fixes an issue with markers not reflecting the name of the objects when returned through the S3 API. We trim the leading slash from objects but not from markers. This causes tools like rclone to fail at pagination. 
