### PR TITLE
Fix race in `SlabBufferManager`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,34 +49,39 @@ jobs:
           host port: 3800
           mysql version: '8'
           mysql root password: test
-      - name: Test
-        uses: n8maninger/action-golang-test@v1
-        with:
-          args: "-race;-short"
-      - name: Test Stores - MySQL
-        if: matrix.os == 'ubuntu-latest'
-        uses: n8maninger/action-golang-test@v1
-        env:
-          RENTERD_DB_URI: 127.0.0.1:3800
-          RENTERD_DB_USER: root
-          RENTERD_DB_PASSWORD: test
-        with:
-          package: "./stores"
-          args: "-race;-short"
-      - name: Test Integration
+      # - name: Test
+      #   uses: n8maninger/action-golang-test@v1
+      #   with:
+      #     args: "-race;-short"
+      # - name: Test Stores - MySQL
+      #   if: matrix.os == 'ubuntu-latest'
+      #   uses: n8maninger/action-golang-test@v1
+      #   env:
+      #     RENTERD_DB_URI: 127.0.0.1:3800
+      #     RENTERD_DB_USER: root
+      #     RENTERD_DB_PASSWORD: test
+      #   with:
+      #     package: "./stores"
+      #     args: "-race;-short"
+      - name: Test Loop
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/test/e2e/..."
-          args: "-failfast;-race;-tags=testing;-timeout=30m"
-      - name: Test Integration - MySQL
-        if: matrix.os == 'ubuntu-latest'
-        uses: n8maninger/action-golang-test@v1
-        env:
-          RENTERD_DB_URI: 127.0.0.1:3800
-          RENTERD_DB_USER: root
-          RENTERD_DB_PASSWORD: test
-        with:
-          package: "./internal/test/e2e/..."
-          args: "-failfast;-race;-tags=testing;-timeout=30m"
+          args: "-failfast;-race;-tags=testing;-count=100;-timeout=180m;-run=^TestGouging$"
+      # - name: Test Integration
+      #   uses: n8maninger/action-golang-test@v1
+      #   with:
+      #     package: "./internal/test/e2e/..."
+      #     args: "-failfast;-race;-tags=testing;-timeout=30m"
+      # - name: Test Integration - MySQL
+      #   if: matrix.os == 'ubuntu-latest'
+      #   uses: n8maninger/action-golang-test@v1
+      #   env:
+      #     RENTERD_DB_URI: 127.0.0.1:3800
+      #     RENTERD_DB_USER: root
+      #     RENTERD_DB_PASSWORD: test
+      #   with:
+      #     package: "./internal/test/e2e/..."
+      #     args: "-failfast;-race;-tags=testing;-timeout=30m"
       - name: Build
         run: go build -o bin/ ./cmd/renterd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,39 +49,34 @@ jobs:
           host port: 3800
           mysql version: '8'
           mysql root password: test
-      # - name: Test
-      #   uses: n8maninger/action-golang-test@v1
-      #   with:
-      #     args: "-race;-short"
-      # - name: Test Stores - MySQL
-      #   if: matrix.os == 'ubuntu-latest'
-      #   uses: n8maninger/action-golang-test@v1
-      #   env:
-      #     RENTERD_DB_URI: 127.0.0.1:3800
-      #     RENTERD_DB_USER: root
-      #     RENTERD_DB_PASSWORD: test
-      #   with:
-      #     package: "./stores"
-      #     args: "-race;-short"
-      - name: Test Loop
+      - name: Test
+        uses: n8maninger/action-golang-test@v1
+        with:
+          args: "-race;-short"
+      - name: Test Stores - MySQL
+        if: matrix.os == 'ubuntu-latest'
+        uses: n8maninger/action-golang-test@v1
+        env:
+          RENTERD_DB_URI: 127.0.0.1:3800
+          RENTERD_DB_USER: root
+          RENTERD_DB_PASSWORD: test
+        with:
+          package: "./stores"
+          args: "-race;-short"
+      - name: Test Integration
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/test/e2e/..."
-          args: "-failfast;-race;-tags=testing;-count=100;-timeout=180m;-run=^TestGouging$"
-      # - name: Test Integration
-      #   uses: n8maninger/action-golang-test@v1
-      #   with:
-      #     package: "./internal/test/e2e/..."
-      #     args: "-failfast;-race;-tags=testing;-timeout=30m"
-      # - name: Test Integration - MySQL
-      #   if: matrix.os == 'ubuntu-latest'
-      #   uses: n8maninger/action-golang-test@v1
-      #   env:
-      #     RENTERD_DB_URI: 127.0.0.1:3800
-      #     RENTERD_DB_USER: root
-      #     RENTERD_DB_PASSWORD: test
-      #   with:
-      #     package: "./internal/test/e2e/..."
-      #     args: "-failfast;-race;-tags=testing;-timeout=30m"
+          args: "-failfast;-race;-tags=testing;-timeout=30m"
+      - name: Test Integration - MySQL
+        if: matrix.os == 'ubuntu-latest'
+        uses: n8maninger/action-golang-test@v1
+        env:
+          RENTERD_DB_URI: 127.0.0.1:3800
+          RENTERD_DB_USER: root
+          RENTERD_DB_PASSWORD: test
+        with:
+          package: "./internal/test/e2e/..."
+          args: "-failfast;-race;-tags=testing;-timeout=30m"
       - name: Build
         run: go build -o bin/ ./cmd/renterd

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -468,7 +468,7 @@ func newTestCluster(t *testing.T, opts testClusterOptions) *TestCluster {
 		cluster.AddHostsBlocking(nHosts)
 		cluster.WaitForContracts()
 		cluster.WaitForContractSet(test.ContractSet, nHosts)
-		_ = cluster.WaitForAccounts()
+		cluster.WaitForAccounts()
 	}
 
 	// Ping the UI
