### PR TITLE
Fix S3 HeadObject endpoint not correctly checking 404

### DIFF
--- a/internal/test/e2e/s3_test.go
+++ b/internal/test/e2e/s3_test.go
@@ -113,6 +113,12 @@ func TestS3Basic(t *testing.T) {
 		t.Fatal("unexpected ETag:", info.ETag)
 	}
 
+	// stat object that doesn't exist
+	_, err = s3.StatObject(context.Background(), bucket, "nonexistent", minio.StatObjectOptions{})
+	if err == nil || !strings.Contains(err.Error(), "The specified key does not exist") {
+		t.Fatal(err)
+	}
+
 	// add another bucket
 	tt.OK(s3.MakeBucket(context.Background(), bucket+"2", minio.MakeBucketOptions{}))
 

--- a/worker/client/client.go
+++ b/worker/client/client.go
@@ -100,9 +100,13 @@ func (c *Client) HeadObject(ctx context.Context, bucket, path string, opts api.H
 		return nil, err
 	}
 	if resp.StatusCode != 200 && resp.StatusCode != 206 {
-		err, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		return nil, errors.New(string(err))
+		switch resp.StatusCode {
+		case http.StatusNotFound:
+			return nil, api.ErrObjectNotFound
+		default:
+			return nil, errors.New(http.StatusText(resp.StatusCode))
+		}
 	}
 
 	head, err := parseObjectResponseHeaders(resp.Header)


### PR DESCRIPTION
A result of moving to a HEAD request which doesn't have a body and requires checking the status code. 