### PR TITLE
Debug logging and various minor logging improvements

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -50,7 +50,10 @@ type (
 	// ContractsResponse is the response type for the /rhp/contracts endpoint.
 	ContractsResponse struct {
 		Contracts []Contract `json:"contracts"`
-		Error     string     `json:"error,omitempty"`
+		Errors    map[types.PublicKey]string
+
+		// deprecated
+		Error string `json:"error,omitempty"`
 	}
 
 	MemoryResponse struct {

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -220,8 +220,10 @@ func (c *contractor) performContractMaintenance(ctx context.Context, w Worker) (
 	if err != nil {
 		return false, err
 	}
-	if resp.Error != "" {
-		c.logger.Error(resp.Error)
+	if resp.Errors != nil {
+		for pk, err := range resp.Errors {
+			c.logger.With("hostKey", pk).With("error", err).Warn("failed to fetch revision")
+		}
 	}
 	contracts := resp.Contracts
 	c.logger.Infof("fetched %d contracts from the worker, took %v", len(resp.Contracts), time.Since(start))

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -492,7 +492,7 @@ func main() {
 		dbLogCfg = cfg.Database.Log
 	}
 	busCfg.DBLogger = zapgorm2.Logger{
-		ZapLogger:                 logger,
+		ZapLogger:                 logger.Named("SQL"),
 		LogLevel:                  level,
 		SlowThreshold:             dbLogCfg.SlowThreshold,
 		SkipCallerLookup:          false,

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -2226,6 +2226,12 @@ func (s *SQLStore) createSlices(tx *gorm.DB, objID, multiPartID *uint, contractS
 							DBSectorID:   sectorID,
 							DBContractID: contracts[fcid].ID,
 						})
+					} else {
+						s.logger.Warn("missing contract for shard",
+							"contract", fcid,
+							"root", shard.Root,
+							"latest_host", shard.LatestHost,
+						)
 					}
 				}
 			}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1298,6 +1298,10 @@ func (w *worker) rhpContractsHandlerGET(jc jape.Context) {
 	resp := api.ContractsResponse{Contracts: contracts}
 	if errs != nil {
 		resp.Error = errs.Error()
+		resp.Errors = make(map[types.PublicKey]string)
+		for pk, err := range errs {
+			resp.Errors[pk] = err.Error()
+		}
 	}
 	jc.Encode(resp)
 }


### PR DESCRIPTION
This PR
- adds some logging to contract pruning
- updates the revision fetch logging to break up the errors to make the log look a bit nicer. Also updates it to WARN instead ERROR since there is nothing the user can do in most cases.
- adds some logging in the stores for when a sector is added but the contract doesn't exist