### PR TITLE
Introduce `events` package

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -1,0 +1,87 @@
+package events
+
+import (
+	"context"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/webhooks"
+)
+
+const (
+	WebhookEventsModule = "events"
+
+	WebhookEventConsensusUpdate   = "consensus_update"
+	WebhookEventContractArchived  = "contract_archived"
+	WebhookEventContractRenewal   = "contract_renewal"
+	WebhookEventContractSetUpdate = "contract_set_update"
+	WebhookEventSettingUpdate     = "setting_update"
+)
+
+type (
+	// A BroadCaster broadcasts events using webhooks. This tiny wrapper
+	// hardcodes the webhook 'module' and validates we only broadcasts events.
+	BroadCaster struct {
+		broadcaster webhooks.Broadcaster
+	}
+
+	Event interface{ Event() string }
+
+	EventSettingUpdate struct {
+		Key       string      `json:"key"`
+		Update    interface{} `json:"update,omitempty"`
+		Timestamp time.Time   `json:"timestamp"`
+	}
+
+	EventContractArchived struct {
+		ContractID types.FileContractID `json:"contractID"`
+		Reason     string               `json:"reason"`
+		Timestamp  time.Time            `json:"timestamp"`
+	}
+
+	EventContractRenewal struct {
+		ContractID    types.FileContractID `json:"contractID"`
+		RenewedFromID types.FileContractID `json:"renewedFromID"`
+		Timestamp     time.Time            `json:"timestamp"`
+	}
+
+	EventContractSetUpdate struct {
+		Name      string                 `json:"name"`
+		Contracts []api.ContractMetadata `json:"contracts"`
+		Timestamp time.Time              `json:"timestamp"`
+	}
+
+	EventConsensusUpdate struct {
+		api.ConsensusState
+		TransactionFee types.Currency `json:"transactionFee"`
+	}
+)
+
+func (e EventConsensusUpdate) Event() string   { return WebhookEventConsensusUpdate }
+func (e EventContractArchived) Event() string  { return WebhookEventContractArchived }
+func (e EventContractRenewal) Event() string   { return WebhookEventContractRenewal }
+func (e EventContractSetUpdate) Event() string { return WebhookEventContractSetUpdate }
+func (e EventSettingUpdate) Event() string     { return WebhookEventSettingUpdate }
+
+func NewEventWebhook(url string, event string) webhooks.Webhook {
+	return webhooks.Webhook{
+		Module: WebhookEventsModule,
+		Event:  event,
+		URL:    url,
+	}
+}
+
+func NewBroadcaster(broadcaster webhooks.Broadcaster) *BroadCaster {
+	return &BroadCaster{
+		broadcaster: broadcaster,
+	}
+}
+
+func (s *BroadCaster) BroadcastEvent(ctx context.Context, event Event) error {
+	return s.broadcaster.BroadcastAction(ctx, webhooks.Event{
+		Module:  WebhookEventsModule,
+		Event:   event.Event(),
+		Payload: event,
+	})
+}


### PR DESCRIPTION
This PR is the first in a series of smaller PRs that will eventually add a worker cache. Caching all `bus` requirements for uploading and downloading will definitely yield to improved performance and overall better software. E.g. we will eventually be able to very cleanly refresh uploaders upon renewals and so on.

 In order to be able to cache certain things in the `worker` (things like download contracts, gouging params etc), we have to be able to invalidate this cache. The idea is to use `webhooks` and I think it's a good idea to wrap that into something with a little more structure and type safety so I introduced a package called `events`. An `event` is a new webhook module, very similar to `alerts` that wraps a broadcaster to send events of a certain event type.

The `worker` registers a webhook for every event type with the `bus` and exposes a new endpoint `POST /events` that will handle incoming events and invalidate the cache if necessary. Going to F/U with PRs that broadcast events from the `bus` and one that introduces a worker cache and then a final one that ties it all together. 

Part of a series of PRs that implements https://github.com/SiaFoundation/renterd/issues/1151

