### PR TITLE
Fix evaluation endpoint returning 0 usable hosts due to gouging on period

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -195,10 +195,6 @@ func (ap *Autopilot) configHandlerPOST(jc jape.Context) {
 	if jc.Check("failed to get recommended fee", err) != nil {
 		return
 	}
-	cfg, err := ap.Config(ctx)
-	if jc.Check("failed to get autopilot config", err) != nil {
-		return
-	}
 
 	// fetch hosts
 	hosts, err := ap.bus.SearchHosts(ctx, api.SearchHostOptions{Limit: -1, FilterMode: api.HostFilterModeAllowed})
@@ -207,7 +203,7 @@ func (ap *Autopilot) configHandlerPOST(jc jape.Context) {
 	}
 
 	// evaluate the config
-	jc.Encode(contractor.EvaluateConfig(reqCfg, cs, fee, cfg.CurrentPeriod, rs, gs, hosts))
+	jc.Encode(contractor.EvaluateConfig(reqCfg, cs, fee, rs, gs, hosts))
 }
 
 func (ap *Autopilot) Run() error {

--- a/autopilot/contractor/evaluate.go
+++ b/autopilot/contractor/evaluate.go
@@ -6,8 +6,8 @@ import (
 	"go.sia.tech/renterd/worker"
 )
 
-func countUsableHosts(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Currency, currentPeriod uint64, rs api.RedundancySettings, gs api.GougingSettings, hosts []api.Host) (usables uint64) {
-	gc := worker.NewGougingChecker(gs, cs, fee, currentPeriod, cfg.Contracts.RenewWindow)
+func countUsableHosts(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Currency, period uint64, rs api.RedundancySettings, gs api.GougingSettings, hosts []api.Host) (usables uint64) {
+	gc := worker.NewGougingChecker(gs, cs, fee, period, cfg.Contracts.RenewWindow)
 	for _, host := range hosts {
 		hc := checkHost(cfg, rs, gc, host, minValidScore)
 		if hc.Usability.IsUsable() {
@@ -20,8 +20,9 @@ func countUsableHosts(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.
 // EvaluateConfig evaluates the given configuration and if the gouging settings
 // are too strict for the number of contracts required by 'cfg', it will provide
 // a recommendation on how to loosen it.
-func EvaluateConfig(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Currency, currentPeriod uint64, rs api.RedundancySettings, gs api.GougingSettings, hosts []api.Host) (resp api.ConfigEvaluationResponse) {
-	gc := worker.NewGougingChecker(gs, cs, fee, currentPeriod, cfg.Contracts.RenewWindow)
+func EvaluateConfig(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Currency, rs api.RedundancySettings, gs api.GougingSettings, hosts []api.Host) (resp api.ConfigEvaluationResponse) {
+	period := cfg.Contracts.Period
+	gc := worker.NewGougingChecker(gs, cs, fee, period, cfg.Contracts.RenewWindow)
 
 	resp.Hosts = uint64(len(hosts))
 	for _, host := range hosts {
@@ -88,35 +89,35 @@ func EvaluateConfig(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Cu
 	// MaxRPCPrice
 	tmpGS := maxGS()
 	tmpGS.MaxRPCPrice = gs.MaxRPCPrice
-	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxRPCPrice, cfg, cs, fee, currentPeriod, rs, hosts) {
+	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxRPCPrice, cfg, cs, fee, period, rs, hosts) {
 		optimisedGS.MaxRPCPrice = tmpGS.MaxRPCPrice
 		success = true
 	}
 	// MaxContractPrice
 	tmpGS = maxGS()
 	tmpGS.MaxContractPrice = gs.MaxContractPrice
-	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxContractPrice, cfg, cs, fee, currentPeriod, rs, hosts) {
+	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxContractPrice, cfg, cs, fee, period, rs, hosts) {
 		optimisedGS.MaxContractPrice = tmpGS.MaxContractPrice
 		success = true
 	}
 	// MaxDownloadPrice
 	tmpGS = maxGS()
 	tmpGS.MaxDownloadPrice = gs.MaxDownloadPrice
-	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxDownloadPrice, cfg, cs, fee, currentPeriod, rs, hosts) {
+	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxDownloadPrice, cfg, cs, fee, period, rs, hosts) {
 		optimisedGS.MaxDownloadPrice = tmpGS.MaxDownloadPrice
 		success = true
 	}
 	// MaxUploadPrice
 	tmpGS = maxGS()
 	tmpGS.MaxUploadPrice = gs.MaxUploadPrice
-	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxUploadPrice, cfg, cs, fee, currentPeriod, rs, hosts) {
+	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxUploadPrice, cfg, cs, fee, period, rs, hosts) {
 		optimisedGS.MaxUploadPrice = tmpGS.MaxUploadPrice
 		success = true
 	}
 	// MaxStoragePrice
 	tmpGS = maxGS()
 	tmpGS.MaxStoragePrice = gs.MaxStoragePrice
-	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxStoragePrice, cfg, cs, fee, currentPeriod, rs, hosts) {
+	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxStoragePrice, cfg, cs, fee, period, rs, hosts) {
 		optimisedGS.MaxStoragePrice = tmpGS.MaxStoragePrice
 		success = true
 	}

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -689,18 +689,15 @@ func (c *TestCluster) AddHost(h *Host) {
 	c.hosts = append(c.hosts, h)
 
 	// Fund host from bus.
-	res, err := c.Bus.Wallet(context.Background())
-	c.tt.OK(err)
-
-	fundAmt := res.Confirmed.Div64(2).Div64(uint64(len(c.hosts))) // 50% of bus balance
+	fundAmt := types.Siacoins(100e3)
 	var scos []types.SiacoinOutput
 	for i := 0; i < 10; i++ {
 		scos = append(scos, types.SiacoinOutput{
-			Value:   fundAmt.Div64(10),
+			Value:   fundAmt,
 			Address: h.WalletAddress(),
 		})
 	}
-	c.tt.OK(c.Bus.SendSiacoins(context.Background(), scos, true))
+	c.tt.OK(c.Bus.SendSiacoins(context.Background(), scos, false))
 
 	// Mine transaction.
 	c.MineBlocks(1)
@@ -720,7 +717,7 @@ func (c *TestCluster) AddHost(h *Host) {
 		c.tt.Helper()
 
 		c.MineBlocks(1)
-		_, err = c.Bus.Host(context.Background(), h.PublicKey())
+		_, err := c.Bus.Host(context.Background(), h.PublicKey())
 		if err != nil {
 			return err
 		}

--- a/internal/test/e2e/gouging_test.go
+++ b/internal/test/e2e/gouging_test.go
@@ -23,7 +23,6 @@ func TestGouging(t *testing.T) {
 
 	// create a new test cluster
 	cluster := newTestCluster(t, testClusterOptions{
-		hosts:  int(test.AutopilotConfig.Contracts.Amount),
 		logger: newTestLoggerCustom(zapcore.ErrorLevel),
 	})
 	defer cluster.Shutdown()
@@ -35,6 +34,10 @@ func TestGouging(t *testing.T) {
 
 	// mine enough blocks for the current period to become > period
 	cluster.MineBlocks(int(cfg.Period) * 2)
+
+	// add hosts
+	tt.OKAll(cluster.AddHostsBlocking(int(test.AutopilotConfig.Contracts.Amount)))
+	cluster.WaitForAccounts()
 
 	// build a hosts map
 	hostsMap := make(map[string]*Host)


### PR DESCRIPTION
Seems like we passed the current period instead of the configured period. This PR fixes that. 