### PR TITLE
Remove GORM from production code

### DIFF
--- a/stores/accounts.go
+++ b/stores/accounts.go
@@ -9,7 +9,7 @@ import (
 
 // Accounts returns all accounts from the db.
 func (s *SQLStore) Accounts(ctx context.Context) (accounts []api.Account, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		accounts, err = tx.Accounts(ctx)
 		return err
 	})
@@ -21,7 +21,7 @@ func (s *SQLStore) Accounts(ctx context.Context) (accounts []api.Account, err er
 // sync all accounts after an unclean shutdown and the bus will know not to
 // apply drift.
 func (s *SQLStore) SetUncleanShutdown(ctx context.Context) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.SetUncleanShutdown(ctx)
 	})
 }
@@ -29,7 +29,7 @@ func (s *SQLStore) SetUncleanShutdown(ctx context.Context) error {
 // SaveAccounts saves the given accounts in the db, overwriting any existing
 // ones.
 func (s *SQLStore) SaveAccounts(ctx context.Context, accounts []api.Account) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.SaveAccounts(ctx, accounts)
 	})
 }

--- a/stores/autopilot.go
+++ b/stores/autopilot.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *SQLStore) Autopilots(ctx context.Context) (aps []api.Autopilot, _ error) {
-	err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
+	err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
 		aps, err = tx.Autopilots(ctx)
 		return
 	})
@@ -17,7 +17,7 @@ func (s *SQLStore) Autopilots(ctx context.Context) (aps []api.Autopilot, _ error
 }
 
 func (s *SQLStore) Autopilot(ctx context.Context, id string) (ap api.Autopilot, _ error) {
-	err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
+	err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
 		ap, err = tx.Autopilot(ctx, id)
 		return
 	})
@@ -32,7 +32,7 @@ func (s *SQLStore) UpdateAutopilot(ctx context.Context, ap api.Autopilot) error 
 	if err := ap.Config.Validate(); err != nil {
 		return err
 	}
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.UpdateAutopilot(ctx, ap)
 	})
 }

--- a/stores/chain.go
+++ b/stores/chain.go
@@ -15,7 +15,7 @@ var (
 
 // ChainIndex returns the last stored chain index.
 func (s *SQLStore) ChainIndex(ctx context.Context) (ci types.ChainIndex, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		ci, err = tx.Tip(ctx)
 		return err
 	})
@@ -25,7 +25,7 @@ func (s *SQLStore) ChainIndex(ctx context.Context) (ci types.ChainIndex, err err
 // ProcessChainUpdate returns a callback function that process a chain update
 // inside a transaction.
 func (s *SQLStore) ProcessChainUpdate(ctx context.Context, applyFn chain.ApplyChainUpdateFn) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.ProcessChainUpdate(ctx, applyFn)
 	})
 }
@@ -39,7 +39,7 @@ func (s *SQLStore) UpdateChainState(reverted []chain.RevertUpdate, applied []cha
 
 // ResetChainState deletes all chain data in the database.
 func (s *SQLStore) ResetChainState(ctx context.Context) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.ResetChainState(ctx)
 	})
 }

--- a/stores/chain.go
+++ b/stores/chain.go
@@ -14,19 +14,12 @@ var (
 )
 
 // ChainIndex returns the last stored chain index.
-func (ss *SQLStore) ChainIndex(ctx context.Context) (types.ChainIndex, error) {
-	var ci dbConsensusInfo
-	if err := ss.db.
-		WithContext(ctx).
-		Where(&dbConsensusInfo{Model: Model{ID: consensusInfoID}}).
-		FirstOrCreate(&ci).
-		Error; err != nil {
-		return types.ChainIndex{}, err
-	}
-	return types.ChainIndex{
-		Height: ci.Height,
-		ID:     types.BlockID(ci.BlockID),
-	}, nil
+func (s *SQLStore) ChainIndex(ctx context.Context) (ci types.ChainIndex, err error) {
+	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+		ci, err = tx.Tip(ctx)
+		return err
+	})
+	return
 }
 
 // ProcessChainUpdate returns a callback function that process a chain update

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -268,14 +268,14 @@ func (s *SQLStore) Host(ctx context.Context, hostKey types.PublicKey) (api.Host,
 }
 
 func (s *SQLStore) UpdateHostCheck(ctx context.Context, autopilotID string, hk types.PublicKey, hc api.HostCheck) (err error) {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.UpdateHostCheck(ctx, autopilotID, hk, hc)
 	})
 }
 
 // HostsForScanning returns the address of hosts for scanning.
 func (s *SQLStore) HostsForScanning(ctx context.Context, maxLastScan time.Time, offset, limit int) (hosts []api.HostAddress, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		hosts, err = tx.HostsForScanning(ctx, maxLastScan, offset, limit)
 		return err
 	})
@@ -293,7 +293,7 @@ func (s *SQLStore) ResetLostSectors(ctx context.Context, hk types.PublicKey) err
 
 func (s *SQLStore) SearchHosts(ctx context.Context, autopilotID, filterMode, usabilityMode, addressContains string, keyIn []types.PublicKey, offset, limit int) ([]api.Host, error) {
 	var hosts []api.Host
-	err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
+	err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
 		hosts, err = tx.SearchHosts(ctx, autopilotID, filterMode, usabilityMode, addressContains, keyIn, offset, limit)
 		return
 	})
@@ -310,7 +310,7 @@ func (s *SQLStore) RemoveOfflineHosts(ctx context.Context, minRecentFailures uin
 	if maxDowntime < 0 {
 		return 0, ErrNegativeMaxDowntime
 	}
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		n, err := tx.RemoveOfflineHosts(ctx, minRecentFailures, maxDowntime)
 		removed = uint64(n)
 		return err
@@ -323,7 +323,7 @@ func (s *SQLStore) UpdateHostAllowlistEntries(ctx context.Context, add, remove [
 	if len(add)+len(remove) == 0 && !clear {
 		return nil
 	}
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.UpdateHostAllowlistEntries(ctx, add, remove, clear)
 	})
 }
@@ -333,13 +333,13 @@ func (s *SQLStore) UpdateHostBlocklistEntries(ctx context.Context, add, remove [
 	if len(add)+len(remove) == 0 && !clear {
 		return nil
 	}
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.UpdateHostBlocklistEntries(ctx, add, remove, clear)
 	})
 }
 
 func (s *SQLStore) HostAllowlist(ctx context.Context) (allowlist []types.PublicKey, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		allowlist, err = tx.HostAllowlist(ctx)
 		return err
 	})
@@ -347,7 +347,7 @@ func (s *SQLStore) HostAllowlist(ctx context.Context) (allowlist []types.PublicK
 }
 
 func (s *SQLStore) HostBlocklist(ctx context.Context) (blocklist []string, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		blocklist, err = tx.HostBlocklist(ctx)
 		return err
 	})
@@ -355,13 +355,13 @@ func (s *SQLStore) HostBlocklist(ctx context.Context) (blocklist []string, err e
 }
 
 func (s *SQLStore) RecordHostScans(ctx context.Context, scans []api.HostScan) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.RecordHostScans(ctx, scans)
 	})
 }
 
 func (s *SQLStore) RecordPriceTables(ctx context.Context, priceTableUpdate []api.HostPriceTableUpdate) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.RecordPriceTables(ctx, priceTableUpdate)
 	})
 }

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -1021,15 +1021,15 @@ func (s *SQLStore) Slab(ctx context.Context, key object.EncryptionKey) (slab obj
 	return
 }
 
-func (ss *SQLStore) UpdateSlab(ctx context.Context, s object.Slab, contractSet string) error {
+func (s *SQLStore) UpdateSlab(ctx context.Context, slab object.Slab, contractSet string) error {
 	// sanity check the shards don't contain an empty root
-	for _, s := range s.Shards {
-		if s.Root == (types.Hash256{}) {
+	for _, shard := range slab.Shards {
+		if shard.Root == (types.Hash256{}) {
 			return errors.New("shard root can never be the empty root")
 		}
 	}
 	// Sanity check input.
-	for i, shard := range s.Shards {
+	for i, shard := range slab.Shards {
 		// Verify that all hosts have a contract.
 		if len(shard.Contracts) == 0 {
 			return fmt.Errorf("missing hosts for slab %d", i)
@@ -1037,8 +1037,8 @@ func (ss *SQLStore) UpdateSlab(ctx context.Context, s object.Slab, contractSet s
 	}
 
 	// Update slab.
-	return ss.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
-		return tx.UpdateSlab(ctx, s, contractSet, s.Contracts())
+	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+		return tx.UpdateSlab(ctx, slab, contractSet, slab.Contracts())
 	})
 }
 

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -423,7 +423,7 @@ func (raw rawObject) toSlabSlice() (slice object.SlabSlice, _ error) {
 }
 
 func (s *SQLStore) Bucket(ctx context.Context, bucket string) (b api.Bucket, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
 		b, err = tx.Bucket(ctx, bucket)
 		return
 	})
@@ -431,25 +431,25 @@ func (s *SQLStore) Bucket(ctx context.Context, bucket string) (b api.Bucket, err
 }
 
 func (s *SQLStore) CreateBucket(ctx context.Context, bucket string, policy api.BucketPolicy) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.CreateBucket(ctx, bucket, policy)
 	})
 }
 
 func (s *SQLStore) UpdateBucketPolicy(ctx context.Context, bucket string, policy api.BucketPolicy) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.UpdateBucketPolicy(ctx, bucket, policy)
 	})
 }
 
 func (s *SQLStore) DeleteBucket(ctx context.Context, bucket string) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.DeleteBucket(ctx, bucket)
 	})
 }
 
 func (s *SQLStore) ListBuckets(ctx context.Context) (buckets []api.Bucket, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
 		buckets, err = tx.ListBuckets(ctx)
 		return
 	})
