### PR TITLE
Minor fixes related to slow db queries

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -761,7 +761,7 @@ SELECT c.fcid, c.size, c.size as prunable FROM contracts c WHERE NOT EXISTS (SEL
 		return tx.
 			Raw(`
 SELECT fcid, contract_size as size, CASE WHEN contract_size > sector_size THEN contract_size - sector_size ELSE 0 END as prunable FROM (
-SELECT c.fcid, MAX(c.size) as contract_size, COUNT(cs.db_sector_id) * ? as sector_size FROM contracts c INNER JOIN contract_sectors cs ON cs.db_contract_id = c.id GROUP BY c.fcid
+SELECT c.fcid, MAX(c.size) as contract_size, COUNT(*) * ? as sector_size FROM contracts c INNER JOIN contract_sectors cs ON cs.db_contract_id = c.id GROUP BY c.fcid
 ) i`, rhpv2.SectorSize).
 			Scan(&dataContracts).
 			Error

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -771,6 +771,12 @@ func PrepareSlabHealth(ctx context.Context, tx sql.Tx, limit int64, now time.Tim
 			GROUP BY slabs.id
 			LIMIT ?
 	`, now.Unix(), limit)
+	if err != nil {
+		return fmt.Errorf("failed to create temporary table: %w", err)
+	}
+	if _, err := tx.Exec(ctx, "CREATE INDEX slabs_health_id ON slabs_health (id)"); err != nil {
+		return fmt.Errorf("failed to create index on temporary table: %w", err)
+	}
 	return err
 }
 

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -953,12 +953,18 @@ func (tx *MainDatabaseTx) UpdateSlabHealth(ctx context.Context, limit int64, min
 	_, err = tx.Exec(ctx, `
 		UPDATE objects o
 		INNER JOIN (
-			SELECT sli.db_object_id as id, MIN(h.health) as health
-			FROM slabs_health h
-			INNER JOIN slices sli ON sli.db_slab_id = h.id
+			SELECT sli.db_object_id as id, MIN(sla.health) as health
+			FROM slabs sla
+			INNER JOIN slices sli ON sli.db_slab_id = sla.id
 			GROUP BY sli.db_object_id
 		) AS object_health ON object_health.id = o.id
 		SET o.health = object_health.health
+		WHERE EXISTS (
+			SELECT 1
+			FROM slabs_health h
+			INNER JOIN slices ON slices.db_slab_id = h.id
+			WHERE slices.db_object_id = o.id
+		)
 		`)
 	if err != nil {
 		return 0, fmt.Errorf("failed to update object health: %w", err)

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -930,9 +930,9 @@ func (tx *MainDatabaseTx) UpdateSlabHealth(ctx context.Context, limit int64, min
 
 	_, err = tx.Exec(ctx, `
 		UPDATE objects SET health = (
-			SELECT MIN(h.health)
-			FROM slabs_health h
-			INNER JOIN slices ON slices.db_slab_id = h.id
+			SELECT MIN(sla.health)
+			FROM slabs sla
+			INNER JOIN slices ON slices.db_slab_id = sla.id
 			WHERE slices.db_object_id = objects.id
 		) WHERE EXISTS (
 			SELECT 1

--- a/worker/host.go
+++ b/worker/host.go
@@ -199,14 +199,6 @@ func (h *host) FetchPriceTable(ctx context.Context, rev *types.FileContractRevis
 	fetchPT := func(paymentFn PriceTablePaymentFunc) (hpt api.HostPriceTable, err error) {
 		err = h.transportPool.withTransportV3(ctx, h.hk, h.siamuxAddr, func(ctx context.Context, t *transportV3) (err error) {
 			hpt, err = RPCPriceTable(ctx, t, paymentFn)
-			h.bus.RecordPriceTables(ctx, []api.HostPriceTableUpdate{
-				{
-					HostKey:    h.hk,
-					Success:    isSuccessfulInteraction(err),
-					Timestamp:  time.Now(),
-					PriceTable: hpt,
-				},
-			})
 			return
 		})
 		return

--- a/worker/pricetables.go
+++ b/worker/pricetables.go
@@ -172,9 +172,22 @@ func (p *priceTable) fetch(ctx context.Context, rev *types.FileContractRevision)
 	// otherwise fetch it
 	h := p.hm.Host(p.hk, types.FileContractID{}, host.Settings.SiamuxAddr())
 	hpt, err = h.FetchPriceTable(ctx, rev)
+
+	// record it in the background
+	go func(hpt api.HostPriceTable, success bool) {
+		p.hs.RecordPriceTables(context.Background(), []api.HostPriceTableUpdate{
+			{
+				HostKey:    p.hk,
+				Success:    success,
+				Timestamp:  time.Now(),
+				PriceTable: hpt,
+			},
+		})
+	}(hpt, isSuccessfulInteraction(err))
+
+	// handle error after recording
 	if err != nil {
 		return api.HostPriceTable{}, fmt.Errorf("failed to update pricetable, err %v", err)
 	}
-
 	return
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -345,8 +345,6 @@ func (w *worker) fetchContracts(ctx context.Context, metadatas []api.ContractMet
 }
 
 func (w *worker) rhpPriceTableHandler(jc jape.Context) {
-	ctx := jc.Request.Context()
-
 	// decode the request
 	var rptr api.RHPPriceTableRequest
 	if jc.Decode(&rptr) != nil {
@@ -358,7 +356,7 @@ func (w *worker) rhpPriceTableHandler(jc jape.Context) {
 	var err error
 	var hpt api.HostPriceTable
 	defer func() {
-		w.bus.RecordPriceTables(ctx, []api.HostPriceTableUpdate{
+		w.bus.RecordPriceTables(jc.Request.Context(), []api.HostPriceTableUpdate{
 			{
 				HostKey:    rptr.HostKey,
 				Success:    isSuccessfulInteraction(err),
@@ -369,6 +367,7 @@ func (w *worker) rhpPriceTableHandler(jc jape.Context) {
 	}()
 
 	// apply timeout
+	ctx := jc.Request.Context()
 	if rptr.Timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(rptr.Timeout))

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1490,12 +1490,10 @@ func (w *worker) scanHost(ctx context.Context, timeout time.Duration, hostKey ty
 	default:
 	}
 
-	// record host scan - make sure this isn't interrupted by the same context
-	// used to time out the scan itself because otherwise we won't be able to
-	// record scans that timed out.
-	recordCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	scanErr := w.bus.RecordHostScans(recordCtx, []api.HostScan{
+	// record host scan - make sure this is interrupted by the request ctx and
+	// not the context with the timeout used to time out the scan itself.
+	// Otherwise scans that time out won't be recorded.
+	scanErr := w.bus.RecordHostScans(ctx, []api.HostScan{
 		{
 			HostKey:    hostKey,
 			Success:    isSuccessfulInteraction(err),


### PR DESCRIPTION
- Minor tweak to slab health update to speed it up by making use of indices
- Make sure recording a host scans doesn't abort after 30 seconds when db is under heavy load
- Make sure recording price tables doesn't abort after 30 seconds when db is under heavy load
- Register new price tables in the background, unblocking operations faster and preventing the record operation from being cancelled after a timeout