### PR TITLE
Remove `stats` package

### DIFF
--- a/autopilot/migrator.go
+++ b/autopilot/migrator.go
@@ -13,7 +13,6 @@ import (
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/internal/utils"
 	"go.sia.tech/renterd/object"
-	"go.sia.tech/renterd/stats"
 	"go.uber.org/zap"
 )
 
@@ -29,7 +28,7 @@ type (
 		parallelSlabsPerWorker    uint64
 		signalConsensusNotSynced  chan struct{}
 		signalMaintenanceFinished chan struct{}
-		statsSlabMigrationSpeedMS *stats.DataPoints
+		statsSlabMigrationSpeedMS *utils.DataPoints
 
 		mu                 sync.Mutex
 		migrating          bool
@@ -70,7 +69,7 @@ func newMigrator(ap *Autopilot, healthCutoff float64, parallelSlabsPerWorker uin
 		parallelSlabsPerWorker:    parallelSlabsPerWorker,
 		signalConsensusNotSynced:  make(chan struct{}, 1),
 		signalMaintenanceFinished: make(chan struct{}, 1),
-		statsSlabMigrationSpeedMS: stats.New(time.Hour),
+		statsSlabMigrationSpeedMS: utils.NewDataPoints(time.Hour),
 	}
 }
 

--- a/autopilot/scanner/scanner.go
+++ b/autopilot/scanner/scanner.go
@@ -9,7 +9,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
-	"go.sia.tech/renterd/stats"
+	"go.sia.tech/renterd/internal/utils"
 	"go.uber.org/zap"
 )
 
