### PR TITLE
Migrate allowlists and blocklists to raw SQL

### DIFF
--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -74,10 +74,6 @@ type (
 
 		LastAnnouncement time.Time
 		NetAddress       string `gorm:"index"`
-
-		Allowlist []dbAllowlistEntry `gorm:"many2many:host_allowlist_entry_hosts;constraint:OnDelete:CASCADE"`
-		Blocklist []dbBlocklistEntry `gorm:"many2many:host_blocklist_entry_hosts;constraint:OnDelete:CASCADE"`
-		Checks    []dbHostCheck      `gorm:"foreignKey:DBHostID;constraint:OnDelete:CASCADE"`
 	}
 
 	// dbHostCheck contains information about a host that is collected and used

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -434,7 +434,7 @@ func (ss *SQLStore) HostsForScanning(ctx context.Context, maxLastScan time.Time,
 func (ss *SQLStore) SearchHosts(ctx context.Context, autopilotID, filterMode, usabilityMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]api.Host, error) {
 	var hosts []api.Host
 	err := ss.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
-		hosts, err = tx.SearchHosts(ctx, autopilotID, filterMode, usabilityMode, addressContains, keyIn, offset, limit, ss.hasAllowlist(), ss.hasBlocklist())
+		hosts, err = tx.SearchHosts(ctx, autopilotID, filterMode, usabilityMode, addressContains, keyIn, offset, limit)
 		return
 	})
 	return hosts, err
@@ -465,35 +465,8 @@ func (ss *SQLStore) UpdateHostAllowlistEntries(ctx context.Context, add, remove 
 	}
 	defer ss.updateHasAllowlist(&err)
 
-	// clear allowlist
-	if clear {
-		return ss.retryTransaction(ctx, func(tx *gorm.DB) error {
-			return tx.Where("TRUE").Delete(&dbAllowlistEntry{}).Error
-		})
-	}
-
-	var toInsert []dbAllowlistEntry
-	for _, entry := range add {
-		toInsert = append(toInsert, dbAllowlistEntry{Entry: publicKey(entry)})
-	}
-
-	toDelete := make([]publicKey, len(remove))
-	for i, entry := range remove {
-		toDelete[i] = publicKey(entry)
-	}
-
-	return ss.retryTransaction(ctx, func(tx *gorm.DB) error {
-		if len(toInsert) > 0 {
-			if err := tx.Create(&toInsert).Error; err != nil {
-				return err
-			}
-		}
-		if len(toDelete) > 0 {
-			if err := tx.Delete(&dbAllowlistEntry{}, "entry IN ?", toDelete).Error; err != nil {
-				return err
-			}
-		}
-		return nil
+	return ss.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+		return tx.UpdateHostAllowlistEntries(ctx, add, remove, clear)
 	})
 }
 
@@ -504,30 +477,8 @@ func (ss *SQLStore) UpdateHostBlocklistEntries(ctx context.Context, add, remove 
 	}
 	defer ss.updateHasBlocklist(&err)
 
-	// clear blocklist
-	if clear {
-		return ss.retryTransaction(ctx, func(tx *gorm.DB) error {
-			return tx.Where("TRUE").Delete(&dbBlocklistEntry{}).Error
-		})
-	}
-
-	var toInsert []dbBlocklistEntry
-	for _, entry := range add {
-		toInsert = append(toInsert, dbBlocklistEntry{Entry: entry})
-	}
-
-	return ss.retryTransaction(ctx, func(tx *gorm.DB) error {
-		if len(toInsert) > 0 {
-			if err := tx.Create(&toInsert).Error; err != nil {
-				return err
-			}
-		}
-		if len(remove) > 0 {
-			if err := tx.Delete(&dbBlocklistEntry{}, "entry IN ?", remove).Error; err != nil {
-				return err
-			}
-		}
-		return nil
+	return ss.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+		return tx.UpdateHostBlocklistEntries(ctx, add, remove, clear)
 	})
 }
 

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -463,8 +463,6 @@ func (ss *SQLStore) UpdateHostAllowlistEntries(ctx context.Context, add, remove 
 	if len(add)+len(remove) == 0 && !clear {
 		return nil
 	}
-	defer ss.updateHasAllowlist(&err)
-
 	return ss.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.UpdateHostAllowlistEntries(ctx, add, remove, clear)
 	})
