### PR TITLE
Don't interrupt migrations when refresh fails

### DIFF
--- a/autopilot/alerts.go
+++ b/autopilot/alerts.go
@@ -170,8 +170,7 @@ func newRefreshHealthFailedAlert(err error) alerts.Alert {
 		Severity: alerts.SeverityCritical,
 		Message:  "Health refresh failed",
 		Data: map[string]interface{}{
-			"migrationsInterrupted": false,
-			"error":                 err.Error(),
+			"error": err.Error(),
 		},
 		Timestamp: time.Now(),
 	}

--- a/autopilot/alerts.go
+++ b/autopilot/alerts.go
@@ -170,7 +170,7 @@ func newRefreshHealthFailedAlert(err error) alerts.Alert {
 		Severity: alerts.SeverityCritical,
 		Message:  "Health refresh failed",
 		Data: map[string]interface{}{
-			"migrationsInterrupted": true,
+			"migrationsInterrupted": false,
 			"error":                 err.Error(),
 		},
 		Timestamp: time.Now(),

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -217,7 +217,6 @@ OUTER:
 		if err := b.RefreshHealth(m.ap.shutdownCtx); err != nil {
 			m.ap.RegisterAlert(m.ap.shutdownCtx, newRefreshHealthFailedAlert(err))
 			m.logger.Errorf("failed to recompute cached health before migration: %v", err)
-			return
 		}
 		m.logger.Infof("recomputed slab health in %v", time.Since(start))
 

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -198,28 +198,20 @@ func (m *migrator) performMigrations(p *workerPool) {
 	default:
 	}
 
-OUTER:
-	for {
-		// fetch currently configured set
-		autopilot, err := m.ap.Config(m.ap.shutdownCtx)
-		if err != nil {
-			m.logger.Errorf("failed to fetch autopilot config: %w", err)
-			return
-		}
-		set := autopilot.Config.Contracts.Set
-		if set == "" {
-			m.logger.Error("could not perform migrations, no contract set configured")
-			return
-		}
+	// fetch currently configured set
+	autopilot, err := m.ap.Config(m.ap.shutdownCtx)
+	if err != nil {
+		m.logger.Errorf("failed to fetch autopilot config: %w", err)
+		return
+	}
+	set := autopilot.Config.Contracts.Set
+	if set == "" {
+		m.logger.Error("could not perform migrations, no contract set configured")
+		return
+	}
 
-		// recompute health.
-		start := time.Now()
-		if err := b.RefreshHealth(m.ap.shutdownCtx); err != nil {
-			m.ap.RegisterAlert(m.ap.shutdownCtx, newRefreshHealthFailedAlert(err))
-			m.logger.Errorf("failed to recompute cached health before migration: %v", err)
-		}
-		m.logger.Infof("recomputed slab health in %v", time.Since(start))
-
+	// helper to update 'toMigrate'
+	updateToMigrate := func() {
 		// fetch slabs for migration
 		toMigrateNew, err := b.SlabsForMigration(m.ap.shutdownCtx, m.healthCutoff, set, migratorBatchSize)
 		if err != nil {
@@ -258,7 +250,19 @@ OUTER:
 		sort.Slice(newSlabs, func(i, j int) bool {
 			return newSlabs[i].Health < newSlabs[j].Health
 		})
-		migrateNewMap = nil // free map
+	}
+
+OUTER:
+	for {
+		// recompute health.
+		start := time.Now()
+		if err := b.RefreshHealth(m.ap.shutdownCtx); err != nil {
+			m.ap.RegisterAlert(m.ap.shutdownCtx, newRefreshHealthFailedAlert(err))
+			m.logger.Errorf("failed to recompute cached health before migration: %v", err)
+		} else {
+			m.logger.Infof("recomputed slab health in %v", time.Since(start))
+			updateToMigrate()
+		}
 
 		// log the updated list of slabs to migrate
 		m.logger.Infof("%d slabs to migrate", len(toMigrate))


### PR DESCRIPTION
The repairs update the health of slabs to 100% so even when the refresh fails we can at least try and migrate the slabs we already know are in bad health. 