### PR TITLE
Invalidate worker cache on host updates

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -14,6 +14,7 @@ const (
 	ModuleConsensus   = "consensus"
 	ModuleContract    = "contract"
 	ModuleContractSet = "contract_set"
+	ModuleHost        = "host"
 	ModuleSetting     = "setting"
 
 	EventUpdate  = "update"
@@ -42,6 +43,12 @@ type (
 	EventContractRenew struct {
 		Renewal   ContractMetadata `json:"renewal"`
 		Timestamp time.Time        `json:"timestamp"`
+	}
+
+	EventHostUpdate struct {
+		HostKey   types.PublicKey `json:"hostKey"`
+		NetAddr   string          `json:"netAddr"`
+		Timestamp time.Time       `json:"timestamp"`
 	}
 
 	EventContractSetUpdate struct {
@@ -99,6 +106,15 @@ var (
 		}
 	}
 
+	WebhookHostUpdate = func(url string, headers map[string]string) webhooks.Webhook {
+		return webhooks.Webhook{
+			Event:   EventUpdate,
+			Headers: headers,
+			Module:  ModuleHost,
+			URL:     url,
+		}
+	}
+
 	WebhookSettingUpdate = func(url string, headers map[string]string) webhooks.Webhook {
 		return webhooks.Webhook{
 			Event:   EventUpdate,
@@ -150,6 +166,14 @@ func ParseEventWebhook(event webhooks.Event) (interface{}, error) {
 	case ModuleConsensus:
 		if event.Event == EventUpdate {
 			var e EventConsensusUpdate
+			if err := json.Unmarshal(bytes, &e); err != nil {
+				return nil, err
+			}
+			return e, nil
+		}
+	case ModuleHost:
+		if event.Event == EventUpdate {
+			var e EventHostUpdate
 			if err := json.Unmarshal(bytes, &e); err != nil {
 				return nil, err
 			}

--- a/internal/chain/chainsubscriber.go
+++ b/internal/chain/chainsubscriber.go
@@ -170,6 +170,17 @@ func (s *ChainSubscriber) applyChainUpdate(tx ChainUpdateTx, cau chain.ApplyUpda
 		for hk, ha := range hus {
 			if err := tx.UpdateHost(hk, ha, cau.State.Index.Height, b.ID(), b.Timestamp); err != nil {
 				return fmt.Errorf("failed to update host: %w", err)
+			} else if IsSynced(b) {
+				// broadcast host update
+				s.webhooksMgr.BroadcastAction(s.shutdownCtx, webhooks.Event{
+					Module: api.ModuleHost,
+					Event:  api.EventUpdate,
+					Payload: api.EventHostUpdate{
+						HostKey:   hk,
+						NetAddr:   ha.NetAddress,
+						Timestamp: time.Now().UTC(),
+					},
+				})
 			}
 		}
 	}

--- a/internal/worker/cache.go
+++ b/internal/worker/cache.go
@@ -289,7 +289,6 @@ func (c *cache) handleHostUpdate(e api.EventHostUpdate) {
 	for i, contract := range contracts {
 		if contract.HostKey == e.HostKey {
 			contracts[i].HostIP = e.NetAddr
-			break
 		}
 	}
 

--- a/internal/worker/cache.go
+++ b/internal/worker/cache.go
@@ -174,6 +174,9 @@ func (c *cache) HandleEvent(event webhooks.Event) (err error) {
 	case api.EventContractRenew:
 		log = log.With("fcid", e.Renewal.ID, "renewedFrom", e.Renewal.RenewedFrom, "ts", e.Timestamp)
 		c.handleContractRenew(e)
+	case api.EventHostUpdate:
+		log = log.With("hk", e.HostKey, "ts", e.Timestamp)
+		c.handleHostUpdate(e)
 	case api.EventSettingUpdate:
 		log = log.With("key", e.Key, "ts", e.Timestamp)
 		err = c.handleSettingUpdate(e)
@@ -204,6 +207,7 @@ func (c *cache) Initialize(ctx context.Context, workerAPI string, webhookOpts ..
 		api.WebhookConsensusUpdate(eventsURL, headers),
 		api.WebhookContractArchive(eventsURL, headers),
 		api.WebhookContractRenew(eventsURL, headers),
+		api.WebhookHostUpdate(eventsURL, headers),
 		api.WebhookSettingUpdate(eventsURL, headers),
 	} {
 		if err := c.b.RegisterWebhook(ctx, wh); err != nil {
@@ -266,6 +270,25 @@ func (c *cache) handleContractRenew(event api.EventContractRenew) {
 	for i, contract := range contracts {
 		if contract.ID == event.Renewal.RenewedFrom {
 			contracts[i] = event.Renewal
+			break
+		}
+	}
+
+	c.cache.Set(cacheKeyDownloadContracts, contracts)
+}
+
+func (c *cache) handleHostUpdate(e api.EventHostUpdate) {
+	// return early if the cache doesn't have contracts
+	value, found, _ := c.cache.Get(cacheKeyDownloadContracts)
+	if !found {
+		return
+	}
+	contracts := value.([]api.ContractMetadata)
+
+	// update the host's IP in the cache
+	for i, contract := range contracts {
+		if contract.HostKey == e.HostKey {
+			contracts[i].HostIP = e.NetAddr
 			break
 		}
 	}

--- a/internal/worker/cache_test.go
+++ b/internal/worker/cache_test.go
@@ -149,6 +149,7 @@ func TestWorkerCache(t *testing.T) {
 		{Module: api.ModuleConsensus, Event: api.EventUpdate, Payload: nil},
 		{Module: api.ModuleContract, Event: api.EventArchive, Payload: nil},
 		{Module: api.ModuleContract, Event: api.EventRenew, Payload: nil},
+		{Module: api.ModuleHost, Event: api.EventUpdate, Payload: nil},
 		{Module: api.ModuleSetting, Event: api.EventUpdate, Payload: nil},
 		{Module: api.ModuleSetting, Event: api.EventDelete, Payload: nil},
 	} {


### PR DESCRIPTION
This PR invalidates the worker cache when we process host updates. The host's IP is on the contract metadata so when a host re-announces that metadata is not properly invalidated. We have a cache entry expiry of 5' so it's not that big of a deal but this PR addresses it by updating the metadata.

Fixes #1371