@@ -460,7 +460,7 @@ func (s *SQLStore) ListBuckets(ctx context.Context) (buckets []api.Bucket, err e
 // reduce locking and make sure all results are consistent, everything is done
 // within a single transaction.
 func (s *SQLStore) ObjectsStats(ctx context.Context, opts api.ObjectsStatsOpts) (resp api.ObjectsStatsResponse, _ error) {
-	err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
+	err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
 		resp, err = tx.ObjectsStats(ctx, opts)
 		return
 	})
@@ -470,7 +470,7 @@ func (s *SQLStore) ObjectsStats(ctx context.Context, opts api.ObjectsStatsOpts) 
 func (s *SQLStore) SlabBuffers(ctx context.Context) ([]api.SlabBuffer, error) {
 	var err error
 	var fileNameToContractSet map[string]string
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		fileNameToContractSet, err = tx.SlabBuffers(ctx)
 		return err
 	})
@@ -488,7 +488,7 @@ func (s *SQLStore) SlabBuffers(ctx context.Context) ([]api.SlabBuffer, error) {
 
 func (s *SQLStore) AddContract(ctx context.Context, c rhpv2.ContractRevision, contractPrice, totalCost types.Currency, startHeight uint64, state string) (_ api.ContractMetadata, err error) {
 	var contract api.ContractMetadata
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		contract, err = tx.InsertContract(ctx, c, contractPrice, totalCost, startHeight, types.FileContractID{}, state)
 		return err
 	})
@@ -501,7 +501,7 @@ func (s *SQLStore) AddContract(ctx context.Context, c rhpv2.ContractRevision, co
 
 func (s *SQLStore) Contracts(ctx context.Context, opts api.ContractsOpts) ([]api.ContractMetadata, error) {
 	var contracts []api.ContractMetadata
-	err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
+	err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
 		contracts, err = tx.Contracts(ctx, opts)
 		return
 	})
@@ -513,7 +513,7 @@ func (s *SQLStore) Contracts(ctx context.Context, opts api.ContractsOpts) ([]api
 // contracts and moved to the archive. Both new and old contract will be linked
 // to each other through the RenewedFrom and RenewedTo fields respectively.
 func (s *SQLStore) AddRenewedContract(ctx context.Context, c rhpv2.ContractRevision, contractPrice, totalCost types.Currency, startHeight uint64, renewedFrom types.FileContractID, state string) (renewed api.ContractMetadata, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		renewed, err = tx.RenewContract(ctx, c, contractPrice, totalCost, startHeight, renewedFrom, state)
 		return err
 	})
@@ -524,7 +524,7 @@ func (s *SQLStore) AddRenewedContract(ctx context.Context, c rhpv2.ContractRevis
 }
 
 func (s *SQLStore) AncestorContracts(ctx context.Context, id types.FileContractID, startHeight uint64) (ancestors []api.ArchivedContract, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		ancestors, err = tx.AncestorContracts(ctx, id, startHeight)
 		return err
 	})
@@ -549,7 +549,7 @@ func (s *SQLStore) ArchiveContracts(ctx context.Context, toArchive map[types.Fil
 
 		// archive the contract but don't interrupt the process if one contract
 		// fails
-		if err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+		if err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 			return tx.ArchiveContract(ctx, fcid, reason)
 		}); err != nil {
 			errs = append(errs, fmt.Sprintf("%v: %v", fcid, err))
@@ -575,7 +575,7 @@ func (s *SQLStore) ArchiveAllContracts(ctx context.Context, reason string) error
 }
 
 func (s *SQLStore) Contract(ctx context.Context, id types.FileContractID) (cm api.ContractMetadata, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		cm, err = tx.Contract(ctx, id)
 		return err
 	})
@@ -583,7 +583,7 @@ func (s *SQLStore) Contract(ctx context.Context, id types.FileContractID) (cm ap
 }
 
 func (s *SQLStore) ContractRoots(ctx context.Context, id types.FileContractID) (roots []types.Hash256, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		roots, err = tx.ContractRoots(ctx, id)
 		return err
 	})
@@ -591,7 +591,7 @@ func (s *SQLStore) ContractRoots(ctx context.Context, id types.FileContractID) (
 }
 
 func (s *SQLStore) ContractSets(ctx context.Context) (sets []string, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		sets, err = tx.ContractSets(ctx)
 		return err
 	})
@@ -599,7 +599,7 @@ func (s *SQLStore) ContractSets(ctx context.Context) (sets []string, err error) 
 }
 
 func (s *SQLStore) ContractSizes(ctx context.Context) (sizes map[types.FileContractID]api.ContractSize, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		sizes, err = tx.ContractSizes(ctx)
 		return err
 	})
@@ -607,7 +607,7 @@ func (s *SQLStore) ContractSizes(ctx context.Context) (sizes map[types.FileContr
 }
 
 func (s *SQLStore) ContractSize(ctx context.Context, id types.FileContractID) (cs api.ContractSize, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
 		cs, err = tx.ContractSize(ctx, id)
 		return
 	})
@@ -691,13 +691,13 @@ func (s *SQLStore) SetContractSet(ctx context.Context, name string, contractIds 
 }
 
 func (s *SQLStore) RemoveContractSet(ctx context.Context, name string) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.RemoveContractSet(ctx, name)
 	})
 }
 
 func (s *SQLStore) RenewedContract(ctx context.Context, renewedFrom types.FileContractID) (cm api.ContractMetadata, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		cm, err = tx.RenewedContract(ctx, renewedFrom)
 		return err
 	})
@@ -705,7 +705,7 @@ func (s *SQLStore) RenewedContract(ctx context.Context, renewedFrom types.FileCo
 }
 
 func (s *SQLStore) SearchObjects(ctx context.Context, bucket, substring string, offset, limit int) (objects []api.ObjectMetadata, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		objects, err = tx.SearchObjects(ctx, bucket, substring, offset, limit)
 		return err
 	})
@@ -713,7 +713,7 @@ func (s *SQLStore) SearchObjects(ctx context.Context, bucket, substring string, 
 }
 
 func (s *SQLStore) ObjectEntries(ctx context.Context, bucket, path, prefix, sortBy, sortDir, marker string, offset, limit int) (metadata []api.ObjectMetadata, hasMore bool, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		metadata, hasMore, err = tx.ObjectEntries(ctx, bucket, path, prefix, sortBy, sortDir, marker, offset, limit)
 		return err
 	})
