### PR TITLE
Only broadcast consensus update when we are synced

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -2391,11 +2391,13 @@ func (b *bus) multipartHandlerListPartsPOST(jc jape.Context) {
 }
 
 func (b *bus) ProcessConsensusChange(cc modules.ConsensusChange) {
-	b.events.BroadcastEvent(api.EventConsensusUpdate{
-		ConsensusState: b.consensusState(),
-		TransactionFee: b.tp.RecommendedFee(),
-		Timestamp:      time.Now().UTC(),
-	})
+	if cc.Synced {
+		b.events.BroadcastEvent(api.EventConsensusUpdate{
+			ConsensusState: b.consensusState(),
+			TransactionFee: b.tp.RecommendedFee(),
+			Timestamp:      time.Now().UTC(),
+		})
+	}
 }
 
 // New returns a new Bus.


### PR DESCRIPTION
Probably got lost in a merge somewhere, but we should definitely only broadcast the update when we're synced or otherwise a fresh start is horrible.