### PR TITLE
Handle `context.DeadlineExceeded` when retrying a transaction

### DIFF
--- a/stores/sql.go
+++ b/stores/sql.go
@@ -546,6 +546,7 @@ func (s *SQLStore) retryTransaction(ctx context.Context, fc func(tx *gorm.DB) er
 	abortRetry := func(err error) bool {
 		if err == nil ||
 			errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded) ||
 			errors.Is(err, gorm.ErrRecordNotFound) ||
 			errors.Is(err, errInvalidNumberOfShards) ||
 			errors.Is(err, errShardRootChanged) ||

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -479,6 +479,7 @@ func TestRetryTransaction(t *testing.T) {
 	}
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Microsecond)
+	defer cancel()
 	time.Sleep(time.Millisecond)
 	ss.retryTransaction(ctx, func(tx *gorm.DB) error { return nil })
 	if len(observedLogs.All()) != len(want) {

--- a/stores/sql_test.go
+++ b/stores/sql_test.go
@@ -470,8 +470,17 @@ func TestRetryTransaction(t *testing.T) {
 		t.Fatal("unexpected logs", cmp.Diff(got, want))
 	}
 
-	// retry transaction that aborts, assert no logs were added
-	ss.retryTransaction(context.Background(), func(tx *gorm.DB) error { return context.Canceled })
+	// retry transaction with cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ss.retryTransaction(ctx, func(tx *gorm.DB) error { return nil })
+	if len(observedLogs.All()) != len(want) {
+		t.Fatal("expected no logs")
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Microsecond)
+	time.Sleep(time.Millisecond)
+	ss.retryTransaction(ctx, func(tx *gorm.DB) error { return nil })
 	if len(observedLogs.All()) != len(want) {
 		t.Fatal("expected no logs")
 	}


### PR DESCRIPTION
Caught these errors on `renterd` shutdown, fixed by adding a `context.DeadlineExceeded` case in `abortRetry`.
```
2024-04-23T10:49:08Z INFO  bus  successfully saved 392 accounts
2024-04-23T10:49:42Z ERROR SQL  trace {"error": "context deadline exceeded", "elapsed": "34.701151966s", "rows": 0, "sql": "\nDELETE\nFROM slabs\nWHERE NOT EXISTS (SELECT 1 FROM slices WHERE slices.db_slab_id = slabs.id)\nAND slabs.db_buffered_slab_id IS NULL\n"}
2024-04-23T10:49:42Z WARN  sql  transaction attempt 1/7 failed, retry in 200ms,  err: context deadline exceeded
2024-04-23T10:49:42Z WARN  sql  transaction attempt 2/7 failed, retry in 500ms,  err: context deadline exceeded
2024-04-23T10:49:43Z WARN  sql  transaction attempt 3/7 failed, retry in 1s,  err: context deadline exceeded
2024-04-23T10:49:44Z WARN  sql  transaction attempt 4/7 failed, retry in 3s,  err: context deadline exceeded
2024-04-23T10:49:47Z WARN  sql  transaction attempt 5/7 failed, retry in 10s,  err: context deadline exceeded
2024-04-23T10:49:57Z WARN  sql  transaction attempt 6/7 failed, retry in 10s,  err: context deadline exceeded
```