### PR TITLE
Ensure critical migrations succeed by refilling EAs on hosts that are gouging their prices

### DIFF
--- a/internal/test/e2e/gouging_test.go
+++ b/internal/test/e2e/gouging_test.go
@@ -13,6 +13,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/internal/test"
+	"go.uber.org/zap/zapcore"
 	"lukechampine.com/frand"
 )
 
@@ -72,6 +73,7 @@ func TestGouging(t *testing.T) {
 	if err := b.UpdateSetting(context.Background(), api.SettingGouging, gs); err != nil {
 		t.Fatal(err)
 	}
+
 	// fetch current contract set
 	contracts, err := b.Contracts(context.Background(), api.ContractsOpts{ContractSet: cfg.Set})
 	tt.OK(err)
@@ -132,6 +134,60 @@ func TestGouging(t *testing.T) {
 		_, err := w.UploadObject(context.Background(), bytes.NewReader(data), api.DefaultBucketName, path, api.UploadObjectOptions{})
 		return err
 	})
+}
+
+// TestAccountFunding is a regression tests that verify we can fund an account
+// even if the host is considered gouging, this protects us from not being able
+// to download from certain critical hosts when we migrate away from them.
+func TestAccountFunding(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// run without autopilot
+	opts := clusterOptsDefault
+	opts.skipRunningAutopilot = true
+	opts.logger = newTestLoggerCustom(zapcore.ErrorLevel)
+
+	// create a new test cluster
+	cluster := newTestCluster(t, opts)
+	defer cluster.Shutdown()
+
+	// convenience variables
+	b := cluster.Bus
+	w := cluster.Worker
+	tt := cluster.tt
+
+	// add a host
+	hosts := cluster.AddHosts(1)
+	h, err := b.Host(context.Background(), hosts[0].PublicKey())
+	tt.OK(err)
+
+	// scan the host
+	_, err = w.RHPScan(context.Background(), h.PublicKey, h.NetAddress, 10*time.Second)
+	tt.OK(err)
+
+	// manually form a contract with the host
+	cs, _ := b.ConsensusState(context.Background())
+	wallet, _ := b.Wallet(context.Background())
+	rev, _, err := w.RHPForm(context.Background(), cs.BlockHeight+test.AutopilotConfig.Contracts.Period+test.AutopilotConfig.Contracts.RenewWindow, h.PublicKey, h.NetAddress, wallet.Address, types.Siacoins(1), types.Siacoins(1))
+	tt.OK(err)
+	c, err := b.AddContract(context.Background(), rev, rev.Revision.MissedHostPayout().Sub(types.Siacoins(1)), types.Siacoins(1), cs.BlockHeight, api.ContractStatePending)
+	tt.OK(err)
+
+	// fund the account
+	tt.OK(w.RHPFund(context.Background(), c.ID, c.HostKey, c.HostIP, c.SiamuxAddr, types.Siacoins(1).Div64(2)))
+
+	// update host so it's gouging
+	settings := hosts[0].settings.Settings()
+	settings.StoragePrice = types.Siacoins(1)
+	tt.OK(hosts[0].UpdateSettings(settings))
+
+	// ensure the price table expires so the worker is forced to fetch it
+	time.Sleep(defaultHostSettings.PriceTableValidity)
+
+	// fund the account again
+	tt.OK(w.RHPFund(context.Background(), c.ID, c.HostKey, c.HostIP, c.SiamuxAddr, types.Siacoins(1)))
 }
 
 func TestHostMinVersion(t *testing.T) {

--- a/worker/host.go
+++ b/worker/host.go
@@ -229,9 +229,17 @@ func (h *host) FundAccount(ctx context.Context, balance types.Currency, rev *typ
 	return h.acc.WithDeposit(ctx, func() (types.Currency, error) {
 		if err := h.transportPool.withTransportV3(ctx, h.hk, h.siamuxAddr, func(ctx context.Context, t *transportV3) error {
 			// fetch pricetable
-			pt, err := h.priceTable(ctx, rev)
+			pt, err := h.priceTables.fetch(ctx, h.hk, rev)
 			if err != nil {
 				return err
+			}
+
+			// check only the unused defaults
+			gc, err := GougingCheckerFromContext(ctx, false)
+			if err != nil {
+				return err
+			} else if err := gc.CheckUnusedDefaults(pt.HostPriceTable); err != nil {
+				return fmt.Errorf("%w: %v", errPriceTableGouging, err)
 			}
 
 			// check whether we have money left in the contract


### PR DESCRIPTION
Often times when critical migrations fail it is because we don't fund the ephemeral account when the host is considered price gouging. Since we have checks in place that will prevent uploads, as well as checks that prevent drastically overpaying on downloads, I think the best approach is to allow refilling ephemeral accounts, even if the host is price gouging. Of course we do want _some_ checks so I extracted the unused defaults check. In practice that final refill should be enough to get all data migrated away from that host. 

```
failed to migrate slab; failed to download slab for migration: failed to download slab: completed=8 inflight=0 launched=29 relaunched=0 overpaid=0 downloaders=377 unused=1 errors=22 72e8ea2c: ephemeral account balance was insufficient ed25519:72e8ea2c2de3987608c360b574327c201ecbe34037dd47d51135370828650706, err: ephemeral account balance was insufficient; account requires resync e5468eef: ephemeral account balance was insufficient ed25519:e5468eef5f7879ad0c863718d013b416521be8a5b8180c2158a58d76eafdf152, 
```

```
{"level":"debug","ts":"2024-07-11T11:59:13Z","logger":"autopilot.autopilot.accounts","caller":"autopilot/accounts.go:158","msg":"failed to fund account: couldn't fund account: price table gouging detected: TxnFeeMaxRecommended 130.95640083505565715 uS exceeds 50 uS\n","accountID":"ed25519:a6d6d5022fa877404f1ca897bff34a09b11fd0e2f483761a54e3c400d7000c91","hostKey":"ed25519:bba8d89d4fb310ec51d85ee6e04ea9d4e2537a97c9463482fe3b5b7780de57b2","balance":"420835038399998552965117","expected":"1 SC"}
```

Edit: debugging `areq` and seeing the same issues for sync account led me to https://github.com/SiaFoundation/renterd/commit/cdad429c95609afa9303c3d66cb1cae67dfe725d where you merged something very similar. I added the unused fields check there as well.