### PR TITLE
ci: remove polling for repo dispatch

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,9 +1,8 @@
 name: Update UI and open PR
 
 on:
-  # Run daily
-  schedule:
-    - cron: '0 0 * * *'
+  repository_dispatch:
+    types: [update-ui]
   # Enable manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
- When the UI action that builds Go modules completes it will call a repo dispatch