### PR TITLE
Remove redundant contracts call

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -220,3 +220,13 @@ func (c Contract) RemainingCollateral() types.Currency {
 	}
 	return c.Revision.MissedHostPayout().Sub(c.ContractPrice)
 }
+
+// InSet returns whether the contract is in the given set.
+func (cm ContractMetadata) InSet(set string) bool {
+	for _, s := range cm.ContractSets {
+		if s == set {
+			return true
+		}
+	}
+	return false
+}

--- a/autopilot/accounts.go
+++ b/autopilot/accounts.go
@@ -126,17 +126,14 @@ func (a *accounts) refillWorkerAccounts(ctx context.Context, w Worker) {
 		return
 	}
 
-	// fetch all contract set contracts
-	contractSetContracts, err := a.c.Contracts(ctx, api.ContractsOpts{ContractSet: cfg.Config.Contracts.Set})
-	if err != nil {
-		a.l.Errorw(fmt.Sprintf("failed to fetch contract set contracts: %v", err))
-		return
-	}
-
-	// build a map of contract set contracts
+	// filter all contract set contracts
+	var contractSetContracts []api.ContractMetadata
 	inContractSet := make(map[types.FileContractID]struct{})
-	for _, contract := range contractSetContracts {
-		inContractSet[contract.ID] = struct{}{}
+	for _, c := range contracts {
+		if c.InSet(cfg.Config.Contracts.Set) {
+			contractSetContracts = append(contractSetContracts, c)
+			inContractSet[c.ID] = struct{}{}
+		}
 	}
 
 	// refill accounts in separate goroutines

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -784,10 +784,12 @@ func (w *worker) slabMigrateHandler(jc jape.Context) {
 		return
 	}
 
-	// fetch upload contracts
-	ulContracts, err := w.bus.Contracts(ctx, api.ContractsOpts{ContractSet: up.ContractSet})
-	if jc.Check("couldn't fetch contracts from bus", err) != nil {
-		return
+	// filter upload contracts
+	var ulContracts []api.ContractMetadata
+	for _, c := range dlContracts {
+		if c.InSet(up.ContractSet) {
+			ulContracts = append(ulContracts, c)
+		}
 	}
 
 	// migrate the slab


### PR DESCRIPTION
There's a PR to be merged where I suggest adding an `InSet` method to the `ContractMetadata`. I found a spot where I could use it myself so I figured I'd PR it. There's one or two places where we fetch all contracts, and then fetch contract set contracts, which is a subset of the contracts we just fetched.