### PR TITLE
Add 1h leeway to revision submission buffer

### DIFF
--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -132,7 +132,7 @@ var (
 		},
 		Autopilot: config.Autopilot{
 			Enabled:                        true,
-			RevisionSubmissionBuffer:       144,
+			RevisionSubmissionBuffer:       150, // 144 + 6 blocks leeway
 			AccountsRefillInterval:         defaultAccountRefillInterval,
 			Heartbeat:                      30 * time.Minute,
 			MigrationHealthCutoff:          0.75,


### PR DESCRIPTION
The contractor uses the same submission buffer the host does, this causes race conditions between the contract's maintenance and the uploaders. I figured it's fine to add a 1h leeway to the buffer to ensure we handle the contract properly before we run into the buffer. The host returns an `internal error` when this happens so we (mistakenly) penalise it for being a bad host and failing the sector upload.
```
{"level":"debug","ts":"2024-07-16T15:46:44Z","logger":"worker.worker.uploadmanager","caller":"worker/uploader.go:138","msg":"sector upload failure was penalised","uploadError":"failed to upload sector to contract fcid:6556f6b59512c18c273cf8dca642a8f1344eb9f8d66cf1909155ece4421a5a81; AppendSector: ReadResponse: host responded with error: 'internal error'","uploadDuration":"0s","totalDuration":"1.341102166s","overdrive":false,"penalty":3600000,"hk":"ed25519:36c8b07e61548a57e16dfabdfcc07dc157974a75010ab1684643d933e83fa7b1"}
```

 ```
 {"level":"warn","ts":1721144838.8014224,"logger":"rhp3.ExecuteProgram","caller":"v3/rhp.go:208","msg":"RPC failed","sessionID":"7316a1a1e5c7e384","peerAddress":"147.135.54.153:45626","rpcID":"5d91a0cbfafbe7ec","error":"failed to process payment: failed to process contract payment: failed to lock contract fcid:6556f6b59512c18c273cf8dca642a8f1344eb9f8d66cf1909155ece4421a5a81: contract is not good for modification: contract is too close to the proof window to be revised (479384 > 479382)","elapsed":0.00060472}
 ```