### PR TITLE
Call checkHost the same way before and during evaluation the autopilot config

### DIFF
--- a/autopilot/contractor/evaluate.go
+++ b/autopilot/contractor/evaluate.go
@@ -9,7 +9,6 @@ import (
 func countUsableHosts(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Currency, period uint64, rs api.RedundancySettings, gs api.GougingSettings, hosts []api.Host) (usables uint64) {
 	gc := worker.NewGougingChecker(gs, cs, fee, period, cfg.Contracts.RenewWindow)
 	for _, host := range hosts {
-		host.PriceTable.HostBlockHeight = cs.BlockHeight // ignore block height
 		hc := checkHost(cfg, rs, gc, host, minValidScore)
 		if hc.Usability.IsUsable() {
 			usables++
@@ -26,8 +25,9 @@ func EvaluateConfig(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Cu
 	gc := worker.NewGougingChecker(gs, cs, fee, period, cfg.Contracts.RenewWindow)
 
 	resp.Hosts = uint64(len(hosts))
-	for _, host := range hosts {
-		hc := checkHost(cfg, rs, gc, host, 0)
+	for i, host := range hosts {
+		hosts[i].PriceTable.HostBlockHeight = cs.BlockHeight // ignore block height
+		hc := checkHost(cfg, rs, gc, host, minValidScore)
 		if hc.Usability.IsUsable() {
 			resp.Usable++
 			continue


### PR DESCRIPTION
Not doing so caused slight differences in the returned value. e.g. it seemed like the number of usable hosts can improve by manually tweaking settings but no recommendation was returned.

Deployed this to Arequipa for testing @alexfreska 
If you set the target to `300` it should give you a recommendation now.

```bash
--- Current contracts ---
Contracts: 266
--- Target contracts ---
Contracts.Amount: 300
--- Before ---
MaxDownloadPrice: 1 KS
{
  "hosts": 722,
  "usable": 273,
  "unusable": {
    "blocked": 0,
    "gouging": {
      "contract": 12,
      "download": 109,
      "gouging": 131,
      "pruning": 7,
      "upload": 24
    },
    "notAcceptingContracts": 83,
    "notScanned": 86
  },
  "recommendation": {
    "gougingSettings": {
      "maxRPCPrice": "10000000000000000000",
      "maxContractPrice": "5000000000000000000000000",
      "maxDownloadPrice": "1155000000000000000000000000",
      "maxUploadPrice": "333333333000000000000000000",
      "maxStoragePrice": "154166666667",
      "hostBlockHeightLeeway": 12,
      "minPriceTableValidity": 600000000000,
      "minAccountExpiry": 86400000000000,
      "minMaxEphemeralAccountBalance": "1000000000000000000000000",
      "migrationSurchargeMultiplier": 10
    }
  }
}
--- After ---
MaxDownloadPrice: 1.03 KS
{
  "hosts": 722,
  "usable": 274,
  "unusable": {
    "blocked": 0,
    "gouging": {
      "contract": 12,
      "download": 107,
      "gouging": 131,
      "pruning": 7,
      "upload": 24
    },
    "notAcceptingContracts": 83,
    "notScanned": 86
  },
  "recommendation": {
    "gougingSettings": {
      "maxRPCPrice": "10000000000000000000",
      "maxContractPrice": "5000000000000000000000000",
      "maxDownloadPrice": "1135575000000000000000000000",
      "maxUploadPrice": "333333333000000000000000000",
      "maxStoragePrice": "154166666667",
      "hostBlockHeightLeeway": 12,
      "minPriceTableValidity": 600000000000,
      "minAccountExpiry": 86400000000000,
      "minMaxEphemeralAccountBalance": "1000000000000000000000000",
      "migrationSurchargeMultiplier": 10
    }
  }
}
```