### PR TITLE
Interrupt migrations when consensus becomes unsynced

### DIFF
--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -27,6 +27,7 @@ type (
 		logger                    *zap.SugaredLogger
 		healthCutoff              float64
 		parallelSlabsPerWorker    uint64
+		signalConsensusNotSynced  chan struct{}
 		signalMaintenanceFinished chan struct{}
 		statsSlabMigrationSpeedMS *stats.DataPoints
 
@@ -67,6 +68,7 @@ func newMigrator(ap *Autopilot, healthCutoff float64, parallelSlabsPerWorker uin
 		logger:                    ap.logger.Named("migrator"),
 		healthCutoff:              healthCutoff,
 		parallelSlabsPerWorker:    parallelSlabsPerWorker,
+		signalConsensusNotSynced:  make(chan struct{}, 1),
 		signalMaintenanceFinished: make(chan struct{}, 1),
 		statsSlabMigrationSpeedMS: stats.New(time.Hour),
 	}
@@ -157,8 +159,14 @@ func (m *migrator) performMigrations(p *workerPool) {
 						m.statsSlabMigrationSpeedMS.Track(float64(time.Since(start).Milliseconds()))
 						if err != nil {
 							m.logger.Errorf("%v: migration %d/%d failed, key: %v, health: %v, overpaid: %v, err: %v", id, j.slabIdx+1, j.batchSize, j.Key, j.Health, res.SurchargeApplied, err)
-							skipAlert := utils.IsErr(err, api.ErrSlabNotFound)
-							if !skipAlert {
+							if utils.IsErr(err, api.ErrConsensusNotSynced) {
+								// interrupt migrations if consensus is not synced
+								select {
+								case m.signalConsensusNotSynced <- struct{}{}:
+								default:
+								}
+								return
+							} else if !utils.IsErr(err, api.ErrSlabNotFound) {
 								// fetch all object IDs for the slab we failed to migrate
 								var objectIds map[string][]string
 								if res, err := m.objectIDsForSlabKey(ctx, j.Key); err != nil {
@@ -264,19 +272,20 @@ OUTER:
 		// log the updated list of slabs to migrate
 		m.logger.Infof("%d slabs to migrate", len(toMigrate))
 
-		// register an alert to notify users about ongoing migrations.
-		if len(toMigrate) > 0 {
-			m.ap.RegisterAlert(m.ap.shutdownCtx, newOngoingMigrationsAlert(len(toMigrate), m.slabMigrationEstimate(len(toMigrate))))
-		}
-
 		// return if there are no slabs to migrate
 		if len(toMigrate) == 0 {
 			return
 		}
 
+		// register an alert to notify users about ongoing migrations
+		m.ap.RegisterAlert(m.ap.shutdownCtx, newOngoingMigrationsAlert(len(toMigrate), m.slabMigrationEstimate(len(toMigrate))))
+
 		for i, slab := range toMigrate {
 			select {
 			case <-m.ap.shutdownCtx.Done():
+				return
+			case <-m.signalConsensusNotSynced:
+				m.logger.Info("migrations interrupted - consensus is not synced")
 				return
 			case <-m.signalMaintenanceFinished:
 				m.logger.Info("migrations interrupted - updating slabs for migration")
@@ -284,8 +293,6 @@ OUTER:
 			case jobs <- job{slab, i, len(toMigrate), set, b}:
 			}
 		}
-
-		return
 	}
 }
 

--- a/internal/chain/chainsubscriber.go
+++ b/internal/chain/chainsubscriber.go
@@ -485,7 +485,7 @@ func (s *ChainSubscriber) updateKnownContracts(fcid types.FileContractID, known 
 }
 
 func IsSynced(b types.Block) bool {
-	return time.Since(b.Timestamp) <= time.Hour
+	return time.Since(b.Timestamp) <= 3*time.Hour
 }
 
 func v1ContractUpdate(fce types.FileContractElement, rev *types.FileContractElement, resolved, valid bool) contractUpdate {


### PR DESCRIPTION
There's no point in migrating trying to migrate the remaining unhealthy slabs if we encounter `ErrConsensusNotSynced`. Instead we log and interrupt the migrations, essentially pausing migrations until the next iteration of the autopilot loop. Happend on `arequipa`, resulting in 100k+ migration alerts. Looking at block deltas, block `479246` seems like a likely culprit.

```
479003 2024-07-14T23:20:29Z 31m7s
479017 2024-07-15T01:50:12Z 40m35s
479040 2024-07-15T06:02:13Z 36m53s
479068 2024-07-15T10:26:56Z 39m13s
479077 2024-07-15T12:18:08Z 33m41s
479114 2024-07-15T19:06:26Z 30m51s
479116 2024-07-15T20:03:21Z 33m40s
479134 2024-07-15T23:22:41Z 35m23s
479138 2024-07-16T01:07:29Z 40m10s
479177 2024-07-16T06:36:39Z 32m27s
479215 2024-07-16T12:12:58Z 34m30s
479246 2024-07-16T17:25:16Z 1h1m3s
479260 2024-07-16T20:31:29Z 32m2s
479268 2024-07-16T21:39:30Z 32m23s
479289 2024-07-17T01:16:59Z 37m23s
479318 2024-07-17T05:23:12Z 45m24s
479380 2024-07-17T12:46:53Z 35m53s
```