@@ -850,7 +850,7 @@ func fetchUsedContracts(tx *gorm.DB, usedContractsByHost map[types.PublicKey]map
 }
 
 func (s *SQLStore) RenameObject(ctx context.Context, bucket, keyOld, keyNew string, force bool) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		// create new dir
 		dirID, err := tx.MakeDirsForPath(ctx, keyNew)
 		if err != nil {
@@ -868,7 +868,7 @@ func (s *SQLStore) RenameObject(ctx context.Context, bucket, keyOld, keyNew stri
 }
 
 func (s *SQLStore) RenameObjects(ctx context.Context, bucket, prefixOld, prefixNew string, force bool) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		// create new dir
 		dirID, err := tx.MakeDirsForPath(ctx, prefixNew)
 		if err != nil {
@@ -891,7 +891,7 @@ func (s *SQLStore) AddPartialSlab(ctx context.Context, data []byte, minShards, t
 }
 
 func (s *SQLStore) CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath, dstPath, mimeType string, metadata api.ObjectUserMetadata) (om api.ObjectMetadata, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		if srcBucket != dstBucket || srcPath != dstPath {
 			_, err = tx.DeleteObject(ctx, dstBucket, dstPath)
 			if err != nil {
@@ -905,7 +905,7 @@ func (s *SQLStore) CopyObject(ctx context.Context, srcBucket, dstBucket, srcPath
 }
 
 func (s *SQLStore) DeleteHostSector(ctx context.Context, hk types.PublicKey, root types.Hash256) (deletedSectors int, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		deletedSectors, err = tx.DeleteHostSector(ctx, hk, root)
 		return err
 	})
@@ -925,7 +925,7 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, 
 
 	// UpdateObject is ACID.
 	var prune bool
-	err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		// Try to delete. We want to get rid of the object and its slices if it
 		// exists.
 		//
@@ -966,7 +966,7 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, path, contractSet, 
 
 func (s *SQLStore) RemoveObject(ctx context.Context, bucket, path string) error {
 	var prune bool
-	err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
+	err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
 		prune, err = tx.DeleteObject(ctx, bucket, path)
 		return
 	})
@@ -986,7 +986,7 @@ func (s *SQLStore) RemoveObjects(ctx context.Context, bucket, prefix string) err
 		start := time.Now()
 		var done bool
 		var duration time.Duration
-		if err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+		if err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 			deleted, err := tx.DeleteObjects(ctx, bucket, prefix, objectDeleteBatchSizes[batchSizeIdx])
 			if err != nil {
 				return err
@@ -1014,7 +1014,7 @@ func (s *SQLStore) RemoveObjects(ctx context.Context, bucket, prefix string) err
 }
 
 func (s *SQLStore) Slab(ctx context.Context, key object.EncryptionKey) (slab object.Slab, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		slab, err = tx.Slab(ctx, key)
 		return err
 	})
@@ -1037,7 +1037,7 @@ func (s *SQLStore) UpdateSlab(ctx context.Context, slab object.Slab, contractSet
 	}
 
 	// Update slab.
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.UpdateSlab(ctx, slab, contractSet, slab.Contracts())
 	})
 }
@@ -1046,7 +1046,7 @@ func (s *SQLStore) RefreshHealth(ctx context.Context) error {
 	for {
 		// update slabs
 		var rowsAffected int64
-		err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
+		err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
 			rowsAffected, err = tx.UpdateSlabHealth(ctx, refreshHealthBatchSize, refreshHealthMinHealthValidity, refreshHealthMaxHealthValidity)
 			return
 		})
@@ -1200,7 +1200,7 @@ func (s *SQLStore) objectHydrate(tx *gorm.DB, bucket, path string, obj rawObject
 
 // ObjectMetadata returns an object's metadata
 func (s *SQLStore) ObjectMetadata(ctx context.Context, bucket, path string) (obj api.Object, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		obj, err = tx.ObjectMetadata(ctx, bucket, path)
 		return err
 	})
