### PR TITLE
Move threadedUploadPackedSlabs out of bufferSizeLimitReached

### DIFF
--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -19,6 +19,7 @@ import (
 	"go.sia.tech/jape"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/autopilot"
+	"go.sia.tech/renterd/build"
 	"go.sia.tech/renterd/bus"
 	"go.sia.tech/renterd/config"
 	"go.sia.tech/renterd/internal/node"
@@ -421,7 +422,10 @@ func newTestCluster(t *testing.T, opts testClusterOptions) *TestCluster {
 	tt.OK(busClient.UpdateSetting(ctx, api.SettingS3Authentication, api.S3AuthenticationSettings{
 		V4Keypairs: map[string]string{test.S3AccessKeyID: test.S3SecretAccessKey},
 	}))
-	tt.OK(busClient.UpdateSetting(ctx, api.SettingUploadPacking, api.UploadPackingSettings{Enabled: enableUploadPacking}))
+	tt.OK(busClient.UpdateSetting(ctx, api.SettingUploadPacking, api.UploadPackingSettings{
+		Enabled:               enableUploadPacking,
+		SlabBufferMaxSizeSoft: build.DefaultUploadPackingSettings.SlabBufferMaxSizeSoft,
+	}))
 
 	// Fund the bus.
 	if funding {

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -202,10 +202,10 @@ func (w *worker) upload(ctx context.Context, r io.Reader, contracts []api.Contra
 				}
 			}
 		}
-
-		// make sure there's a goroutine uploading the remainder of the packed slabs
-		go w.threadedUploadPackedSlabs(up.rs, up.contractSet, lockingPriorityBackgroundUpload)
 	}
+
+	// make sure there's a goroutine uploading any packed slabs
+	go w.threadedUploadPackedSlabs(up.rs, up.contractSet, lockingPriorityBackgroundUpload)
 
 	return eTag, nil
 }


### PR DESCRIPTION
@freopen noticed that partial slabs weren't uploading before the limit was reached anymore and [debugged it](https://github.com/SiaFoundation/renterd/commit/716091ba82e81dfe74449e926b2386fd445d2128#r140736503)

That's a very good catch thanks for reporting! This PR should take care of the issue.