### PR TITLE
Use constant id for health refresh failure alerts

### DIFF
--- a/autopilot/alerts.go
+++ b/autopilot/alerts.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	alertAccountRefillID = alerts.RandomAlertID() // constant until restarted
+	alertHealthRefreshID = alerts.RandomAlertID() // constant until restarted
 	alertLowBalanceID    = alerts.RandomAlertID() // constant until restarted
 	alertMigrationID     = alerts.RandomAlertID() // constant until restarted
 	alertPruningID       = alerts.RandomAlertID() // constant until restarted
@@ -166,7 +167,7 @@ func newMigrationFailedAlert(slabKey object.EncryptionKey, health float64, objec
 
 func newRefreshHealthFailedAlert(err error) alerts.Alert {
 	return alerts.Alert{
-		ID:       alerts.RandomAlertID(),
+		ID:       alertHealthRefreshID,
 		Severity: alerts.SeverityCritical,
 		Message:  "Health refresh failed",
 		Data: map[string]interface{}{

--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -268,6 +268,7 @@ OUTER:
 			m.ap.RegisterAlert(m.ap.shutdownCtx, newRefreshHealthFailedAlert(err))
 			m.logger.Errorf("failed to recompute cached health before migration: %v", err)
 		} else {
+			m.ap.DismissAlert(m.ap.shutdownCtx, alertHealthRefreshID)
 			m.logger.Infof("recomputed slab health in %v", time.Since(start))
 			updateToMigrate()
 		}


### PR DESCRIPTION
There's not much of an upside to using a random id for health refreshes. This PR dismisses the alert when health refreshes succeed, ensuring these critical alerts auto-dismiss if they succeed. Bit of a trade off obviously but I like this better (?). 