### PR TITLE
use debug level logging in testing

### DIFF
--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -168,7 +168,7 @@ type testClusterOptions struct {
 
 // newTestLogger creates a console logger used for testing.
 func newTestLogger() *zap.Logger {
-	return newTestLoggerCustom(zapcore.ErrorLevel)
+	return newTestLoggerCustom(zapcore.DebugLevel)
 }
 
 // newTestLoggerCustom creates a console logger used for testing and allows

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -27,7 +27,6 @@ import (
 	"go.sia.tech/renterd/object"
 	"go.sia.tech/renterd/wallet"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"lukechampine.com/frand"
 )
 
@@ -1453,9 +1452,7 @@ func TestWalletTransactions(t *testing.T) {
 		t.SkipNow()
 	}
 
-	cluster := newTestCluster(t, testClusterOptions{
-		logger: newTestLoggerCustom(zapcore.DebugLevel),
-	})
+	cluster := newTestCluster(t, clusterOptsDefault)
 	defer cluster.Shutdown()
 	b := cluster.Bus
 	tt := cluster.tt
@@ -1709,9 +1706,7 @@ func TestWallet(t *testing.T) {
 		t.SkipNow()
 	}
 
-	cluster := newTestCluster(t, testClusterOptions{
-		logger: newTestLoggerCustom(zapcore.DebugLevel),
-	})
+	cluster := newTestCluster(t, clusterOptsDefault)
 	defer cluster.Shutdown()
 	b := cluster.Bus
 	tt := cluster.tt
@@ -1916,9 +1911,7 @@ func TestAlerts(t *testing.T) {
 		t.SkipNow()
 	}
 
-	cluster := newTestCluster(t, testClusterOptions{
-		logger: newTestLoggerCustom(zapcore.DebugLevel),
-	})
+	cluster := newTestCluster(t, clusterOptsDefault)
 	defer cluster.Shutdown()
 	b := cluster.Bus
 	tt := cluster.tt


### PR DESCRIPTION
I find myself committing a custom test logger that logs on `DEBUG` level quite often when I run into an NDF on the CI. Figured it's fine to have `DEBUG` level logging by default in all e2e tests.