### PR TITLE
Add workflow to automatically add issues and prs to project board

### DIFF
--- a/.github/workflows/project-add.yml
+++ b/.github/workflows/project-add.yml
@@ -1,0 +1,21 @@
+name: Add bugs to bugs project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          # You can target a project in a different organization
+          # to the issue
+          project-url: https://github.com/orgs/SiaFoundation/projects/5
+          github-token: ${{ secrets.PAT_ADD_TO_PROJECT }}


### PR DESCRIPTION
This will add all `renterd` issues and prs to the project board.

This is a workaround for the super low "project-add" workflow limit in the project's workflow menu. 