### PR TITLE
Various migrations in metadata.go

### DIFF
--- a/stores/chain_test.go
+++ b/stores/chain_test.go
@@ -77,15 +77,15 @@ func TestProcessChainUpdate(t *testing.T) {
 
 	// assert contract was updated successfully
 	var we uint64
-	if c, err := ss.contract(context.Background(), fileContractID(fcid)); err != nil {
+	if c, err := ss.Contract(context.Background(), fcid); err != nil {
 		t.Fatal("unexpected error", err)
 	} else if c.RevisionHeight != 1 {
 		t.Fatal("unexpected revision height", c.RevisionHeight)
-	} else if c.RevisionNumber != "2" {
+	} else if c.RevisionNumber != 2 {
 		t.Fatal("unexpected revision number", c.RevisionNumber)
 	} else if c.Size != 3 {
 		t.Fatal("unexpected size", c.Size)
-	} else if c.State.String() != api.ContractStateActive {
+	} else if c.State != api.ContractStateActive {
 		t.Fatal("unexpected state", c.State)
 	} else {
 		we = c.WindowEnd
@@ -97,11 +97,11 @@ func TestProcessChainUpdate(t *testing.T) {
 	}); err != nil {
 		t.Fatal("unexpected error", err)
 	}
-	if c, err := ss.contract(context.Background(), fileContractID(fcid)); err != nil {
+	if c, err := ss.Contract(context.Background(), fcid); err != nil {
 		t.Fatal("unexpected error", err)
 	} else if c.RevisionHeight != 2 {
 		t.Fatal("unexpected revision height", c.RevisionHeight)
-	} else if c.RevisionNumber != "2" {
+	} else if c.RevisionNumber != 2 {
 		t.Fatal("unexpected revision number", c.RevisionNumber)
 	} else if c.Size != 3 {
 		t.Fatal("unexpected size", c.Size)
@@ -113,9 +113,9 @@ func TestProcessChainUpdate(t *testing.T) {
 	}); err != nil {
 		t.Fatal("unexpected error", err)
 	}
-	if c, err := ss.contract(context.Background(), fileContractID(fcid)); err != nil {
+	if c, err := ss.Contract(context.Background(), fcid); err != nil {
 		t.Fatal("unexpected error", err)
-	} else if c.State.String() != api.ContractStateFailed {
+	} else if c.State != api.ContractStateFailed {
 		t.Fatal("unexpected state", c.State)
 	}
 

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2621,14 +2621,8 @@ func TestObjectsStats(t *testing.T) {
 		t.Fatal(err)
 	}
 	totalUploadedSize += c.Size
-	newContract, err := ss.contract(context.Background(), fileContractID(newContractID))
-	if err != nil {
-		t.Fatal(err)
-	}
 	for _, contractSector := range contractSectors {
-		contractSector.DBContractID = newContract.ID
-		err = ss.db.Create(&contractSector).Error
-		if err != nil {
+		if _, err := ss.DB().Exec(context.Background(), "INSERT INTO contract_sectors (db_contract_id, db_sector_id) VALUES ((SELECT id FROM contracts WHERE fcid = ?), ?)", sql.FileContractID(newContractID), contractSector.DBSectorID); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -484,46 +484,6 @@ func TestSQLContractStore(t *testing.T) {
 	}
 }
 
-func TestContractsForHost(t *testing.T) {
-	// create a SQL store
-	ss := newTestSQLStore(t, defaultTestSQLStoreConfig)
-	defer ss.Close()
-
-	// add 2 hosts
-	hks, err := ss.addTestHosts(2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// add 2 contracts
-	_, _, err = ss.addTestContracts(hks)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// fetch raw hosts
-	var hosts []dbHost
-	if err := ss.db.
-		Model(&dbHost{}).
-		Find(&hosts).
-		Error; err != nil {
-		t.Fatal(err)
-	}
-	if len(hosts) != 2 {
-		t.Fatal("unexpected number of hosts")
-	}
-
-	contracts, _ := contractsForHost(ss.db, hosts[0])
-	if len(contracts) != 1 || types.PublicKey(contracts[0].Host.PublicKey).String() != types.PublicKey(hosts[0].PublicKey).String() {
-		t.Fatal("unexpected", len(contracts), contracts)
-	}
-
-	contracts, _ = contractsForHost(ss.db, hosts[1])
-	if len(contracts) != 1 || types.PublicKey(contracts[0].Host.PublicKey).String() != types.PublicKey(hosts[1].PublicKey).String() {
-		t.Fatalf("unexpected contracts, %+v", contracts)
-	}
-}
-
 // TestContractRoots tests the ContractRoots function on the store.
 func TestContractRoots(t *testing.T) {
 	// create a SQL store

--- a/stores/slabbuffer_test.go
+++ b/stores/slabbuffer_test.go
@@ -32,7 +32,7 @@ func TestRecordAppendToCompletedBuffer(t *testing.T) {
 	minShards := uint8(1)
 	totalShards := uint8(2)
 	maxSize := bufferedSlabSize(minShards)
-	_, _, err = mgr.AddPartialSlab(context.Background(), frand.Bytes(maxSize-100), minShards, totalShards, set.ID)
+	_, _, err = mgr.AddPartialSlab(context.Background(), frand.Bytes(maxSize-100), minShards, totalShards, set.Name)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(mgr.completeBuffers[gid]) != 1 {
@@ -52,7 +52,7 @@ func TestRecordAppendToCompletedBuffer(t *testing.T) {
 
 	// add a slab that should fit in the buffer but since the first buffer is
 	// complete we ignore it
-	_, _, err = mgr.AddPartialSlab(context.Background(), frand.Bytes(1), minShards, totalShards, set.ID)
+	_, _, err = mgr.AddPartialSlab(context.Background(), frand.Bytes(1), minShards, totalShards, set.Name)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(mgr.completeBuffers[gid]) != 1 {
@@ -82,7 +82,7 @@ func TestMarkBufferCompleteTwice(t *testing.T) {
 	gid := bufferGID(1, 2, uint32(set.ID))
 
 	// create an incomplete buffer
-	_, _, err = mgr.AddPartialSlab(context.Background(), frand.Bytes(1), 1, 2, set.ID)
+	_, _, err = mgr.AddPartialSlab(context.Background(), frand.Bytes(1), 1, 2, set.Name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -93,6 +93,12 @@ type (
 		// opts argument can be used to filter the result.
 		Contracts(ctx context.Context, opts api.ContractsOpts) ([]api.ContractMetadata, error)
 
+		// ContractSetID returns the ID of the contract set with the given name.
+		// NOTE: Our locking strategy requires that the contract set ID is
+		// unique. So even after a contract set was deleted, the ID must not be
+		// reused.
+		ContractSetID(ctx context.Context, contractSet string) (int64, error)
+
 		// ContractSets returns the names of all contract sets.
 		ContractSets(ctx context.Context) ([]string, error)
 

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -37,13 +37,13 @@ type (
 	DatabaseTx interface {
 		// AbortMultipartUpload aborts a multipart upload and deletes it from
 		// the database.
-		AbortMultipartUpload(ctx context.Context, bucket, path string, uploadID string) error
+		AbortMultipartUpload(ctx context.Context, bucket, key string, uploadID string) error
 
 		// Accounts returns all accounts from the db.
 		Accounts(ctx context.Context) ([]api.Account, error)
 
 		// AddMultipartPart adds a part to an unfinished multipart upload.
-		AddMultipartPart(ctx context.Context, bucket, path, contractSet, eTag, uploadID string, partNumber int, slices object.SlabSlices) error
+		AddMultipartPart(ctx context.Context, bucket, key, contractSet, eTag, uploadID string, partNumber int, slices object.SlabSlices) error
 
 		// AddPeer adds a peer to the store.
 		AddPeer(ctx context.Context, addr string) error
@@ -196,6 +196,9 @@ type (
 
 		// MultipartUploads returns a list of all multipart uploads.
 		MultipartUploads(ctx context.Context, bucket, prefix, keyMarker, uploadIDMarker string, limit int) (api.MultipartListUploadsResponse, error)
+
+		// ObjectMetadata returns an object's metadata.
+		ObjectMetadata(ctx context.Context, bucket, key string) (api.Object, error)
 
 		// ObjectsStats returns overall stats about stored objects
 		ObjectsStats(ctx context.Context, opts api.ObjectsStatsOpts) (api.ObjectsStatsResponse, error)

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -280,6 +280,10 @@ type (
 		// SearchHosts returns a list of hosts that match the provided filters
 		SearchHosts(ctx context.Context, autopilotID, filterMode, usabilityMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]api.Host, error)
 
+		// SearchObjects returns a list of objects that contain the provided
+		// substring.
+		SearchObjects(ctx context.Context, bucket, substring string, offset, limit int) ([]api.ObjectMetadata, error)
+
 		// SetUncleanShutdown sets the clean shutdown flag on the accounts to
 		// 'false' and also marks them as requiring a resync.
 		SetUncleanShutdown(ctx context.Context) error

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -290,6 +290,9 @@ type (
 		// Settings returns all available settings from the database.
 		Settings(ctx context.Context) ([]string, error)
 
+		// Slab returns the slab with the given ID or api.ErrSlabNotFound.
+		Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error)
+
 		// SlabBuffers returns the filenames and associated contract sets of all
 		// slab buffers.
 		SlabBuffers(ctx context.Context) (map[string]string, error)

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -241,6 +241,17 @@ func Contracts(ctx context.Context, tx sql.Tx, opts api.ContractsOpts) ([]api.Co
 	return QueryContracts(ctx, tx, whereExprs, whereArgs)
 }
 
+func ContractSetID(ctx context.Context, tx sql.Tx, contractSet string) (int64, error) {
+	var id int64
+	err := tx.QueryRow(ctx, "SELECT id FROM contract_sets WHERE name = ?", contractSet).Scan(&id)
+	if errors.Is(err, dsql.ErrNoRows) {
+		return 0, api.ErrContractSetNotFound
+	} else if err != nil {
+		return 0, fmt.Errorf("failed to fetch contract set id: %w", err)
+	}
+	return id, nil
+}
+
 func ContractSets(ctx context.Context, tx sql.Tx) ([]string, error) {
 	rows, err := tx.Query(ctx, "SELECT name FROM contract_sets")
 	if err != nil {

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -522,6 +522,10 @@ func (tx *MainDatabaseTx) MultipartUploads(ctx context.Context, bucket, prefix, 
 	return ssql.MultipartUploads(ctx, tx, bucket, prefix, keyMarker, uploadIDMarker, limit)
 }
 
+func (tx *MainDatabaseTx) ObjectMetadata(ctx context.Context, bucket, path string) (api.Object, error) {
+	return ssql.ObjectMetadata(ctx, tx, bucket, path)
+}
+
 func (tx *MainDatabaseTx) ObjectsStats(ctx context.Context, opts api.ObjectsStatsOpts) (api.ObjectsStatsResponse, error) {
 	return ssql.ObjectsStats(ctx, tx, opts)
 }

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -727,6 +727,10 @@ func (tx *MainDatabaseTx) SearchHosts(ctx context.Context, autopilotID, filterMo
 	return ssql.SearchHosts(ctx, tx, autopilotID, filterMode, usabilityMode, addressContains, keyIn, offset, limit)
 }
 
+func (tx *MainDatabaseTx) SearchObjects(ctx context.Context, bucket, substring string, offset, limit int) ([]api.ObjectMetadata, error) {
+	return ssql.SearchObjects(ctx, tx, bucket, substring, offset, limit)
+}
+
 func (tx *MainDatabaseTx) Setting(ctx context.Context, key string) (string, error) {
 	return ssql.Setting(ctx, tx, key)
 }

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -739,6 +739,10 @@ func (tx *MainDatabaseTx) SetUncleanShutdown(ctx context.Context) error {
 	return ssql.SetUncleanShutdown(ctx, tx)
 }
 
+func (tx *MainDatabaseTx) Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error) {
+	return ssql.Slab(ctx, tx, key)
+}
+
 func (tx *MainDatabaseTx) SlabBuffers(ctx context.Context) (map[string]string, error) {
 	return ssql.SlabBuffers(ctx, tx)
 }

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -283,6 +283,10 @@ func (tx *MainDatabaseTx) Contracts(ctx context.Context, opts api.ContractsOpts)
 	return ssql.Contracts(ctx, tx, opts)
 }
 
+func (tx *MainDatabaseTx) ContractSetID(ctx context.Context, contractSet string) (int64, error) {
+	return ssql.ContractSetID(ctx, tx, contractSet)
+}
+
 func (tx *MainDatabaseTx) ContractSets(ctx context.Context) ([]string, error) {
 	return ssql.ContractSets(ctx, tx)
 }

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -519,6 +519,10 @@ func (tx *MainDatabaseTx) MultipartUploads(ctx context.Context, bucket, prefix, 
 	return ssql.MultipartUploads(ctx, tx, bucket, prefix, keyMarker, uploadIDMarker, limit)
 }
 
+func (tx *MainDatabaseTx) ObjectMetadata(ctx context.Context, bucket, path string) (api.Object, error) {
+	return ssql.ObjectMetadata(ctx, tx, bucket, path)
+}
+
 func (tx *MainDatabaseTx) ObjectsStats(ctx context.Context, opts api.ObjectsStatsOpts) (api.ObjectsStatsResponse, error) {
 	return ssql.ObjectsStats(ctx, tx, opts)
 }

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -737,6 +737,10 @@ func (tx *MainDatabaseTx) SetUncleanShutdown(ctx context.Context) error {
 	return ssql.SetUncleanShutdown(ctx, tx)
 }
 
+func (tx *MainDatabaseTx) Slab(ctx context.Context, key object.EncryptionKey) (object.Slab, error) {
+	return ssql.Slab(ctx, tx, key)
+}
+
 func (tx *MainDatabaseTx) SlabBuffers(ctx context.Context) (map[string]string, error) {
 	return ssql.SlabBuffers(ctx, tx)
 }

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -287,6 +287,10 @@ func (tx *MainDatabaseTx) Contracts(ctx context.Context, opts api.ContractsOpts)
 	return ssql.Contracts(ctx, tx, opts)
 }
 
+func (tx *MainDatabaseTx) ContractSetID(ctx context.Context, contractSet string) (int64, error) {
+	return ssql.ContractSetID(ctx, tx, contractSet)
+}
+
 func (tx *MainDatabaseTx) ContractSets(ctx context.Context) ([]string, error) {
 	return ssql.ContractSets(ctx, tx)
 }

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -725,6 +725,10 @@ func (tx *MainDatabaseTx) SearchHosts(ctx context.Context, autopilotID, filterMo
 	return ssql.SearchHosts(ctx, tx, autopilotID, filterMode, usabilityMode, addressContains, keyIn, offset, limit)
 }
 
+func (tx *MainDatabaseTx) SearchObjects(ctx context.Context, bucket, substring string, offset, limit int) ([]api.ObjectMetadata, error) {
+	return ssql.SearchObjects(ctx, tx, bucket, substring, offset, limit)
+}
+
 func (tx *MainDatabaseTx) Setting(ctx context.Context, key string) (string, error) {
 	return ssql.Setting(ctx, tx, key)
 }


### PR DESCRIPTION
This PR removes GORM from
- `SearchObjects`
- `AddPartialSlab`
- `Slab`
- `RefreshHealth`
- `PackedSlabsForUpload`
- `ObjectMetadata` 

and removes
- `contractsForHost` (unused) together with `TestContractsForHost`