### PR TITLE
Remove deadcode linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -104,7 +104,6 @@ linters:
     - tagliatelle
     - unused
     - unparam
-    - deadcode
 
 issues:
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.


### PR DESCRIPTION
Keep getting `WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.` but it seems like we already have `unused` so I'm removing `deadcode`