### PR TITLE
Migrate ContractPruneMetrics to raw SQL

### DIFF
--- a/stores/metrics_test.go
+++ b/stores/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"lukechampine.com/frand"
@@ -92,8 +93,8 @@ func TestContractPruneMetrics(t *testing.T) {
 			t.Fatal("expected metrics to be sorted by time")
 		}
 		for _, m := range metrics {
-			if !cmp.Equal(m, fcid2Metric[m.ContractID], cmp.Comparer(api.CompareTimeRFC3339)) {
-				t.Fatal("unexpected metric", cmp.Diff(m, fcid2Metric[m.ContractID]))
+			if !cmp.Equal(m, fcid2Metric[m.ContractID], cmpopts.IgnoreUnexported(api.ContractPruneMetric{}), cmp.Comparer(api.CompareTimeRFC3339)) {
+				t.Fatal("unexpected metric", m, fcid2Metric[m.ContractID])
 			}
 			cmpFn(m)
 		}

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -16,11 +16,11 @@ type (
 	Database interface {
 		io.Closer
 
-		// Transaction starts a new transaction.
-		Transaction(ctx context.Context, fn func(DatabaseTx) error) error
-
 		// Migrate runs all missing migrations on the database.
 		Migrate(ctx context.Context) error
+
+		// Transaction starts a new transaction.
+		Transaction(ctx context.Context, fn func(DatabaseTx) error) error
 
 		// Version returns the database version and name.
 		Version(ctx context.Context) (string, string, error)
@@ -212,8 +212,24 @@ type (
 
 	MetricsDatabase interface {
 		io.Closer
+
+		// Migrate runs all missing migrations on the database.
 		Migrate(ctx context.Context) error
+
+		// Transaction starts a new transaction.
+		Transaction(ctx context.Context, fn func(MetricsDatabaseTx) error) error
+
+		// Version returns the database version and name.
 		Version(ctx context.Context) (string, string, error)
+	}
+
+	MetricsDatabaseTx interface {
+		// ContractPruneMetrics returns the contract prune metrics for the given
+		// time range and options.
+		ContractPruneMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.ContractPruneMetricsQueryOpts) ([]api.ContractPruneMetric, error)
+
+		// RecordContractPruneMetric records a contract prune metric.
+		RecordContractPruneMetric(ctx context.Context, metrics ...api.ContractPruneMetric) error
 	}
 
 	UsedContract struct {

--- a/stores/sql/metrics.go
+++ b/stores/sql/metrics.go
@@ -1,0 +1,136 @@
+package sql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/internal/sql"
+)
+
+const (
+	tableContractPruneMetric = "contract_prunes"
+)
+
+func ContractPruneMetrics(ctx context.Context, tx sql.Tx, start time.Time, n uint64, interval time.Duration, opts api.ContractPruneMetricsQueryOpts) (metrics []api.ContractPruneMetric, _ error) {
+	where, err := whereClauseFromQueryOpts(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build where clause: %w", err)
+	}
+
+	rows, err := queryPeriods(ctx, tx, tableContractPruneMetric, start, n, interval, where)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch contract metrics: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cpm api.ContractPruneMetric
+		var placeHolder int64
+		var placeHolderTime time.Time
+		var timestamp UnixTimeMS
+		if err := rows.Scan(&placeHolder, &placeHolderTime, &timestamp, (*FileContractID)(&cpm.ContractID), (*PublicKey)(&cpm.HostKey), &cpm.HostVersion, (*Unsigned64)(&cpm.Pruned), (*Unsigned64)(&cpm.Remaining), &cpm.Duration); err != nil {
+			return nil, fmt.Errorf("failed to scan contract prune metric: %w", err)
+		}
+		cpm.Timestamp = api.TimeRFC3339(timestamp)
+		metrics = append(metrics, cpm)
+	}
+
+	return metrics, nil
+}
+
+func RecordContractPruneMetric(ctx context.Context, tx sql.Tx, metrics ...api.ContractPruneMetric) error {
+	insertStmt, err := tx.Prepare(ctx, fmt.Sprintf("INSERT INTO %s (created_at, timestamp, fcid, host, host_version, pruned, remaining, duration) VALUES (?, ?,?, ?, ?, ?, ?, ?)", tableContractPruneMetric))
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement to insert contract prune metric: %w", err)
+	}
+	defer insertStmt.Close()
+
+	for _, metric := range metrics {
+		res, err := insertStmt.Exec(ctx,
+			time.Now().UTC(),
+			UnixTimeMS(metric.Timestamp),
+			FileContractID(metric.ContractID),
+			PublicKey(metric.HostKey),
+			metric.HostVersion,
+			Unsigned64(metric.Pruned),
+			Unsigned64(metric.Remaining),
+			metric.Duration,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to insert contract prune metric: %w", err)
+		} else if n, err := res.RowsAffected(); err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		} else if n == 0 {
+			return fmt.Errorf("failed to insert contract prune metric: no rows affected")
+		}
+	}
+
+	return nil
+}
+
+func queryPeriods(ctx context.Context, tx sql.Tx, table string, start time.Time, n uint64, interval time.Duration, where whereClause) (*sql.LoggedRows, error) {
+	if n > api.MetricMaxIntervals {
+		return nil, api.ErrMaxIntervalsExceeded
+	}
+
+	return tx.Query(ctx, fmt.Sprintf(`
+	WITH RECURSIVE periods AS (
+		SELECT ? AS period_start
+		UNION ALL
+		SELECT period_start + ?
+		FROM periods
+		WHERE period_start < ? - ?
+	)
+	SELECT %s.* FROM %s
+	INNER JOIN (
+	SELECT
+		p.period_start as Period,
+		MIN(obj.id) AS id
+	FROM
+		periods p
+	INNER JOIN
+		%s obj ON obj.timestamp >= p.period_start AND obj.timestamp < p.period_start + ?
+	WHERE %s
+	GROUP BY
+		p.period_start
+	) i ON %s.id = i.id ORDER BY Period ASC
+`, table, table, table, where.query, table), append([]interface{}{
+		UnixTimeMS(start),
+		interval.Milliseconds(),
+		UnixTimeMS(start.Add(time.Duration(n) * interval)),
+		interval.Milliseconds(),
+		interval.Milliseconds(),
+	}, where.params...))
+}
+
+type whereClause struct {
+	query  string
+	params []interface{}
+}
+
+func whereClauseFromQueryOpts(opts interface{}) (where whereClause, _ error) {
+	where.query = "1=1"
+
+	switch opts := opts.(type) {
+	case api.ContractPruneMetricsQueryOpts:
+		if opts.ContractID != (types.FileContractID{}) {
+			where.query += " AND fcid = ?"
+			where.params = append(where.params, FileContractID(opts.ContractID))
+		}
+		if opts.HostKey != (types.PublicKey{}) {
+			where.query += " AND host = ?"
+			where.params = append(where.params, PublicKey(opts.HostKey))
+		}
+		if opts.HostVersion != "" {
+			where.query += " AND host_version = ?"
+			where.params = append(where.params, opts.HostVersion)
+		}
+	default:
+		return whereClause{}, fmt.Errorf("unknown query opts type: %T", opts)
+	}
+
+	return
+}

