### PR TITLE
Extract build steps that are independent of `os` and `go-version` into separate job

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [ "dev", "master" ]
   pull_request:
-    branches: [ "dev", "master" ]
+    branches: [ "master" ]
   schedule:
     - cron: '22 22 * * 4'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,22 +7,11 @@ on:
       - master
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest , macos-latest, windows-latest ]
-        go-version: [ '1.21', '1.22' ]
+  analyze:
+    runs-on: ubuntu-latest
     steps:
-      - name: Configure Windows
-        if: matrix.os == 'windows-latest'
-        run: git config --global core.autocrlf false # fixes go lint fmt error
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ matrix.go-version }}
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -36,6 +25,23 @@ jobs:
             autopilot
             bus bus/client
             worker worker/client
+  test:
+    needs: analyze
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest , macos-latest, windows-latest ]
+        go-version: [ '1.21', '1.22' ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Configure Windows
+        if: matrix.os == 'windows-latest'
+        run: git config --global core.autocrlf false # fixes go lint fmt error
       - name: Configure MySQL
         if: matrix.os == 'ubuntu-latest'
         uses: mirromutth/mysql-action@v1.1


### PR DESCRIPTION
Our jobs are kind of slow so I was looking at ways to speed them up. I couldn't really find any low hanging fruit but ended up extracting two steps (lint & analyze) I think should be run separately because they do not depend on the `os` or `go-version`. It saves us roughly a minute so nothing ground breaking. 

I ended up removing the `dev` trigger for the CodeQL job. I'm fine reverting that change but I feel we run that a lot without any real upside (so far). I can't remember the time it failed and made me change my PR for the better, since it takes more than two minutes on every single run maybe it's fine to only run it when we merge dev.