### PR TITLE
Update ctx.Err() usage to context.Cause(ctx)

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -2050,7 +2050,7 @@ UPDATE objects SET health = (
 		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return context.Cause(ctx)
 		case <-time.After(time.Second):
 		}
 	}

--- a/worker/download.go
+++ b/worker/download.go
@@ -731,7 +731,7 @@ loop:
 		case <-s.mgr.shutdownCtx.Done():
 			return nil, false, errors.New("download stopped")
 		case <-ctx.Done():
-			return nil, false, ctx.Err()
+			return nil, false, context.Cause(ctx)
 		case <-resps.c:
 			resetOverdrive()
 		}

--- a/worker/host_test.go
+++ b/worker/host_test.go
@@ -97,7 +97,7 @@ func (h *testHost) UploadSector(ctx context.Context, sectorRoot types.Hash256, s
 		select {
 		case <-time.After(h.uploadDelay):
 		case <-ctx.Done():
-			return ctx.Err()
+			return context.Cause(ctx)
 		}
 	}
 	return nil

--- a/worker/pricetables.go
+++ b/worker/pricetables.go
@@ -137,7 +137,7 @@ func (p *priceTable) fetch(ctx context.Context, rev *types.FileContractRevision)
 	} else if ongoing {
 		select {
 		case <-ctx.Done():
-			return api.HostPriceTable{}, fmt.Errorf("%w; %w", errPriceTableUpdateTimedOut, ctx.Err())
+			return api.HostPriceTable{}, fmt.Errorf("%w; %w", errPriceTableUpdateTimedOut, context.Cause(ctx))
 		case <-update.done:
 		}
 		return update.hpt, update.err

--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -645,8 +645,8 @@ func (w *worker) withTransportV2(ctx context.Context, hostKey types.PublicKey, h
 	}()
 	defer func() {
 		close(done)
-		if ctx.Err() != nil {
-			err = ctx.Err()
+		if context.Cause(ctx) != nil {
+			err = context.Cause(ctx)
 		}
 	}()
 	t, err := rhpv2.NewRenterTransport(conn, hostKey)

--- a/worker/rhpv3.go
+++ b/worker/rhpv3.go
@@ -237,7 +237,7 @@ func dialTransport(ctx context.Context, siamuxAddr string, hostKey types.PublicK
 	case <-ctx.Done():
 		conn.Close()
 		<-done
-		return nil, ctx.Err()
+		return nil, context.Cause(ctx)
 	case <-done:
 		return t, err
 	}

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -873,7 +873,7 @@ loop:
 		case <-u.shutdownCtx.Done():
 			return nil, 0, 0, ErrShuttingDown
 		case <-ctx.Done():
-			return nil, 0, 0, ctx.Err()
+			return nil, 0, 0, context.Cause(ctx)
 		case resp := <-respChan:
 			// receive the response
 			used, done = slab.receive(resp)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1431,7 +1431,7 @@ func (w *worker) scanHost(ctx context.Context, timeout time.Duration, hostKey ty
 		// scan: second try
 		select {
 		case <-ctx.Done():
-			return rhpv2.HostSettings{}, rhpv3.HostPriceTable{}, 0, ctx.Err()
+			return rhpv2.HostSettings{}, rhpv3.HostPriceTable{}, 0, context.Cause(ctx)
 		case <-time.After(time.Second):
 		}
 		settings, pt, duration, err = scan()
@@ -1449,7 +1449,7 @@ func (w *worker) scanHost(ctx context.Context, timeout time.Duration, hostKey ty
 	// repercussions
 	select {
 	case <-ctx.Done():
-		return rhpv2.HostSettings{}, rhpv3.HostPriceTable{}, 0, ctx.Err()
+		return rhpv2.HostSettings{}, rhpv3.HostPriceTable{}, 0, context.Cause(ctx)
 	default:
 	}
 


### PR DESCRIPTION
This PR updates a few spots where we return `ctx.Err()` instead of `context.Cause(ctx)` to make sure we return the proper shutdown error instead of the standard "context was cancelled".