### PR TITLE
Only register lost sectors alert if the percentage of sectors lost exceeds a certain threshold.

### DIFF
--- a/autopilot/contractor/alerts.go
+++ b/autopilot/contractor/alerts.go
@@ -8,6 +8,13 @@ import (
 	"go.sia.tech/renterd/api"
 )
 
+const (
+	// alertLostSectorsThresholdPct defines the the threshold at which we
+	// register the lost sectors alert. A value of 0.01 means that we register
+	// the alert if the host lost 1% (or more) of its stored data.
+	alertLostSectorsThresholdPct = 0.01
+)
+
 var (
 	alertChurnID         = alerts.RandomAlertID() // constant until restarted
 	alertLostSectorsID   = alerts.RandomAlertID() // constant until restarted
@@ -46,4 +53,8 @@ func newLostSectorsAlert(hk types.PublicKey, lostSectors uint64) alerts.Alert {
 		},
 		Timestamp: time.Now(),
 	}
+}
+
+func registerLostSectorsAlert(dataLost, dataStored uint64) bool {
+	return dataLost > 0 && float64(dataLost) >= float64(dataStored)*alertLostSectorsThresholdPct
 }

--- a/autopilot/contractor/alerts_test.go
+++ b/autopilot/contractor/alerts_test.go
@@ -1,0 +1,26 @@
+package contractor
+
+import (
+	"testing"
+
+	rhpv2 "go.sia.tech/core/rhp/v2"
+)
+
+func TestRegisterLostSectorsAlert(t *testing.T) {
+	for _, tc := range []struct {
+		dataLost   uint64
+		dataStored uint64
+		expected   bool
+	}{
+		{0, 0, false},
+		{0, rhpv2.SectorSize, false},
+		{rhpv2.SectorSize, 0, true},
+		{rhpv2.SectorSize, 99 * rhpv2.SectorSize, true},
+		{rhpv2.SectorSize, 100 * rhpv2.SectorSize, true},  // exactly 1%
+		{rhpv2.SectorSize, 101 * rhpv2.SectorSize, false}, // just short of 1%
+	} {
+		if result := registerLostSectorsAlert(tc.dataLost, tc.dataStored); result != tc.expected {
+			t.Fatalf("unexpected result for dataLost=%d, dataStored=%d: %v", tc.dataLost, tc.dataStored, result)
+		}
+	}
+}

--- a/autopilot/contractor/contractor.go
+++ b/autopilot/contractor/contractor.go
@@ -298,7 +298,7 @@ func (c *Contractor) performContractMaintenance(ctx *mCtx, w Worker) (bool, erro
 	// check if any used hosts have lost data to warn the user
 	var toDismiss []types.Hash256
 	for _, h := range hosts {
-		if h.Interactions.LostSectors > 0 {
+		if registerLostSectorsAlert(h.Interactions.LostSectors*rhpv2.SectorSize, h.StoredData) {
 			c.alerter.RegisterAlert(ctx, newLostSectorsAlert(h.PublicKey, h.Interactions.LostSectors))
 		} else {
 			toDismiss = append(toDismiss, alerts.IDForHost(alertLostSectorsID, h.PublicKey))


### PR DESCRIPTION
I noticed a handful of "Host has lost sectors" alerts on my node and `arequipa`.  Since we hint at blocking these hosts and since these alerts aren't really all that actionable I introduced a threshold, as Nate suggested in the last engineering sync. This is hardcoded to be 1% of the host's stored data.