### PR TITLE
Fix "transaction spends nonexisting siacoin output" when refreshing contracts

### DIFF
--- a/internal/node/transactionpool.go
+++ b/internal/node/transactionpool.go
@@ -41,7 +41,18 @@ func (tp txpool) AcceptTransactionSet(txns []types.Transaction) error {
 }
 
 func (tp txpool) UnconfirmedParents(txn types.Transaction) ([]types.Transaction, error) {
-	pool := tp.Transactions()
+	return unconfirmedParents(txn, tp.Transactions()), nil
+}
+
+func (tp txpool) Subscribe(subscriber modules.TransactionPoolSubscriber) {
+	tp.tp.TransactionPoolSubscribe(subscriber)
+}
+
+func (tp txpool) Close() error {
+	return tp.tp.Close()
+}
+
+func unconfirmedParents(txn types.Transaction, pool []types.Transaction) []types.Transaction {
 	outputToParent := make(map[types.SiacoinOutputID]*types.Transaction)
 	for i, txn := range pool {
 		for j := range txn.SiacoinOutputs {
@@ -58,15 +69,7 @@ func (tp txpool) UnconfirmedParents(txn types.Transaction) ([]types.Transaction,
 			}
 		}
 	}
-	return parents, nil
-}
-
-func (tp txpool) Subscribe(subscriber modules.TransactionPoolSubscriber) {
-	tp.tp.TransactionPoolSubscribe(subscriber)
-}
-
-func (tp txpool) Close() error {
-	return tp.tp.Close()
+	return parents
 }
 
 func NewTransactionPool(tp modules.TransactionPool) bus.TransactionPool {

--- a/internal/node/transactionpool_test.go
+++ b/internal/node/transactionpool_test.go
@@ -1,0 +1,40 @@
+package node
+
+import (
+	"reflect"
+	"testing"
+
+	"go.sia.tech/core/types"
+)
+
+func TestUnconfirmedParents(t *testing.T) {
+	grandparent := types.Transaction{
+		SiacoinOutputs: []types.SiacoinOutput{{}},
+	}
+	parent := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{
+			{
+				ParentID: grandparent.SiacoinOutputID(0),
+			},
+		},
+		SiacoinOutputs: []types.SiacoinOutput{{}},
+	}
+	txn := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{
+			{
+				ParentID: parent.SiacoinOutputID(0),
+			},
+		},
+		SiacoinOutputs: []types.SiacoinOutput{{}},
+	}
+	pool := []types.Transaction{grandparent, parent}
+
+	parents := unconfirmedParents(txn, pool)
+	if len(parents) != 2 {
+		t.Fatalf("expected 2 parents, got %v", len(parents))
+	} else if !reflect.DeepEqual(parents[0], grandparent) {
+		t.Fatalf("expected grandparent")
+	} else if !reflect.DeepEqual(parents[1], parent) {
+		t.Fatalf("expected parent")
+	}
+}


### PR DESCRIPTION
`UnconfirmedParents` would only ever return direct parents for a txn but not grandparents and so on. Leading to hosts not knowing about certain parents yet and txns failing.