### PR TITLE
Make v2 hardfork height a build flag

### DIFF
--- a/internal/test/e2e/build_v1.go
+++ b/internal/test/e2e/build_v1.go
@@ -1,0 +1,9 @@
+//go:build !v2
+
+package e2e
+
+// configuration for pre-v2-hardfork tests
+const (
+	HardforkV2AllowHeight   = 10000
+	HardforkV2RequireHeight = 20000
+)

--- a/internal/test/e2e/build_v2.go
+++ b/internal/test/e2e/build_v2.go
@@ -1,0 +1,9 @@
+//go:build v2
+
+package e2e
+
+// configuration for post-v2-hardfork tests
+const (
+	HardforkV2AllowHeight   = 2
+	HardforkV2RequireHeight = 3
+)

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -877,8 +877,8 @@ func testNetwork() (*consensus.Network, types.Block) {
 	n.HardforkOak.Height = 1
 	n.HardforkASIC.Height = 1
 	n.HardforkFoundation.Height = 1
-	n.HardforkV2.AllowHeight = 1000
-	n.HardforkV2.RequireHeight = 1020
+	n.HardforkV2.AllowHeight = HardforkV2AllowHeight
+	n.HardforkV2.RequireHeight = HardforkV2RequireHeight
 
 	// TODO: remove once we got rid of all siad dependencies
 	utils.ConvertToCore(stypes.GenesisBlock, (*types.V1Block)(&genesis))


### PR DESCRIPTION
Small preparation for eventually running our integration test suite twice until we hit the hard fork. Once for the v1 chain and once for the v2 chain.
