### PR TITLE
Migrate RenameObject to raw SQL

### DIFF
--- a/internal/sql/migrations.go
+++ b/internal/sql/migrations.go
@@ -111,9 +111,13 @@ var (
 						for rows.Next() {
 							var o obj
 							if err := rows.Scan(&o.ID, &o.ObjectID); err != nil {
+								_ = rows.Close()
 								return fmt.Errorf("failed to scan object: %v", err)
 							}
 							objBatch = append(objBatch, o)
+						}
+						if err := rows.Close(); err != nil {
+							return fmt.Errorf("failed to close rows: %v", err)
 						}
 						if len(objBatch) == 0 {
 							break // done

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -14,8 +14,9 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/internal/sql"
+	isql "go.sia.tech/renterd/internal/sql"
 	"go.sia.tech/renterd/object"
+	sql "go.sia.tech/renterd/stores/sql"
 	"go.sia.tech/siad/modules"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
@@ -1524,28 +1525,22 @@ func fetchUsedContracts(tx *gorm.DB, usedContractsByHost map[types.PublicKey]map
 }
 
 func (s *SQLStore) RenameObject(ctx context.Context, bucket, keyOld, keyNew string, force bool) error {
-	return s.retryTransaction(ctx, func(tx *gorm.DB) error {
+	return s.bMain.Transaction(func(tx sql.DatabaseTx) error {
 		if force {
 			// delete potentially existing object at destination
-			if _, err := s.deleteObject(tx, bucket, keyNew); err != nil {
+			if _, err := tx.DeleteObject(bucket, keyNew); err != nil {
 				return fmt.Errorf("RenameObject: failed to delete object: %w", err)
 			}
 		}
 		// create new dir
-		dirID, err := makeDirsForPath(tx, keyNew)
+		dirID, err := tx.MakeDirsForPath(keyNew)
 		if err != nil {
 			return err
 		}
 		// update object
-		tx = tx.Exec(`UPDATE objects SET object_id = ?, db_directory_id = ? WHERE object_id = ? AND ?`, keyNew, dirID, keyOld, sqlWhereBucket("objects", bucket))
-		if tx.Error != nil &&
-			(strings.Contains(tx.Error.Error(), "UNIQUE constraint failed") || strings.Contains(tx.Error.Error(), "Duplicate entry")) {
-			return api.ErrObjectExists
-		} else if tx.Error != nil {
-			return tx.Error
-		}
-		if tx.RowsAffected == 0 {
-			return fmt.Errorf("%w: key %v", api.ErrObjectNotFound, keyOld)
+		err = tx.RenameObject(bucket, keyOld, keyNew, dirID)
+		if err != nil {
+			return err
 		}
 		// delete old dir if empty
 		s.triggerSlabPruning()
@@ -1787,7 +1782,7 @@ func (s *SQLStore) dirID(tx *gorm.DB, dirPath string) (uint, error) {
 
 func makeDirsForPath(tx *gorm.DB, path string) (uint, error) {
 	// Create root dir.
-	dirID := uint(sql.DirectoriesRootID)
+	dirID := uint(isql.DirectoriesRootID)
 	if err := tx.Model(&dbDirectory{}).
 		Clauses(clause.OnConflict{
 			DoNothing: true,

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1526,19 +1526,13 @@ func fetchUsedContracts(tx *gorm.DB, usedContractsByHost map[types.PublicKey]map
 
 func (s *SQLStore) RenameObject(ctx context.Context, bucket, keyOld, keyNew string, force bool) error {
 	return s.bMain.Transaction(func(tx sql.DatabaseTx) error {
-		if force {
-			// delete potentially existing object at destination
-			if _, err := tx.DeleteObject(bucket, keyNew); err != nil {
-				return fmt.Errorf("RenameObject: failed to delete object: %w", err)
-			}
-		}
 		// create new dir
 		dirID, err := tx.MakeDirsForPath(keyNew)
 		if err != nil {
 			return err
 		}
 		// update object
-		err = tx.RenameObject(bucket, keyOld, keyNew, dirID)
+		err = tx.RenameObject(bucket, keyOld, keyNew, dirID, force)
 		if err != nil {
 			return err
 		}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -21,6 +21,7 @@ import (
 	"go.sia.tech/renterd/config"
 	"go.sia.tech/renterd/internal/test"
 	"go.sia.tech/renterd/object"
+	sql "go.sia.tech/renterd/stores/sql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
 	"lukechampine.com/frand"
@@ -4136,7 +4137,12 @@ func TestSlabCleanup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dirID, err := makeDirsForPath(ss.db, "1")
+	var dirID uint
+	err := ss.bMain.Transaction(func(tx sql.DatabaseTx) error {
+		var err error
+		dirID, err = tx.MakeDirsForPath("1")
+		return err
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4841,7 +4847,12 @@ func TestDirectories(t *testing.T) {
 	}
 
 	for _, o := range objects {
-		dirID, err := makeDirsForPath(ss.db, o)
+		var dirID uint
+		err := ss.bMain.Transaction(func(tx sql.DatabaseTx) error {
+			var err error
+			dirID, err = tx.MakeDirsForPath(o)
+			return err
+		})
 		if err != nil {
 			t.Fatal(err)
 		} else if dirID == 0 {

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -3,24 +3,37 @@ package sql
 import (
 	"context"
 	"io"
-
-	"go.sia.tech/renterd/stores/sql/mysql"
-	"go.sia.tech/renterd/stores/sql/sqlite"
 )
-
-// All database implementations must satisfy the interfaces.
-var _ Database = (*mysql.MainDatabase)(nil)
-var _ Database = (*sqlite.MainDatabase)(nil)
-var _ MetricsDatabase = (*mysql.MetricsDatabase)(nil)
-var _ MetricsDatabase = (*sqlite.MetricsDatabase)(nil)
 
 // The database interfaces define all methods that a SQL database must implement
 // to be used by the SQLStore.
 type (
 	Database interface {
 		io.Closer
+
+		// Transaction starts a new transaction.
+		Transaction(fn func(DatabaseTx) error) error
+
+		// Migrate runs all missing migrations on the database.
 		Migrate() error
+
+		// Version returns the database version and name.
 		Version(ctx context.Context) (string, string, error)
+	}
+
+	DatabaseTx interface {
+		// DeleteObject deletes an object from the database and returns true if
+		// the requested object was actually deleted.
+		DeleteObject(bucket, key string) (bool, error)
+
+		// MakeDirsForPath creates all directories for a given object's path.
+		MakeDirsForPath(path string) (uint, error)
+
+		// RenameObject renames an object in the database from keyOld to keyNew
+		// and the new directory dirID. returns api.ErrObjectExists if the an
+		// object already exists at the target location or api.ErrObjectNotFound
+		// if the object at keyOld doesn't exist.
+		RenameObject(bucket, keyOld, keyNew string, dirID uint) error
 	}
 
 	MetricsDatabase interface {

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -32,8 +32,10 @@ type (
 		// RenameObject renames an object in the database from keyOld to keyNew
 		// and the new directory dirID. returns api.ErrObjectExists if the an
 		// object already exists at the target location or api.ErrObjectNotFound
-		// if the object at keyOld doesn't exist.
-		RenameObject(bucket, keyOld, keyNew string, dirID uint) error
+		// if the object at keyOld doesn't exist. If force is true, the instead
+		// of returning api.ErrObjectExists, the existing object will be
+		// deleted.
+		RenameObject(bucket, keyOld, keyNew string, dirID uint, force bool) error
 	}
 
 	MetricsDatabase interface {

--- a/stores/sql/mysql/common.go
+++ b/stores/sql/mysql/common.go
@@ -7,6 +7,10 @@ import (
 	"go.sia.tech/renterd/internal/sql"
 )
 
+var deadlockMsgs = []string{
+	"Deadlock found when trying to get lock",
+}
+
 //go:embed all:migrations/*
 var migrationsFs embed.FS
 

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -139,12 +139,19 @@ func (tx *MainDatabaseTx) MakeDirsForPath(path string) (uint, error) {
 	return dirID, nil
 }
 
-func (tx *MainDatabaseTx) RenameObject(bucket, keyOld, keyNew string, dirID uint) error {
-	var exists bool
-	if err := tx.QueryRow("SELECT EXISTS (SELECT 1 FROM objects WHERE object_id = ? AND db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?))", keyNew, bucket).Scan(&exists); err != nil {
-		return err
-	} else if exists {
-		return api.ErrObjectExists
+func (tx *MainDatabaseTx) RenameObject(bucket, keyOld, keyNew string, dirID uint, force bool) error {
+	if force {
+		// delete potentially existing object at destination
+		if _, err := tx.DeleteObject(bucket, keyNew); err != nil {
+			return fmt.Errorf("RenameObject: failed to delete object: %w", err)
+		}
+	} else {
+		var exists bool
+		if err := tx.QueryRow("SELECT EXISTS (SELECT 1 FROM objects WHERE object_id = ? AND db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?))", keyNew, bucket).Scan(&exists); err != nil {
+			return err
+		} else if exists {
+			return api.ErrObjectExists
+		}
 	}
 	resp, err := tx.Exec(`UPDATE objects SET object_id = ?, db_directory_id = ? WHERE object_id = ? AND db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?)`, keyNew, dirID, keyOld, bucket)
 	if err != nil {

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -108,7 +108,7 @@ func (tx *MainDatabaseTx) MakeDirsForPath(path string) (uint, error) {
 
 	// Create root dir.
 	dirID := uint(sql.DirectoriesRootID)
-	if _, err := insertDirStmt.Exec('/', dirID); err != nil {
+	if _, err := tx.Exec("INSERT INTO directories (id, name, db_parent_id) VALUES (?, '/', NULL) ON DUPLICATE KEY UPDATE id = id", dirID); err != nil {
 		return 0, fmt.Errorf("failed to create root directory: %w", err)
 	}
 

--- a/stores/sql/mysql/metrics.go
+++ b/stores/sql/mysql/metrics.go
@@ -18,7 +18,7 @@ type MetricsDatabase struct {
 
 // NewMetricsDatabase creates a new MySQL backend.
 func NewMetricsDatabase(db *dsql.DB, log *zap.SugaredLogger, lqd, ltd time.Duration) *MetricsDatabase {
-	store := sql.NewDB(db, log.Desugar(), "Deadlock found when trying to get lock", lqd, ltd)
+	store := sql.NewDB(db, log.Desugar(), deadlockMsgs, lqd, ltd)
 	return &MetricsDatabase{
 		db:  store,
 		log: log,

--- a/stores/sql/sqlite/common.go
+++ b/stores/sql/sqlite/common.go
@@ -9,6 +9,11 @@ import (
 	"go.sia.tech/renterd/internal/sql"
 )
 
+var deadlockMsgs = []string{
+	"database is locked",
+	"database table is locked",
+}
+
 //go:embed all:migrations/*
 var migrationsFs embed.FS
 

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -96,7 +96,7 @@ func (tx *MainDatabaseTx) MakeDirsForPath(path string) (uint, error) {
 
 	// Create root dir.
 	dirID := uint(sql.DirectoriesRootID)
-	if _, err := insertDirStmt.Exec('/', dirID); err != nil {
+	if _, err := tx.Exec("INSERT INTO directories (id, name, db_parent_id) VALUES (?, '/', NULL) ON CONFLICT(id) DO NOTHING", dirID); err != nil {
 		return 0, fmt.Errorf("failed to create root directory: %w", err)
 	}
 

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -128,10 +128,14 @@ func (tx *MainDatabaseTx) MakeDirsForPath(path string) (uint, error) {
 }
 
 func (tx *MainDatabaseTx) RenameObject(bucket, keyOld, keyNew string, dirID uint) error {
-	resp, err := tx.Exec(`UPDATE objects SET object_id = ?, db_directory_id = ? WHERE object_id = ? AND db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?)`, keyNew, dirID, keyOld, bucket)
-	if err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed") {
+	var exists bool
+	if err := tx.QueryRow("SELECT EXISTS (SELECT 1 FROM objects WHERE object_id = ? AND db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?))", keyNew, bucket).Scan(&exists); err != nil {
+		return err
+	} else if exists {
 		return api.ErrObjectExists
-	} else if err != nil {
+	}
+	resp, err := tx.Exec(`UPDATE objects SET object_id = ?, db_directory_id = ? WHERE object_id = ? AND db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?)`, keyNew, dirID, keyOld, bucket)
+	if err != nil {
 		return err
 	} else if n, err := resp.RowsAffected(); err != nil {
 		return err

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -8,15 +8,23 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/internal/sql"
+	ssql "go.sia.tech/renterd/stores/sql"
 
 	"go.uber.org/zap"
 )
 
-type MainDatabase struct {
-	db  *sql.DB
-	log *zap.SugaredLogger
-}
+type (
+	MainDatabase struct {
+		db  *sql.DB
+		log *zap.SugaredLogger
+	}
+
+	MainDatabaseTx struct {
+		sql.Tx
+	}
+)
 
 // NewMainDatabase creates a new SQLite backend.
 func NewMainDatabase(db *dsql.DB, log *zap.SugaredLogger, lqd, ltd time.Duration) *MainDatabase {
@@ -44,6 +52,36 @@ func (b *MainDatabase) CreateMigrationTable() error {
 }
 
 func (b *MainDatabase) MakeDirsForPath(tx sql.Tx, path string) (uint, error) {
+	mtx := &MainDatabaseTx{tx}
+	return mtx.MakeDirsForPath(path)
+}
+
+func (b *MainDatabase) Migrate() error {
+	return sql.PerformMigrations(b, migrationsFs, "main", sql.MainMigrations(b, migrationsFs, b.log))
+}
+
+func (b *MainDatabase) Transaction(fn func(tx ssql.DatabaseTx) error) error {
+	return b.db.Transaction(func(tx sql.Tx) error {
+		return fn(&MainDatabaseTx{tx})
+	})
+}
+
+func (b *MainDatabase) Version(_ context.Context) (string, string, error) {
+	return version(b.db)
+}
+
+func (tx *MainDatabaseTx) DeleteObject(bucket string, key string) (bool, error) {
+	resp, err := tx.Exec("DELETE FROM objects WHERE object_id = ? AND db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?) LIMIT 1", key, bucket)
+	if err != nil {
+		return false, err
+	} else if n, err := resp.RowsAffected(); err != nil {
+		return false, err
+	} else {
+		return n != 0, nil
+	}
+}
+
+func (tx *MainDatabaseTx) MakeDirsForPath(path string) (uint, error) {
 	insertDirStmt, err := tx.Prepare("INSERT INTO directories (name, db_parent_id) VALUES (?, ?) ON CONFLICT(name) DO NOTHING")
 	if err != nil {
 		return 0, fmt.Errorf("failed to prepare statement: %w", err)
@@ -89,10 +127,16 @@ func (b *MainDatabase) MakeDirsForPath(tx sql.Tx, path string) (uint, error) {
 	return dirID, nil
 }
 
-func (b *MainDatabase) Migrate() error {
-	return sql.PerformMigrations(b, migrationsFs, "main", sql.MainMigrations(b, migrationsFs, b.log))
-}
-
-func (b *MainDatabase) Version(_ context.Context) (string, string, error) {
-	return version(b.db)
+func (tx *MainDatabaseTx) RenameObject(bucket, keyOld, keyNew string, dirID uint) error {
+	resp, err := tx.Exec(`UPDATE objects SET object_id = ?, db_directory_id = ? WHERE object_id = ? AND db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?)`, keyNew, dirID, keyOld, bucket)
+	if err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed") {
+		return api.ErrObjectExists
+	} else if err != nil {
+		return err
+	} else if n, err := resp.RowsAffected(); err != nil {
+		return err
+	} else if n == 0 {
+		return fmt.Errorf("%w: key %v", api.ErrObjectNotFound, keyOld)
+	}
+	return nil
 }

--- a/stores/sql/sqlite/metrics.go
+++ b/stores/sql/sqlite/metrics.go
@@ -17,7 +17,7 @@ type MetricsDatabase struct {
 
 // NewSQLiteDatabase creates a new SQLite backend.
 func NewMetricsDatabase(db *dsql.DB, log *zap.SugaredLogger, lqd, ltd time.Duration) *MetricsDatabase {
-	store := sql.NewDB(db, log.Desugar(), "database is locked", lqd, ltd)
+	store := sql.NewDB(db, log.Desugar(), deadlockMsgs, lqd, ltd)
 	return &MetricsDatabase{
 		db:  store,
 		log: log,


### PR DESCRIPTION
This is the first method migrated to the new raw sql database type. Starting with a smaller one to keep things easy.

NOTE: `DeleteObject` is different for SQLite and MySQL on purpose. SQLite is less granular when it comes to locking so in my experience performing the writing operation sooner rather than later in the txn reduces the frequency of locking errors.

MySQL on the other hand seemed to benefit from reading the value first to avoid the optimistic locking MySQL performs in the common case.

I'm sure now that we keep these implementations separate we will find many more spots where reorganising queries within transactions will help us improve performance for individual database engines. 