@@ -1402,7 +1402,7 @@ func (s *SQLStore) pruneSlabsLoop() {
 		pruneSuccess := true
 		for {
 			var deleted int64
-			err := s.bMain.Transaction(s.shutdownCtx, func(dt sql.DatabaseTx) error {
+			err := s.db.Transaction(s.shutdownCtx, func(dt sql.DatabaseTx) error {
 				var err error
 				deleted, err = dt.PruneSlabs(s.shutdownCtx, slabPruningBatchSize)
 				return err
@@ -1430,7 +1430,7 @@ func (s *SQLStore) pruneSlabsLoop() {
 		}
 
 		// prune dirs
-		err := s.bMain.Transaction(s.shutdownCtx, func(dt sql.DatabaseTx) error {
+		err := s.db.Transaction(s.shutdownCtx, func(dt sql.DatabaseTx) error {
 			return dt.PruneEmptydirs(s.shutdownCtx)
 		})
 		if err != nil {
@@ -1469,7 +1469,7 @@ func (s *SQLStore) triggerSlabPruning() {
 func (s *SQLStore) invalidateSlabHealthByFCID(ctx context.Context, fcids []types.FileContractID) error {
 	for {
 		var affected int64
-		err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
+		err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) (err error) {
 			affected, err = tx.InvalidateSlabHealthByFCID(ctx, fcids, refreshHealthBatchSize)
 			return
 		})
@@ -1486,7 +1486,7 @@ func (s *SQLStore) invalidateSlabHealthByFCID(ctx context.Context, fcids []types
 // a delimiter for now (see backend.go) but it would be interesting to have
 // arbitrary 'delim' support in ListObjects.
 func (s *SQLStore) ListObjects(ctx context.Context, bucket, prefix, sortBy, sortDir, marker string, limit int) (resp api.ObjectsListResponse, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		resp, err = tx.ListObjects(ctx, bucket, prefix, sortBy, sortDir, marker, limit)
 		return err
 	})

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -168,11 +168,11 @@ func TestObjectBasic(t *testing.T) {
 
 	// delete a sector
 	var sectors []dbSector
-	if err := ss.db.Find(&sectors).Error; err != nil {
+	if err := ss.gormDB.Find(&sectors).Error; err != nil {
 		t.Fatal(err)
 	} else if len(sectors) != 2 {
 		t.Fatal("unexpected number of sectors")
-	} else if tx := ss.db.Delete(sectors[0]); tx.Error != nil || tx.RowsAffected != 1 {
+	} else if tx := ss.gormDB.Delete(sectors[0]); tx.Error != nil || tx.RowsAffected != 1 {
 		t.Fatal("unexpected number of sectors deleted", tx.Error, tx.RowsAffected)
 	}
 
@@ -261,7 +261,7 @@ func TestObjectMetadata(t *testing.T) {
 
 	// assert metadata CASCADE on object delete
 	var cnt int64
-	if err := ss.db.Model(&dbObjectUserMetadata{}).Count(&cnt).Error; err != nil {
+	if err := ss.gormDB.Model(&dbObjectUserMetadata{}).Count(&cnt).Error; err != nil {
 		t.Fatal(err)
 	} else if cnt != 2 {
 		t.Fatal("unexpected number of metadata entries", cnt)
@@ -273,7 +273,7 @@ func TestObjectMetadata(t *testing.T) {
 	}
 
 	// assert records are gone
-	if err := ss.db.Model(&dbObjectUserMetadata{}).Count(&cnt).Error; err != nil {
+	if err := ss.gormDB.Model(&dbObjectUserMetadata{}).Count(&cnt).Error; err != nil {
 		t.Fatal(err)
 	} else if cnt != 0 {
 		t.Fatal("unexpected number of metadata entries", cnt)
@@ -462,7 +462,7 @@ func TestSQLContractStore(t *testing.T) {
 	// Make sure the db was cleaned up properly through the CASCADE delete.
 	tableCountCheck := func(table interface{}, tblCount int64) error {
 		var count int64
-		if err := ss.db.Model(table).Count(&count).Error; err != nil {
+		if err := ss.gormDB.Model(table).Count(&count).Error; err != nil {
 			return err
 		}
 		if count != tblCount {
@@ -476,7 +476,7 @@ func TestSQLContractStore(t *testing.T) {
 
 	// Check join table count as well.
 	var count int64
-	if err := ss.db.Table("contract_sectors").Count(&count).Error; err != nil {
+	if err := ss.gormDB.Table("contract_sectors").Count(&count).Error; err != nil {
 		t.Fatal(err)
 	}
 	if count != 0 {
@@ -741,7 +741,7 @@ func TestRenewedContract(t *testing.T) {
 
 	// Archived contract should exist.
 	var ac dbArchivedContract
-	err = ss.db.Model(&dbArchivedContract{}).
+	err = ss.gormDB.Model(&dbArchivedContract{}).
 		Where("fcid", fileContractID(fcid1)).
 		Take(&ac).
 		Error
@@ -905,7 +905,7 @@ func TestArchiveContracts(t *testing.T) {
 	ffcids[0] = fileContractID(fcids[1])
 	ffcids[1] = fileContractID(fcids[2])
 	var acs []dbArchivedContract
-	err = ss.db.Model(&dbArchivedContract{}).
+	err = ss.gormDB.Model(&dbArchivedContract{}).
 		Where("fcid IN (?)", ffcids).
 		Find(&acs).
 		Error
@@ -1243,7 +1243,7 @@ func TestSQLMetadataStore(t *testing.T) {
 	countCheck := func(objCount, sliceCount, slabCount, sectorCount int64) error {
 		tableCountCheck := func(table interface{}, tblCount int64) error {
 			var count int64
-			if err := ss.db.Model(table).Count(&count).Error; err != nil {
+			if err := ss.gormDB.Model(table).Count(&count).Error; err != nil {
 				return err
 			}
 			if count != tblCount {
@@ -1486,7 +1486,7 @@ func TestObjectEntries(t *testing.T) {
 	}
 
 	// update health of objects to match the overridden health of the slabs
-	if err := updateAllObjectsHealth(ss.db); err != nil {
+	if err := updateAllObjectsHealth(ss.gormDB); err != nil {
 		t.Fatal()
 	}
 
@@ -1921,7 +1921,7 @@ func TestUnhealthySlabsNoContracts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ss.db.Table("contract_sectors").Where("TRUE").Delete(&dbContractSector{}).Error; err != nil {
+	if err := ss.gormDB.Table("contract_sectors").Where("TRUE").Delete(&dbContractSector{}).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -2060,7 +2060,7 @@ func TestContractSectors(t *testing.T) {
 
 	// Check the join table. Should be empty.
 	var css []dbContractSector
-	if err := ss.db.Find(&css).Error; err != nil {
+	if err := ss.gormDB.Find(&css).Error; err != nil {
 		t.Fatal(err)
 	}
 	if len(css) != 0 {
@@ -2084,10 +2084,10 @@ func TestContractSectors(t *testing.T) {
 	}
 
 	// Delete the sector.
-	if err := ss.db.Delete(&dbSector{Model: Model{ID: 1}}).Error; err != nil {
+	if err := ss.gormDB.Delete(&dbSector{Model: Model{ID: 1}}).Error; err != nil {
 		t.Fatal(err)
 	}
-	if err := ss.db.Find(&css).Error; err != nil {
+	if err := ss.gormDB.Find(&css).Error; err != nil {
 		t.Fatal(err)
 	}
 	if len(css) != 0 {
@@ -2144,7 +2144,7 @@ func TestUpdateSlab(t *testing.T) {
 	// helper to fetch a slab from the database
 	fetchSlab := func() (slab dbSlab) {
 		t.Helper()
-		if err = ss.db.
+		if err = ss.gormDB.
 			Where(&dbSlab{Key: key}).
 			Preload("Shards.Contracts").
 			Take(&slab).
@@ -2227,7 +2227,7 @@ func TestUpdateSlab(t *testing.T) {
 
 	// assert there's still only one entry in the dbslab table
 	var cnt int64
-	if err := ss.db.Model(&dbSlab{}).Count(&cnt).Error; err != nil {
+	if err := ss.gormDB.Model(&dbSlab{}).Count(&cnt).Error; err != nil {
 		t.Fatal(err)
 	} else if cnt != 1 {
 		t.Fatalf("unexpected number of entries in dbslab, %v != 1", cnt)
@@ -2262,7 +2262,7 @@ func TestUpdateSlab(t *testing.T) {
 		t.Fatal(err)
 	}
 	var s dbSlab
-	if err := ss.db.Where(&dbSlab{Key: key}).
+	if err := ss.gormDB.Where(&dbSlab{Key: key}).
 		Joins("DBContractSet").
 		Preload("Shards").
 		Take(&s).
@@ -2497,7 +2497,7 @@ func TestRenameObjects(t *testing.T) {
 	}
 	var directories []dbDirectory
 	test.Retry(100, 100*time.Millisecond, func() error {
-		if err := ss.db.Find(&directories).Error; err != nil {
+		if err := ss.gormDB.Find(&directories).Error; err != nil {
 			return err
 		} else if len(directories) != len(expectedDirs) {
 			return fmt.Errorf("unexpected number of directories, %v != %v", len(directories), len(expectedDirs))
@@ -2565,7 +2565,7 @@ func TestObjectsStats(t *testing.T) {
 	// Get all entries in contract_sectors and store them again with a different
 	// contract id. This should cause the uploaded size to double.
 	var contractSectors []dbContractSector
-	err = ss.db.Find(&contractSectors).Error
+	err = ss.gormDB.Find(&contractSectors).Error
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2717,7 +2717,7 @@ func TestPartialSlab(t *testing.T) {
 
 	var buffer bufferedSlab
 	sk, _ := slabs[0].Key.MarshalBinary()
-	if err := ss.db.Joins("DBSlab").Take(&buffer, "DBSlab.key = ?", secretKey(sk)).Error; err != nil {
+	if err := ss.gormDB.Joins("DBSlab").Take(&buffer, "DBSlab.key = ?", secretKey(sk)).Error; err != nil {
 		t.Fatal(err)
 	}
 	if buffer.Filename == "" {
@@ -2779,7 +2779,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 	buffer = bufferedSlab{}
 	sk, _ = slabs[0].Key.MarshalBinary()
-	if err := ss.db.Joins("DBSlab").Take(&buffer, "DBSlab.key = ?", secretKey(sk)).Error; err != nil {
+	if err := ss.gormDB.Joins("DBSlab").Take(&buffer, "DBSlab.key = ?", secretKey(sk)).Error; err != nil {
 		t.Fatal(err)
 	}
 	assertBuffer(buffer1Name, 4194303, false, false)
@@ -2820,13 +2820,13 @@ func TestPartialSlab(t *testing.T) {
 	}
 	buffer = bufferedSlab{}
 	sk, _ = slabs[0].Key.MarshalBinary()
-	if err := ss.db.Joins("DBSlab").Take(&buffer, "DBSlab.key = ?", secretKey(sk)).Error; err != nil {
+	if err := ss.gormDB.Joins("DBSlab").Take(&buffer, "DBSlab.key = ?", secretKey(sk)).Error; err != nil {
 		t.Fatal(err)
 	}
 	assertBuffer(buffer1Name, rhpv2.SectorSize, true, false)
 	buffer = bufferedSlab{}
 	sk, _ = slabs[1].Key.MarshalBinary()
-	if err := ss.db.Joins("DBSlab").Take(&buffer, "DBSlab.key = ?", secretKey(sk)).Error; err != nil {
+	if err := ss.gormDB.Joins("DBSlab").Take(&buffer, "DBSlab.key = ?", secretKey(sk)).Error; err != nil {
 		t.Fatal(err)
 	}
 	buffer2Name := buffer.Filename
@@ -2854,11 +2854,11 @@ func TestPartialSlab(t *testing.T) {
 	assertBuffer(buffer2Name, 1, false, false)
 
 	var foo []bufferedSlab
-	if err := ss.db.Find(&foo).Error; err != nil {
+	if err := ss.gormDB.Find(&foo).Error; err != nil {
 		t.Fatal(err)
 	}
 	buffer = bufferedSlab{}
-	if err := ss.db.Take(&buffer, "id = ?", packedSlabs[0].BufferID).Error; err != nil {
+	if err := ss.gormDB.Take(&buffer, "id = ?", packedSlabs[0].BufferID).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -2877,7 +2877,7 @@ func TestPartialSlab(t *testing.T) {
 	}
 
 	buffer = bufferedSlab{}
-	if err := ss.db.Take(&buffer, "id = ?", packedSlabs[0].BufferID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+	if err := ss.gormDB.Take(&buffer, "id = ?", packedSlabs[0].BufferID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
 		t.Fatal("shouldn't be able to find buffer", err)
 	}
 	assertBuffer(buffer2Name, 1, false, false)
@@ -3084,7 +3084,7 @@ func TestContractSizes(t *testing.T) {
 // dbObject retrieves a dbObject from the store.
 func (s *SQLStore) dbObject(key string) (dbObject, error) {
 	var obj dbObject
-	tx := s.db.Where(&dbObject{ObjectID: key}).
+	tx := s.gormDB.Where(&dbObject{ObjectID: key}).
 		Preload("Slabs").
 		Take(&obj)
 	if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
@@ -3096,7 +3096,7 @@ func (s *SQLStore) dbObject(key string) (dbObject, error) {
 // dbSlab retrieves a dbSlab from the store.
 func (s *SQLStore) dbSlab(key []byte) (dbSlab, error) {
 	var slab dbSlab
-	tx := s.db.Where(&dbSlab{Key: key}).
+	tx := s.gormDB.Where(&dbSlab{Key: key}).
 		Preload("Shards.Contracts.Host").
 		Take(&slab)
 	if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
@@ -3364,7 +3364,7 @@ func TestBucketObjects(t *testing.T) {
 
 	// See if we can fetch the object by slab.
 	var ec object.EncryptionKey
-	if obj, err := ss.objectRaw(ss.db, b1, "/bar"); err != nil {
+	if obj, err := ss.objectRaw(ss.gormDB, b1, "/bar"); err != nil {
 		t.Fatal(err)
 	} else if err := ec.UnmarshalBinary(obj[0].SlabKey); err != nil {
 		t.Fatal(err)
@@ -3498,7 +3498,7 @@ func TestMarkSlabUploadedAfterRenew(t *testing.T) {
 	}
 
 	var count int64
-	if err := ss.db.Model(&dbContractSector{}).Count(&count).Error; err != nil {
+	if err := ss.gormDB.Model(&dbContractSector{}).Count(&count).Error; err != nil {
 		t.Fatal(err)
 	} else if count != 1 {
 		t.Fatal("expected 1 sector", count)
@@ -3549,7 +3549,7 @@ func TestListObjects(t *testing.T) {
 	}
 
 	// update health of objects to match the overridden health of the slabs
-	if err := updateAllObjectsHealth(ss.db); err != nil {
+	if err := updateAllObjectsHealth(ss.gormDB); err != nil {
 		t.Fatal()
 	}
 
@@ -3633,7 +3633,7 @@ func TestDeleteHostSector(t *testing.T) {
 
 	// get all contracts
 	var dbContracts []dbContract
-	if err := ss.db.Model(&dbContract{}).Preload("Host").Find(&dbContracts).Error; err != nil {
+	if err := ss.gormDB.Model(&dbContract{}).Preload("Host").Find(&dbContracts).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -3654,13 +3654,13 @@ func TestDeleteHostSector(t *testing.T) {
 			},
 		},
 	}
-	if err := ss.db.Create(&slab).Error; err != nil {
+	if err := ss.gormDB.Create(&slab).Error; err != nil {
 		t.Fatal(err)
 	}
 
 	// Make sure 4 contractSector entries exist.
 	var n int64
-	if err := ss.db.Model(&dbContractSector{}).
+	if err := ss.gormDB.Model(&dbContractSector{}).
 		Count(&n).
 		Error; err != nil {
 		t.Fatal(err)
@@ -3676,7 +3676,7 @@ func TestDeleteHostSector(t *testing.T) {
 	}
 
 	// Make sure 2 contractSector entries exist.
-	if err := ss.db.Model(&dbContractSector{}).
+	if err := ss.gormDB.Model(&dbContractSector{}).
 		Count(&n).
 		Error; err != nil {
 		t.Fatal(err)
@@ -3686,7 +3686,7 @@ func TestDeleteHostSector(t *testing.T) {
 
 	// Find the slab. It should have an invalid health.
 	var s dbSlab
-	if err := ss.db.Preload("Shards").Take(&s).Error; err != nil {
+	if err := ss.gormDB.Preload("Shards").Take(&s).Error; err != nil {
 		t.Fatal(err)
 	} else if s.HealthValid() {
 		t.Fatal("expected health to be invalid")
@@ -3696,7 +3696,7 @@ func TestDeleteHostSector(t *testing.T) {
 
 	// Fetch the sector and assert the contracts association.
 	var sectors []dbSector
-	if err := ss.db.Model(&dbSector{}).Preload("Contracts").Find(&sectors).Preload("Contracts").Error; err != nil {
+	if err := ss.gormDB.Model(&dbSector{}).Preload("Contracts").Find(&sectors).Preload("Contracts").Error; err != nil {
 		t.Fatal(err)
 	} else if len(sectors) != 1 {
 		t.Fatal("expected 1 sector", len(sectors))
@@ -3738,7 +3738,7 @@ func TestDeleteHostSector(t *testing.T) {
 	}
 
 	// Fetch the sector and check the public key has the default value
-	if err := ss.db.Model(&dbSector{}).Find(&sectors).Error; err != nil {
+	if err := ss.gormDB.Model(&dbSector{}).Find(&sectors).Error; err != nil {
 		t.Fatal(err)
 	} else if len(sectors) != 1 {
 		t.Fatal("expected 1 sector", len(sectors))
@@ -3839,7 +3839,7 @@ func TestSlabHealthInvalidation(t *testing.T) {
 		var slab dbSlab
 		if key, err := slabKey.MarshalBinary(); err != nil {
 			t.Fatal(err)
-		} else if err := ss.db.Model(&dbSlab{}).Where(&dbSlab{Key: key}).Take(&slab).Error; err != nil {
+		} else if err := ss.gormDB.Model(&dbSlab{}).Where(&dbSlab{Key: key}).Take(&slab).Error; err != nil {
 			t.Fatal(err)
 		} else if slab.HealthValid() != expected {
 			t.Fatal("unexpected health valid", slab.HealthValid(), slab.HealthValidUntil, time.Now(), time.Unix(slab.HealthValidUntil, 0))
@@ -3961,7 +3961,7 @@ func TestSlabHealthInvalidation(t *testing.T) {
 	// assert the health validity is always updated to a random time in the future that matches the boundaries
 	for i := 0; i < 1e3; i++ {
 		// reset health validity
-		if tx := ss.db.Exec("UPDATE slabs SET health_valid_until = 0;"); tx.Error != nil {
+		if tx := ss.gormDB.Exec("UPDATE slabs SET health_valid_until = 0;"); tx.Error != nil {
 			t.Fatal(err)
 		}
 
@@ -3975,7 +3975,7 @@ func TestSlabHealthInvalidation(t *testing.T) {
 		var slab dbSlab
 		if key, err := s1.MarshalBinary(); err != nil {
 			t.Fatal(err)
-		} else if err := ss.db.Model(&dbSlab{}).Where(&dbSlab{Key: key}).Take(&slab).Error; err != nil {
+		} else if err := ss.gormDB.Model(&dbSlab{}).Where(&dbSlab{Key: key}).Take(&slab).Error; err != nil {
 			t.Fatal(err)
 		}
 
@@ -4113,18 +4113,18 @@ func TestSlabCleanup(t *testing.T) {
 
 	// create contract set
 	cs := dbContractSet{}
-	if err := ss.db.Create(&cs).Error; err != nil {
+	if err := ss.gormDB.Create(&cs).Error; err != nil {
 		t.Fatal(err)
 	}
 
 	// create buffered slab
 	bsID := uint(1)
-	if err := ss.db.Exec("INSERT INTO buffered_slabs (filename) VALUES ('foo');").Error; err != nil {
+	if err := ss.gormDB.Exec("INSERT INTO buffered_slabs (filename) VALUES ('foo');").Error; err != nil {
 		t.Fatal(err)
 	}
 
 	var dirID int64
-	err := ss.bMain.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
+	err := ss.db.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
 		var err error
 		dirID, err = tx.MakeDirsForPath(context.Background(), "1")
 		return err
@@ -4140,7 +4140,7 @@ func TestSlabCleanup(t *testing.T) {
 		DBBucketID:    ss.DefaultBucketID(),
 		Health:        1,
 	}
-	if err := ss.db.Create(&obj1).Error; err != nil {
+	if err := ss.gormDB.Create(&obj1).Error; err != nil {
 		t.Fatal(err)
 	}
 	obj2 := dbObject{
@@ -4149,7 +4149,7 @@ func TestSlabCleanup(t *testing.T) {
 		DBBucketID:    ss.DefaultBucketID(),
 		Health:        1,
 	}
-	if err := ss.db.Create(&obj2).Error; err != nil {
+	if err := ss.gormDB.Create(&obj2).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -4161,7 +4161,7 @@ func TestSlabCleanup(t *testing.T) {
 		Key:              secretKey(ek),
 		HealthValidUntil: 100,
 	}
-	if err := ss.db.Create(&slab).Error; err != nil {
+	if err := ss.gormDB.Create(&slab).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -4170,14 +4170,14 @@ func TestSlabCleanup(t *testing.T) {
 		DBObjectID: &obj1.ID,
 		DBSlabID:   slab.ID,
 	}
-	if err := ss.db.Create(&slice1).Error; err != nil {
+	if err := ss.gormDB.Create(&slice1).Error; err != nil {
 		t.Fatal(err)
 	}
 	slice2 := dbSlice{
 		DBObjectID: &obj2.ID,
 		DBSlabID:   slab.ID,
 	}
-	if err := ss.db.Create(&slice2).Error; err != nil {
+	if err := ss.gormDB.Create(&slice2).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -4189,7 +4189,7 @@ func TestSlabCleanup(t *testing.T) {
 
 	// check slice count
 	var slabCntr int64
-	if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
+	if err := ss.gormDB.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
 		t.Fatal(err)
 	} else if slabCntr != 1 {
 		t.Fatalf("expected 1 slabs, got %v", slabCntr)
@@ -4199,7 +4199,7 @@ func TestSlabCleanup(t *testing.T) {
 	err = ss.RemoveObjectBlocking(context.Background(), api.DefaultBucketName, obj2.ObjectID)
 	if err != nil {
 		t.Fatal(err)
-	} else if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
+	} else if err := ss.gormDB.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
 		t.Fatal(err)
 	} else if slabCntr != 0 {
 		t.Fatalf("expected 0 slabs, got %v", slabCntr)
@@ -4214,7 +4214,7 @@ func TestSlabCleanup(t *testing.T) {
 		Key:              ek,
 		HealthValidUntil: 100,
 	}
-	if err := ss.db.Create(&bufferedSlab).Error; err != nil {
+	if err := ss.gormDB.Create(&bufferedSlab).Error; err != nil {
 		t.Fatal(err)
 	}
 	obj3 := dbObject{
@@ -4223,17 +4223,17 @@ func TestSlabCleanup(t *testing.T) {
 		DBBucketID:    ss.DefaultBucketID(),
 		Health:        1,
 	}
-	if err := ss.db.Create(&obj3).Error; err != nil {
+	if err := ss.gormDB.Create(&obj3).Error; err != nil {
 		t.Fatal(err)
 	}
 	slice := dbSlice{
 		DBObjectID: &obj3.ID,
 		DBSlabID:   bufferedSlab.ID,
 	}
-	if err := ss.db.Create(&slice).Error; err != nil {
+	if err := ss.gormDB.Create(&slice).Error; err != nil {
 		t.Fatal(err)
 	}
-	if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
+	if err := ss.gormDB.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
 		t.Fatal(err)
 	} else if slabCntr != 1 {
 		t.Fatalf("expected 1 slabs, got %v", slabCntr)
@@ -4243,7 +4243,7 @@ func TestSlabCleanup(t *testing.T) {
 	err = ss.RemoveObjectBlocking(context.Background(), api.DefaultBucketName, obj3.ObjectID)
 	if err != nil {
 		t.Fatal(err)
-	} else if err := ss.db.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
+	} else if err := ss.gormDB.Model(&dbSlab{}).Count(&slabCntr).Error; err != nil {
 		t.Fatal(err)
 	} else if slabCntr != 1 {
 		t.Fatalf("expected 1 slabs, got %v", slabCntr)
@@ -4306,7 +4306,7 @@ func TestUpdateObjectReuseSlab(t *testing.T) {
 
 	// fetch the object
 	var dbObj dbObject
-	if err := ss.db.Where("db_bucket_id", ss.DefaultBucketID()).Take(&dbObj).Error; err != nil {
+	if err := ss.gormDB.Where("db_bucket_id", ss.DefaultBucketID()).Take(&dbObj).Error; err != nil {
 		t.Fatal(err)
 	} else if dbObj.ID != 1 {
 		t.Fatal("unexpected id", dbObj.ID)
@@ -4322,7 +4322,7 @@ func TestUpdateObjectReuseSlab(t *testing.T) {
 
 	// fetch its slices
 	var dbSlices []dbSlice
-	if err := ss.db.Where("db_object_id", dbObj.ID).Find(&dbSlices).Error; err != nil {
+	if err := ss.gormDB.Where("db_object_id", dbObj.ID).Find(&dbSlices).Error; err != nil {
 		t.Fatal(err)
 	} else if len(dbSlices) != 2 {
 		t.Fatal("invalid number of slices", len(dbSlices))
@@ -4339,7 +4339,7 @@ func TestUpdateObjectReuseSlab(t *testing.T) {
 		// fetch the slab
 		var dbSlab dbSlab
 		key, _ := obj.Slabs[i].Key.MarshalBinary()
-		if err := ss.db.Where("id", dbSlice.DBSlabID).Take(&dbSlab).Error; err != nil {
+		if err := ss.gormDB.Where("id", dbSlice.DBSlabID).Take(&dbSlab).Error; err != nil {
 			t.Fatal(err)
 		} else if dbSlab.ID != uint(i+1) {
 			t.Fatal("unexpected id", dbSlab.ID)
@@ -4359,7 +4359,7 @@ func TestUpdateObjectReuseSlab(t *testing.T) {
 
 		// fetch the sectors
 		var dbSectors []dbSector
-		if err := ss.db.Where("db_slab_id", dbSlab.ID).Find(&dbSectors).Error; err != nil {
+		if err := ss.gormDB.Where("db_slab_id", dbSlab.ID).Find(&dbSectors).Error; err != nil {
 			t.Fatal(err)
 		} else if len(dbSectors) != totalShards {
 			t.Fatal("invalid number of sectors", len(dbSectors))
@@ -4412,7 +4412,7 @@ func TestUpdateObjectReuseSlab(t *testing.T) {
 
 	// fetch the object
 	var dbObj2 dbObject
-	if err := ss.db.Where("db_bucket_id", ss.DefaultBucketID()).
+	if err := ss.gormDB.Where("db_bucket_id", ss.DefaultBucketID()).
 		Where("object_id", "2").
 		Take(&dbObj2).Error; err != nil {
 		t.Fatal(err)
@@ -4424,7 +4424,7 @@ func TestUpdateObjectReuseSlab(t *testing.T) {
 
 	// fetch its slices
 	var dbSlices2 []dbSlice
-	if err := ss.db.Where("db_object_id", dbObj2.ID).Find(&dbSlices2).Error; err != nil {
+	if err := ss.gormDB.Where("db_object_id", dbObj2.ID).Find(&dbSlices2).Error; err != nil {
 		t.Fatal(err)
 	} else if len(dbSlices2) != 2 {
 		t.Fatal("invalid number of slices", len(dbSlices))
@@ -4443,7 +4443,7 @@ func TestUpdateObjectReuseSlab(t *testing.T) {
 	// fetch the slab
 	var dbSlab2 dbSlab
 	key, _ := obj2.Slabs[0].Key.MarshalBinary()
-	if err := ss.db.Where("id", dbSlice2.DBSlabID).Take(&dbSlab2).Error; err != nil {
+	if err := ss.gormDB.Where("id", dbSlice2.DBSlabID).Take(&dbSlab2).Error; err != nil {
 		t.Fatal(err)
 	} else if dbSlab2.ID != uint(len(dbSlices)+1) {
 		t.Fatal("unexpected id", dbSlab2.ID)
@@ -4455,7 +4455,7 @@ func TestUpdateObjectReuseSlab(t *testing.T) {
 
 	// fetch the sectors
 	var dbSectors2 []dbSector
-	if err := ss.db.Where("db_slab_id", dbSlab2.ID).Find(&dbSectors2).Error; err != nil {
+	if err := ss.gormDB.Where("db_slab_id", dbSlab2.ID).Find(&dbSectors2).Error; err != nil {
 		t.Fatal(err)
 	} else if len(dbSectors2) != totalShards {
 		t.Fatal("invalid number of sectors", len(dbSectors2))
@@ -4478,7 +4478,7 @@ func TestUpdateObjectReuseSlab(t *testing.T) {
 	}
 
 	var contractSectors []dbContractSector
-	if err := ss.db.Find(&contractSectors).Error; err != nil {
+	if err := ss.gormDB.Find(&contractSectors).Error; err != nil {
 		t.Fatal(err)
 	} else if len(contractSectors) != 3*totalShards {
 		t.Fatal("invalid number of contract sectors", len(contractSectors))
@@ -4613,7 +4613,7 @@ func TestFetchUsedContracts(t *testing.T) {
 
 	// assert empty map returns no contracts
 	usedContracts := make(map[types.PublicKey]map[types.FileContractID]struct{})
-	contracts, err := fetchUsedContracts(ss.db, usedContracts)
+	contracts, err := fetchUsedContracts(ss.gormDB, usedContracts)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(contracts) != 0 {
@@ -4625,7 +4625,7 @@ func TestFetchUsedContracts(t *testing.T) {
 	usedContracts[hk1][types.FileContractID{1}] = struct{}{}
 
 	// assert we get the used contract
-	contracts, err = fetchUsedContracts(ss.db, usedContracts)
+	contracts, err = fetchUsedContracts(ss.gormDB, usedContracts)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(contracts) != 1 {
@@ -4642,7 +4642,7 @@ func TestFetchUsedContracts(t *testing.T) {
 	}
 
 	// assert used contracts contains one entry and it points to the renewal
-	contracts, err = fetchUsedContracts(ss.db, usedContracts)
+	contracts, err = fetchUsedContracts(ss.gormDB, usedContracts)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(contracts) != 1 {
@@ -4658,7 +4658,7 @@ func TestFetchUsedContracts(t *testing.T) {
 
 	// assert used contracts now contains an entry for both contracts and both
 	// point to the renewed contract
-	contracts, err = fetchUsedContracts(ss.db, usedContracts)
+	contracts, err = fetchUsedContracts(ss.gormDB, usedContracts)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(contracts) != 2 {
@@ -4685,7 +4685,7 @@ func TestDirectories(t *testing.T) {
 
 	for _, o := range objects {
 		var dirID int64
-		err := ss.bMain.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
+		err := ss.db.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
 			var err error
 			dirID, err = tx.MakeDirsForPath(context.Background(), o)
 			return err
@@ -4730,7 +4730,7 @@ func TestDirectories(t *testing.T) {
 	}
 
 	var dbDirs []dbDirectory
-	if err := ss.db.Find(&dbDirs).Error; err != nil {
+	if err := ss.gormDB.Find(&dbDirs).Error; err != nil {
 		t.Fatal(err)
 	} else if len(dbDirs) != len(expectedDirs) {
 		t.Fatalf("expected %v dirs, got %v", len(expectedDirs), len(dbDirs))
@@ -4751,7 +4751,7 @@ func TestDirectories(t *testing.T) {
 	})
 
 	var n int64
-	if err := ss.db.Model(&dbDirectory{}).Count(&n).Error; err != nil {
+	if err := ss.gormDB.Model(&dbDirectory{}).Count(&n).Error; err != nil {
 		t.Fatal(err)
 	} else if n != 1 {
 		t.Fatal("expected 1 dir, got", n)

--- a/stores/metrics.go
+++ b/stores/metrics.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *SQLStore) ContractMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.ContractMetricsQueryOpts) (metrics []api.ContractMetric, err error) {
-	err = s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
+	err = s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
 		metrics, txErr = tx.ContractMetrics(ctx, start, n, interval, opts)
 		return
 	})
@@ -17,7 +17,7 @@ func (s *SQLStore) ContractMetrics(ctx context.Context, start time.Time, n uint6
 }
 
 func (s *SQLStore) ContractPruneMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.ContractPruneMetricsQueryOpts) (metrics []api.ContractPruneMetric, err error) {
-	err = s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
+	err = s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
 		metrics, txErr = tx.ContractPruneMetrics(ctx, start, n, interval, opts)
 		return
 	})
@@ -25,7 +25,7 @@ func (s *SQLStore) ContractPruneMetrics(ctx context.Context, start time.Time, n 
 }
 
 func (s *SQLStore) ContractSetChurnMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.ContractSetChurnMetricsQueryOpts) (metrics []api.ContractSetChurnMetric, err error) {
-	err = s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
+	err = s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
 		metrics, txErr = tx.ContractSetChurnMetrics(ctx, start, n, interval, opts)
 		return
 	})
@@ -33,7 +33,7 @@ func (s *SQLStore) ContractSetChurnMetrics(ctx context.Context, start time.Time,
 }
 
 func (s *SQLStore) ContractSetMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.ContractSetMetricsQueryOpts) (metrics []api.ContractSetMetric, err error) {
-	err = s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
+	err = s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
 		metrics, txErr = tx.ContractSetMetrics(ctx, start, n, interval, opts)
 		return
 	})
@@ -41,7 +41,7 @@ func (s *SQLStore) ContractSetMetrics(ctx context.Context, start time.Time, n ui
 }
 
 func (s *SQLStore) PerformanceMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.PerformanceMetricsQueryOpts) (metrics []api.PerformanceMetric, err error) {
-	err = s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
+	err = s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
 		metrics, txErr = tx.PerformanceMetrics(ctx, start, n, interval, opts)
 		return
 	})
@@ -49,43 +49,43 @@ func (s *SQLStore) PerformanceMetrics(ctx context.Context, start time.Time, n ui
 }
 
 func (s *SQLStore) RecordContractMetric(ctx context.Context, metrics ...api.ContractMetric) error {
-	return s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
+	return s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
 		return tx.RecordContractMetric(ctx, metrics...)
 	})
 }
 
 func (s *SQLStore) RecordContractPruneMetric(ctx context.Context, metrics ...api.ContractPruneMetric) error {
-	return s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
+	return s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
 		return tx.RecordContractPruneMetric(ctx, metrics...)
 	})
 }
 
 func (s *SQLStore) RecordContractSetChurnMetric(ctx context.Context, metrics ...api.ContractSetChurnMetric) error {
-	return s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
+	return s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
 		return tx.RecordContractSetChurnMetric(ctx, metrics...)
 	})
 }
 
 func (s *SQLStore) RecordContractSetMetric(ctx context.Context, metrics ...api.ContractSetMetric) error {
-	return s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
+	return s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
 		return tx.RecordContractSetMetric(ctx, metrics...)
 	})
 }
 
 func (s *SQLStore) RecordPerformanceMetric(ctx context.Context, metrics ...api.PerformanceMetric) error {
-	return s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
+	return s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
 		return tx.RecordPerformanceMetric(ctx, metrics...)
 	})
 }
 
 func (s *SQLStore) RecordWalletMetric(ctx context.Context, metrics ...api.WalletMetric) error {
-	return s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
+	return s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
 		return tx.RecordWalletMetric(ctx, metrics...)
 	})
 }
 
 func (s *SQLStore) WalletMetrics(ctx context.Context, start time.Time, n uint64, interval time.Duration, opts api.WalletMetricsQueryOpts) (metrics []api.WalletMetric, err error) {
-	err = s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
+	err = s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) (txErr error) {
 		metrics, txErr = tx.WalletMetrics(ctx, start, n, interval, opts)
 		return
 	})
@@ -93,7 +93,7 @@ func (s *SQLStore) WalletMetrics(ctx context.Context, start time.Time, n uint64,
 }
 
 func (s *SQLStore) PruneMetrics(ctx context.Context, metric string, cutoff time.Time) error {
-	return s.bMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
+	return s.dbMetrics.Transaction(ctx, func(tx sql.MetricsDatabaseTx) error {
 		return tx.PruneMetrics(ctx, metric, cutoff)
 	})
 }

--- a/stores/multipart_test.go
+++ b/stores/multipart_test.go
@@ -73,7 +73,7 @@ func TestMultipartUploadWithUploadPackingRegression(t *testing.T) {
 
 	// Assert metadata was persisted and is linked to the multipart upload
 	var metadatas []dbObjectUserMetadata
-	if err := ss.db.Model(&dbObjectUserMetadata{}).Find(&metadatas).Error; err != nil {
+	if err := ss.gormDB.Model(&dbObjectUserMetadata{}).Find(&metadatas).Error; err != nil {
 		t.Fatal(err)
 	} else if len(metadatas) != len(testMetadata) {
 		t.Fatal("expected metadata to be persisted")
@@ -87,13 +87,13 @@ func TestMultipartUploadWithUploadPackingRegression(t *testing.T) {
 	// Complete the upload. Check that the number of slices stays the same.
 	var nSlicesBefore int64
 	var nSlicesAfter int64
-	if err := ss.db.Model(&dbSlice{}).Count(&nSlicesBefore).Error; err != nil {
+	if err := ss.gormDB.Model(&dbSlice{}).Count(&nSlicesBefore).Error; err != nil {
 		t.Fatal(err)
 	} else if nSlicesBefore == 0 {
 		t.Fatal("expected some slices")
 	} else if _, err = ss.CompleteMultipartUpload(ctx, api.DefaultBucketName, objName, resp.UploadID, parts, api.CompleteMultipartOptions{}); err != nil {
 		t.Fatal(err)
-	} else if err := ss.db.Model(&dbSlice{}).Count(&nSlicesAfter).Error; err != nil {
+	} else if err := ss.gormDB.Model(&dbSlice{}).Count(&nSlicesAfter).Error; err != nil {
 		t.Fatal(err)
 	} else if nSlicesBefore != nSlicesAfter {
 		t.Fatalf("expected number of slices to stay the same, but got %v before and %v after", nSlicesBefore, nSlicesAfter)
@@ -115,7 +115,7 @@ func TestMultipartUploadWithUploadPackingRegression(t *testing.T) {
 	}
 
 	// Assert metadata was converted and the multipart upload id was nullified
-	if err := ss.db.Model(&dbObjectUserMetadata{}).Find(&metadatas).Error; err != nil {
+	if err := ss.gormDB.Model(&dbObjectUserMetadata{}).Find(&metadatas).Error; err != nil {
 		t.Fatal(err)
 	} else if len(metadatas) != len(testMetadata) {
 		t.Fatal("expected metadata to be persisted")

--- a/stores/peers.go
+++ b/stores/peers.go
@@ -15,14 +15,14 @@ var (
 // AddPeer adds a peer to the store. If the peer already exists, nil should be
 // returned.
 func (s *SQLStore) AddPeer(addr string) error {
-	return s.bMain.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
 		return tx.AddPeer(context.Background(), addr)
 	})
 }
 
 // Peers returns the set of known peers.
 func (s *SQLStore) Peers() (peers []syncer.PeerInfo, err error) {
-	err = s.bMain.Transaction(context.Background(), func(tx sql.DatabaseTx) (txErr error) {
+	err = s.db.Transaction(context.Background(), func(tx sql.DatabaseTx) (txErr error) {
 		peers, txErr = tx.Peers(context.Background())
 		return
 	})
@@ -32,7 +32,7 @@ func (s *SQLStore) Peers() (peers []syncer.PeerInfo, err error) {
 // PeerInfo returns the metadata for the specified peer or ErrPeerNotFound
 // if the peer wasn't found in the store.
 func (s *SQLStore) PeerInfo(addr string) (info syncer.PeerInfo, err error) {
-	err = s.bMain.Transaction(context.Background(), func(tx sql.DatabaseTx) (txErr error) {
+	err = s.db.Transaction(context.Background(), func(tx sql.DatabaseTx) (txErr error) {
 		info, txErr = tx.PeerInfo(context.Background(), addr)
 		return
 	})
@@ -42,7 +42,7 @@ func (s *SQLStore) PeerInfo(addr string) (info syncer.PeerInfo, err error) {
 // UpdatePeerInfo updates the metadata for the specified peer. If the peer
 // is not found, the error should be ErrPeerNotFound.
 func (s *SQLStore) UpdatePeerInfo(addr string, fn func(*syncer.PeerInfo)) error {
-	return s.bMain.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
 		return tx.UpdatePeerInfo(context.Background(), addr, fn)
 	})
 }
@@ -50,14 +50,14 @@ func (s *SQLStore) UpdatePeerInfo(addr string, fn func(*syncer.PeerInfo)) error 
 // Ban temporarily bans one or more IPs. The addr should either be a single
 // IP with port (e.g. 1.2.3.4:5678) or a CIDR subnet (e.g. 1.2.3.4/16).
 func (s *SQLStore) Ban(addr string, duration time.Duration, reason string) error {
-	return s.bMain.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
 		return tx.BanPeer(context.Background(), addr, duration, reason)
 	})
 }
 
 // Banned returns true, nil if the peer is banned.
 func (s *SQLStore) Banned(addr string) (banned bool, err error) {
-	err = s.bMain.Transaction(context.Background(), func(tx sql.DatabaseTx) (txErr error) {
+	err = s.db.Transaction(context.Background(), func(tx sql.DatabaseTx) (txErr error) {
 		banned, txErr = tx.PeerBanned(context.Background(), addr)
 		return
 	})

--- a/stores/settingsdb.go
+++ b/stores/settingsdb.go
@@ -13,7 +13,7 @@ func (s *SQLStore) DeleteSetting(ctx context.Context, key string) error {
 	defer s.settingsMu.Unlock()
 
 	// delete from database first
-	if err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	if err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.DeleteSettings(ctx, key)
 	}); err != nil {
 		return err
@@ -36,7 +36,7 @@ func (s *SQLStore) Setting(ctx context.Context, key string) (string, error) {
 
 	// Check database.
 	var err error
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		value, err = tx.Setting(ctx, key)
 		return err
 	})
@@ -49,7 +49,7 @@ func (s *SQLStore) Setting(ctx context.Context, key string) (string, error) {
 
 // Settings implements the bus.SettingStore interface.
 func (s *SQLStore) Settings(ctx context.Context) (settings []string, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		settings, err = tx.Settings(ctx)
 		return err
 	})
@@ -62,7 +62,7 @@ func (s *SQLStore) UpdateSetting(ctx context.Context, key, value string) error {
 	s.settingsMu.Lock()
 	defer s.settingsMu.Unlock()
 
-	err := s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err := s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.UpdateSetting(ctx, key, value)
 	})
 	if err != nil {

--- a/stores/slabbuffer_test.go
+++ b/stores/slabbuffer_test.go
@@ -13,7 +13,7 @@ func TestRecordAppendToCompletedBuffer(t *testing.T) {
 	defer ss.Close()
 
 	completionThreshold := int64(1000)
-	mgr, err := newSlabBufferManager(context.Background(), ss.alerts, ss.bMain, ss.logger, completionThreshold, t.TempDir())
+	mgr, err := newSlabBufferManager(context.Background(), ss.alerts, ss.db, ss.logger, completionThreshold, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,7 +21,7 @@ func TestRecordAppendToCompletedBuffer(t *testing.T) {
 
 	// get contract set for its id
 	var set dbContractSet
-	if err := ss.db.Where("name", testContractSet).Take(&set).Error; err != nil {
+	if err := ss.gormDB.Where("name", testContractSet).Take(&set).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -66,7 +66,7 @@ func TestMarkBufferCompleteTwice(t *testing.T) {
 	ss := newTestSQLStore(t, defaultTestSQLStoreConfig)
 	defer ss.Close()
 
-	mgr, err := newSlabBufferManager(context.Background(), ss.alerts, ss.bMain, ss.logger, 0, t.TempDir())
+	mgr, err := newSlabBufferManager(context.Background(), ss.alerts, ss.db, ss.logger, 0, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestMarkBufferCompleteTwice(t *testing.T) {
 
 	// get contract set for its id
 	var set dbContractSet
-	if err := ss.db.Where("name", testContractSet).Take(&set).Error; err != nil {
+	if err := ss.gormDB.Where("name", testContractSet).Take(&set).Error; err != nil {
 		t.Fatal(err)
 	}
 

--- a/stores/types.go
+++ b/stores/types.go
@@ -28,7 +28,6 @@ type (
 	currency       types.Currency
 	bCurrency      types.Currency
 	fileContractID types.FileContractID
-	hash256        types.Hash256
 	publicKey      types.PublicKey
 	hostSettings   rhpv2.HostSettings
 	hostPriceTable rhpv3.HostPriceTable
@@ -98,29 +97,6 @@ func (k *secretKey) Scan(value interface{}) error {
 // Value returns an key value, implements driver.Valuer interface.
 func (k secretKey) Value() (driver.Value, error) {
 	return []byte(k), nil
-}
-
-// GormDataType implements gorm.GormDataTypeInterface.
-func (hash256) GormDataType() string {
-	return "bytes"
-}
-
-// Scan scan value into address, implements sql.Scanner interface.
-func (h *hash256) Scan(value interface{}) error {
-	bytes, ok := value.([]byte)
-	if !ok {
-		return errors.New(fmt.Sprint("failed to unmarshal hash256 value:", value))
-	}
-	if len(bytes) != len(hash256{}) {
-		return fmt.Errorf("failed to unmarshal hash256 value due to invalid number of bytes %v != %v: %v", len(bytes), len(fileContractID{}), value)
-	}
-	*h = *(*hash256)(bytes)
-	return nil
-}
-
-// Value returns an addr value, implements driver.Valuer interface.
-func (h hash256) Value() (driver.Value, error) {
-	return h[:], nil
 }
 
 // GormDataType implements gorm.GormDataTypeInterface.

--- a/stores/wallet.go
+++ b/stores/wallet.go
@@ -15,7 +15,7 @@ var (
 // Tip returns the consensus change ID and block height of the last wallet
 // change.
 func (s *SQLStore) Tip() (ci types.ChainIndex, err error) {
-	err = s.bMain.Transaction(s.shutdownCtx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(s.shutdownCtx, func(tx sql.DatabaseTx) error {
 		ci, err = tx.Tip(s.shutdownCtx)
 		return err
 	})
@@ -24,7 +24,7 @@ func (s *SQLStore) Tip() (ci types.ChainIndex, err error) {
 
 // UnspentSiacoinElements returns a list of all unspent siacoin outputs
 func (s *SQLStore) UnspentSiacoinElements() (elements []types.SiacoinElement, err error) {
-	err = s.bMain.Transaction(context.Background(), func(tx sql.DatabaseTx) (err error) {
+	err = s.db.Transaction(context.Background(), func(tx sql.DatabaseTx) (err error) {
 		elements, err = tx.UnspentSiacoinElements(context.Background())
 		return
 	})
@@ -34,7 +34,7 @@ func (s *SQLStore) UnspentSiacoinElements() (elements []types.SiacoinElement, er
 // WalletEvents returns a paginated list of events, ordered by maturity height,
 // descending. If no more events are available, (nil, nil) is returned.
 func (s *SQLStore) WalletEvents(offset, limit int) (events []wallet.Event, err error) {
-	err = s.bMain.Transaction(context.Background(), func(tx sql.DatabaseTx) (err error) {
+	err = s.db.Transaction(context.Background(), func(tx sql.DatabaseTx) (err error) {
 		events, err = tx.WalletEvents(context.Background(), offset, limit)
 		return
 	})
@@ -43,7 +43,7 @@ func (s *SQLStore) WalletEvents(offset, limit int) (events []wallet.Event, err e
 
 // WalletEventCount returns the number of events relevant to the wallet.
 func (s *SQLStore) WalletEventCount() (count uint64, err error) {
-	err = s.bMain.Transaction(context.Background(), func(tx sql.DatabaseTx) (err error) {
+	err = s.db.Transaction(context.Background(), func(tx sql.DatabaseTx) (err error) {
 		count, err = tx.WalletEventCount(context.Background())
 		return
 	})

--- a/stores/webhooks.go
+++ b/stores/webhooks.go
@@ -8,19 +8,19 @@ import (
 )
 
 func (s *SQLStore) AddWebhook(ctx context.Context, wh webhooks.Webhook) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.AddWebhook(ctx, wh)
 	})
 }
 
 func (s *SQLStore) DeleteWebhook(ctx context.Context, wh webhooks.Webhook) error {
-	return s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		return tx.DeleteWebhook(ctx, wh)
 	})
 }
 
 func (s *SQLStore) Webhooks(ctx context.Context) (whs []webhooks.Webhook, err error) {
-	err = s.bMain.Transaction(ctx, func(tx sql.DatabaseTx) error {
+	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		whs, err = tx.Webhooks(ctx)
 		return err
 	})


### PR DESCRIPTION
This removes GORM from our production code entirely. It's now only used in tests.

Therefore `db` was renamed to `gormDB` to make it clear that it's no longer to be used.
`bMain` is now `db`.