### PR TITLE
Avoid panic when evaluating config if autopilot is not configured

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -203,7 +203,15 @@ func (ap *Autopilot) configHandlerPOST(jc jape.Context) {
 	}
 
 	// evaluate the config
-	jc.Encode(contractor.EvaluateConfig(reqCfg, cs, fee, rs, gs, hosts))
+	res, err := contractor.EvaluateConfig(reqCfg, cs, fee, rs, gs, hosts)
+	if errors.Is(err, contractor.ErrMissingRequiredFields) {
+		jc.Error(err, http.StatusBadRequest)
+		return
+	} else if err != nil {
+		jc.Error(err, http.StatusInternalServerError)
+		return
+	}
+	jc.Encode(res)
 }
 
 func (ap *Autopilot) Run() error {

--- a/autopilot/contractor/evaluate.go
+++ b/autopilot/contractor/evaluate.go
@@ -21,6 +21,11 @@ func countUsableHosts(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.
 // are too strict for the number of contracts required by 'cfg', it will provide
 // a recommendation on how to loosen it.
 func EvaluateConfig(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Currency, rs api.RedundancySettings, gs api.GougingSettings, hosts []api.Host) (resp api.ConfigEvaluationResponse) {
+	// we need an allowance and a target amount of contracts to evaluate
+	if cfg.Contracts.Allowance.IsZero() || cfg.Contracts.Amount == 0 {
+		return
+	}
+
 	period := cfg.Contracts.Period
 	gc := worker.NewGougingChecker(gs, cs, fee, period, cfg.Contracts.RenewWindow)
 

--- a/autopilot/contractor/hostscore.go
+++ b/autopilot/contractor/hostscore.go
@@ -52,6 +52,8 @@ func hostScore(cfg api.AutopilotConfig, h api.Host, expectedRedundancy float64) 
 
 // priceAdjustmentScore computes a score between 0 and 1 for a host giving its
 // price settings and the autopilot's configuration.
+//   - If the given config is missing required fields (e.g. allowance or amount),
+//     math.SmallestNonzeroFloat64 is returned.
 //   - 0.5 is returned if the host's costs exactly match the settings.
 //   - If the host is cheaper than expected, a linear bonus is applied. The best
 //     score of 1 is reached when the ratio between host cost and expectations is
@@ -63,7 +65,7 @@ func priceAdjustmentScore(hostCostPerPeriod types.Currency, cfg api.ContractsCon
 	// return early if the allowance or amount of hosts is zero, avoiding a
 	// division by zero panic below.
 	if cfg.Allowance.IsZero() || cfg.Amount == 0 {
-		return 0.5
+		return math.SmallestNonzeroFloat64
 	}
 
 	hostPeriodBudget := cfg.Allowance.Div64(cfg.Amount)

--- a/autopilot/contractor/hostscore.go
+++ b/autopilot/contractor/hostscore.go
@@ -60,6 +60,12 @@ func hostScore(cfg api.AutopilotConfig, h api.Host, expectedRedundancy float64) 
 //     A 2x ratio will already cause the score to drop to 0.16 and a 3x ratio causes
 //     it to drop to 0.05.
 func priceAdjustmentScore(hostCostPerPeriod types.Currency, cfg api.ContractsConfig) float64 {
+	// return early if the allowance or amount of hosts is zero, avoiding a
+	// division by zero panic below.
+	if cfg.Allowance.IsZero() || cfg.Amount == 0 {
+		return 0.5
+	}
+
 	hostPeriodBudget := cfg.Allowance.Div64(cfg.Amount)
 
 	ratio := new(big.Rat).SetFrac(hostCostPerPeriod.Big(), hostPeriodBudget.Big())

--- a/autopilot/contractor/hostscore_test.go
+++ b/autopilot/contractor/hostscore_test.go
@@ -103,6 +103,15 @@ func TestHostScore(t *testing.T) {
 	if hostScore(cfg, h1, redundancy).Score() <= hostScore(cfg, h2, redundancy).Score() {
 		t.Fatal("unexpected")
 	}
+
+	// assert zero allowance does not panic
+	cfg.Contracts.Allowance = types.ZeroCurrency
+	_ = hostScore(cfg, h1, redundancy)
+
+	// assert missing amount does not panic
+	cfg.Contracts.Allowance = types.Siacoins(1000) // reset
+	cfg.Contracts.Amount = 0
+	_ = hostScore(cfg, h1, redundancy)
 }
 
 func TestPriceAdjustmentScore(t *testing.T) {


### PR DESCRIPTION
Run into a panic setting up a `testnet` node. Turns out the new UI sends configs for evaluation even though the autopilot hasn't been configured yet. We should probably create a `UI` issue for this as well but we need to harden against this on both sides.

```
http: panic serving 127.0.0.1:60434: runtime error: integer divide by zero
goroutine 1368 [running]:
net/http.(*conn).serve.func1()
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/http/server.go:1898 +0xb0
panic({0x101e977a0?, 0x10245df30?})
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/runtime/panic.go:770 +0x124
math/bits.Div64(0x14000884f88?, 0x10121e12c?, 0xc18b450f0ba1dff0?)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/math/bits/bits.go:520 +0x170
go.sia.tech/core/types.Currency.quoRem64({0x8459515cec0?, 0x8489330?}, 0x0)
	/Users/peterjan/go/pkg/mod/go.sia.tech/core@v0.2.3/types/currency.go:215 +0x48
go.sia.tech/core/types.Currency.Div64(...)
	/Users/peterjan/go/pkg/mod/go.sia.tech/core@v0.2.3/types/currency.go:174
go.sia.tech/renterd/autopilot/contractor.priceAdjustmentScore({0x8489330?, 0xeddde8f32?}, {{0x140005942a0, 0x9}, 0x0, {0x0, 0x0}, 0x0, 0x0, 0x0, ...})
	/Users/peterjan/code/siafoundation/renterd/autopilot/contractor/hostscore.go:63 +0x68
```