### PR TITLE
Keep track of chain indices in a separate table.

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -32,6 +32,8 @@ var (
 	ErrContractSetNotFound = errors.New("couldn't find contract set")
 )
 
+type ContractState string
+
 type (
 	// A Contract wraps the contract metadata with the latest contract revision.
 	Contract struct {

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -1,0 +1,10 @@
+package chain
+
+import (
+	"go.sia.tech/coreutils/chain"
+)
+
+type (
+	Manager          = chain.Manager
+	HostAnnouncement = chain.HostAnnouncement
+)

--- a/chain/subscriber.go
+++ b/chain/subscriber.go
@@ -1,0 +1,29 @@
+package chain
+
+import (
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/chain"
+	"go.sia.tech/renterd/api"
+)
+
+type (
+	ChainStore interface {
+		BeginChainUpdateTx() (ChainUpdateTx, error)
+		ChainIndex() (types.ChainIndex, error)
+	}
+
+	ChainUpdateTx interface {
+		Commit() error
+		Rollback() error
+
+		ContractState(fcid types.FileContractID) (api.ContractState, error)
+		UpdateChainIndex(index types.ChainIndex) error
+		UpdateContract(fcid types.FileContractID, revisionHeight, revisionNumber, size uint64) error
+		UpdateContractState(fcid types.FileContractID, state api.ContractState) error
+		UpdateContractProofHeight(fcid types.FileContractID, proofHeight uint64) error
+		UpdateFailedContracts(blockHeight uint64) error
+		UpdateHost(hk types.PublicKey, ha chain.HostAnnouncement, bh uint64, blockID types.BlockID, ts time.Time) error
+	}
+)

--- a/stores/chain.go
+++ b/stores/chain.go
@@ -163,6 +163,24 @@ func (u *chainUpdateTx) RevertIndex(index types.ChainIndex, removed, unspent []t
 		return err
 	}
 
+	// remove events for the index
+	if err := u.tx.
+		Model(&dbWalletEvent{}).
+		Where("db_chain_index_id", ci.ID).
+		Delete(&dbWalletEvent{}).
+		Error; err != nil {
+		return err
+	}
+
+	// remove outputs for the index
+	if err := u.tx.
+		Model(&dbWalletOutput{}).
+		Where("db_chain_index_id", ci.ID).
+		Delete(&dbWalletOutput{}).
+		Error; err != nil {
+		return err
+	}
+
 	// recreate unspent outputs
 	for _, e := range unspent {
 		if err := u.tx.
@@ -183,8 +201,7 @@ func (u *chainUpdateTx) RevertIndex(index types.ChainIndex, removed, unspent []t
 		}
 	}
 
-	// remove the chain index, this cascades down to the outputs and events
-	return u.tx.Delete(&ci).Error
+	return nil
 }
 
 // UpdateChainIndex updates the chain index in the database.

--- a/stores/chain.go
+++ b/stores/chain.go
@@ -1,0 +1,356 @@
+package stores
+
+import (
+	"fmt"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/wallet"
+	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/chain"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var (
+	_ chain.ChainStore    = (*SQLStore)(nil)
+	_ chain.ChainUpdateTx = (*chainUpdateTx)(nil)
+)
+
+// chainUpdateTx implements the ChainUpdateTx interface.
+type chainUpdateTx struct {
+	tx *gorm.DB
+}
+
+// BeginChainUpdateTx starts a transaction and wraps it in a chainUpdateTx. This
+// transaction will be used to process a chain update in the subscriber.
+func (s *SQLStore) BeginChainUpdateTx() (chain.ChainUpdateTx, error) {
+	tx := s.db.Begin()
+	if tx.Error != nil {
+		return nil, tx.Error
+	}
+	return &chainUpdateTx{tx: tx}, nil
+}
+
+// ApplyIndex is called with the chain index that is being applied. Any
+// transactions and siacoin elements that were created by the index should be
+// added and any siacoin elements that were spent should be removed.
+func (u *chainUpdateTx) ApplyIndex(index types.ChainIndex, created, spent []types.SiacoinElement, events []wallet.Event) error {
+	// remove spent outputs
+	for _, e := range spent {
+		// TODO: check if rows affected is > 0?
+		if err := u.tx.
+			Where("output_id", hash256(e.ID)).
+			Delete(&dbWalletOutput{}).
+			Error; err != nil {
+			return err
+		}
+	}
+
+	// create outputs
+	for _, e := range created {
+		if err := u.tx.
+			Clauses(clause.OnConflict{
+				DoNothing: true,
+				Columns:   []clause.Column{{Name: "output_id"}},
+			}).
+			Create(&dbWalletOutput{
+				OutputID:       hash256(e.ID),
+				LeafIndex:      e.StateElement.LeafIndex,
+				MerkleProof:    merkleProof{proof: e.StateElement.MerkleProof},
+				Value:          currency(e.SiacoinOutput.Value),
+				Address:        hash256(e.SiacoinOutput.Address),
+				MaturityHeight: e.MaturityHeight,
+				Height:         index.Height,
+				BlockID:        hash256(index.ID),
+			}).Error; err != nil {
+			return nil
+		}
+	}
+
+	// create events
+	for _, e := range events {
+		if err := u.tx.
+			Clauses(clause.OnConflict{
+				DoNothing: true,
+				Columns:   []clause.Column{{Name: "event_id"}},
+			}).
+			Create(&dbWalletEvent{
+				EventID:        hash256(e.ID),
+				Inflow:         currency(e.Inflow),
+				Outflow:        currency(e.Outflow),
+				Transaction:    e.Transaction,
+				MaturityHeight: e.MaturityHeight,
+				Source:         string(e.Source),
+				Timestamp:      e.Timestamp.Unix(),
+				Height:         e.Index.Height,
+				BlockID:        hash256(e.Index.ID),
+			}).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Commit commits the updates to the database.
+func (u *chainUpdateTx) Commit() error {
+	return u.tx.Commit().Error
+}
+
+// Rollback rolls back the transaction
+func (u *chainUpdateTx) Rollback() error {
+	return u.tx.Rollback().Error
+}
+
+// ContractState returns the state of a file contract.
+func (u *chainUpdateTx) ContractState(fcid types.FileContractID) (api.ContractState, error) {
+	var state contractState
+	err := u.tx.
+		Select("state").
+		Model(&dbContract{}).
+		Where("fcid = ?", fileContractID(fcid)).
+		Scan(&state).
+		Error
+
+	if err == gorm.ErrRecordNotFound {
+		err = u.tx.
+			Select("state").
+			Model(&dbArchivedContract{}).
+			Where("fcid = ?", fileContractID(fcid)).
+			Scan(&state).
+			Error
+	}
+
+	if err != nil {
+		return "", err
+	}
+	return api.ContractState(state.String()), nil
+}
+
+// RemoveSiacoinElements is called with all siacoin elements that were spent in
+// the update.
+func (u *chainUpdateTx) RemoveSiacoinElements(ids []types.SiacoinOutputID) error {
+	for _, id := range ids {
+		if err := u.tx.
+			Where("output_id", hash256(id)).
+			Delete(&dbWalletOutput{}).
+			Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RevertIndex is called with the chain index that is being reverted. Any
+// transactions and siacoin elements that were created by the index should be
+// removed.
+func (u *chainUpdateTx) RevertIndex(index types.ChainIndex, removed, unspent []types.SiacoinElement) error {
+	// recreate unspent outputs
+	for _, e := range unspent {
+		if err := u.tx.
+			Clauses(clause.OnConflict{
+				DoNothing: true,
+				Columns:   []clause.Column{{Name: "output_id"}},
+			}).
+			Create(&dbWalletOutput{
+				OutputID:       hash256(e.ID),
+				LeafIndex:      e.StateElement.LeafIndex,
+				MerkleProof:    merkleProof{proof: e.StateElement.MerkleProof},
+				Value:          currency(e.SiacoinOutput.Value),
+				Address:        hash256(e.SiacoinOutput.Address),
+				MaturityHeight: e.MaturityHeight,
+				Height:         index.Height,
+				BlockID:        hash256(index.ID),
+			}).Error; err != nil {
+			return nil
+		}
+	}
+
+	// remove outputs created at the reverted index
+	for _, e := range removed {
+		if err := u.tx.
+			Where("output_id", hash256(e.ID)).
+			Delete(&dbWalletOutput{}).
+			Error; err != nil {
+			return err
+		}
+	}
+
+	// remove events created at the reverted index
+	return u.tx.
+		Model(&dbWalletEvent{}).
+		Where("height = ? AND block_id = ?", index.Height, hash256(index.ID)).
+		Delete(&dbWalletEvent{}).
+		Error
+}
+
+// UpdateChainIndex updates the chain index in the database.
+func (u *chainUpdateTx) UpdateChainIndex(index types.ChainIndex) error {
+	return u.tx.
+		Model(&dbConsensusInfo{}).
+		Where(&dbConsensusInfo{Model: Model{ID: consensusInfoID}}).
+		Updates(map[string]interface{}{
+			"height":   index.Height,
+			"block_id": hash256(index.ID),
+		}).
+		Error
+}
+
+// UpdateContract updates the revision height, revision number, and size the
+// contract with given fcid.
+func (u *chainUpdateTx) UpdateContract(fcid types.FileContractID, revisionHeight, revisionNumber, size uint64) error {
+	updates := map[string]interface{}{
+		"revision_height": revisionHeight,
+	}
+	if revisionNumber > 0 {
+		updates["revision_number"] = fmt.Sprint(revisionNumber)
+	}
+	if size > 0 {
+		updates["size"] = size
+	}
+
+	if err := u.tx.
+		Model(&dbContract{}).
+		Where("fcid = ?", fileContractID(fcid)).
+		Updates(updates).
+		Error; err != nil {
+		return err
+	}
+	return u.tx.
+		Model(&dbArchivedContract{}).
+		Where("fcid = ?", fileContractID(fcid)).
+		Updates(updates).
+		Error
+}
+
+// UpdateContractState updates the state of the contract with given fcid.
+func (u *chainUpdateTx) UpdateContractState(fcid types.FileContractID, state api.ContractState) error {
+	var cs contractState
+	if err := cs.LoadString(string(state)); err != nil {
+		return err
+	}
+
+	if err := u.tx.
+		Model(&dbContract{}).
+		Where("fcid = ?", fileContractID(fcid)).
+		Update("state", cs).
+		Error; err != nil {
+		return err
+	}
+	return u.tx.
+		Model(&dbArchivedContract{}).
+		Where("fcid = ?", fileContractID(fcid)).
+		Update("state", cs).
+		Error
+}
+
+// UpdateContractProofHeight updates the proof height of the contract with given
+// fcid.
+func (u *chainUpdateTx) UpdateContractProofHeight(fcid types.FileContractID, proofHeight uint64) error {
+	if err := u.tx.
+		Model(&dbContract{}).
+		Where("fcid = ?", fileContractID(fcid)).
+		Update("proof_height", proofHeight).
+		Error; err != nil {
+		return err
+	}
+	return u.tx.
+		Model(&dbArchivedContract{}).
+		Where("fcid = ?", fileContractID(fcid)).
+		Update("proof_height", proofHeight).
+		Error
+}
+
+// UpdateFailedContracts marks active contract as failed if the current
+// blockheight surposses their window_end.
+func (u *chainUpdateTx) UpdateFailedContracts(blockHeight uint64) error {
+	return u.tx.
+		Model(&dbContract{}).
+		Where("state = ? AND ? > window_end", contractStateActive, blockHeight).
+		Update("state", contractStateFailed).
+		Error
+}
+
+// UpdateHost creates the announcement and upserts the host in the database.
+func (u *chainUpdateTx) UpdateHost(hk types.PublicKey, ha chain.HostAnnouncement, bh uint64, blockID types.BlockID, ts time.Time) error {
+	// create the announcement
+	if err := u.tx.Create(&dbAnnouncement{
+		HostKey:     publicKey(hk),
+		BlockHeight: bh,
+		BlockID:     blockID.String(),
+		NetAddress:  ha.NetAddress,
+	}).Error; err != nil {
+		return err
+	}
+
+	// create the host
+	if err := u.tx.Create(&dbHost{
+		PublicKey:        publicKey(hk),
+		LastAnnouncement: ts.UTC(),
+		NetAddress:       ha.NetAddress,
+	}).Error; err != nil {
+		return err
+	}
+
+	// fetch blocklists
+	allowlist, blocklist, err := getBlocklists(u.tx)
+	if err != nil {
+		return fmt.Errorf("%w; failed to fetch blocklists", err)
+	}
+
+	// return early if there are no allowlist or blocklist entries
+	if len(allowlist)+len(blocklist) == 0 {
+		return nil
+	}
+
+	// update blocklist
+	if err := updateBlocklist(u.tx, hk, allowlist, blocklist); err != nil {
+		return fmt.Errorf("%w; failed to update blocklist for host %v", err, hk)
+	}
+
+	return nil
+}
+
+// UpdateStateElements updates the proofs of all state elements affected by the
+// update.
+func (u *chainUpdateTx) UpdateStateElements(elements []types.StateElement) error {
+	for _, se := range elements {
+		if err := u.tx.
+			Model(&dbWalletOutput{}).
+			Where("output_id", hash256(se.ID)).
+			Updates(map[string]interface{}{
+				"merkle_proof": merkleProof{proof: se.MerkleProof},
+				"leaf_index":   se.LeafIndex,
+			}).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WalletStateElements implements the ChainStore interface and returns all state
+// elements in the database.
+func (u *chainUpdateTx) WalletStateElements() ([]types.StateElement, error) {
+	type row struct {
+		ID          hash256
+		LeafIndex   uint64
+		MerkleProof merkleProof
+	}
+	var rows []row
+	if err := u.tx.
+		Model(&dbWalletOutput{}).
+		Select("output_id AS id", "leaf_index", "merkle_proof").
+		Find(&rows).
+		Error; err != nil {
+		return nil, err
+	}
+	elements := make([]types.StateElement, 0, len(rows))
+	for _, r := range rows {
+		elements = append(elements, types.StateElement{
+			ID:          types.Hash256(r.ID),
+			LeafIndex:   r.LeafIndex,
+			MerkleProof: r.MerkleProof.proof,
+		})
+	}
+	return elements, nil
+}

--- a/stores/chain_test.go
+++ b/stores/chain_test.go
@@ -101,6 +101,24 @@ func TestChainUpdateTx(t *testing.T) {
 		we = c.WindowEnd
 	}
 
+	// assert we only update revision height if the rev number doesn't increase
+	tx, err = ss.BeginChainUpdateTx()
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	} else if err := tx.UpdateContract(fcid, 2, 2, 4); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if err := tx.Commit(); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if c, err := ss.contract(context.Background(), fileContractID(fcid)); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if c.RevisionHeight != 2 {
+		t.Fatal("unexpected revision height", c.RevisionHeight)
+	} else if c.RevisionNumber != "2" {
+		t.Fatal("unexpected revision number", c.RevisionNumber)
+	} else if c.Size != 3 {
+		t.Fatal("unexpected size", c.Size)
+	}
+
 	// assert update failed contracts is successful
 	tx, err = ss.BeginChainUpdateTx()
 	if err != nil {

--- a/stores/chain_test.go
+++ b/stores/chain_test.go
@@ -1,0 +1,131 @@
+package stores
+
+import (
+	"context"
+	"testing"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/chain"
+)
+
+// TestChainUpdateTx tests the chain update transaction.
+func TestChainUpdateTx(t *testing.T) {
+	ss := newTestSQLStore(t, defaultTestSQLStoreConfig)
+
+	// add test host and contract
+	hks, err := ss.addTestHosts(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fcids, _, err := ss.addTestContracts(hks)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(fcids) != 1 {
+		t.Fatal("expected one contract", len(fcids))
+	}
+	fcid := fcids[0]
+
+	// assert commit with no changes is successful
+	tx, err := ss.BeginChainUpdateTx()
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal("unexpected error", err)
+	}
+
+	// assert rollback with no changes is successful
+	tx, err = ss.BeginChainUpdateTx()
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatal("unexpected error", err)
+	}
+
+	// assert contract state returns the correct state
+	tx, err = ss.BeginChainUpdateTx()
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	state, err := tx.ContractState(fcid)
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	} else if state != api.ContractStatePending {
+		t.Fatal("expected pending state", state)
+	}
+
+	// assert update chain index is successful
+	if curr, err := ss.ChainIndex(); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if curr.Height != 0 {
+		t.Fatal("unexpected height", curr.Height)
+	}
+	index := types.ChainIndex{Height: 1}
+	if err := tx.UpdateChainIndex(index); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if err := tx.Commit(); err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	if got, err := ss.ChainIndex(); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if got.Height != index.Height {
+		t.Fatal("unexpected height", got.Height)
+	}
+
+	// assert update contract is successful
+	var we uint64
+	tx, err = ss.BeginChainUpdateTx()
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	} else if err := tx.UpdateContract(fcid, 1, 2, 3); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if err := tx.UpdateContractState(fcid, api.ContractStateActive); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if err := tx.UpdateContractProofHeight(fcid, 4); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if err := tx.Commit(); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if c, err := ss.contract(context.Background(), fileContractID(fcid)); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if c.RevisionHeight != 1 {
+		t.Fatal("unexpected revision height", c.RevisionHeight)
+	} else if c.RevisionNumber != "2" {
+		t.Fatal("unexpected revision number", c.RevisionNumber)
+	} else if c.Size != 3 {
+		t.Fatal("unexpected size", c.Size)
+	} else if c.State.String() != api.ContractStateActive {
+		t.Fatal("unexpected state", c.State)
+	} else {
+		we = c.WindowEnd
+	}
+
+	// assert update failed contracts is successful
+	tx, err = ss.BeginChainUpdateTx()
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	} else if err := tx.UpdateFailedContracts(we + 1); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if err := tx.Commit(); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if c, err := ss.contract(context.Background(), fileContractID(fcid)); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if c.State.String() != api.ContractStateFailed {
+		t.Fatal("unexpected state", c.State)
+	}
+
+	// assert update host is successful
+	tx, err = ss.BeginChainUpdateTx()
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	} else if err := tx.UpdateHost(hks[0], chain.HostAnnouncement{NetAddress: "foo"}, 1, types.BlockID{}, types.CurrentTimestamp()); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if err := tx.Commit(); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if h, err := ss.Host(context.Background(), hks[0]); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if h.NetAddress != "foo" {
+		t.Fatal("unexpected net address", h.NetAddress)
+	}
+}

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -1119,11 +1119,46 @@ func insertAnnouncements(tx *gorm.DB, as []announcement) error {
 }
 
 func applyRevisionUpdate(db *gorm.DB, fcid types.FileContractID, rev revisionUpdate) error {
-	return updateActiveAndArchivedContract(db, fcid, map[string]interface{}{
-		"revision_height": rev.height,
-		"revision_number": fmt.Sprint(rev.number),
-		"size":            rev.size,
-	})
+	// isUpdatedRevision indicates whether the given revision number is greater
+	// than the one currently set on the contract
+	isUpdatedRevision := func(currRevStr string) bool {
+		var currRev uint64
+		_, _ = fmt.Sscan(currRevStr, &currRev)
+		return rev.number > currRev
+	}
+
+	// update either active or archived contract
+	var update interface{}
+	var c dbContract
+	if err := db.
+		Model(&dbContract{}).
+		Where("fcid", fileContractID(fcid)).
+		Take(&c).Error; err == nil {
+		c.RevisionHeight = rev.height
+		if isUpdatedRevision(c.RevisionNumber) {
+			c.RevisionNumber = fmt.Sprint(rev.number)
+			c.Size = rev.size
+		}
+		update = c
+	} else if err == gorm.ErrRecordNotFound {
+		// try archived contracts
+		var ac dbArchivedContract
+		if err := db.
+			Model(&dbArchivedContract{}).
+			Where("fcid", fileContractID(fcid)).
+			Take(&ac).Error; err == nil {
+			ac.RevisionHeight = rev.height
+			if isUpdatedRevision(ac.RevisionNumber) {
+				ac.RevisionNumber = fmt.Sprint(rev.number)
+				ac.Size = rev.size
+			}
+			update = ac
+		}
+	}
+	if update == nil {
+		return nil
+	}
+	return db.Save(update).Error
 }
 
 func updateContractState(db *gorm.DB, fcid types.FileContractID, cs contractState) error {

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -1160,6 +1160,26 @@ func updateActiveAndArchivedContract(tx *gorm.DB, fcid types.FileContractID, upd
 	return nil
 }
 
+func getBlocklists(tx *gorm.DB) ([]dbAllowlistEntry, []dbBlocklistEntry, error) {
+	var allowlist []dbAllowlistEntry
+	if err := tx.
+		Model(&dbAllowlistEntry{}).
+		Find(&allowlist).
+		Error; err != nil {
+		return nil, nil, err
+	}
+
+	var blocklist []dbBlocklistEntry
+	if err := tx.
+		Model(&dbBlocklistEntry{}).
+		Find(&blocklist).
+		Error; err != nil {
+		return nil, nil, err
+	}
+
+	return allowlist, blocklist, nil
+}
+
 func updateBlocklist(tx *gorm.DB, hk types.PublicKey, allowlist []dbAllowlistEntry, blocklist []dbBlocklistEntry) error {
 	// fetch the host
 	var host dbHost

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -1184,10 +1184,10 @@ func updateProofHeight(db *gorm.DB, fcid types.FileContractID, blockHeight uint6
 
 func updateActiveAndArchivedContract(tx *gorm.DB, fcid types.FileContractID, updates map[string]interface{}) error {
 	err1 := tx.Model(&dbContract{}).
-		Where("fcid = ?", fileContractID(fcid)).
+		Where("fcid", fileContractID(fcid)).
 		Updates(updates).Error
 	err2 := tx.Model(&dbArchivedContract{}).
-		Where("fcid = ?", fileContractID(fcid)).
+		Where("fcid", fileContractID(fcid)).
 		Updates(updates).Error
 	if err1 != nil || err2 != nil {
 		return fmt.Errorf("%s; %s", err1, err2)

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1389,7 +1389,7 @@ func (s *SQLStore) RecordContractSpending(ctx context.Context, records []api.Con
 		err := s.retryTransaction(ctx, func(tx *gorm.DB) error {
 			var contract dbContract
 			err := tx.Model(&dbContract{}).
-				Where("fcid = ?", fileContractID(fcid)).
+				Where("fcid", fileContractID(fcid)).
 				Joins("Host").
 				Take(&contract).Error
 			if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -4127,7 +4127,13 @@ func TestSlabCleanup(t *testing.T) {
 		HealthValidUntil: 100,
 	}
 	if err := ss.db.Create(&bufferedSlab).Error; err != nil {
-		t.Fatal(err)
+		if strings.Contains(err.Error(), "database table is locked") {
+			time.Sleep(time.Second) // wait for slabs to be pruned in the background
+			err = ss.db.Create(&bufferedSlab).Error
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	obj3 := dbObject{
 		ObjectID:   "3",

--- a/stores/migrations/mysql/main/migration_00009_coreutils_wallet.sql
+++ b/stores/migrations/mysql/main/migration_00009_coreutils_wallet.sql
@@ -16,14 +16,13 @@ CREATE TABLE `wallet_events` (
   `maturity_height` bigint unsigned DEFAULT NULL,
   `source` longtext,
   `timestamp` bigint DEFAULT NULL,
-  `height` bigint unsigned DEFAULT NULL,
-  `block_id` varbinary(32) NOT NULL,
+  `db_chain_index_id` bigint unsigned NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `event_id` (`event_id`),
   KEY `idx_wallet_events_maturity_height` (`maturity_height`),
   KEY `idx_wallet_events_source` (`source`(191)), -- 191 is the max length for utf8mb4
   KEY `idx_wallet_events_timestamp` (`timestamp`),
-  KEY `idx_wallet_events_height` (`height`)
+  CONSTRAINT `fk_wallet_events_chain_index` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- dbWalletOutput
@@ -36,10 +35,21 @@ CREATE TABLE `wallet_outputs` (
   `value` longtext,
   `address` varbinary(32) DEFAULT NULL,
   `maturity_height` bigint unsigned DEFAULT NULL,
-  `height` bigint unsigned DEFAULT NULL,
-  `block_id` varbinary(32) NOT NULL,
+  `db_chain_index_id` bigint unsigned NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `output_id` (`output_id`),
   KEY `idx_wallet_outputs_maturity_height` (`maturity_height`),
-  KEY `idx_wallet_outputs_height` (`height`)
+  KEY `idx_wallet_outputs_height` (`height`),
+  CONSTRAINT `fk_wallet_outputs_chain_index` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- dbChainIndex
+CREATE TABLE `chain_indices` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(3) DEFAULT NULL,
+  `height` bigint unsigned DEFAULT NULL,
+  `block_id` varbinary(32) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `height` (`height`),
+  UNIQUE KEY `block_id` (`block_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/stores/migrations/mysql/main/migration_00009_coreutils_wallet.sql
+++ b/stores/migrations/mysql/main/migration_00009_coreutils_wallet.sql
@@ -39,7 +39,6 @@ CREATE TABLE `wallet_outputs` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `output_id` (`output_id`),
   KEY `idx_wallet_outputs_maturity_height` (`maturity_height`),
-  KEY `idx_wallet_outputs_height` (`height`),
   CONSTRAINT `fk_wallet_outputs_chain_index` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 

--- a/stores/migrations/mysql/main/schema.sql
+++ b/stores/migrations/mysql/main/schema.sql
@@ -502,6 +502,17 @@ CREATE TABLE `syncer_bans` (
   KEY `idx_syncer_bans_expiration` (`expiration`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
+-- dbChainIndex
+CREATE TABLE `chain_indices` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(3) DEFAULT NULL,
+  `height` bigint unsigned DEFAULT NULL,
+  `block_id` varbinary(32) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `height` (`height`),
+  UNIQUE KEY `block_id` (`block_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
 -- dbWalletEvent
 CREATE TABLE `wallet_events` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
@@ -536,19 +547,7 @@ CREATE TABLE `wallet_outputs` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `output_id` (`output_id`),
   KEY `idx_wallet_outputs_maturity_height` (`maturity_height`),
-  KEY `idx_wallet_outputs_height` (`height`),
   CONSTRAINT `fk_wallet_outputs_chain_index` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-
--- dbChainIndex
-CREATE TABLE `chain_indices` (
-  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-  `created_at` datetime(3) DEFAULT NULL,
-  `height` bigint unsigned DEFAULT NULL,
-  `block_id` varbinary(32) NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `height` (`height`),
-  UNIQUE KEY `block_id` (`block_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- create default bucket

--- a/stores/migrations/mysql/main/schema.sql
+++ b/stores/migrations/mysql/main/schema.sql
@@ -513,14 +513,13 @@ CREATE TABLE `wallet_events` (
   `maturity_height` bigint unsigned DEFAULT NULL,
   `source` longtext,
   `timestamp` bigint DEFAULT NULL,
-  `height` bigint unsigned DEFAULT NULL,
-  `block_id` varbinary(32) NOT NULL,
+  `db_chain_index_id` bigint unsigned NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `event_id` (`event_id`),
   KEY `idx_wallet_events_maturity_height` (`maturity_height`),
   KEY `idx_wallet_events_source` (`source`(191)), -- 191 is the max length for utf8mb4
   KEY `idx_wallet_events_timestamp` (`timestamp`),
-  KEY `idx_wallet_events_height` (`height`)
+  CONSTRAINT `fk_wallet_events_chain_index` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- dbWalletOutput
@@ -533,12 +532,23 @@ CREATE TABLE `wallet_outputs` (
   `value` longtext,
   `address` varbinary(32) DEFAULT NULL,
   `maturity_height` bigint unsigned DEFAULT NULL,
-  `height` bigint unsigned DEFAULT NULL,
-  `block_id` varbinary(32) NOT NULL,
+  `db_chain_index_id` bigint unsigned NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `output_id` (`output_id`),
   KEY `idx_wallet_outputs_maturity_height` (`maturity_height`),
-  KEY `idx_wallet_outputs_height` (`height`)
+  KEY `idx_wallet_outputs_height` (`height`),
+  CONSTRAINT `fk_wallet_outputs_chain_index` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- dbChainIndex
+CREATE TABLE `chain_indices` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(3) DEFAULT NULL,
+  `height` bigint unsigned DEFAULT NULL,
+  `block_id` varbinary(32) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `height` (`height`),
+  UNIQUE KEY `block_id` (`block_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- create default bucket

--- a/stores/migrations/sqlite/main/migration_00009_coreutils_wallet.sql
+++ b/stores/migrations/sqlite/main/migration_00009_coreutils_wallet.sql
@@ -6,15 +6,18 @@ DROP TABLE IF EXISTS `transactions`;
 ALTER TABLE `consensus_infos` DROP COLUMN `cc_id`;
 
 -- dbWalletEvent
-CREATE TABLE `wallet_events` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`event_id` blob NOT NULL,`inflow` text,`outflow` text,`transaction` text,`maturity_height` integer,`source` text,`timestamp` integer,`height` integer, `block_id` blob);
+CREATE TABLE `wallet_events` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`event_id` blob NOT NULL,`inflow` text,`outflow` text,`transaction` text,`maturity_height` integer,`source` text,`timestamp` integer,`db_chain_index_id` integer,CONSTRAINT `fk_wallet_events_chain_index` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices`(`id`) ON DELETE CASCADE);
 CREATE UNIQUE INDEX `idx_wallet_events_event_id` ON `wallet_events`(`event_id`);
 CREATE INDEX `idx_wallet_events_maturity_height` ON `wallet_events`(`maturity_height`);
 CREATE INDEX `idx_wallet_events_source` ON `wallet_events`(`source`);
 CREATE INDEX `idx_wallet_events_timestamp` ON `wallet_events`(`timestamp`);
-CREATE INDEX `idx_wallet_events_height` ON `wallet_events`(`height`);
 
 -- dbWalletOutput
-CREATE TABLE `wallet_outputs` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`output_id` blob NOT NULL,`leaf_index` integer,`merkle_proof` blob NOT NULL,`value` text,`address` blob,`maturity_height` integer,`height` integer, `block_id` blob);
+CREATE TABLE `wallet_outputs` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`output_id` blob NOT NULL,`leaf_index` integer,`merkle_proof` blob NOT NULL,`value` text,`address` blob,`maturity_height` integer,`db_chain_index_id` integer,CONSTRAINT `fk_contract_set_contracts_db_contract` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices`(`id`) ON DELETE CASCADE);
 CREATE UNIQUE INDEX `idx_wallet_outputs_output_id` ON `wallet_outputs`(`output_id`);
 CREATE INDEX `idx_wallet_outputs_maturity_height` ON `wallet_outputs`(`maturity_height`);
-CREATE INDEX `idx_wallet_outputs_height` ON `wallet_outputs`(`height`);
+
+-- dbChainIndex
+CREATE TABLE `chain_indices` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`height` integer, `block_id` blob);
+CREATE UNIQUE INDEX `idx_chain_indices_height` ON `chain_indices`(`height`);
+CREATE UNIQUE INDEX `idx_chain_indices_block_id` ON `chain_indices`(`block_id`);

--- a/stores/migrations/sqlite/main/schema.sql
+++ b/stores/migrations/sqlite/main/schema.sql
@@ -206,18 +206,21 @@ CREATE UNIQUE INDEX `idx_syncer_bans_net_cidr` ON `syncer_bans`(`net_cidr`);
 CREATE INDEX `idx_syncer_bans_expiration` ON `syncer_bans`(`expiration`);
 
 -- dbWalletEvent
-CREATE TABLE `wallet_events` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`event_id` blob NOT NULL,`inflow` text,`outflow` text,`transaction` text,`maturity_height` integer,`source` text,`timestamp` integer,`height` integer, `block_id` blob);
+CREATE TABLE `wallet_events` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`event_id` blob NOT NULL,`inflow` text,`outflow` text,`transaction` text,`maturity_height` integer,`source` text,`timestamp` integer,`db_chain_index_id` integer,CONSTRAINT `fk_wallet_events_chain_index` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices`(`id`) ON DELETE CASCADE);
 CREATE UNIQUE INDEX `idx_wallet_events_event_id` ON `wallet_events`(`event_id`);
 CREATE INDEX `idx_wallet_events_maturity_height` ON `wallet_events`(`maturity_height`);
 CREATE INDEX `idx_wallet_events_source` ON `wallet_events`(`source`);
 CREATE INDEX `idx_wallet_events_timestamp` ON `wallet_events`(`timestamp`);
-CREATE INDEX `idx_wallet_events_height` ON `wallet_events`(`height`);
 
 -- dbWalletOutput
-CREATE TABLE `wallet_outputs` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`output_id` blob NOT NULL,`leaf_index` integer,`merkle_proof` blob NOT NULL,`value` text,`address` blob,`maturity_height` integer,`height` integer, `block_id` blob);
+CREATE TABLE `wallet_outputs` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`output_id` blob NOT NULL,`leaf_index` integer,`merkle_proof` blob NOT NULL,`value` text,`address` blob,`maturity_height` integer,`db_chain_index_id` integer,CONSTRAINT `fk_contract_set_contracts_db_contract` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices`(`id`) ON DELETE CASCADE);
 CREATE UNIQUE INDEX `idx_wallet_outputs_output_id` ON `wallet_outputs`(`output_id`);
 CREATE INDEX `idx_wallet_outputs_maturity_height` ON `wallet_outputs`(`maturity_height`);
-CREATE INDEX `idx_wallet_outputs_height` ON `wallet_outputs`(`height`);
+
+-- dbChainIndex
+CREATE TABLE `chain_indices` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`height` integer, `block_id` blob);
+CREATE UNIQUE INDEX `idx_chain_indices_height` ON `chain_indices`(`height`);
+CREATE UNIQUE INDEX `idx_chain_indices_block_id` ON `chain_indices`(`block_id`);
 
 -- create default bucket
 INSERT INTO buckets (created_at, name) VALUES (CURRENT_TIMESTAMP, 'default');

--- a/stores/migrations/sqlite/main/schema.sql
+++ b/stores/migrations/sqlite/main/schema.sql
@@ -205,6 +205,11 @@ CREATE TABLE `syncer_bans` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` 
 CREATE UNIQUE INDEX `idx_syncer_bans_net_cidr` ON `syncer_bans`(`net_cidr`);
 CREATE INDEX `idx_syncer_bans_expiration` ON `syncer_bans`(`expiration`);
 
+-- dbChainIndex
+CREATE TABLE `chain_indices` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`height` integer, `block_id` blob);
+CREATE UNIQUE INDEX `idx_chain_indices_height` ON `chain_indices`(`height`);
+CREATE UNIQUE INDEX `idx_chain_indices_block_id` ON `chain_indices`(`block_id`);
+
 -- dbWalletEvent
 CREATE TABLE `wallet_events` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`event_id` blob NOT NULL,`inflow` text,`outflow` text,`transaction` text,`maturity_height` integer,`source` text,`timestamp` integer,`db_chain_index_id` integer,CONSTRAINT `fk_wallet_events_chain_index` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices`(`id`) ON DELETE CASCADE);
 CREATE UNIQUE INDEX `idx_wallet_events_event_id` ON `wallet_events`(`event_id`);
@@ -216,11 +221,6 @@ CREATE INDEX `idx_wallet_events_timestamp` ON `wallet_events`(`timestamp`);
 CREATE TABLE `wallet_outputs` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`output_id` blob NOT NULL,`leaf_index` integer,`merkle_proof` blob NOT NULL,`value` text,`address` blob,`maturity_height` integer,`db_chain_index_id` integer,CONSTRAINT `fk_contract_set_contracts_db_contract` FOREIGN KEY (`db_chain_index_id`) REFERENCES `chain_indices`(`id`) ON DELETE CASCADE);
 CREATE UNIQUE INDEX `idx_wallet_outputs_output_id` ON `wallet_outputs`(`output_id`);
 CREATE INDEX `idx_wallet_outputs_maturity_height` ON `wallet_outputs`(`maturity_height`);
-
--- dbChainIndex
-CREATE TABLE `chain_indices` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`height` integer, `block_id` blob);
-CREATE UNIQUE INDEX `idx_chain_indices_height` ON `chain_indices`(`height`);
-CREATE UNIQUE INDEX `idx_chain_indices_block_id` ON `chain_indices`(`block_id`);
 
 -- create default bucket
 INSERT INTO buckets (created_at, name) VALUES (CURRENT_TIMESTAMP, 'default');

--- a/stores/subscriber.go
+++ b/stores/subscriber.go
@@ -538,8 +538,10 @@ func (cs *chainSubscriber) AddEvents(events []wallet.Event) error {
 				MaturityHeight: event.MaturityHeight,
 				Source:         string(event.Source),
 				Timestamp:      event.Timestamp.Unix(),
-				Height:         event.Index.Height,
-				BlockID:        hash256(event.Index.ID),
+				DBChainIndex: dbChainIndex{
+					Height:  event.Index.Height,
+					BlockID: hash256(event.Index.ID),
+				},
 			},
 		})
 	}
@@ -562,8 +564,10 @@ func (cs *chainSubscriber) AddSiacoinElements(elements []wallet.SiacoinElement) 
 				Value:          currency(el.SiacoinOutput.Value),
 				Address:        hash256(el.SiacoinOutput.Address),
 				MaturityHeight: el.MaturityHeight,
-				Height:         el.Index.Height,
-				BlockID:        hash256(el.Index.ID),
+				DBChainIndex: dbChainIndex{
+					Height:  el.Index.Height,
+					BlockID: hash256(el.Index.ID),
+				},
 			},
 		}
 	}
@@ -620,7 +624,7 @@ func (cs *chainSubscriber) RevertIndex(index types.ChainIndex) error {
 	// remove any events that were added in the reverted block
 	filtered := cs.events[:0]
 	for i := range cs.events {
-		if cs.events[i].event.Index() != index {
+		if cs.events[i].event.DBChainIndex.convert() != index {
 			filtered = append(filtered, cs.events[i])
 		}
 	}
@@ -628,7 +632,7 @@ func (cs *chainSubscriber) RevertIndex(index types.ChainIndex) error {
 
 	// remove any siacoin elements that were added in the reverted block
 	for id, el := range cs.outputs {
-		if el.se.Index() == index {
+		if el.se.DBChainIndex.convert() == index {
 			delete(cs.outputs, id)
 		}
 	}


### PR DESCRIPTION
Add chain index type to easily revert all entities introduced at a certain index by making use of CASCADE deletes