### PR TITLE
Take revision submission buffer into account when refilling ephemeral accounts

### DIFF
--- a/autopilot/accounts.go
+++ b/autopilot/accounts.go
@@ -30,7 +30,8 @@ type accounts struct {
 	l  *zap.SugaredLogger
 	w  *workerPool
 
-	refillInterval time.Duration
+	refillInterval           time.Duration
+	revisionSubmissionBuffer uint64
 
 	mu                sync.Mutex
 	inProgressRefills map[types.Hash256]struct{}
@@ -45,7 +46,7 @@ type ContractStore interface {
 	Contracts(ctx context.Context, opts api.ContractsOpts) ([]api.ContractMetadata, error)
 }
 
-func newAccounts(ap *Autopilot, a AccountStore, c ContractStore, w *workerPool, l *zap.SugaredLogger, refillInterval time.Duration) *accounts {
+func newAccounts(ap *Autopilot, a AccountStore, c ContractStore, w *workerPool, l *zap.SugaredLogger, refillInterval time.Duration, revisionSubmissionBuffer uint64) *accounts {
 	return &accounts{
 		ap: ap,
 		a:  a,
@@ -53,8 +54,9 @@ func newAccounts(ap *Autopilot, a AccountStore, c ContractStore, w *workerPool, 
 		l:  l.Named("accounts"),
 		w:  w,
 
-		refillInterval:    refillInterval,
-		inProgressRefills: make(map[types.Hash256]struct{}),
+		refillInterval:           refillInterval,
+		revisionSubmissionBuffer: revisionSubmissionBuffer,
+		inProgressRefills:        make(map[types.Hash256]struct{}),
 	}
 }
 
@@ -110,6 +112,13 @@ func (a *accounts) refillWorkerAccounts(ctx context.Context, w Worker) {
 		return
 	}
 
+	// fetch consensus state
+	cs, err := a.ap.bus.ConsensusState(ctx)
+	if err != nil {
+		a.l.Errorw(fmt.Sprintf("failed to fetch consensus state for refill: %v", err))
+		return
+	}
+
 	// fetch worker id
 	workerID, err := w.ID(ctx)
 	if err != nil {
@@ -144,9 +153,11 @@ func (a *accounts) refillWorkerAccounts(ctx context.Context, w Worker) {
 		// launch refill if not already in progress
 		if a.markRefillInProgress(workerID, c.HostKey) {
 			go func(contract api.ContractMetadata) {
+				defer a.markRefillDone(workerID, contract.HostKey)
+
 				rCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 				defer cancel()
-				accountID, refilled, rerr := refillWorkerAccount(rCtx, a.a, w, contract)
+				accountID, refilled, rerr := refillWorkerAccount(rCtx, a.a, w, contract, cs.BlockHeight, a.revisionSubmissionBuffer)
 				if rerr != nil {
 					if rerr.Is(errMaxDriftExceeded) {
 						// register the alert if error is errMaxDriftExceeded
@@ -170,8 +181,6 @@ func (a *accounts) refillWorkerAccounts(ctx context.Context, w Worker) {
 						)
 					}
 				}
-
-				a.markRefillDone(workerID, contract.HostKey)
 			}(c)
 		}
 	}
@@ -193,7 +202,7 @@ func (err *refillError) Is(target error) bool {
 	return errors.Is(err.err, target)
 }
 
-func refillWorkerAccount(ctx context.Context, a AccountStore, w Worker, contract api.ContractMetadata) (accountID rhpv3.Account, refilled bool, rerr *refillError) {
+func refillWorkerAccount(ctx context.Context, a AccountStore, w Worker, contract api.ContractMetadata, bh, revisionSubmissionBuffer uint64) (accountID rhpv3.Account, refilled bool, rerr *refillError) {
 	wrapErr := func(err error, keysAndValues ...interface{}) *refillError {
 		if err == nil {
 			return nil
@@ -214,6 +223,20 @@ func refillWorkerAccount(ctx context.Context, a AccountStore, w Worker, contract
 	account, err = a.Account(ctx, accountID, contract.HostKey)
 	if err != nil {
 		rerr = wrapErr(err)
+		return
+	}
+
+	// check if the contract is too close to the proof window to be revised,
+	// trying to refill the account would result in the host not returning the
+	// revision and returning an obfuscated error
+	if (bh + revisionSubmissionBuffer) > contract.WindowStart {
+		rerr = wrapErr(fmt.Errorf("not refilling account since contract is too close to the proof window to be revised (%v > %v)", bh+revisionSubmissionBuffer, contract.WindowStart),
+			"accountID", account.ID,
+			"hostKey", contract.HostKey,
+			"bh", bh,
+			"revisionSubmissionBuffer", revisionSubmissionBuffer,
+			"contractWindowStart", contract.WindowStart,
+		)
 		return
 	}
 

--- a/autopilot/accounts.go
+++ b/autopilot/accounts.go
@@ -233,9 +233,7 @@ func refillWorkerAccount(ctx context.Context, a AccountStore, w Worker, contract
 		rerr = wrapErr(fmt.Errorf("not refilling account since contract is too close to the proof window to be revised (%v > %v)", bh+revisionSubmissionBuffer, contract.WindowStart),
 			"accountID", account.ID,
 			"hostKey", contract.HostKey,
-			"bh", bh,
-			"revisionSubmissionBuffer", revisionSubmissionBuffer,
-			"contractWindowStart", contract.WindowStart,
+			"blockHeight", bh,
 		)
 		return
 	}

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -154,7 +154,7 @@ func New(id string, bus Bus, workers []Worker, logger *zap.Logger, heartbeat tim
 	ap.s = scanner
 	ap.c = contractor.New(bus, bus, ap.logger, revisionSubmissionBuffer, revisionBroadcastInterval)
 	ap.m = newMigrator(ap, migrationHealthCutoff, migratorParallelSlabsPerWorker)
-	ap.a = newAccounts(ap, ap.bus, ap.bus, ap.workers, ap.logger, accountsRefillInterval)
+	ap.a = newAccounts(ap, ap.bus, ap.bus, ap.workers, ap.logger, accountsRefillInterval, revisionSubmissionBuffer)
 
 	return ap, nil
 }


### PR DESCRIPTION
Encountered this error on `renterd` side a lot when trying to fund ephemeral accounts. Turns out the contract is too close to the proof window to be revised, so funding is not possible. I passed down the `revisionSubmissionBuffer` and return early in `refillWorkerAccount`.

```
{"level":"debug","ts":"2024-07-16T16:04:56Z","logger":"autopilot.autopilot.accounts","caller":"autopilot/accounts.go:158","msg":"failed to fund account: couldn't fund account: unable to fetch revision with contract: LatestRevision: ReadResponse: host responded with error: 'internal error'\n","accountID":"ed25519:b3143551b31919df6f23d0f9636ba5d263db0b686a8ebfb787a46e1d47ead5d1","hostKey":"ed25519:da2e16500a5413f31170a37334e91eeccf38af620861991bad21a9e9eb9061e7","balance":"-1807848587969294024770","expected":"1 SC"}
```

```
{"level":"warn","ts":1721145896.809674,"logger":"rhp3.LatestRevision","caller":"v3/rhp.go:208","msg":"RPC failed","sessionID":"3092e8db54fc931b","peerAddress":"147.135.54.153:56258","rpcID":"607fe2a089f0c8a0","error":"failed to process payment: failed to process contract payment: failed to lock contract fcid:d86622975ddb3356e29a50cf77342ab813c8f7c5d897d06651d0d8006b437540: contract is not good for modification: contract is too close to the proof window to be revised (479387 > 479382)","elapsed":1.507075184}
```