### PR TITLE
Merge host types

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -17,7 +17,6 @@ import (
 	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/build"
-	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/utils"
 	"go.sia.tech/renterd/object"
 	"go.sia.tech/renterd/wallet"
@@ -54,7 +53,7 @@ type Bus interface {
 
 	// hostdb
 	Host(ctx context.Context, hostKey types.PublicKey) (api.Host, error)
-	HostsForScanning(ctx context.Context, opts api.HostsForScanningOptions) ([]hostdb.HostAddress, error)
+	HostsForScanning(ctx context.Context, opts api.HostsForScanningOptions) ([]api.HostAddress, error)
 	RemoveOfflineHosts(ctx context.Context, minRecentScanFailures uint64, maxDowntime time.Duration) (uint64, error)
 	SearchHosts(ctx context.Context, opts api.SearchHostOptions) ([]api.Host, error)
 	UpdateHostCheck(ctx context.Context, autopilotID string, hostKey types.PublicKey, hostCheck api.HostCheck) error
@@ -701,7 +700,7 @@ func (ap *Autopilot) hostHandlerGET(jc jape.Context) {
 	check, ok := hi.Checks[ap.id]
 	if ok {
 		jc.Encode(api.HostResponse{
-			Host: hi.Host,
+			Host: hi,
 			Checks: &api.HostChecks{
 				Gouging:          check.Gouging.Gouging(),
 				GougingBreakdown: check.Gouging,
@@ -714,7 +713,7 @@ func (ap *Autopilot) hostHandlerGET(jc jape.Context) {
 		return
 	}
 
-	jc.Encode(api.HostResponse{Host: hi.Host})
+	jc.Encode(api.HostResponse{Host: hi})
 }
 
 func (ap *Autopilot) hostsHandlerPOST(jc jape.Context) {
@@ -747,7 +746,7 @@ func (ap *Autopilot) hostsHandlerPOST(jc jape.Context) {
 	for i, host := range hosts {
 		if check, ok := host.Checks[ap.id]; ok {
 			resps[i] = api.HostResponse{
-				Host: host.Host,
+				Host: host,
 				Checks: &api.HostChecks{
 					Gouging:          check.Gouging.Gouging(),
 					GougingBreakdown: check.Gouging,
@@ -758,7 +757,7 @@ func (ap *Autopilot) hostsHandlerPOST(jc jape.Context) {
 				},
 			}
 		} else {
-			resps[i] = api.HostResponse{Host: host.Host}
+			resps[i] = api.HostResponse{Host: host}
 		}
 	}
 	jc.Encode(resps)

--- a/autopilot/autopilot_test.go
+++ b/autopilot/autopilot_test.go
@@ -9,7 +9,6 @@ import (
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 )
 
 func TestOptimiseGougingSetting(t *testing.T) {
@@ -18,32 +17,30 @@ func TestOptimiseGougingSetting(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		hosts = append(hosts, api.Host{
 
-			Host: hostdb.Host{
-				KnownSince: time.Unix(0, 0),
-				PriceTable: hostdb.HostPriceTable{
-					HostPriceTable: rhpv3.HostPriceTable{
-						CollateralCost: types.Siacoins(1),
-						MaxCollateral:  types.Siacoins(1000),
-					},
+			KnownSince: time.Unix(0, 0),
+			PriceTable: api.HostPriceTable{
+				HostPriceTable: rhpv3.HostPriceTable{
+					CollateralCost: types.Siacoins(1),
+					MaxCollateral:  types.Siacoins(1000),
 				},
-				Settings: rhpv2.HostSettings{
-					AcceptingContracts: true,
-					Collateral:         types.Siacoins(1),
-					MaxCollateral:      types.Siacoins(1000),
-					Version:            "1.6.0",
-				},
-				Interactions: hostdb.Interactions{
-					Uptime:                  time.Hour * 1000,
-					LastScan:                time.Now(),
-					LastScanSuccess:         true,
-					SecondToLastScanSuccess: true,
-					TotalScans:              100,
-				},
-				LastAnnouncement: time.Unix(0, 0),
-				Scanned:          true,
 			},
-			Blocked: false,
-			Checks:  nil,
+			Settings: rhpv2.HostSettings{
+				AcceptingContracts: true,
+				Collateral:         types.Siacoins(1),
+				MaxCollateral:      types.Siacoins(1000),
+				Version:            "1.6.0",
+			},
+			Interactions: api.HostInteractions{
+				Uptime:                  time.Hour * 1000,
+				LastScan:                time.Now(),
+				LastScanSuccess:         true,
+				SecondToLastScanSuccess: true,
+				TotalScans:              100,
+			},
+			LastAnnouncement: time.Unix(0, 0),
+			Scanned:          true,
+			Blocked:          false,
+			Checks:           nil,
 		})
 	}
 

--- a/autopilot/contractor.go
+++ b/autopilot/contractor.go
@@ -15,7 +15,6 @@ import (
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/utils"
 	"go.sia.tech/renterd/wallet"
 	"go.sia.tech/renterd/worker"
@@ -103,7 +102,7 @@ type (
 	}
 
 	scoredHost struct {
-		host  hostdb.Host
+		host  api.Host
 		score float64
 	}
 
@@ -761,7 +760,7 @@ func (c *contractor) runContractChecks(ctx context.Context, contracts []api.Cont
 		}
 
 		// decide whether the contract is still good
-		ci := contractInfo{contract: contract, priceTable: host.Host.PriceTable.HostPriceTable, settings: host.Host.Settings}
+		ci := contractInfo{contract: contract, priceTable: host.PriceTable.HostPriceTable, settings: host.Settings}
 		usable, recoverable, refresh, renew, reasons := c.isUsableContract(state.cfg, state, ci, bh, ipFilter)
 		ci.usable = usable
 		ci.recoverable = recoverable
@@ -1323,7 +1322,7 @@ func (c *contractor) candidateHosts(ctx context.Context, hosts []api.Host, usedH
 		h.PriceTable.HostBlockHeight = cs.BlockHeight
 		hc := checkHost(state.cfg, state.rs, gc, h, minScore, storedData[h.PublicKey])
 		if hc.Usability.IsUsable() {
-			candidates = append(candidates, scoredHost{h.Host, hc.Score.Score()})
+			candidates = append(candidates, scoredHost{h, hc.Score.Score()})
 			continue
 		}
 
@@ -1505,7 +1504,7 @@ func (c *contractor) refreshContract(ctx context.Context, w Worker, ci contractI
 	return refreshedContract, true, nil
 }
 
-func (c *contractor) formContract(ctx context.Context, w Worker, host hostdb.Host, minInitialContractFunds, maxInitialContractFunds types.Currency, budget *types.Currency) (cm api.ContractMetadata, proceed bool, err error) {
+func (c *contractor) formContract(ctx context.Context, w Worker, host api.Host, minInitialContractFunds, maxInitialContractFunds types.Currency, budget *types.Currency) (cm api.ContractMetadata, proceed bool, err error) {
 	// convenience variables
 	state := c.ap.State()
 	hk := host.PublicKey
@@ -1632,7 +1631,7 @@ func initialContractFundingMinMax(cfg api.AutopilotConfig) (min types.Currency, 
 	return
 }
 
-func refreshPriceTable(ctx context.Context, w Worker, host *hostdb.Host) error {
+func refreshPriceTable(ctx context.Context, w Worker, host *api.Host) error {
 	// return early if the host's pricetable is not expired yet
 	if time.Now().Before(host.PriceTable.Expiry) {
 		return nil

--- a/autopilot/host_test.go
+++ b/autopilot/host_test.go
@@ -8,7 +8,7 @@ import (
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
-	"go.sia.tech/renterd/hostdb"
+	"go.sia.tech/renterd/api"
 	"lukechampine.com/frand"
 )
 
@@ -40,20 +40,20 @@ func TestHost(t *testing.T) {
 	}
 }
 
-func newTestHosts(n int) []hostdb.Host {
-	hosts := make([]hostdb.Host, n)
+func newTestHosts(n int) []api.Host {
+	hosts := make([]api.Host, n)
 	for i := 0; i < n; i++ {
 		hosts[i] = newTestHost(randomHostKey(), newTestHostPriceTable(), newTestHostSettings())
 	}
 	return hosts
 }
 
-func newTestHost(hk types.PublicKey, pt rhpv3.HostPriceTable, settings rhpv2.HostSettings) hostdb.Host {
-	return hostdb.Host{
+func newTestHost(hk types.PublicKey, pt rhpv3.HostPriceTable, settings rhpv2.HostSettings) api.Host {
+	return api.Host{
 		NetAddress:       randomIP().String(),
 		KnownSince:       time.Now(),
 		LastAnnouncement: time.Now(),
-		Interactions: hostdb.Interactions{
+		Interactions: api.HostInteractions{
 			TotalScans:              2,
 			LastScan:                time.Now().Add(-time.Minute),
 			LastScanSuccess:         true,
@@ -65,7 +65,7 @@ func newTestHost(hk types.PublicKey, pt rhpv3.HostPriceTable, settings rhpv2.Hos
 			FailedInteractions:     0,
 		},
 		PublicKey:  hk,
-		PriceTable: hostdb.HostPriceTable{HostPriceTable: pt, Expiry: time.Now().Add(time.Minute)},
+		PriceTable: api.HostPriceTable{HostPriceTable: pt, Expiry: time.Now().Add(time.Minute)},
 		Settings:   settings,
 		Scanned:    true,
 	}

--- a/autopilot/hostfilter.go
+++ b/autopilot/hostfilter.go
@@ -140,7 +140,7 @@ func checkHost(cfg api.AutopilotConfig, rs api.RedundancySettings, gc worker.Gou
 			// not gouging, this because the core package does not have overflow
 			// checks in its cost calculations needed to calculate the period
 			// cost
-			sb = hostScore(cfg, h.Host, storedData, rs.Redundancy())
+			sb = hostScore(cfg, h, storedData, rs.Redundancy())
 			if sb.Score() < minScore {
 				ub.LowScore = true
 			}

--- a/autopilot/hosts_test.go
+++ b/autopilot/hosts_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"go.sia.tech/core/types"
-	"go.sia.tech/renterd/hostdb"
+	"go.sia.tech/renterd/api"
 	"lukechampine.com/frand"
 )
 
@@ -18,7 +18,7 @@ func TestScoredHostsRandSelectByScore(t *testing.T) {
 
 	var hosts scoredHosts
 	for hk, score := range hostToScores {
-		hosts = append(hosts, scoredHost{score: score, host: hostdb.Host{PublicKey: hk}})
+		hosts = append(hosts, scoredHost{score: score, host: api.Host{PublicKey: hk}})
 	}
 
 	for i := 0; i < 1000; i++ {
@@ -55,8 +55,8 @@ func TestScoredHostsRandSelectByScore(t *testing.T) {
 	// assert select is random on equal inputs
 	counts := make([]int, 2)
 	hosts = scoredHosts{
-		{score: .1, host: hostdb.Host{PublicKey: types.PublicKey{1}}},
-		{score: .1, host: hostdb.Host{PublicKey: types.PublicKey{2}}},
+		{score: .1, host: api.Host{PublicKey: types.PublicKey{1}}},
+		{score: .1, host: api.Host{PublicKey: types.PublicKey{2}}},
 	}
 	for i := 0; i < 100; i++ {
 		if hosts.randSelectByScore(1)[0].host.PublicKey == (types.PublicKey{1}) {

--- a/autopilot/hostscore_test.go
+++ b/autopilot/hostscore_test.go
@@ -9,7 +9,6 @@ import (
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 )
 
 var cfg = api.AutopilotConfig{
@@ -34,7 +33,7 @@ var cfg = api.AutopilotConfig{
 func TestHostScore(t *testing.T) {
 	day := 24 * time.Hour
 
-	newHost := func(s rhpv2.HostSettings) hostdb.Host {
+	newHost := func(s rhpv2.HostSettings) api.Host {
 		return newTestHost(randomHostKey(), newTestHostPriceTable(), s)
 	}
 	h1 := newHost(newTestHostSettings())

--- a/autopilot/scanner.go
+++ b/autopilot/scanner.go
@@ -11,7 +11,6 @@ import (
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/utils"
 	"go.uber.org/zap"
 )
@@ -32,7 +31,7 @@ type (
 		// scanner tests with every interface change
 		bus interface {
 			SearchHosts(ctx context.Context, opts api.SearchHostOptions) ([]api.Host, error)
-			HostsForScanning(ctx context.Context, opts api.HostsForScanningOptions) ([]hostdb.HostAddress, error)
+			HostsForScanning(ctx context.Context, opts api.HostsForScanningOptions) ([]api.HostAddress, error)
 			RemoveOfflineHosts(ctx context.Context, minRecentScanFailures uint64, maxDowntime time.Duration) (uint64, error)
 		}
 

--- a/autopilot/scanner_test.go
+++ b/autopilot/scanner_test.go
@@ -9,13 +9,12 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 type mockBus struct {
-	hosts []hostdb.Host
+	hosts []api.Host
 	reqs  []string
 }
 
@@ -32,14 +31,10 @@ func (b *mockBus) SearchHosts(ctx context.Context, opts api.SearchHostOptions) (
 		end = len(b.hosts)
 	}
 
-	hosts := make([]api.Host, len(b.hosts[start:end]))
-	for i, h := range b.hosts[start:end] {
-		hosts[i] = api.Host{Host: h}
-	}
-	return hosts, nil
+	return b.hosts[start:end], nil
 }
 
-func (b *mockBus) HostsForScanning(ctx context.Context, opts api.HostsForScanningOptions) ([]hostdb.HostAddress, error) {
+func (b *mockBus) HostsForScanning(ctx context.Context, opts api.HostsForScanningOptions) ([]api.HostAddress, error) {
 	hosts, err := b.SearchHosts(ctx, api.SearchHostOptions{
 		Offset: opts.Offset,
 		Limit:  opts.Limit,
@@ -47,9 +42,9 @@ func (b *mockBus) HostsForScanning(ctx context.Context, opts api.HostsForScannin
 	if err != nil {
 		return nil, err
 	}
-	var hostAddresses []hostdb.HostAddress
+	var hostAddresses []api.HostAddress
 	for _, h := range hosts {
-		hostAddresses = append(hostAddresses, hostdb.HostAddress{
+		hostAddresses = append(hostAddresses, api.HostAddress{
 			NetAddress: h.NetAddress,
 			PublicKey:  h.PublicKey,
 		})
@@ -80,8 +75,8 @@ func (w *mockWorker) RHPScan(ctx context.Context, hostKey types.PublicKey, hostI
 	return api.RHPScanResponse{}, nil
 }
 
-func (w *mockWorker) RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string) (hostdb.HostPriceTable, error) {
-	return hostdb.HostPriceTable{}, nil
+func (w *mockWorker) RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string) (api.HostPriceTable, error) {
+	return api.HostPriceTable{}, nil
 }
 
 func TestScanner(t *testing.T) {

--- a/autopilot/workerpool.go
+++ b/autopilot/workerpool.go
@@ -9,7 +9,6 @@ import (
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/object"
 	"lukechampine.com/frand"
 )
@@ -23,7 +22,7 @@ type Worker interface {
 	RHPBroadcast(ctx context.Context, fcid types.FileContractID) (err error)
 	RHPForm(ctx context.Context, endHeight uint64, hk types.PublicKey, hostIP string, renterAddress types.Address, renterFunds types.Currency, hostCollateral types.Currency) (rhpv2.ContractRevision, []types.Transaction, error)
 	RHPFund(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, hostIP, siamuxAddr string, balance types.Currency) (err error)
-	RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (hostdb.HostPriceTable, error)
+	RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (api.HostPriceTable, error)
 	RHPPruneContract(ctx context.Context, fcid types.FileContractID, timeout time.Duration) (pruned, remaining uint64, err error)
 	RHPRenew(ctx context.Context, fcid types.FileContractID, endHeight uint64, hk types.PublicKey, hostIP string, hostAddress, renterAddress types.Address, renterFunds, minNewCollateral types.Currency, expectedStorage, windowSize uint64) (api.RHPRenewResponse, error)
 	RHPScan(ctx context.Context, hostKey types.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -23,7 +23,6 @@ import (
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/build"
 	"go.sia.tech/renterd/bus/client"
-	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/object"
 	"go.sia.tech/renterd/wallet"
 	"go.sia.tech/renterd/webhooks"
@@ -94,9 +93,9 @@ type (
 		Host(ctx context.Context, hostKey types.PublicKey) (api.Host, error)
 		HostAllowlist(ctx context.Context) ([]types.PublicKey, error)
 		HostBlocklist(ctx context.Context) ([]string, error)
-		HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) ([]hostdb.HostAddress, error)
-		RecordHostScans(ctx context.Context, scans []hostdb.HostScan) error
-		RecordPriceTables(ctx context.Context, priceTableUpdate []hostdb.PriceTableUpdate) error
+		HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) ([]api.HostAddress, error)
+		RecordHostScans(ctx context.Context, scans []api.HostScan) error
+		RecordPriceTables(ctx context.Context, priceTableUpdate []api.HostPriceTableUpdate) error
 		RemoveOfflineHosts(ctx context.Context, minRecentScanFailures uint64, maxDowntime time.Duration) (uint64, error)
 		ResetLostSectors(ctx context.Context, hk types.PublicKey) error
 		SearchHosts(ctx context.Context, autopilotID, filterMode, usabilityMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]api.Host, error)

--- a/bus/client/hosts.go
+++ b/bus/client/hosts.go
@@ -8,7 +8,6 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 )
 
 // Host returns information about a particular host known to the server.
@@ -39,7 +38,7 @@ func (c *Client) Hosts(ctx context.Context, opts api.GetHostsOptions) (hosts []a
 
 // HostsForScanning returns 'limit' host addresses at given 'offset' which
 // haven't been scanned after lastScan.
-func (c *Client) HostsForScanning(ctx context.Context, opts api.HostsForScanningOptions) (hosts []hostdb.HostAddress, err error) {
+func (c *Client) HostsForScanning(ctx context.Context, opts api.HostsForScanningOptions) (hosts []api.HostAddress, err error) {
 	values := url.Values{}
 	opts.Apply(values)
 	err = c.c.WithContext(ctx).GET("/hosts/scanning?"+values.Encode(), &hosts)
@@ -47,7 +46,7 @@ func (c *Client) HostsForScanning(ctx context.Context, opts api.HostsForScanning
 }
 
 // RecordHostInteraction records an interaction for the supplied host.
-func (c *Client) RecordHostScans(ctx context.Context, scans []hostdb.HostScan) (err error) {
+func (c *Client) RecordHostScans(ctx context.Context, scans []api.HostScan) (err error) {
 	err = c.c.WithContext(ctx).POST("/hosts/scans", api.HostsScanRequest{
 		Scans: scans,
 	}, nil)
@@ -55,7 +54,7 @@ func (c *Client) RecordHostScans(ctx context.Context, scans []hostdb.HostScan) (
 }
 
 // RecordHostInteraction records an interaction for the supplied host.
-func (c *Client) RecordPriceTables(ctx context.Context, priceTableUpdates []hostdb.PriceTableUpdate) (err error) {
+func (c *Client) RecordPriceTables(ctx context.Context, priceTableUpdates []api.HostPriceTableUpdate) (err error) {
 	err = c.c.WithContext(ctx).POST("/hosts/pricetables", api.HostsPriceTablesRequest{
 		PriceTableUpdates: priceTableUpdates,
 	}, nil)

--- a/hostdb/hostdb.go
+++ b/hostdb/hostdb.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"gitlab.com/NebulousLabs/encoding"
-	rhpv2 "go.sia.tech/core/rhp/v2"
-	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/siad/crypto"
 	"go.sia.tech/siad/modules"
@@ -58,73 +56,4 @@ func ForEachAnnouncement(b types.Block, height uint64, fn func(types.PublicKey, 
 			})
 		}
 	}
-}
-
-// Interactions contains metadata about a host's interactions.
-type Interactions struct {
-	TotalScans              uint64        `json:"totalScans"`
-	LastScan                time.Time     `json:"lastScan"`
-	LastScanSuccess         bool          `json:"lastScanSuccess"`
-	LostSectors             uint64        `json:"lostSectors"`
-	SecondToLastScanSuccess bool          `json:"secondToLastScanSuccess"`
-	Uptime                  time.Duration `json:"uptime"`
-	Downtime                time.Duration `json:"downtime"`
-
-	SuccessfulInteractions float64 `json:"successfulInteractions"`
-	FailedInteractions     float64 `json:"failedInteractions"`
-}
-
-type HostScan struct {
-	HostKey    types.PublicKey `json:"hostKey"`
-	Success    bool
-	Timestamp  time.Time
-	Settings   rhpv2.HostSettings
-	PriceTable rhpv3.HostPriceTable
-}
-
-type PriceTableUpdate struct {
-	HostKey    types.PublicKey `json:"hostKey"`
-	Success    bool
-	Timestamp  time.Time
-	PriceTable HostPriceTable
-}
-
-// HostAddress contains the address of a specific host identified by a public
-// key.
-type HostAddress struct {
-	PublicKey  types.PublicKey `json:"publicKey"`
-	NetAddress string          `json:"netAddress"`
-}
-
-// A Host pairs a host's public key with a set of interactions.
-type Host struct {
-	KnownSince       time.Time          `json:"knownSince"`
-	LastAnnouncement time.Time          `json:"lastAnnouncement"`
-	PublicKey        types.PublicKey    `json:"publicKey"`
-	NetAddress       string             `json:"netAddress"`
-	PriceTable       HostPriceTable     `json:"priceTable"`
-	Settings         rhpv2.HostSettings `json:"settings"`
-	Interactions     Interactions       `json:"interactions"`
-	Scanned          bool               `json:"scanned"`
-}
-
-// A HostPriceTable extends the host price table with its expiry.
-type HostPriceTable struct {
-	rhpv3.HostPriceTable
-	Expiry time.Time `json:"expiry"`
-}
-
-// IsAnnounced returns whether the host has been announced.
-func (h Host) IsAnnounced() bool {
-	return !h.LastAnnouncement.IsZero()
-}
-
-// IsOnline returns whether a host is considered online.
-func (h Host) IsOnline() bool {
-	if h.Interactions.TotalScans == 0 {
-		return false
-	} else if h.Interactions.TotalScans == 1 {
-		return h.Interactions.LastScanSuccess
-	}
-	return h.Interactions.LastScanSuccess || h.Interactions.SecondToLastScanSuccess
 }

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -23,7 +23,6 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/test"
 	"go.sia.tech/renterd/object"
 	"go.sia.tech/renterd/wallet"
@@ -166,7 +165,7 @@ func TestNewTestCluster(t *testing.T) {
 		if len(hi.Checks.UnusableReasons) != 0 {
 			t.Fatal("usable hosts don't have any reasons set")
 		}
-		if reflect.DeepEqual(hi.Host, hostdb.Host{}) {
+		if reflect.DeepEqual(hi.Host, api.Host{}) {
 			t.Fatal("host wasn't set")
 		}
 	}
@@ -188,7 +187,7 @@ func TestNewTestCluster(t *testing.T) {
 		if len(hi.Checks.UnusableReasons) != 0 {
 			t.Fatal("usable hosts don't have any reasons set")
 		}
-		if reflect.DeepEqual(hi.Host, hostdb.Host{}) {
+		if reflect.DeepEqual(hi.Host, api.Host{}) {
 			t.Fatal("host wasn't set")
 		}
 		allHosts[hi.Host.PublicKey] = struct{}{}

--- a/internal/test/e2e/pruning_test.go
+++ b/internal/test/e2e/pruning_test.go
@@ -11,7 +11,6 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/test"
 )
 
@@ -32,10 +31,10 @@ func TestHostPruning(t *testing.T) {
 	now := time.Now()
 	recordFailedInteractions := func(n int, hk types.PublicKey) {
 		t.Helper()
-		his := make([]hostdb.HostScan, n)
+		his := make([]api.HostScan, n)
 		for i := 0; i < n; i++ {
 			now = now.Add(time.Hour).Add(time.Minute) // 1m leeway
-			his[i] = hostdb.HostScan{
+			his[i] = api.HostScan{
 				HostKey:   hk,
 				Timestamp: now,
 				Success:   false,

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -41,7 +41,7 @@ var (
 )
 
 type (
-	// dbHost defines a hostdb.Interaction as persisted in the DB. Deleting a
+	// dbHost defines a api.Interaction as persisted in the DB. Deleting a
 	// host from the db will cascade the deletion and also delete the
 	// corresponding announcements and interactions with that host.
 	//
@@ -322,31 +322,29 @@ func (h dbHost) convert(blocked bool) api.Host {
 		checks[check.DBAutopilot.Identifier] = check.convert()
 	}
 	return api.Host{
-		Host: hostdb.Host{
-			KnownSince:       h.CreatedAt,
-			LastAnnouncement: h.LastAnnouncement,
-			NetAddress:       h.NetAddress,
-			Interactions: hostdb.Interactions{
-				TotalScans:              h.TotalScans,
-				LastScan:                lastScan,
-				LastScanSuccess:         h.LastScanSuccess,
-				SecondToLastScanSuccess: h.SecondToLastScanSuccess,
-				Uptime:                  h.Uptime,
-				Downtime:                h.Downtime,
-				SuccessfulInteractions:  h.SuccessfulInteractions,
-				FailedInteractions:      h.FailedInteractions,
-				LostSectors:             h.LostSectors,
-			},
-			PriceTable: hostdb.HostPriceTable{
-				HostPriceTable: h.PriceTable.convert(),
-				Expiry:         h.PriceTableExpiry.Time,
-			},
-			PublicKey: types.PublicKey(h.PublicKey),
-			Scanned:   h.Scanned,
-			Settings:  h.Settings.convert(),
+		KnownSince:       h.CreatedAt,
+		LastAnnouncement: h.LastAnnouncement,
+		NetAddress:       h.NetAddress,
+		Interactions: api.HostInteractions{
+			TotalScans:              h.TotalScans,
+			LastScan:                lastScan,
+			LastScanSuccess:         h.LastScanSuccess,
+			SecondToLastScanSuccess: h.SecondToLastScanSuccess,
+			Uptime:                  h.Uptime,
+			Downtime:                h.Downtime,
+			SuccessfulInteractions:  h.SuccessfulInteractions,
+			FailedInteractions:      h.FailedInteractions,
+			LostSectors:             h.LostSectors,
 		},
-		Blocked: blocked,
-		Checks:  checks,
+		PriceTable: api.HostPriceTable{
+			HostPriceTable: h.PriceTable.convert(),
+			Expiry:         h.PriceTableExpiry.Time,
+		},
+		PublicKey: types.PublicKey(h.PublicKey),
+		Scanned:   h.Scanned,
+		Settings:  h.Settings.convert(),
+		Blocked:   blocked,
+		Checks:    checks,
 	}
 }
 
@@ -571,7 +569,7 @@ func (ss *SQLStore) UpdateHostCheck(ctx context.Context, autopilotID string, hk 
 }
 
 // HostsForScanning returns the address of hosts for scanning.
-func (ss *SQLStore) HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) ([]hostdb.HostAddress, error) {
+func (ss *SQLStore) HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) ([]api.HostAddress, error) {
 	if offset < 0 {
 		return nil, ErrNegativeOffset
 	}
@@ -580,7 +578,7 @@ func (ss *SQLStore) HostsForScanning(ctx context.Context, maxLastScan time.Time,
 		PublicKey  publicKey `gorm:"unique;index;NOT NULL"`
 		NetAddress string
 	}
-	var hostAddresses []hostdb.HostAddress
+	var hostAddresses []api.HostAddress
 
 	err := ss.db.
 		WithContext(ctx).
@@ -591,7 +589,7 @@ func (ss *SQLStore) HostsForScanning(ctx context.Context, maxLastScan time.Time,
 		Order("last_scan ASC").
 		FindInBatches(&hosts, hostRetrievalBatchSize, func(tx *gorm.DB, batch int) error {
 			for _, h := range hosts {
-				hostAddresses = append(hostAddresses, hostdb.HostAddress{
+				hostAddresses = append(hostAddresses, api.HostAddress{
 					PublicKey:  types.PublicKey(h.PublicKey),
 					NetAddress: h.NetAddress,
 				})
@@ -844,7 +842,7 @@ func (ss *SQLStore) HostBlocklist(ctx context.Context) (blocklist []string, err 
 	return
 }
 
-func (ss *SQLStore) RecordHostScans(ctx context.Context, scans []hostdb.HostScan) error {
+func (ss *SQLStore) RecordHostScans(ctx context.Context, scans []api.HostScan) error {
 	if len(scans) == 0 {
 		return nil // nothing to do
 	}
@@ -965,7 +963,7 @@ func (ss *SQLStore) RecordHostScans(ctx context.Context, scans []hostdb.HostScan
 	})
 }
 
-func (ss *SQLStore) RecordPriceTables(ctx context.Context, priceTableUpdate []hostdb.PriceTableUpdate) error {
+func (ss *SQLStore) RecordPriceTables(ctx context.Context, priceTableUpdate []api.HostPriceTableUpdate) error {
 	if len(priceTableUpdate) == 0 {
 		return nil // nothing to do
 	}

--- a/stores/hostdb_test.go
+++ b/stores/hostdb_test.go
@@ -422,7 +422,7 @@ func TestSearchHosts(t *testing.T) {
 		t.Fatal(err)
 	} else if len(his) != 1 {
 		t.Fatal("unexpected", len(his))
-	} else if his[0].Host.PublicKey != hk2 {
+	} else if his[0].PublicKey != hk2 {
 		t.Fatal("unexpected")
 	}
 

--- a/worker/client/rhp.go
+++ b/worker/client/rhp.go
@@ -8,7 +8,6 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 )
@@ -53,7 +52,7 @@ func (c *Client) RHPFund(ctx context.Context, contractID types.FileContractID, h
 }
 
 // RHPPriceTable fetches a price table for a host.
-func (c *Client) RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (pt hostdb.HostPriceTable, err error) {
+func (c *Client) RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (pt api.HostPriceTable, err error) {
 	req := api.RHPPriceTableRequest{
 		HostKey:    hostKey,
 		SiamuxAddr: siamuxAddr,

--- a/worker/host.go
+++ b/worker/host.go
@@ -12,7 +12,6 @@ import (
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 	"go.uber.org/zap"
 )
 
@@ -23,7 +22,7 @@ type (
 		DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint32, overpay bool) error
 		UploadSector(ctx context.Context, sectorRoot types.Hash256, sector *[rhpv2.SectorSize]byte, rev types.FileContractRevision) error
 
-		FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error)
+		FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (hpt api.HostPriceTable, err error)
 		FetchRevision(ctx context.Context, fetchTimeout time.Duration) (types.FileContractRevision, error)
 
 		FundAccount(ctx context.Context, balance types.Currency, rev *types.FileContractRevision) error
@@ -187,12 +186,12 @@ func (h *host) RenewContract(ctx context.Context, rrr api.RHPRenewRequest) (_ rh
 	return rev, txnSet, contractPrice, renewErr
 }
 
-func (h *host) FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error) {
+func (h *host) FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (hpt api.HostPriceTable, err error) {
 	// fetchPT is a helper function that performs the RPC given a payment function
-	fetchPT := func(paymentFn PriceTablePaymentFunc) (hpt hostdb.HostPriceTable, err error) {
+	fetchPT := func(paymentFn PriceTablePaymentFunc) (hpt api.HostPriceTable, err error) {
 		err = h.transportPool.withTransportV3(ctx, h.hk, h.siamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
 			hpt, err = RPCPriceTable(ctx, t, paymentFn)
-			h.bus.RecordPriceTables(ctx, []hostdb.PriceTableUpdate{
+			h.bus.RecordPriceTables(ctx, []api.HostPriceTableUpdate{
 				{
 					HostKey:    h.hk,
 					Success:    isSuccessfulInteraction(err),

--- a/worker/host_test.go
+++ b/worker/host_test.go
@@ -13,7 +13,6 @@ import (
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/test"
 	"lukechampine.com/frand"
 )
@@ -22,7 +21,7 @@ type (
 	testHost struct {
 		*hostMock
 		*contractMock
-		hptFn func() hostdb.HostPriceTable
+		hptFn func() api.HostPriceTable
 	}
 
 	testHostManager struct {
@@ -57,7 +56,7 @@ func newTestHost(h *hostMock, c *contractMock) *testHost {
 	return newTestHostCustom(h, c, newTestHostPriceTable)
 }
 
-func newTestHostCustom(h *hostMock, c *contractMock, hptFn func() hostdb.HostPriceTable) *testHost {
+func newTestHostCustom(h *hostMock, c *contractMock, hptFn func() api.HostPriceTable) *testHost {
 	return &testHost{
 		hostMock:     h,
 		contractMock: c,
@@ -65,11 +64,11 @@ func newTestHostCustom(h *hostMock, c *contractMock, hptFn func() hostdb.HostPri
 	}
 }
 
-func newTestHostPriceTable() hostdb.HostPriceTable {
+func newTestHostPriceTable() api.HostPriceTable {
 	var uid rhpv3.SettingsID
 	frand.Read(uid[:])
 
-	return hostdb.HostPriceTable{
+	return api.HostPriceTable{
 		HostPriceTable: rhpv3.HostPriceTable{UID: uid, HostBlockHeight: 100, Validity: time.Minute},
 		Expiry:         time.Now().Add(time.Minute),
 	}
@@ -103,7 +102,7 @@ func (h *testHost) FetchRevision(ctx context.Context, fetchTimeout time.Duration
 	return rev, nil
 }
 
-func (h *testHost) FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (hostdb.HostPriceTable, error) {
+func (h *testHost) FetchPriceTable(ctx context.Context, rev *types.FileContractRevision) (api.HostPriceTable, error) {
 	return h.hptFn(), nil
 }
 

--- a/worker/interactions.go
+++ b/worker/interactions.go
@@ -1,13 +1,13 @@
 package worker
 
 import (
-	"go.sia.tech/renterd/hostdb"
+	"go.sia.tech/renterd/api"
 )
 
 type (
 	HostInteractionRecorder interface {
-		RecordHostScan(...hostdb.HostScan)
-		RecordPriceTableUpdate(...hostdb.PriceTableUpdate)
+		RecordHostScan(...api.HostScan)
+		RecordPriceTableUpdate(...api.HostPriceTableUpdate)
 	}
 )
 

--- a/worker/mocks_test.go
+++ b/worker/mocks_test.go
@@ -15,7 +15,6 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/object"
 	"go.sia.tech/renterd/webhooks"
 )
@@ -267,10 +266,8 @@ func newHostMock(hk types.PublicKey) *hostMock {
 	return &hostMock{
 		hk: hk,
 		hi: api.Host{
-			Host: hostdb.Host{
-				PublicKey: hk,
-				Scanned:   true,
-			},
+			PublicKey: hk,
+			Scanned:   true,
 		},
 	}
 }
@@ -298,11 +295,11 @@ func (hs *hostStoreMock) Host(ctx context.Context, hostKey types.PublicKey) (api
 	return h.hi, nil
 }
 
-func (hs *hostStoreMock) RecordHostScans(ctx context.Context, scans []hostdb.HostScan) error {
+func (hs *hostStoreMock) RecordHostScans(ctx context.Context, scans []api.HostScan) error {
 	return nil
 }
 
-func (hs *hostStoreMock) RecordPriceTables(ctx context.Context, priceTableUpdate []hostdb.PriceTableUpdate) error {
+func (hs *hostStoreMock) RecordPriceTables(ctx context.Context, priceTableUpdate []api.HostPriceTableUpdate) error {
 	return nil
 }
 

--- a/worker/pricetables.go
+++ b/worker/pricetables.go
@@ -10,7 +10,7 @@ import (
 
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
-	"go.sia.tech/renterd/hostdb"
+	"go.sia.tech/renterd/api"
 	"lukechampine.com/frand"
 )
 
@@ -47,14 +47,14 @@ type (
 		hk types.PublicKey
 
 		mu     sync.Mutex
-		hpt    hostdb.HostPriceTable
+		hpt    api.HostPriceTable
 		update *priceTableUpdate
 	}
 
 	priceTableUpdate struct {
 		err  error
 		done chan struct{}
-		hpt  hostdb.HostPriceTable
+		hpt  api.HostPriceTable
 	}
 )
 
@@ -75,7 +75,7 @@ func newPriceTables(hm HostManager, hs HostStore) *priceTables {
 }
 
 // fetch returns a price table for the given host
-func (pts *priceTables) fetch(ctx context.Context, hk types.PublicKey, rev *types.FileContractRevision) (hostdb.HostPriceTable, error) {
+func (pts *priceTables) fetch(ctx context.Context, hk types.PublicKey, rev *types.FileContractRevision) (api.HostPriceTable, error) {
 	pts.mu.Lock()
 	pt, exists := pts.priceTables[hk]
 	if !exists {
@@ -105,7 +105,7 @@ func (pt *priceTable) ongoingUpdate() (bool, *priceTableUpdate) {
 	return ongoing, pt.update
 }
 
-func (p *priceTable) fetch(ctx context.Context, rev *types.FileContractRevision) (hpt hostdb.HostPriceTable, err error) {
+func (p *priceTable) fetch(ctx context.Context, rev *types.FileContractRevision) (hpt api.HostPriceTable, err error) {
 	// grab the current price table
 	p.mu.Lock()
 	hpt = p.hpt
@@ -115,7 +115,7 @@ func (p *priceTable) fetch(ctx context.Context, rev *types.FileContractRevision)
 	// current price table is considered to gouge on the block height
 	gc, err := GougingCheckerFromContext(ctx, false)
 	if err != nil {
-		return hostdb.HostPriceTable{}, err
+		return api.HostPriceTable{}, err
 	}
 
 	// figure out whether we should update the price table, if not we can return
@@ -137,7 +137,7 @@ func (p *priceTable) fetch(ctx context.Context, rev *types.FileContractRevision)
 	} else if ongoing {
 		select {
 		case <-ctx.Done():
-			return hostdb.HostPriceTable{}, fmt.Errorf("%w; %w", errPriceTableUpdateTimedOut, ctx.Err())
+			return api.HostPriceTable{}, fmt.Errorf("%w; %w", errPriceTableUpdateTimedOut, ctx.Err())
 		case <-update.done:
 		}
 		return update.hpt, update.err
@@ -166,14 +166,14 @@ func (p *priceTable) fetch(ctx context.Context, rev *types.FileContractRevision)
 
 	// sanity check the host has been scanned before fetching the price table
 	if !host.Scanned {
-		return hostdb.HostPriceTable{}, fmt.Errorf("host %v was not scanned", p.hk)
+		return api.HostPriceTable{}, fmt.Errorf("host %v was not scanned", p.hk)
 	}
 
 	// otherwise fetch it
 	h := p.hm.Host(p.hk, types.FileContractID{}, host.Settings.SiamuxAddr())
 	hpt, err = h.FetchPriceTable(ctx, rev)
 	if err != nil {
-		return hostdb.HostPriceTable{}, fmt.Errorf("failed to update pricetable, err %v", err)
+		return api.HostPriceTable{}, fmt.Errorf("failed to update pricetable, err %v", err)
 	}
 
 	return

--- a/worker/pricetables_test.go
+++ b/worker/pricetables_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/hostdb"
 )
 
 func TestPriceTables(t *testing.T) {
@@ -45,7 +44,7 @@ func TestPriceTables(t *testing.T) {
 	// manage the host, make sure fetching the price table blocks
 	fetchPTBlockChan := make(chan struct{})
 	validPT := newTestHostPriceTable()
-	hm.addHost(newTestHostCustom(h, c, func() hostdb.HostPriceTable {
+	hm.addHost(newTestHostCustom(h, c, func() api.HostPriceTable {
 		<-fetchPTBlockChan
 		return validPT
 	}))

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -24,7 +24,6 @@ import (
 	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/build"
-	"go.sia.tech/renterd/hostdb"
 	"go.sia.tech/renterd/internal/utils"
 	"go.sia.tech/renterd/object"
 	"go.sia.tech/renterd/webhooks"
@@ -106,8 +105,8 @@ type (
 	}
 
 	HostStore interface {
-		RecordHostScans(ctx context.Context, scans []hostdb.HostScan) error
-		RecordPriceTables(ctx context.Context, priceTableUpdate []hostdb.PriceTableUpdate) error
+		RecordHostScans(ctx context.Context, scans []api.HostScan) error
+		RecordPriceTables(ctx context.Context, priceTableUpdate []api.HostPriceTableUpdate) error
 		RecordContractSpending(ctx context.Context, records []api.ContractSpendingRecord) error
 
 		Host(ctx context.Context, hostKey types.PublicKey) (api.Host, error)
@@ -355,9 +354,9 @@ func (w *worker) rhpPriceTableHandler(jc jape.Context) {
 
 	// defer interaction recording
 	var err error
-	var hpt hostdb.HostPriceTable
+	var hpt api.HostPriceTable
 	defer func() {
-		w.bus.RecordPriceTables(ctx, []hostdb.PriceTableUpdate{
+		w.bus.RecordPriceTables(ctx, []api.HostPriceTableUpdate{
 			{
 				HostKey:    rptr.HostKey,
 				Success:    isSuccessfulInteraction(err),
@@ -1524,7 +1523,7 @@ func (w *worker) scanHost(ctx context.Context, timeout time.Duration, hostKey ty
 	// record scans that timed out.
 	recordCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	scanErr := w.bus.RecordHostScans(recordCtx, []hostdb.HostScan{
+	scanErr := w.bus.RecordHostScans(recordCtx, []api.HostScan{
 		{
 			HostKey:    hostKey,
 			Success:    isSuccessfulInteraction(err),


### PR DESCRIPTION
We currently have two `Host` types. One in the `hostdb` package and one in the `api` package. Merging these removes unnecessary nesting and cleans up our API interfaces since we should exclusively return types from the `api` package. The `hostdb` package is now left with announcements stuff, which will be removed by `its-happening` after which we can remove the `hostdb` package entirely.