### PR TITLE
Forgive failed refresh only when contract is in set

### DIFF
--- a/autopilot/contractor/contractor.go
+++ b/autopilot/contractor/contractor.go
@@ -696,8 +696,9 @@ LOOP:
 		// if we were not able to the contract's revision, we can't properly
 		// perform the checks that follow, however we do want to be lenient if
 		// this contract is in the current set and we still have leeway left
+		_, inSet := inCurrentSet[fcid]
 		if contract.Revision == nil {
-			if _, found := inCurrentSet[fcid]; !found || remainingKeepLeeway == 0 {
+			if !inSet || remainingKeepLeeway == 0 {
 				toStopUsing[fcid] = errContractNoRevision.Error()
 			} else if !ctx.AllowRedundantIPs() && ipFilter.IsRedundantIP(contract.HostIP, contract.HostKey) {
 				toStopUsing[fcid] = fmt.Sprintf("%v; %v", api.ErrUsabilityHostRedundantIP, errContractNoRevision)
@@ -711,7 +712,7 @@ LOOP:
 
 		// decide whether the contract is still good
 		ci := contractInfo{contract: contract, priceTable: host.PriceTable.HostPriceTable, settings: host.Settings}
-		usable, recoverable, refresh, renew, reasons := c.isUsableContract(ctx.AutopilotConfig(), ctx.state.RS, ci, bh, ipFilter)
+		usable, recoverable, refresh, renew, reasons := c.isUsableContract(ctx.AutopilotConfig(), ctx.state.RS, ci, inSet, bh, ipFilter)
 		ci.usable = usable
 		ci.recoverable = recoverable
 		if !usable {


### PR DESCRIPTION
I noticed on Arequipa that sometimes after a reboot 6 or so contracts are added to the set which before failed to refresh. That is a result of the refresh failures not being persisted.

That reminded me that we probably don't want to forgive a failed refresh if a contract wasn't in the set to begin with since it will only increase churn if it causes another contract to be pushed out of the set for the next 6 hours instead.