### PR TITLE
Update price pinning json

### DIFF
--- a/api/setting.go
+++ b/api/setting.go
@@ -102,11 +102,11 @@ type (
 		Threshold float64 `json:"threshold"`
 
 		// Autopilots contains the pinned settings for every autopilot.
-		Autopilots map[string]AutopilotPins `json:"autopilots,omitempty"`
+		Autopilots map[string]AutopilotPins `json:"autopilots"`
 
 		// GougingSettingsPins contains the pinned settings for the gouging
 		// settings.
-		GougingSettingsPins GougingSettingsPins `json:"gougingSettingsPins,omitempty"`
+		GougingSettingsPins GougingSettingsPins `json:"gougingSettingsPins"`
 	}
 
 	// AutopilotPins contains the available autopilot settings that can be


### PR DESCRIPTION
Related to https://github.com/SiaFoundation/web/pull/671

Changes the json to not omit any fields, making it a bit more obvious what fields are available to configure.