### PR TITLE
Wait on syncer to close

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -225,7 +225,7 @@ func NewBus(cfg BusConfig, dir string, seed types.PrivateKey, logger *zap.Logger
 	shutdownFn := func(ctx context.Context) error {
 		return errors.Join(
 			cs.Close(),
-			s.Close(),
+			s.Close(ctx),
 			w.Close(),
 			b.Shutdown(ctx),
 			sqlStore.Close(),


### PR DESCRIPTION
I encountered a segmentation fault when restarting `arequipa`. The `syncer` doesn't have its own `Close` method so we wrap it but we don't properly wait until it gracefully exits.

```
unexpected fault address 0x7f21bb84c000
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x7f21bb84c000 pc=0x473841]

...

	/usr/local/go/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc002929fe8 sp=0xc002929fe0 pc=0x472901
created by go.sia.tech/coreutils/syncer.(*Syncer).runPeer in goroutine 47273
	/go/pkg/mod/go.sia.tech/coreutils@v0.2.1/syncer/syncer.go:289 +0x28f
```