@@ -43,7 +43,7 @@ type (
 		scanThreads   int
 		scanInterval  time.Duration
 
-		statsHostPingMS *stats.DataPoints
+		statsHostPingMS *utils.DataPoints
 
 		shutdownChan chan struct{}
 		wg           sync.WaitGroup
@@ -79,7 +79,7 @@ func New(hs HostStore, scanBatchSize, scanThreads uint64, scanMinInterval time.D
 		scanThreads:   int(scanThreads),
 		scanInterval:  scanMinInterval,
 
-		statsHostPingMS: stats.NoDecay(),
+		statsHostPingMS: utils.NewDataPoints(0),
 		logger:          logger.Named("scanner"),
 
 		interruptChan: make(chan struct{}),

--- a/internal/utils/stats.go
+++ b/internal/utils/stats.go
@@ -1,4 +1,4 @@
-package stats
+package utils
 
 import (
 	"math"
@@ -29,15 +29,7 @@ type (
 	Float64Data = stats.Float64Data
 )
 
-func Default() *DataPoints {
-	return New(statsDecayHalfTime)
-}
-
-func NoDecay() *DataPoints {
-	return New(0)
-}
-
-func New(halfLife time.Duration) *DataPoints {
+func NewDataPoints(halfLife time.Duration) *DataPoints {
 	return &DataPoints{
 		size:        1000,
 		Float64Data: make([]float64, 0),

--- a/worker/download.go
+++ b/worker/download.go
@@ -15,7 +15,6 @@ import (
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/internal/utils"
 	"go.sia.tech/renterd/object"
-	"go.sia.tech/renterd/stats"
 	"go.uber.org/zap"
 )
 
@@ -39,8 +38,8 @@ type (
 		maxOverdrive     uint64
 		overdriveTimeout time.Duration
 
-		statsOverdrivePct                *stats.DataPoints
-		statsSlabDownloadSpeedBytesPerMS *stats.DataPoints
+		statsOverdrivePct                *utils.DataPoints
+		statsSlabDownloadSpeedBytesPerMS *utils.DataPoints
 
 		shutdownCtx context.Context
 
@@ -146,8 +145,8 @@ func newDownloadManager(ctx context.Context, hm HostManager, mm MemoryManager, o
 		maxOverdrive:     maxOverdrive,
 		overdriveTimeout: overdriveTimeout,
 
-		statsOverdrivePct:                stats.NoDecay(),
-		statsSlabDownloadSpeedBytesPerMS: stats.NoDecay(),
+		statsOverdrivePct:                utils.NewDataPoints(0),
+		statsSlabDownloadSpeedBytesPerMS: utils.NewDataPoints(0),
 
 		shutdownCtx: ctx,
 

--- a/worker/downloader.go
+++ b/worker/downloader.go
@@ -10,7 +10,7 @@ import (
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
-	"go.sia.tech/renterd/stats"
+	"go.sia.tech/renterd/internal/utils"
 )
 
 const (
@@ -26,8 +26,8 @@ type (
 	downloader struct {
 		host Host
 
-		statsDownloadSpeedBytesPerMS    *stats.DataPoints // keep track of this separately for stats (no decay is applied)
-		statsSectorDownloadEstimateInMS *stats.DataPoints
+		statsDownloadSpeedBytesPerMS    *utils.DataPoints // keep track of this separately for stats (no decay is applied)
+		statsSectorDownloadEstimateInMS *utils.DataPoints
 
 		signalWorkChan chan struct{}
 		shutdownCtx    context.Context
@@ -44,8 +44,8 @@ func newDownloader(ctx context.Context, host Host) *downloader {
 	return &downloader{
 		host: host,
 
-		statsSectorDownloadEstimateInMS: stats.Default(),
-		statsDownloadSpeedBytesPerMS:    stats.NoDecay(),
+		statsSectorDownloadEstimateInMS: utils.NewDataPoints(10 * time.Minute),
+		statsDownloadSpeedBytesPerMS:    utils.NewDataPoints(0),
 
 		signalWorkChan: make(chan struct{}, 1),
 		shutdownCtx:    ctx,

--- a/worker/upload.go
+++ b/worker/upload.go
@@ -17,8 +17,8 @@ import (
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/internal/utils"
 	"go.sia.tech/renterd/object"
-	"go.sia.tech/renterd/stats"
 	"go.uber.org/zap"
 )
 
@@ -51,8 +51,8 @@ type (
 		maxOverdrive     uint64
 		overdriveTimeout time.Duration
 
-		statsOverdrivePct              *stats.DataPoints
-		statsSlabUploadSpeedBytesPerMS *stats.DataPoints
+		statsOverdrivePct              *utils.DataPoints
+		statsSlabUploadSpeedBytesPerMS *utils.DataPoints
 
 		shutdownCtx context.Context
 
@@ -317,8 +317,8 @@ func newUploadManager(ctx context.Context, hm HostManager, mm MemoryManager, os 
 		maxOverdrive:     maxOverdrive,
 		overdriveTimeout: overdriveTimeout,
 
-		statsOverdrivePct:              stats.NoDecay(),
-		statsSlabUploadSpeedBytesPerMS: stats.NoDecay(),
+		statsOverdrivePct:              utils.NewDataPoints(0),
+		statsSlabUploadSpeedBytesPerMS: utils.NewDataPoints(0),
 
 		shutdownCtx: ctx,
 
@@ -341,8 +341,8 @@ func (mgr *uploadManager) newUploader(os ObjectStore, cl ContractLocker, cs Cont
 		signalNewUpload: make(chan struct{}, 1),
 
 		// stats
-		statsSectorUploadEstimateInMS:    stats.Default(),
-		statsSectorUploadSpeedBytesPerMS: stats.NoDecay(),
+		statsSectorUploadEstimateInMS:    utils.NewDataPoints(10 * time.Minute),
+		statsSectorUploadSpeedBytesPerMS: utils.NewDataPoints(0),
 
 		// covered by mutex
 		host:      hm.Host(c.HostKey, c.ID, c.SiamuxAddr),

--- a/worker/uploader.go
+++ b/worker/uploader.go
@@ -12,7 +12,6 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/internal/utils"
-	"go.sia.tech/renterd/stats"
 	"go.uber.org/zap"
 )
 
@@ -50,8 +49,8 @@ type (
 		consecutiveFailures uint64
 		lastRecompute       time.Time
 
-		statsSectorUploadEstimateInMS    *stats.DataPoints
-		statsSectorUploadSpeedBytesPerMS *stats.DataPoints
+		statsSectorUploadEstimateInMS    *utils.DataPoints
+		statsSectorUploadSpeedBytesPerMS *utils.DataPoints
 	}
 )
 


### PR DESCRIPTION
In time we can probably get rid of this altogether, until then perhaps we can tuck it away in `internal/utils`. 