### PR TITLE
Dismiss pruning alerts for contract IDs that are no longer prunable

### DIFF
--- a/autopilot/alerts.go
+++ b/autopilot/alerts.go
@@ -73,23 +73,17 @@ func newAccountRefillAlert(id rhpv3.Account, contract api.ContractMetadata, err 
 	}
 }
 
-func newContractPruningFailedAlert(hk types.PublicKey, version string, fcid types.FileContractID, err error) *alerts.Alert {
-	data := map[string]interface{}{"error": err.Error()}
-	if hk != (types.PublicKey{}) {
-		data["hostKey"] = hk.String()
-	}
-	if version != "" {
-		data["hostVersion"] = version
-	}
-	if fcid != (types.FileContractID{}) {
-		data["contractID"] = fcid.String()
-	}
-
-	return &alerts.Alert{
-		ID:        alerts.IDForContract(alertPruningID, fcid),
-		Severity:  alerts.SeverityWarning,
-		Message:   "Contract pruning failed",
-		Data:      data,
+func newContractPruningFailedAlert(hk types.PublicKey, version string, fcid types.FileContractID, err error) alerts.Alert {
+	return alerts.Alert{
+		ID:       alerts.IDForContract(alertPruningID, fcid),
+		Severity: alerts.SeverityWarning,
+		Message:  "Contract pruning failed",
+		Data: map[string]interface{}{
+			"contractID":  fcid.String(),
+			"error":       err.Error(),
+			"hostKey":     hk.String(),
+			"hostVersion": version,
+		},
 		Timestamp: time.Now(),
 	}
 }

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -117,6 +117,7 @@ type Autopilot struct {
 	mu               sync.Mutex
 	pruning          bool
 	pruningLastStart time.Time
+	pruningAlertIDs  map[types.FileContractID]types.Hash256
 
 	maintenanceTxnIDs []types.TransactionID
 }
@@ -136,6 +137,8 @@ func New(id string, bus Bus, workers []Worker, logger *zap.Logger, heartbeat tim
 		shutdownCtxCancel: shutdownCtxCancel,
 
 		tickerDuration: heartbeat,
+
+		pruningAlertIDs: make(map[types.FileContractID]types.Hash256),
 	}
 	scanner, err := newScanner(
 		ap,

--- a/autopilot/contract_pruning.go
+++ b/autopilot/contract_pruning.go
@@ -19,75 +19,31 @@ var (
 )
 
 const (
-	// timeoutPruneContract is the amount of time we wait for a contract to get
-	// pruned.
+	// timeoutPruneContract defines the maximum amount of time we lock a
+	// contract for pruning
 	timeoutPruneContract = 10 * time.Minute
 )
 
-type (
-	pruneResult struct {
-		ts time.Time
+func (ap *Autopilot) dismissPruneAlerts(prunable []api.ContractPrunableData) {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
 
-		fcid    types.FileContractID
-		hk      types.PublicKey
-		version string
+	// use a sane timeout
+	ctx, cancel := context.WithTimeout(ap.shutdownCtx, 5*time.Minute)
+	defer cancel()
 
-		pruned    uint64
-		remaining uint64
-		duration  time.Duration
-
-		err error
+	// fetch contract ids that are prunable
+	prunableIDs := make(map[types.FileContractID]struct{})
+	for _, contract := range prunable {
+		prunableIDs[contract.ID] = struct{}{}
 	}
 
-	pruneMetrics []api.ContractPruneMetric
-)
-
-func (pr pruneResult) String() string {
-	msg := fmt.Sprintf("contract %v", pr.fcid)
-	if pr.hk != (types.PublicKey{}) {
-		msg += fmt.Sprintf(", host %v version %s", pr.hk, pr.version)
-	}
-	if pr.pruned > 0 {
-		msg += fmt.Sprintf(", pruned %d bytes, remaining %d bytes, elapsed %v", pr.pruned, pr.remaining, pr.duration)
-	}
-	if pr.err != nil {
-		msg += fmt.Sprintf(", err: %v", pr.err)
-	}
-	return msg
-}
-
-func (pm pruneMetrics) String() string {
-	var total uint64
-	for _, m := range pm {
-		total += m.Pruned
-	}
-	return fmt.Sprintf("pruned %d (%s) from %v contracts", total, humanReadableSize(int(total)), len(pm))
-}
-
-func (pr pruneResult) toAlert() (id types.Hash256, alert *alerts.Alert) {
-	id = alerts.IDForContract(alertPruningID, pr.fcid)
-
-	if shouldTrigger := pr.err != nil && !((utils.IsErr(pr.err, errInvalidMerkleProof) && build.VersionCmp(pr.version, "1.6.0") < 0) ||
-		utils.IsErr(pr.err, api.ErrContractNotFound) || // contract got archived
-		utils.IsErr(pr.err, utils.ErrConnectionRefused) ||
-		utils.IsErr(pr.err, utils.ErrConnectionTimedOut) ||
-		utils.IsErr(pr.err, utils.ErrConnectionResetByPeer) ||
-		utils.IsErr(pr.err, errInvalidHandshakeSignature) ||
-		utils.IsErr(pr.err, utils.ErrNoRouteToHost) ||
-		utils.IsErr(pr.err, utils.ErrNoSuchHost)); shouldTrigger {
-		alert = newContractPruningFailedAlert(pr.hk, pr.version, pr.fcid, pr.err)
-	}
-	return
-}
-
-func (pr pruneResult) toMetric() api.ContractPruneMetric {
-	return api.ContractPruneMetric{
-		Timestamp:  api.TimeRFC3339(pr.ts),
-		ContractID: pr.fcid,
-		HostKey:    pr.hk,
-		Pruned:     pr.pruned,
-		Remaining:  pr.remaining,
-		Duration:   pr.duration,
+	// dismiss alerts for contracts that are no longer prunable
+	for fcid, alertID := range ap.pruningAlertIDs {
+		if _, ok := prunableIDs[fcid]; !ok {
+			ap.DismissAlert(ctx, alertID)
+			delete(ap.pruningAlertIDs, fcid)
+		}
 	}
 }
 
@@ -131,7 +87,11 @@ func (ap *Autopilot) fetchPrunableContracts() (prunable []api.ContractPrunableDa
 	return
 }
 
-func (ap *Autopilot) hostForContract(ctx context.Context, fcid types.FileContractID) (host api.Host, metadata api.ContractMetadata, err error) {
+func (ap *Autopilot) fetchHostContract(fcid types.FileContractID) (host api.Host, metadata api.ContractMetadata, err error) {
+	// use a sane timeout
+	ctx, cancel := context.WithTimeout(ap.shutdownCtx, time.Minute)
+	defer cancel()
+
 	// fetch the contract
 	metadata, err = ap.bus.Contract(ctx, fcid)
 	if err != nil {
@@ -151,102 +111,92 @@ func (ap *Autopilot) performContractPruning(wp *workerPool) {
 	if err != nil {
 		ap.logger.Error(err)
 		return
-	} else if len(prunable) == 0 {
-		ap.logger.Info("no contracts to prune")
-		return
 	}
 
-	// prune every contract individually, one at a time and for a maximum
-	// duration of 'timeoutPruneContract' to limit the amount of time we lock
-	// the contract as contracts on old hosts can take a long time to prune
-	var metrics pruneMetrics
-	wp.withWorker(func(w Worker) {
-		for _, contract := range prunable {
-			// return if we're stopped
-			if ap.isStopped() {
-				return
-			}
+	// dismiss alerts for contracts that are no longer prunable
+	ap.dismissPruneAlerts(prunable)
 
-			// prune contract
-			result := ap.pruneContract(w, contract.ID)
-			if result.err != nil {
-				ap.logger.Error(result)
-			} else {
-				ap.logger.Info(result)
-			}
-
-			// handle alert
-			ctx, cancel := context.WithTimeout(ap.shutdownCtx, time.Minute)
-			if id, alert := result.toAlert(); alert != nil {
-				ap.RegisterAlert(ctx, *alert)
-			} else {
-				ap.DismissAlert(ctx, id)
-			}
-			cancel()
-
-			// handle metrics
-			metrics = append(metrics, result.toMetric())
+	// loop prunable contracts
+	var total uint64
+	for _, contract := range prunable {
+		// check if we're stopped
+		if ap.isStopped() {
+			break
 		}
-	})
 
-	// record metrics
-	ctx, cancel := context.WithTimeout(ap.shutdownCtx, time.Minute)
-	if err := ap.bus.RecordContractPruneMetric(ctx, metrics...); err != nil {
-		ap.logger.Error(err)
+		// fetch host
+		h, _, err := ap.fetchHostContract(contract.ID)
+		if utils.IsErr(err, api.ErrContractNotFound) {
+			continue // contract got archived
+		} else if err != nil {
+			ap.logger.Errorf("failed to fetch host for contract '%v', err %v", contract.ID, err)
+			continue
+		}
+
+		// prune contract using a random worker
+		wp.withWorker(func(w Worker) {
+			total += ap.pruneContract(w, contract.ID, h.PublicKey, h.Settings.Version)
+		})
 	}
-	cancel()
 
-	// log metrics
-	ap.logger.Info(metrics)
+	// log total pruned
+	ap.logger.Info(fmt.Sprintf("pruned %d (%s) from %v contracts", total, humanReadableSize(int(total)), len(prunable)))
 }
 
-func (ap *Autopilot) pruneContract(w Worker, fcid types.FileContractID) pruneResult {
-	// create a sane timeout
-	ctx, cancel := context.WithTimeout(ap.shutdownCtx, 2*timeoutPruneContract)
+func (ap *Autopilot) pruneContract(w Worker, fcid types.FileContractID, hk types.PublicKey, hostVersion string) uint64 {
+	// use a sane timeout
+	ctx, cancel := context.WithTimeout(ap.shutdownCtx, timeoutPruneContract+5*time.Minute)
 	defer cancel()
-
-	// fetch the host
-	host, _, err := ap.hostForContract(ctx, fcid)
-	if err != nil {
-		return pruneResult{fcid: fcid, err: err}
-	}
 
 	// prune the contract
 	start := time.Now()
 	pruned, remaining, err := w.RHPPruneContract(ctx, fcid, timeoutPruneContract)
-	if err != nil && pruned == 0 {
-		return pruneResult{fcid: fcid, hk: host.PublicKey, version: host.Settings.Version, err: err}
-	} else if err != nil && utils.IsErr(err, context.DeadlineExceeded) {
+	duration := time.Since(start)
+
+	// ignore slow pruning until host network is 1.6.0+
+	if utils.IsErr(err, context.DeadlineExceeded) && pruned > 0 {
 		err = nil
 	}
 
-	return pruneResult{
-		ts: start,
+	// handle metrics
+	if err == nil || pruned > 0 {
+		if err := ap.bus.RecordContractPruneMetric(ctx, api.ContractPruneMetric{
+			Timestamp: api.TimeRFC3339(start),
 
-		fcid:    fcid,
-		hk:      host.PublicKey,
-		version: host.Settings.Version,
+			ContractID:  fcid,
+			HostKey:     hk,
+			HostVersion: hostVersion,
 
-		pruned:    pruned,
-		remaining: remaining,
-		duration:  time.Since(start),
-
-		err: err,
+			Pruned:    pruned,
+			Remaining: remaining,
+			Duration:  duration,
+		}); err != nil {
+			ap.logger.Error(err)
+		}
 	}
-}
 
-func humanReadableSize(b int) string {
-	const unit = 1024
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
+	// handle logs
+	if err != nil && pruned > 0 {
+		ap.logger.Errorf("contract %v, host %v version %s, pruned %d bytes, remaining %d bytes, elapsed %v, err %v", fcid, hk, hostVersion, pruned, remaining, duration, err)
+	} else if err != nil {
+		ap.logger.Errorf("contract %v, host %v version %s, err %v", fcid, hk, hostVersion, err)
+	} else {
+		ap.logger.Infof("contract %v, host %v version %s, pruned %d bytes, remaining %d bytes, elapsed %v", fcid, hk, hostVersion, pruned, remaining, duration)
 	}
-	div, exp := int64(unit), 0
-	for n := b / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
+
+	// handle alerts
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	alertID := alerts.IDForContract(alertPruningID, fcid)
+	if shouldSendPruneAlert(err, hostVersion) {
+		ap.RegisterAlert(ctx, newContractPruningFailedAlert(hk, hostVersion, fcid, err))
+		ap.pruningAlertIDs[fcid] = alertID // store id to dismiss stale alerts
+	} else {
+		ap.DismissAlert(ctx, alertID)
+		delete(ap.pruningAlertIDs, fcid)
 	}
-	return fmt.Sprintf("%.1f %ciB",
-		float64(b)/float64(div), "KMGTPE"[exp])
+
+	return pruned
 }
 
 func (ap *Autopilot) tryPerformPruning(wp *workerPool) {
@@ -267,4 +217,28 @@ func (ap *Autopilot) tryPerformPruning(wp *workerPool) {
 		ap.pruning = false
 		ap.mu.Unlock()
 	}()
+}
+
+func humanReadableSize(b int) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB",
+		float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+func shouldSendPruneAlert(err error, version string) bool {
+	return err != nil && !((utils.IsErr(err, errInvalidMerkleProof) && build.VersionCmp(version, "1.6.0") < 0) ||
+		utils.IsErr(err, utils.ErrConnectionRefused) ||
+		utils.IsErr(err, utils.ErrConnectionTimedOut) ||
+		utils.IsErr(err, utils.ErrConnectionResetByPeer) ||
+		utils.IsErr(err, errInvalidHandshakeSignature) ||
+		utils.IsErr(err, utils.ErrNoRouteToHost) ||
+		utils.IsErr(err, utils.ErrNoSuchHost))
 }


### PR DESCRIPTION
As the title suggests this PR dismisses stale prune alerts. This is important because we currently don't dismiss alerts if the contracts is not listed as prunable, this can be because it dropped out of the contract set but also on renewals for instance. It's kind of annoying to do this though because alert IDs are hashes but the state I had to keep is very very minimal imo. Took the opportunity to get rid of `pruneResult` which has always bothered me a bit. I also changed it so we only send a metric when either the error was `nil` or we managed to pruned at least 1 byte. That makes sense I think, we currently log metrics for failures too but not sure why we did that in the first place.

Keeping it in `DRAFT` until I've tested it on my node.