### PR TITLE
Remove redundant `MaxCollateral` from gouging checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,6 @@ updated using the settings API:
 	"maxUploadPrice": "3000000000000000000000000000",             // 3000 SC per 1 TiB
 	"migrationSurchargeMultiplier": 10,                           // overpay up to 10x for sectors migrations on critical slabs
 	"minAccountExpiry": 86400000000000,                           // 1 day
-	"minMaxCollateral": "10000000000000000000000000",             // at least up to 10 SC per contract
 	"minMaxEphemeralAccountBalance": "1000000000000000000000000", // 1 SC
 	"minPriceTableValidity": 300000000000                         // 5 minutes
 }

--- a/api/setting.go
+++ b/api/setting.go
@@ -38,10 +38,6 @@ type (
 
 	// GougingSettings contain some price settings used in price gouging.
 	GougingSettings struct {
-		// MinMaxCollateral is the minimum value for 'MaxCollateral' in the host's
-		// price settings
-		MinMaxCollateral types.Currency `json:"minMaxCollateral"`
-
 		// MaxRPCPrice is the maximum allowed base price for RPCs
 		MaxRPCPrice types.Currency `json:"maxRPCPrice"`
 

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -804,7 +804,6 @@ func evaluateConfig(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Cu
 
 			// these are not optimised, so we keep the same values as the user
 			// provided
-			MinMaxCollateral:              gs.MinMaxCollateral,
 			HostBlockHeightLeeway:         gs.HostBlockHeightLeeway,
 			MinPriceTableValidity:         gs.MinPriceTableValidity,
 			MinAccountExpiry:              gs.MinAccountExpiry,

--- a/autopilot/hostscore.go
+++ b/autopilot/hostscore.go
@@ -161,7 +161,7 @@ func collateralScore(cfg api.AutopilotConfig, pt rhpv3.HostPriceTable, allocatio
 	cutoffMultiplier := uint64(4)
 
 	if expectedCollateral.Cmp(cutoff) < 0 {
-		return 0 // expectedCollateral <= cutoff -> score is 0
+		return math.SmallestNonzeroFloat64 // expectedCollateral <= cutoff -> score is basically 0
 	} else if expectedCollateral.Cmp(cutoff.Mul64(cutoffMultiplier)) >= 0 {
 		return 1 // expectedCollateral is 10x cutoff -> score is 1
 	} else {

--- a/build/env_default.go
+++ b/build/env_default.go
@@ -22,7 +22,6 @@ var (
 	// configured with on startup. These values can be adjusted using the
 	// settings API.
 	DefaultGougingSettings = api.GougingSettings{
-		MinMaxCollateral:              types.Siacoins(10),                                  // at least up to 10 SC per contract
 		MaxRPCPrice:                   types.Siacoins(1).Div64(1000),                       // 1mS per RPC
 		MaxContractPrice:              types.Siacoins(1),                                   // 1 SC per contract
 		MaxDownloadPrice:              types.Siacoins(3000),                                // 3000 SC per 1 TiB

--- a/build/env_testnet.go
+++ b/build/env_testnet.go
@@ -24,7 +24,6 @@ var (
 	//
 	// NOTE: default gouging settings for testnet are identical to mainnet.
 	DefaultGougingSettings = api.GougingSettings{
-		MinMaxCollateral:              types.Siacoins(10),                                  // at least up to 10 SC per contract
 		MaxRPCPrice:                   types.Siacoins(1).Div64(1000),                       // 1mS per RPC
 		MaxContractPrice:              types.Siacoins(15),                                  // 15 SC per contract
 		MaxDownloadPrice:              types.Siacoins(3000),                                // 3000 SC per 1 TiB

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -39,7 +39,6 @@ var (
 	}
 
 	GougingSettings = api.GougingSettings{
-		MinMaxCollateral: types.Siacoins(10),                   // at least up to 10 SC per contract
 		MaxRPCPrice:      types.Siacoins(1).Div64(1000),        // 1mS per RPC
 		MaxContractPrice: types.Siacoins(10),                   // 10 SC per contract
 		MaxDownloadPrice: types.Siacoins(1).Mul64(1000),        // 1000 SC per 1 TiB

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -171,14 +171,6 @@ func checkPriceGougingHS(gs api.GougingSettings, hs *rhpv2.HostSettings) error {
 		return fmt.Errorf("contract price exceeds max: %v > %v", hs.ContractPrice, gs.MaxContractPrice)
 	}
 
-	// check max collateral
-	if hs.MaxCollateral.IsZero() {
-		return errors.New("MaxCollateral of host is 0")
-	}
-	if hs.MaxCollateral.Cmp(gs.MinMaxCollateral) < 0 {
-		return fmt.Errorf("MaxCollateral is below minimum: %v < %v", hs.MaxCollateral, gs.MinMaxCollateral)
-	}
-
 	// check max EA balance
 	if hs.MaxEphemeralAccountBalance.Cmp(gs.MinMaxEphemeralAccountBalance) < 0 {
 		return fmt.Errorf("'MaxEphemeralAccountBalance' is less than the allowed minimum value, %v < %v", hs.MaxEphemeralAccountBalance, gs.MinMaxEphemeralAccountBalance)
@@ -219,10 +211,6 @@ func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, txnFee t
 	if pt.MaxCollateral.IsZero() {
 		return errors.New("MaxCollateral of host is 0")
 	}
-	if pt.MaxCollateral.Cmp(gs.MinMaxCollateral) < 0 {
-		return fmt.Errorf("MaxCollateral is below minimum: %v < %v", pt.MaxCollateral, gs.MinMaxCollateral)
-	}
-
 	// check ReadLengthCost - should be 1H as it's unused by hosts
 	if types.NewCurrency64(1).Cmp(pt.ReadLengthCost) < 0 {
 		return fmt.Errorf("ReadLengthCost of host is %v but should be %v", pt.ReadLengthCost, types.NewCurrency64(1))


### PR DESCRIPTION
By removing the `MinMaxCollateral` from the gouging checks, we stop avoiding interactions with hosts that are only considered to be gouging due to their collateral settings.
That means we only care about the `MaxCollateral` setting in the scoring algorithm. The result is that a host with insufficient `MaxCollateral` will be dropped from the contract set due to bad score if enough hosts with a good score exist.