### PR TITLE
Batch pruning of slabs after deleting objects from the database

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -2727,7 +2727,7 @@ func (s *SQLStore) pruneSlabsLoop() {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second+sumDurations(s.retryTransactionIntervals))
 		err := s.retryTransaction(ctx, pruneSlabs)
 		if err != nil {
 			s.logger.Errorw("failed to prune slabs", zap.Error(err))

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -4097,24 +4097,29 @@ func TestSlabCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	time.Sleep(100 * time.Millisecond)
 
 	// check slice count
 	var slabCntr int64
-	if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
-		t.Fatal(err)
-	} else if slabCntr != 1 {
-		t.Fatalf("expected 1 slabs, got %v", slabCntr)
-	}
+	ss.Retry(100, 100*time.Millisecond, func() error {
+		if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
+			return err
+		} else if slabCntr != 1 {
+			return fmt.Errorf("expected 1 slabs, got %v", slabCntr)
+		}
+		return nil
+	})
 
 	// delete second object
 	err = ss.RemoveObject(context.Background(), api.DefaultBucketName, obj2.ObjectID)
 	if err != nil {
 		t.Fatal(err)
 	}
+	time.Sleep(100 * time.Millisecond)
 
 	ss.Retry(100, 100*time.Millisecond, func() error {
 		if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
-			t.Fatal(err)
+			return err
 		} else if slabCntr != 0 {
 			return fmt.Errorf("expected 0 slabs, got %v", slabCntr)
 		}
@@ -4159,11 +4164,16 @@ func TestSlabCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
-		t.Fatal(err)
-	} else if slabCntr != 1 {
-		t.Fatalf("expected 1 slabs, got %v", slabCntr)
-	}
+	time.Sleep(100 * time.Millisecond)
+
+	ss.Retry(100, 100*time.Millisecond, func() error {
+		if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
+			return err
+		} else if slabCntr != 1 {
+			return fmt.Errorf("expected 1 slabs, got %v", slabCntr)
+		}
+		return nil
+	})
 }
 
 func TestUpsertSectors(t *testing.T) {

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1058,9 +1058,9 @@ func TestSQLMetadataStore(t *testing.T) {
 	// incremented due to the object and slab being overwritten.
 	two := uint(2)
 	expectedObj.Slabs[0].DBObjectID = &two
-	expectedObj.Slabs[0].DBSlabID = 3
+	expectedObj.Slabs[0].DBSlabID = 1
 	expectedObj.Slabs[1].DBObjectID = &two
-	expectedObj.Slabs[1].DBSlabID = 4
+	expectedObj.Slabs[1].DBSlabID = 2
 	if !reflect.DeepEqual(obj, expectedObj) {
 		t.Fatal("object mismatch", cmp.Diff(obj, expectedObj))
 	}
@@ -1082,7 +1082,7 @@ func TestSQLMetadataStore(t *testing.T) {
 		TotalShards:     1,
 		Shards: []dbSector{
 			{
-				DBSlabID:   3,
+				DBSlabID:   1,
 				SlabIndex:  1,
 				Root:       obj1.Slabs[0].Shards[0].Root[:],
 				LatestHost: publicKey(obj1.Slabs[0].Shards[0].LatestHost),
@@ -1122,7 +1122,7 @@ func TestSQLMetadataStore(t *testing.T) {
 		TotalShards:     1,
 		Shards: []dbSector{
 			{
-				DBSlabID:   4,
+				DBSlabID:   2,
 				SlabIndex:  1,
 				Root:       obj1.Slabs[1].Shards[0].Root[:],
 				LatestHost: publicKey(obj1.Slabs[1].Shards[0].LatestHost),
@@ -4028,7 +4028,7 @@ func TestRefreshHealth(t *testing.T) {
 	}
 }
 
-func TestSlabCleanupTrigger(t *testing.T) {
+func TestSlabCleanup(t *testing.T) {
 	ss := newTestSQLStore(t, defaultTestSQLStoreConfig)
 	defer ss.Close()
 
@@ -4112,11 +4112,14 @@ func TestSlabCleanupTrigger(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
-		t.Fatal(err)
-	} else if slabCntr != 0 {
-		t.Fatalf("expected 0 slabs, got %v", slabCntr)
-	}
+	ss.Retry(100, 100*time.Millisecond, func() error {
+		if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
+			t.Fatal(err)
+		} else if slabCntr != 0 {
+			return fmt.Errorf("expected 0 slabs, got %v", slabCntr)
+		}
+		return nil
+	})
 
 	// create another object that references a slab with buffer
 	ek, _ = object.GenerateEncryptionKey().MarshalBinary()

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -4097,7 +4097,6 @@ func TestSlabCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(100 * time.Millisecond)
 
 	// check slice count
 	var slabCntr int64
@@ -4115,7 +4114,6 @@ func TestSlabCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(100 * time.Millisecond)
 
 	ss.Retry(100, 100*time.Millisecond, func() error {
 		if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
@@ -4164,7 +4162,6 @@ func TestSlabCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(100 * time.Millisecond)
 
 	ss.Retry(100, 100*time.Millisecond, func() error {
 		if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -305,10 +305,8 @@ func (s *SQLStore) AbortMultipartUpload(ctx context.Context, bucket, path string
 			}
 			return errors.New("failed to delete multipart upload for unknown reason")
 		}
-		// Prune the slabs.
-		if err := pruneSlabs(tx); err != nil {
-			return fmt.Errorf("failed to prune slabs: %w", err)
-		}
+		// Prune the dangling slabs.
+		s.pruneSlabs()
 		return nil
 	})
 }
@@ -459,9 +457,7 @@ func (s *SQLStore) CompleteMultipartUpload(ctx context.Context, bucket, path str
 		}
 
 		// Prune the slabs.
-		if err := pruneSlabs(tx); err != nil {
-			return fmt.Errorf("failed to prune slabs: %w", err)
-		}
+		s.pruneSlabs()
 		return nil
 	})
 	if err != nil {

--- a/stores/multipart.go
+++ b/stores/multipart.go
@@ -306,7 +306,7 @@ func (s *SQLStore) AbortMultipartUpload(ctx context.Context, bucket, path string
 			return errors.New("failed to delete multipart upload for unknown reason")
 		}
 		// Prune the dangling slabs.
-		s.pruneSlabs()
+		s.triggerSlabPruning()
 		return nil
 	})
 }
@@ -457,7 +457,7 @@ func (s *SQLStore) CompleteMultipartUpload(ctx context.Context, bucket, path str
 		}
 
 		// Prune the slabs.
-		s.pruneSlabs()
+		s.triggerSlabPruning()
 		return nil
 	})
 	if err != nil {

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -285,6 +285,7 @@ func NewSQLStore(cfg Config) (*SQLStore, modules.ConsensusChangeID, error) {
 	if err != nil {
 		return nil, modules.ConsensusChangeID{}, err
 	}
+	ss.initSlabPruning()
 	return ss, ccid, nil
 }
 
@@ -303,6 +304,15 @@ func (ss *SQLStore) hasAllowlist() bool {
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 	return ss.allowListCnt > 0
+}
+
+func (s *SQLStore) initSlabPruning() {
+	s.wg.Add(1)
+	go func() {
+		s.pruneSlabsLoop()
+		s.wg.Done()
+	}()
+	s.pruneSlabs()
 }
 
 func (ss *SQLStore) updateHasAllowlist(err *error) {

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -250,8 +250,6 @@ func NewSQLStore(cfg Config) (*SQLStore, modules.ConsensusChangeID, error) {
 	}
 
 	shutdownCtx, shutdownCtxCancel := context.WithCancel(context.Background())
-	slabPruneOngoing := make(chan struct{})
-	close(slabPruneOngoing)
 	ss := &SQLStore{
 		alerts:                 cfg.Alerts,
 		db:                     db,
@@ -621,4 +619,12 @@ func (s *SQLStore) ResetConsensusSubscription(ctx context.Context) error {
 	}
 	s.persistMu.Unlock()
 	return nil
+}
+
+func sumDurations(durations []time.Duration) time.Duration {
+	var sum time.Duration
+	for _, d := range durations {
+		sum += d
+	}
+	return sum
 }


### PR DESCRIPTION
This speeds up deletions and avoids redundant deletions in scenarios where files get deleted rapidly. e.g. when running `rclone sync` which might replace lots of files one-by-one.

It also puts the pruning of slabs into a background goroutine. There is no reason for an object deletion to fail when pruning slabs fails. This might lead to brief inconsistencies on the object stats endpoint but will greatly improve the speed at which we can delete objects and also reduce the database locking necessary when pruning slabs.

Closes https://github.com/SiaFoundation/renterd/issues/1149