@@ -574,7 +574,9 @@ func (c *TestCluster) MineBlocks(n int) {
 	if len(c.hosts) == 0 {
 		c.tt.OK(c.miner.Mine(wallet.Address, n))
 		c.Sync()
+		return
 	}
+
 	// Otherwise mine blocks in batches of 3 to avoid going out of sync with
 	// hosts by too many blocks.
 	for mined := 0; mined < n; {

--- a/stores/slabbuffer.go
+++ b/stores/slabbuffer.go
@@ -307,10 +307,9 @@ func (mgr *SlabBufferManager) SlabBuffers() (sbs []api.SlabBuffer) {
 
 func (mgr *SlabBufferManager) SlabsForUpload(ctx context.Context, lockingDuration time.Duration, minShards, totalShards uint8, set uint, limit int) (slabs []api.PackedSlab, _ error) {
 	mgr.mu.Lock()
-	buffers := mgr.completeBuffers[bufferGID(minShards, totalShards, uint32(set))]
-	mgr.mu.Unlock()
+	defer mgr.mu.Unlock()
 
-	for _, buffer := range buffers {
+	for _, buffer := range mgr.completeBuffers[bufferGID(minShards, totalShards, uint32(set))] {
 		if !buffer.acquireForUpload(lockingDuration) {
 			continue
 		}

--- a/stores/slabbuffer.go
+++ b/stores/slabbuffer.go
@@ -306,10 +306,13 @@ func (mgr *SlabBufferManager) SlabBuffers() (sbs []api.SlabBuffer) {
 }
 
 func (mgr *SlabBufferManager) SlabsForUpload(ctx context.Context, lockingDuration time.Duration, minShards, totalShards uint8, set uint, limit int) (slabs []api.PackedSlab, _ error) {
+	// Deep copy complete buffers. We don't want to block the manager while we
+	// perform disk I/O.
 	mgr.mu.Lock()
-	defer mgr.mu.Unlock()
+	buffers := append([]*SlabBuffer{}, mgr.completeBuffers[bufferGID(minShards, totalShards, uint32(set))]...)
+	mgr.mu.Unlock()
 
-	for _, buffer := range mgr.completeBuffers[bufferGID(minShards, totalShards, uint32(set))] {
+	for _, buffer := range buffers {
 		if !buffer.acquireForUpload(lockingDuration) {
 			continue
 		}


### PR DESCRIPTION
This PR fixes the following race

```
 ==================
  WARNING: DATA RACE
  Write at 0x00c002b56060 by goroutine 199842:
    go.sia.tech/renterd/stores.(*SlabBufferManager).RemoveBuffers()
  Error: /Users/runner/work/renterd/renterd/stores/slabbuffer.go:367 +0x744
    go.sia.tech/renterd/stores.(*SQLStore).MarkPackedSlabsUploaded()
  Error: /Users/runner/work/renterd/renterd/stores/metadata.go:2528 +0x2b0

...
  
  Previous read at 0x00c002b56060 by goroutine 199673:
    go.sia.tech/renterd/stores.(*SlabBufferManager).SlabsForUpload()
  Error: /Users/runner/work/renterd/renterd/stores/slabbuffer.go:313 +0x18c
    go.sia.tech/renterd/stores.(*SQLStore).PackedSlabsForUpload()
  Error: /Users/runner/work/renterd/renterd/stores/metadata.go:2467 +0x1d0
    go.sia.tech/renterd/bus.(*bus).packedSlabsHandlerFetchPOST()

... 
  
  Goroutine 199673 (running) created at:
    net/http.(*Server).Serve()
  Error: /Users/runner/hostedtoolcache/go/1.21.9/arm64/src/net/http/server.go:3086 +0x638
    go.sia.tech/renterd/internal/test/e2e.newTestCluster.func1()
  Error: /Users/runner/work/renterd/renterd/internal/test/e2e/cluster.go:393 +0x4c
  ==================
  ```
  
  We were grabbing pointers, but I see why we didn't grab the lock in the first place but I think that it's fine to have `RemoveBuffers` and `SlabsForUpload` grab the main lock due to the nature of the manager and how we use `MarkPackedSlabsUploaded` and `SlabsForUpload`. 