### PR TITLE
Apply production defaults for database logger in testing too

### DIFF
--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -32,6 +32,8 @@ import (
 	"lukechampine.com/frand"
 
 	"go.sia.tech/renterd/worker"
+	gormlogger "gorm.io/gorm/logger"
+	"moul.io/zapgorm2"
 )
 
 const (
@@ -238,6 +240,18 @@ func newTestCluster(t *testing.T, opts testClusterOptions) *TestCluster {
 	apSettings := test.AutopilotConfig
 	if opts.autopilotSettings != nil {
 		apSettings = *opts.autopilotSettings
+	}
+
+	// default database logger
+	if busCfg.DBLogger == nil {
+		busCfg.DBLogger = zapgorm2.Logger{
+			ZapLogger:                 logger.Named("SQL"),
+			LogLevel:                  gormlogger.Warn,
+			SlowThreshold:             100 * time.Millisecond,
+			SkipCallerLookup:          false,
+			IgnoreRecordNotFoundError: true,
+			Context:                   nil,
+		}
 	}
 
 	// Check if we are testing against an external database. If so, we create a


### PR DESCRIPTION
Running tests locally now spam "record not found" warnings.

```
2024/04/16 12:20:49 /Users/peterjan/code/siafoundation/renterd/stores/peers.go:192 record not found
[0.154ms] [rows:0] SELECT * FROM `syncer_bans` WHERE net_cidr IN ("127.0.0.1/32","127.0.0.0/31","127.0.0.0/30","127.0.0.0/29","127.0.0.0/28","127.0.0.0/27","127.0.0.0/26","127.0.0.0/25","127.0.0.0/24","127.0.0.0/23","127.0.0.0/22","127.0.0.0/21","127.0.0.0/20","127.0.0.0/19","127.0.0.0/18","127.0.0.0/17","127.0.0.0/16","127.0.0.0/15","127.0.0.0/14","127.0.0.0/13","127.0.0.0/12","127.0.0.0/11","127.0.0.0/10","127.0.0.0/9","127.0.0.0/8","126.0.0.0/7","124.0.0.0/6","120.0.0.0/5","112.0.0.0/4","96.0.0.0/3","64.0.0.0/2","0.0.0.0/1") ORDER BY expiration DESC,`syncer_bans`.`id` LIMIT 1

2024/04/16 12:20:49 /Users/peterjan/code/siafoundation/renterd/stores/peers.go:192 record not found
[0.138ms] [rows:0] SELECT * FROM `syncer_bans` WHERE net_cidr IN ("127.0.0.1/32","127.0.0.0/31","127.0.0.0/30","127.0.0.0/29","127.0.0.0/28","127.0.0.0/27","127.0.0.0/26","127.0.0.0/25","127.0.0.0/24","127.0.0.0/23","127.0.0.0/22","127.0.0.0/21","127.0.0.0/20","127.0.0.0/19","127.0.0.0/18","127.0.0.0/17","127.0.0.0/16","127.0.0.0/15","127.0.0.0/14","127.0.0.0/13","127.0.0.0/12","127.0.0.0/11","127.0.0.0/10","127.0.0.0/9","127.0.0.0/8","126.0.0.0/7","124.0.0.0/6","120.0.0.0/5","112.0.0.0/4","96.0.0.0/3","64.0.0.0/2","0.0.0.0/1") ORDER BY expiration DESC,`syncer_bans`.`id` LIMIT 1
```

I figured we probably want to default to our production defaults in our integration tests too.