### PR TITLE
Update worker constants for pruning 

### DIFF
--- a/autopilot/contractor/alerts.go
+++ b/autopilot/contractor/alerts.go
@@ -41,7 +41,7 @@ func newContractRenewalFailedAlert(contract api.ContractMetadata, interrupted bo
 	}
 }
 
-func newLostSectorsAlert(hk types.PublicKey, lostSectors uint64) alerts.Alert {
+func newLostSectorsAlert(hk types.PublicKey, version, release string, lostSectors uint64) alerts.Alert {
 	return alerts.Alert{
 		ID:       alerts.IDForHost(alertLostSectorsID, hk),
 		Severity: alerts.SeverityWarning,
@@ -49,6 +49,8 @@ func newLostSectorsAlert(hk types.PublicKey, lostSectors uint64) alerts.Alert {
 		Data: map[string]interface{}{
 			"lostSectors": lostSectors,
 			"hostKey":     hk.String(),
+			"hostVersion": version,
+			"hostRelease": release,
 			"hint":        "The host has reported that it can't serve at least one sector. Consider blocking this host through the blocklist feature. If you think this was a mistake and you want to ignore this warning for now you can reset the lost sector count",
 		},
 		Timestamp: time.Now(),

--- a/autopilot/contractor/contractor.go
+++ b/autopilot/contractor/contractor.go
@@ -299,7 +299,7 @@ func (c *Contractor) performContractMaintenance(ctx *mCtx, w Worker) (bool, erro
 	var toDismiss []types.Hash256
 	for _, h := range hosts {
 		if registerLostSectorsAlert(h.Interactions.LostSectors*rhpv2.SectorSize, h.StoredData) {
-			c.alerter.RegisterAlert(ctx, newLostSectorsAlert(h.PublicKey, h.Interactions.LostSectors))
+			c.alerter.RegisterAlert(ctx, newLostSectorsAlert(h.PublicKey, h.Settings.Version, h.Settings.Release, h.Interactions.LostSectors))
 		} else {
 			toDismiss = append(toDismiss, alerts.IDForHost(alertLostSectorsID, h.PublicKey))
 		}

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -755,7 +755,7 @@ func (tx *MainDatabaseTx) upsertSectors(ctx context.Context, sectors []upsertSec
 	}
 	defer insertSectorStmt.Close()
 
-	querySectorSlabIDStmt, err := tx.Prepare(ctx, "SELECT db_slab_id FROM sectors WHERE id = last_insert_id()")
+	querySectorSlabIDStmt, err := tx.Prepare(ctx, "SELECT db_slab_id FROM sectors WHERE id = ?")
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare statement to query slab id: %w", err)
 	}
@@ -775,7 +775,7 @@ func (tx *MainDatabaseTx) upsertSectors(ctx context.Context, sectors []upsertSec
 			return nil, fmt.Errorf("failed to insert sector: %w", err)
 		} else if sectorID, err = res.LastInsertId(); err != nil {
 			return nil, fmt.Errorf("failed to fetch sector id: %w", err)
-		} else if err := querySectorSlabIDStmt.QueryRow(ctx).Scan(&slabID); err != nil {
+		} else if err := querySectorSlabIDStmt.QueryRow(ctx, sectorID).Scan(&slabID); err != nil {
 			return nil, fmt.Errorf("failed to fetch slab id: %w", err)
 		} else if slabID != s.slabID {
 			return nil, fmt.Errorf("failed to insert sector for slab %v: already exists for slab %v", s.slabID, slabID)

--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -25,9 +25,9 @@ const (
 	minMessageSize = 4096
 
 	// maxMerkleProofResponseSize caps the response message size to a generous
-	// 32 MiB max length since batchSizeDeleteSectors assumes ~16MiB of
-	// roots. So we double that to be safe.
-	maxMerkleProofResponseSize = 1200 * 1 << 20 // 1200 MB
+	// value of 100 MB worth of roots. This is approximately double the size of
+	// what we have observed on the live network for 5TB+ contracts to be safe.
+	maxMerkleProofResponseSize = 100 * 1 << 20 // 100 MB
 )
 
 var (

--- a/worker/rhpv2.go
+++ b/worker/rhpv2.go
@@ -27,7 +27,7 @@ const (
 	// maxMerkleProofResponseSize caps the response message size to a generous
 	// 32 MiB max length since batchSizeDeleteSectors assumes ~16MiB of
 	// roots. So we double that to be safe.
-	maxMerkleProofResponseSize = 8 * 1 << 22 // 32 MiB
+	maxMerkleProofResponseSize = 1200 * 1 << 20 // 1200 MB
 )
 
 var (

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -35,8 +35,8 @@ import (
 )
 
 const (
-	batchSizeDeleteSectors = uint64(500000) // ~16MiB of roots
-	batchSizeFetchSectors  = uint64(130000) // ~4MiB of roots
+	batchSizeDeleteSectors = uint64(1000)  // 4GiB of contract data
+	batchSizeFetchSectors  = uint64(25600) // 100GiB of contract data
 
 	defaultLockTimeout          = time.Minute
 	defaultRevisionFetchTimeout = 30 * time.Second


### PR DESCRIPTION
With this update Arequipa has been pruning all night without producing any "EOF" alerts. 
That's because the responses become small enough so that the host doesn't close the connection.

1000 roots per batch is significantly smaller than the 500k we had before but the roundabout with `hostd` should be fast enough to not cause too much of a slowdown. It's also a lot better for `hostd`'s db since it won't have to commit as many changes at once.