### PR TITLE
Recommend MySQL for production setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Sia applications. Useful links:
 - [Project Roadmap](https://github.com/orgs/SiaFoundation/projects/5)
 - [Setup Guide](https://docs.sia.tech/renting/setting-up-renterd)
 
+## Database
+
+`renterd` requires a database to store its operational data. We support both
+SQLite and MySQL, with SQLite set as the default due to its ease of setup.
+SQLite is ideal for testing and development purposes, whereas MySQL is
+recommended for production environments.
 
 ## Configuration
 

--- a/cmd/renterd/config.go
+++ b/cmd/renterd/config.go
@@ -246,8 +246,8 @@ func setAdvancedConfig() {
 	// database
 	fmt.Println("")
 	fmt.Println("The database is used to store the renter's metadata.")
-	fmt.Println("The embedded SQLite database is recommended for small (< 50TB), single-user setups. Choose this for the easiest setup.")
-	fmt.Println("MySQL database is recommended for larger (> 50TB) or multi-user setups. MySQL requires a separate MySQL server to connect to.")
+	fmt.Println("The embedded SQLite database requires no additional configuration and is ideal for testing or demo purposes.")
+	fmt.Println("For production usage, we recommend MySQL, which requires a separate MySQL server.")
 	setStoreConfig()
 }
 


### PR DESCRIPTION
I updated `renterd` to suggest MySQL for production usage, in my opinion making a distinction between small/personal nodes and anything else confuses people. It's also kind of annoying because if you turn your 10TB node into a 100TB node you'll have to migrate databases. I know SQLite works perfectly fine up until 50TB+ even but since MySQL performs better we might as well suggest it for usage in production?

Extending docs with MySQL setup guides can be tracked here https://github.com/SiaFoundation/docs/issues/77 - I don't think we need to add that to `renterd`'s `README`.