@@ -475,8 +473,6 @@ func (ss *SQLStore) UpdateHostBlocklistEntries(ctx context.Context, add, remove 
 	if len(add)+len(remove) == 0 && !clear {
 		return nil
 	}
-	defer ss.updateHasBlocklist(&err)
-
 	return ss.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.UpdateHostBlocklistEntries(ctx, add, remove, clear)
 	})

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -74,6 +74,10 @@ type (
 
 		LastAnnouncement time.Time
 		NetAddress       string `gorm:"index"`
+
+		Allowlist []dbAllowlistEntry `gorm:"many2many:host_allowlist_entry_hosts;constraint:OnDelete:CASCADE"`
+		Blocklist []dbBlocklistEntry `gorm:"many2many:host_blocklist_entry_hosts;constraint:OnDelete:CASCADE"`
+		Checks    []dbHostCheck      `gorm:"foreignKey:DBHostID;constraint:OnDelete:CASCADE"`
 	}
 
 	// dbHostCheck contains information about a host that is collected and used

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -108,8 +108,6 @@ type (
 
 		wg           sync.WaitGroup
 		mu           sync.Mutex
-		allowListCnt uint64
-		blockListCnt uint64
 		lastPrunedAt time.Time
 		closed       bool
 
@@ -237,16 +235,6 @@ func NewSQLStore(cfg Config) (*SQLStore, modules.ConsensusChangeID, error) {
 		return nil, modules.ConsensusChangeID{}, err
 	}
 
-	// Check allowlist and blocklist counts
-	allowlistCnt, err := tableCount(db, &dbAllowlistEntry{})
-	if err != nil {
-		return nil, modules.ConsensusChangeID{}, err
-	}
-	blocklistCnt, err := tableCount(db, &dbBlocklistEntry{})
-	if err != nil {
-		return nil, modules.ConsensusChangeID{}, err
-	}
-
 	// Fetch contract ids.
 	var activeFCIDs, archivedFCIDs []fileContractID
 	if err := db.Model(&dbContract{}).
@@ -276,8 +264,6 @@ func NewSQLStore(cfg Config) (*SQLStore, modules.ConsensusChangeID, error) {
 		knownContracts:         isOurContract,
 		lastSave:               time.Now(),
 		persistInterval:        cfg.PersistInterval,
-		allowListCnt:           uint64(allowlistCnt),
-		blockListCnt:           uint64(blocklistCnt),
 		settings:               make(map[string]string),
 		slabPruneSigChan:       make(chan struct{}, 1),
 		unappliedContractState: make(map[types.FileContractID]contractState),
@@ -321,12 +307,6 @@ func isSQLite(db *gorm.DB) bool {
 	}
 }
 
-func (ss *SQLStore) hasAllowlist() bool {
-	ss.mu.Lock()
-	defer ss.mu.Unlock()
-	return ss.allowListCnt > 0
-}
-
 func (s *SQLStore) initSlabPruning() error {
 	// start pruning loop
 	s.wg.Add(1)
@@ -340,49 +320,6 @@ func (s *SQLStore) initSlabPruning() error {
 		_, err := tx.PruneSlabs(s.shutdownCtx, math.MaxInt64)
 		return err
 	})
-}
-
-func (ss *SQLStore) updateHasAllowlist(err *error) {
-	if *err != nil {
-		return
-	}
-
-	cnt, cErr := tableCount(ss.db, &dbAllowlistEntry{})
-	if cErr != nil {
-		*err = cErr
-		return
-	}
-
-	ss.mu.Lock()
-	ss.allowListCnt = uint64(cnt)
-	ss.mu.Unlock()
-}
-
-func (ss *SQLStore) hasBlocklist() bool {
-	ss.mu.Lock()
-	defer ss.mu.Unlock()
-	return ss.blockListCnt > 0
-}
-
-func (ss *SQLStore) updateHasBlocklist(err *error) {
-	if *err != nil {
-		return
-	}
-
-	cnt, cErr := tableCount(ss.db, &dbBlocklistEntry{})
-	if cErr != nil {
-		*err = cErr
-		return
-	}
-
-	ss.mu.Lock()
-	ss.blockListCnt = uint64(cnt)
-	ss.mu.Unlock()
-}
-
-func tableCount(db *gorm.DB, model interface{}) (cnt int64, err error) {
-	err = db.Model(model).Count(&cnt).Error
-	return
 }
 
 // Close closes the underlying database connection of the store.

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -145,7 +145,7 @@ type (
 		SaveAccounts(ctx context.Context, accounts []api.Account) error
 
 		// SearchHosts returns a list of hosts that match the provided filters
-		SearchHosts(ctx context.Context, autopilotID, filterMode, usabilityMode, addressContains string, keyIn []types.PublicKey, offset, limit int, hasAllowList, hasBlocklist bool) ([]api.Host, error)
+		SearchHosts(ctx context.Context, autopilotID, filterMode, usabilityMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]api.Host, error)
 
 		// SetUncleanShutdown sets the clean shutdown flag on the accounts to
 		// 'false' and also marks them as requiring a resync.