--- a/stores/sql/mysql/metrics.go
+++ b/stores/sql/mysql/metrics.go
@@ -2,19 +2,30 @@ package mysql
 
 import (
 	"context"
+	"encoding/hex"
 	"time"
 
 	dsql "database/sql"
 
+	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/internal/sql"
+	ssql "go.sia.tech/renterd/stores/sql"
+	"lukechampine.com/frand"
 
 	"go.uber.org/zap"
 )
 
-type MetricsDatabase struct {
-	log *zap.SugaredLogger
-	db  *sql.DB
-}
+type (
+	MetricsDatabase struct {
+		log *zap.SugaredLogger
+		db  *sql.DB
+	}
+
+	MetricsDatabaseTx struct {
+		sql.Tx
+		log *zap.SugaredLogger
+	}
+)
 
 // NewMetricsDatabase creates a new MySQL backend.
 func NewMetricsDatabase(db *dsql.DB, log *zap.SugaredLogger, lqd, ltd time.Duration) (*MetricsDatabase, error) {
@@ -45,6 +56,24 @@ func (b *MetricsDatabase) Migrate(ctx context.Context) error {
 	return sql.PerformMigrations(ctx, b, migrationsFs, "metrics", sql.MetricsMigrations(ctx, migrationsFs, b.log))
 }
 
+func (b *MetricsDatabase) Transaction(ctx context.Context, fn func(tx ssql.MetricsDatabaseTx) error) error {
+	return b.db.Transaction(ctx, func(tx sql.Tx) error {
+		return fn(b.wrapTxn(tx))
+	})
+}
+
 func (b *MetricsDatabase) Version(ctx context.Context) (string, string, error) {
 	return version(ctx, b.db)
+}
+
+func (b *MetricsDatabase) wrapTxn(tx sql.Tx) *MetricsDatabaseTx {
+	return &MetricsDatabaseTx{tx, b.log.Named(hex.EncodeToString(frand.Bytes(16)))}
+}
+
+func (tx *MetricsDatabaseTx) ContractPruneMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.ContractPruneMetricsQueryOpts) ([]api.ContractPruneMetric, error) {
+	return ssql.ContractPruneMetrics(ctx, tx, start, n, interval, opts)
+}
+
+func (tx *MetricsDatabaseTx) RecordContractPruneMetric(ctx context.Context, metrics ...api.ContractPruneMetric) error {
+	return ssql.RecordContractPruneMetric(ctx, tx, metrics...)
 }


### PR DESCRIPTION
I'll get rid of the `dbContractPruneMetric` type when I migrate `PruneMetrics`.