### PR TITLE
Remove SlabPruningCooldown from the bus config.

### DIFF
--- a/bus/client/client_test.go
+++ b/bus/client/client_test.go
@@ -80,7 +80,6 @@ func newTestClient(dir string) (*client.Client, func() error, func(context.Conte
 		},
 		Miner:               node.NewMiner(client),
 		SlabPruningInterval: time.Minute,
-		SlabPruningCooldown: time.Minute,
 	}, filepath.Join(dir, "bus"), types.GeneratePrivateKey(), zap.New(zapcore.NewNopCore()))
 	if err != nil {
 		return nil, nil, nil, err

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -436,7 +436,6 @@ func main() {
 		Bus:                 cfg.Bus,
 		Network:             network,
 		SlabPruningInterval: time.Hour,
-		SlabPruningCooldown: 30 * time.Second,
 	}
 	// Init db dialector
 	if cfg.Database.MySQL.URI != "" {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -45,7 +45,6 @@ type BusConfig struct {
 	DBDialector         gorm.Dialector
 	DBMetricsDialector  gorm.Dialector
 	SlabPruningInterval time.Duration
-	SlabPruningCooldown time.Duration
 }
 
 type AutopilotConfig struct {

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -896,7 +896,6 @@ func testBusCfg() node.BusConfig {
 		},
 		Network:             testNetwork(),
 		SlabPruningInterval: time.Second,
-		SlabPruningCooldown: 10 * time.Millisecond,
 	}
 }
 


### PR DESCRIPTION
Refactor leftover I'm guessing(?) we weren't using it so I removed it.