@@ -154,6 +154,12 @@ type (
 		// UpdateBucketPolicy updates the policy of the bucket with the provided
 		// one, fully overwriting the existing policy.
 		UpdateBucketPolicy(ctx context.Context, bucket string, policy api.BucketPolicy) error
+
+		// UpdateHostAllowlistEntries updates the allowlist in the database
+		UpdateHostAllowlistEntries(ctx context.Context, add, remove []types.PublicKey, clear bool) error
+
+		// UpdateHostBlocklistEntries updates the blocklist in the database
+		UpdateHostBlocklistEntries(ctx context.Context, add, remove []string, clear bool) error
 
 		// UpdateObjectHealth updates the health of all objects to the lowest
 		// health of all its slabs.

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -89,6 +89,13 @@ type (
 		// prefix and returns 'true' if any object was deleted.
 		DeleteObjects(ctx context.Context, bucket, prefix string, limit int64) (bool, error)
 
+		// HostAllowlist returns the list of public keys of hosts on the
+		// allowlist.
+		HostAllowlist(ctx context.Context) ([]types.PublicKey, error)
+
+		// HostBlocklist returns the list of host addresses on the blocklist.
+		HostBlocklist(ctx context.Context) ([]string, error)
+
 		// InsertObject inserts a new object into the database.
 		InsertObject(ctx context.Context, bucket, key, contractSet string, dirID int64, o object.Object, mimeType, eTag string, md api.ObjectUserMetadata) error
 

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -581,7 +581,7 @@ func (tx *MainDatabaseTx) UpdateHostAllowlistEntries(ctx context.Context, add, r
 	}
 
 	if len(add) > 0 {
-		insertStmt, err := tx.Prepare(ctx, "INSERT INTO host_allowlist_entries (entry) VALUES (?) ON DUPLICATE KEY UPDATES id = last_insert_id(id)")
+		insertStmt, err := tx.Prepare(ctx, "INSERT INTO host_allowlist_entries (entry) VALUES (?) ON DUPLICATE KEY UPDATE id = last_insert_id(id)")
 		if err != nil {
 			return fmt.Errorf("failed to prepare insert statement: %w", err)
 		}
@@ -592,7 +592,7 @@ func (tx *MainDatabaseTx) UpdateHostAllowlistEntries(ctx context.Context, add, r
 			SELECT id
 			FROM hosts
 			WHERE public_key = ?
-		)`)
+		) AS _`)
 		if err != nil {
 			return fmt.Errorf("failed to prepare join statement: %w", err)
 		}
@@ -633,7 +633,7 @@ func (tx *MainDatabaseTx) UpdateHostBlocklistEntries(ctx context.Context, add, r
 	}
 
 	if len(add) > 0 {
-		insertStmt, err := tx.Prepare(ctx, "INSERT INTO host_blocklist_entries (entry) VALUES (?) ON DUPLICATE KEY UPDATES id = last_insert_id(id)")
+		insertStmt, err := tx.Prepare(ctx, "INSERT INTO host_blocklist_entries (entry) VALUES (?) ON DUPLICATE KEY UPDATE id = last_insert_id(id)")
 		if err != nil {
 			return fmt.Errorf("failed to prepare insert statement: %w", err)
 		}
@@ -644,10 +644,10 @@ func (tx *MainDatabaseTx) UpdateHostBlocklistEntries(ctx context.Context, add, r
 			SELECT id
 			FROM hosts
 			WHERE net_address=? OR
-			SUBSTRING_INDEX(net_address,':',1)=? OR
+			SUBSTRING_INDEX(net_address,':',1) = ? OR
 			SUBSTRING_INDEX(net_address,':',1) LIKE ?
-			) AS _
-		)`)
+		) AS _
+		`)
 		if err != nil {
 			return fmt.Errorf("failed to prepare join statement: %w", err)
 		}

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -553,8 +553,8 @@ func (tx MainDatabaseTx) SaveAccounts(ctx context.Context, accounts []api.Accoun
 	return nil
 }
 
-func (tx *MainDatabaseTx) SearchHosts(ctx context.Context, autopilotID, filterMode, usabilityMode, addressContains string, keyIn []types.PublicKey, offset, limit int, hasAllowlist, hasBlocklist bool) ([]api.Host, error) {
-	return ssql.SearchHosts(ctx, tx, autopilotID, filterMode, usabilityMode, addressContains, keyIn, offset, limit, hasAllowlist, hasBlocklist)
+func (tx *MainDatabaseTx) SearchHosts(ctx context.Context, autopilotID, filterMode, usabilityMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]api.Host, error) {
+	return ssql.SearchHosts(ctx, tx, autopilotID, filterMode, usabilityMode, addressContains, keyIn, offset, limit)
 }
 
 func (tx *MainDatabaseTx) SetUncleanShutdown(ctx context.Context) error {
@@ -563,6 +563,113 @@ func (tx *MainDatabaseTx) SetUncleanShutdown(ctx context.Context) error {
 
 func (tx *MainDatabaseTx) UpdateBucketPolicy(ctx context.Context, bucket string, bp api.BucketPolicy) error {
 	return ssql.UpdateBucketPolicy(ctx, tx, bucket, bp)
+}
+
+func (tx *MainDatabaseTx) UpdateHostAllowlistEntries(ctx context.Context, add, remove []types.PublicKey, clear bool) error {
+	if clear {
+		if _, err := tx.Exec(ctx, "DELETE FROM host_allowlist_entries"); err != nil {
+			return fmt.Errorf("failed to clear host allowlist entries: %w", err)
+		}
+	}
+
+	if len(add) > 0 {
+		insertStmt, err := tx.Prepare(ctx, "INSERT INTO host_allowlist_entries (entry) VALUES (?) ON DUPLICATE KEY UPDATES id = last_insert_id(id)")
+		if err != nil {
+			return fmt.Errorf("failed to prepare insert statement: %w", err)
+		}
+		defer insertStmt.Close()
+		joinStmt, err := tx.Prepare(ctx, `
+			INSERT IGNORE INTO host_allowlist_entry_hosts (db_allowlist_entry_id, db_host_id)
+			SELECT ?, id FROM (
+			SELECT id
+			FROM hosts
+			WHERE public_key = ?
+		)`)
+		if err != nil {
+			return fmt.Errorf("failed to prepare join statement: %w", err)
+		}
+		defer joinStmt.Close()
+
+		for _, pk := range add {
+			if res, err := insertStmt.Exec(ctx, ssql.PublicKey(pk)); err != nil {
+				return fmt.Errorf("failed to insert host allowlist entry: %w", err)
+			} else if entryID, err := res.LastInsertId(); err != nil {
+				return fmt.Errorf("failed to fetch host allowlist entry id: %w", err)
+			} else if _, err := joinStmt.Exec(ctx, entryID, ssql.PublicKey(pk)); err != nil {
+				return fmt.Errorf("failed to join host allowlist entry: %w", err)
+			}
+		}
+	}
+
+	if !clear && len(remove) > 0 {
+		deleteStmt, err := tx.Prepare(ctx, "DELETE FROM host_allowlist_entries WHERE entry = ?")
+		if err != nil {
+			return fmt.Errorf("failed to prepare delete statement: %w", err)
+		}
+		defer deleteStmt.Close()
+
+		for _, pk := range remove {
+			if _, err := deleteStmt.Exec(ctx, ssql.PublicKey(pk)); err != nil {
+				return fmt.Errorf("failed to delete host allowlist entry: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func (tx *MainDatabaseTx) UpdateHostBlocklistEntries(ctx context.Context, add, remove []string, clear bool) error {
+	if clear {
+		if _, err := tx.Exec(ctx, "DELETE FROM host_blocklist_entries"); err != nil {
+			return fmt.Errorf("failed to clear host blocklist entries: %w", err)
+		}
+	}
+
+	if len(add) > 0 {
+		insertStmt, err := tx.Prepare(ctx, "INSERT INTO host_blocklist_entries (entry) VALUES (?) ON DUPLICATE KEY UPDATES id = last_insert_id(id)")
+		if err != nil {
+			return fmt.Errorf("failed to prepare insert statement: %w", err)
+		}
+		defer insertStmt.Close()
+		joinStmt, err := tx.Prepare(ctx, `
+		INSERT IGNORE INTO host_blocklist_entry_hosts (db_blocklist_entry_id, db_host_id)
+		SELECT ?, id FROM (
+			SELECT id
+			FROM hosts
+			WHERE net_address=? OR
+			SUBSTRING_INDEX(net_address,':',1)=? OR
+			SUBSTRING_INDEX(net_address,':',1) LIKE ?
+			) AS _
+		)`)
+		if err != nil {
+			return fmt.Errorf("failed to prepare join statement: %w", err)
+		}
+		defer joinStmt.Close()
+
+		for _, entry := range add {
+			if res, err := insertStmt.Exec(ctx, entry); err != nil {
+				return fmt.Errorf("failed to insert host blocklist entry: %w", err)
+			} else if entryID, err := res.LastInsertId(); err != nil {
+				return fmt.Errorf("failed to fetch host blocklist entry id: %w", err)
+			} else if _, err := joinStmt.Exec(ctx, entryID, entry, entry, fmt.Sprintf("%%.%s", entry)); err != nil {
+				return fmt.Errorf("failed to join host blocklist entry: %w", err)
+			}
+		}
+	}
+
+	if !clear && len(remove) > 0 {
+		deleteStmt, err := tx.Prepare(ctx, "DELETE FROM host_blocklist_entries WHERE entry = ?")
+		if err != nil {
+			return fmt.Errorf("failed to prepare delete statement: %w", err)
+		}
+		defer deleteStmt.Close()
+
+		for _, entry := range remove {
+			if _, err := deleteStmt.Exec(ctx, entry); err != nil {
+				return fmt.Errorf("failed to delete host blocklist entry: %w", err)
+			}
+		}
+	}
+	return nil
 }
 
 func (tx *MainDatabaseTx) UpdateObjectHealth(ctx context.Context) error {

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -285,6 +285,14 @@ func (tx *MainDatabaseTx) DeleteObjects(ctx context.Context, bucket string, key 
 	}
 }
 
+func (tx *MainDatabaseTx) HostAllowlist(ctx context.Context) ([]types.PublicKey, error) {
+	return ssql.HostAllowlist(ctx, tx)
+}
+
+func (tx *MainDatabaseTx) HostBlocklist(ctx context.Context) ([]string, error) {
+	return ssql.HostBlocklist(ctx, tx)
+}
+
 func (tx *MainDatabaseTx) InsertObject(ctx context.Context, bucket, key, contractSet string, dirID int64, o object.Object, mimeType, eTag string, md api.ObjectUserMetadata) error {
 	// get bucket id
 	var bucketID int64

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -274,6 +274,14 @@ func (tx *MainDatabaseTx) DeleteObjects(ctx context.Context, bucket string, key 
 	}
 }
 
+func (tx *MainDatabaseTx) HostAllowlist(ctx context.Context) ([]types.PublicKey, error) {
+	return ssql.HostAllowlist(ctx, tx)
+}
+
+func (tx *MainDatabaseTx) HostBlocklist(ctx context.Context) ([]string, error) {
+	return ssql.HostBlocklist(ctx, tx)
+}
+
 func (tx *MainDatabaseTx) InsertObject(ctx context.Context, bucket, key, contractSet string, dirID int64, o object.Object, mimeType, eTag string, md api.ObjectUserMetadata) error {
 	// get bucket id
 	var bucketID int64

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -551,8 +551,8 @@ func (tx *MainDatabaseTx) SaveAccounts(ctx context.Context, accounts []api.Accou
 	return nil
 }
 
-func (tx *MainDatabaseTx) SearchHosts(ctx context.Context, autopilotID, filterMode, usabilityMode, addressContains string, keyIn []types.PublicKey, offset, limit int, hasAllowlist, hasBlocklist bool) ([]api.Host, error) {
-	return ssql.SearchHosts(ctx, tx, autopilotID, filterMode, usabilityMode, addressContains, keyIn, offset, limit, hasAllowlist, hasBlocklist)
+func (tx *MainDatabaseTx) SearchHosts(ctx context.Context, autopilotID, filterMode, usabilityMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]api.Host, error) {
+	return ssql.SearchHosts(ctx, tx, autopilotID, filterMode, usabilityMode, addressContains, keyIn, offset, limit)
 }
 
 func (tx *MainDatabaseTx) SetUncleanShutdown(ctx context.Context) error {
@@ -562,6 +562,113 @@ func (tx *MainDatabaseTx) SetUncleanShutdown(ctx context.Context) error {
 func (tx *MainDatabaseTx) UpdateBucketPolicy(ctx context.Context, bucket string, policy api.BucketPolicy) error {
 	return ssql.UpdateBucketPolicy(ctx, tx, bucket, policy)
 }
+
+func (tx *MainDatabaseTx) UpdateHostAllowlistEntries(ctx context.Context, add, remove []types.PublicKey, clear bool) error {
+	if clear {
+		if _, err := tx.Exec(ctx, "DELETE FROM host_allowlist_entries"); err != nil {
+			return fmt.Errorf("failed to clear host allowlist entries: %w", err)
+		}
+	}
+
+	if len(add) > 0 {
+		insertStmt, err := tx.Prepare(ctx, "INSERT INTO host_allowlist_entries (entry) VALUES (?) ON CONFLICT(entry) DO UPDATE SET id = id RETURNING id")
+		if err != nil {
+			return fmt.Errorf("failed to prepare insert statement: %w", err)
+		}
+		defer insertStmt.Close()
+		joinStmt, err := tx.Prepare(ctx, `
+			INSERT OR IGNORE INTO host_allowlist_entry_hosts (db_allowlist_entry_id, db_host_id)
+			SELECT ?, id FROM (
+			SELECT id
+			FROM hosts
+			WHERE public_key = ?
+		)`)
+		if err != nil {
+			return fmt.Errorf("failed to prepare join statement: %w", err)
+		}
+		defer joinStmt.Close()
+
+		for _, pk := range add {
+			if res, err := insertStmt.Exec(ctx, ssql.PublicKey(pk)); err != nil {
+				return fmt.Errorf("failed to insert host allowlist entry: %w", err)
+			} else if entryID, err := res.LastInsertId(); err != nil {
+				return fmt.Errorf("failed to fetch host allowlist entry id: %w", err)
+			} else if _, err := joinStmt.Exec(ctx, entryID, ssql.PublicKey(pk)); err != nil {
+				return fmt.Errorf("failed to join host allowlist entry: %w", err)
+			}
+		}
+	}
+
+	if !clear && len(remove) > 0 {
+		deleteStmt, err := tx.Prepare(ctx, "DELETE FROM host_allowlist_entries WHERE entry = ?")
+		if err != nil {
+			return fmt.Errorf("failed to prepare delete statement: %w", err)
+		}
+		defer deleteStmt.Close()
+
+		for _, pk := range remove {
+			if _, err := deleteStmt.Exec(ctx, ssql.PublicKey(pk)); err != nil {
+				return fmt.Errorf("failed to delete host allowlist entry: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func (tx *MainDatabaseTx) UpdateHostBlocklistEntries(ctx context.Context, add, remove []string, clear bool) error {
+	if clear {
+		if _, err := tx.Exec(ctx, "DELETE FROM host_blocklist_entries"); err != nil {
+			return fmt.Errorf("failed to clear host blocklist entries: %w", err)
+		}
+	}
+
+	if len(add) > 0 {
+		insertStmt, err := tx.Prepare(ctx, "INSERT INTO host_blocklist_entries (entry) VALUES (?) ON CONFLICT(entry) DO UPDATE SET id = id RETURNING id")
+		if err != nil {
+			return fmt.Errorf("failed to prepare insert statement: %w", err)
+		}
+		defer insertStmt.Close()
+		joinStmt, err := tx.Prepare(ctx, `
+		INSERT OR IGNORE INTO host_blocklist_entry_hosts (db_blocklist_entry_id, db_host_id)
+		SELECT ?, id FROM (
+			SELECT id
+			FROM hosts
+			WHERE net_address == ? OR
+				rtrim(rtrim(net_address, replace(net_address, ':', '')),':') == ? OR
+				rtrim(rtrim(net_address, replace(net_address, ':', '')),':') LIKE ?
+		)`)
+		if err != nil {
+			return fmt.Errorf("failed to prepare join statement: %w", err)
+		}
+		defer joinStmt.Close()
+
+		for _, entry := range add {
+			if res, err := insertStmt.Exec(ctx, entry); err != nil {
+				return fmt.Errorf("failed to insert host blocklist entry: %w", err)
+			} else if entryID, err := res.LastInsertId(); err != nil {
+				return fmt.Errorf("failed to fetch host blocklist entry id: %w", err)
+			} else if _, err := joinStmt.Exec(ctx, entryID, entry, entry, fmt.Sprintf("%%.%s", entry)); err != nil {
+				return fmt.Errorf("failed to join host blocklist entry: %w", err)
+			}
+		}
+	}
+
+	if !clear && len(remove) > 0 {
+		deleteStmt, err := tx.Prepare(ctx, "DELETE FROM host_blocklist_entries WHERE entry = ?")
+		if err != nil {
+			return fmt.Errorf("failed to prepare delete statement: %w", err)
+		}
+		defer deleteStmt.Close()
+
+		for _, entry := range remove {
+			if _, err := deleteStmt.Exec(ctx, entry); err != nil {
+				return fmt.Errorf("failed to delete host blocklist entry: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
 func (tx *MainDatabaseTx) UpdateObjectHealth(ctx context.Context) error {
 	return ssql.UpdateObjectHealth(ctx, tx)
 }


### PR DESCRIPTION
Unfortunately this PR doesn't yet get rid of the `dbAllowlist` and `dbBlocklist` types. That's because `updateBlocklist` is still using them and it probably doesn't make sense to update that before merging `its-happening`.