### PR TITLE
Add /wallet/send endpoint

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -98,6 +98,13 @@ type (
 		Immature    types.Currency `json:"immature"`
 	}
 
+	WalletSendRequest struct {
+		Address          types.Address  `json:"address"`
+		Amount           types.Currency `json:"amount"`
+		SubtractMinerFee bool           `json:"subtractMinerFee"`
+		UseUnconfirmed   bool           `json:"useUnconfirmed"`
+	}
+
 	// WalletSignRequest is the request type for the /wallet/sign endpoint.
 	WalletSignRequest struct {
 		Transaction   types.Transaction   `json:"transaction"`

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -29,6 +29,7 @@ import (
 const (
 	defaultPinUpdateInterval = 5 * time.Minute
 	defaultPinRateWindow     = 6 * time.Hour
+	stdTxnSize               = 1200 // bytes
 )
 
 // Client re-exports the client from the client package.
@@ -50,15 +51,18 @@ type (
 	ChainManager interface {
 		AddBlocks(blocks []types.Block) error
 		AddPoolTransactions(txns []types.Transaction) (bool, error)
+		AddV2PoolTransactions(basis types.ChainIndex, txns []types.V2Transaction) (known bool, err error)
 		Block(id types.BlockID) (types.Block, bool)
 		OnReorg(fn func(types.ChainIndex)) (cancel func())
 		PoolTransaction(txid types.TransactionID) (types.Transaction, bool)
 		PoolTransactions() []types.Transaction
+		V2PoolTransactions() []types.V2Transaction
 		RecommendedFee() types.Currency
 		Tip() types.ChainIndex
 		TipState() consensus.State
 		UnconfirmedParents(txn types.Transaction) []types.Transaction
 		UpdatesSince(index types.ChainIndex, max int) (rus []chain.RevertUpdate, aus []chain.ApplyUpdate, err error)
+		V2UnconfirmedParents(txn types.V2Transaction) []types.V2Transaction
 	}
 
 	ChainSubscriber interface {
@@ -206,7 +210,9 @@ type (
 	Syncer interface {
 		Addr() string
 		BroadcastHeader(h gateway.BlockHeader)
+		BroadcastV2BlockOutline(bo gateway.V2BlockOutline)
 		BroadcastTransactionSet([]types.Transaction)
+		BroadcastV2TransactionSet(index types.ChainIndex, txns []types.V2Transaction)
 		Connect(ctx context.Context, addr string) (*syncer.Peer, error)
 		Peers() []*syncer.Peer
 	}
@@ -216,9 +222,12 @@ type (
 		Balance() (wallet.Balance, error)
 		Close() error
 		FundTransaction(txn *types.Transaction, amount types.Currency, useUnconfirmed bool) ([]types.Hash256, error)
+		FundV2Transaction(txn *types.V2Transaction, amount types.Currency, useUnconfirmed bool) (consensus.State, []int, error)
 		Redistribute(outputs int, amount, feePerByte types.Currency) (txns []types.Transaction, toSign []types.Hash256, err error)
+		RedistributeV2(outputs int, amount, feePerByte types.Currency) (txns []types.V2Transaction, toSign [][]int, err error)
 		ReleaseInputs(txns []types.Transaction, v2txns []types.V2Transaction)
 		SignTransaction(txn *types.Transaction, toSign []types.Hash256, cf types.CoveredFields)
+		SignV2Inputs(state consensus.State, txn *types.V2Transaction, toSign []int)
 		SpendableOutputs() ([]types.SiacoinElement, error)
 		Tip() (types.ChainIndex, error)
 		UnconfirmedEvents() ([]wallet.Event, error)
@@ -437,6 +446,7 @@ func (b *bus) Handler() http.Handler {
 		"POST   /wallet/prepare/form":  b.walletPrepareFormHandler,
 		"POST   /wallet/prepare/renew": b.walletPrepareRenewHandler,
 		"POST   /wallet/redistribute":  b.walletRedistributeHandler,
+		"POST   /wallet/send":          b.walletSendSiacoinsHandler,
 		"POST   /wallet/sign":          b.walletSignHandler,
 		"GET    /wallet/transactions":  b.walletTransactionsHandler,
 

--- a/internal/node/syncer.go
+++ b/internal/node/syncer.go
@@ -4,29 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"time"
 
 	"go.sia.tech/core/gateway"
-	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/syncer"
 	"go.uber.org/zap"
 )
 
-type Syncer interface {
-	io.Closer
-	Addr() string
-	BroadcastHeader(h gateway.BlockHeader)
-	BroadcastTransactionSet([]types.Transaction)
-	Connect(ctx context.Context, addr string) (*syncer.Peer, error)
-	Peers() []*syncer.Peer
-}
-
 // NewSyncer creates a syncer using the given configuration. The syncer that is
 // returned is already running, closing it will close the underlying listener
 // causing the syncer to stop.
-func NewSyncer(cfg BusConfig, cm syncer.ChainManager, ps syncer.PeerStore, logger *zap.Logger) (Syncer, error) {
+func NewSyncer(cfg BusConfig, cm syncer.ChainManager, ps syncer.PeerStore, logger *zap.Logger) (*syncer.Syncer, error) {
 	// validate config
 	if cfg.Bootstrap && cfg.Network == nil {
 		return nil, errors.New("cannot bootstrap without a network")

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -697,14 +697,7 @@ func (c *TestCluster) AddHost(h *Host) {
 
 	// Fund host from bus.
 	fundAmt := types.Siacoins(25e3)
-	var scos []types.SiacoinOutput
-	for i := 0; i < 10; i++ {
-		scos = append(scos, types.SiacoinOutput{
-			Value:   fundAmt.Div64(10),
-			Address: h.WalletAddress(),
-		})
-	}
-	c.tt.OK(c.Bus.SendSiacoins(context.Background(), scos, true))
+	c.tt.OKAll(c.Bus.SendSiacoins(context.Background(), h.WalletAddress(), fundAmt, true))
 
 	// Mine transaction.
 	c.MineBlocks(1)

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -2329,13 +2329,8 @@ func TestWalletSendUnconfirmed(t *testing.T) {
 	}
 
 	// send the full balance back to the weallet
-	toSend := wr.Confirmed.Sub(types.Siacoins(1).Div64(100)) // leave some for the fee
-	tt.OK(b.SendSiacoins(context.Background(), []types.SiacoinOutput{
-		{
-			Address: wr.Address,
-			Value:   toSend,
-		},
-	}, false))
+	toSend := wr.Confirmed.Sub(types.Siacoins(1)) // leave some for the fee
+	tt.OKAll(b.SendSiacoins(context.Background(), wr.Address, toSend, false))
 
 	// the unconfirmed balance should have changed to slightly more than toSend
 	// since we paid a fee
@@ -2348,21 +2343,11 @@ func TestWalletSendUnconfirmed(t *testing.T) {
 	fmt.Println(wr.Confirmed, wr.Unconfirmed)
 
 	// try again - this should fail
-	err = b.SendSiacoins(context.Background(), []types.SiacoinOutput{
-		{
-			Address: wr.Address,
-			Value:   toSend,
-		},
-	}, false)
+	_, err = b.SendSiacoins(context.Background(), wr.Address, toSend, false)
 	tt.AssertIs(err, wallet.ErrNotEnoughFunds)
 
 	// try again - this time using unconfirmed transactions
-	tt.OK(b.SendSiacoins(context.Background(), []types.SiacoinOutput{
-		{
-			Address: wr.Address,
-			Value:   toSend,
-		},
-	}, true))
+	tt.OKAll(b.SendSiacoins(context.Background(), wr.Address, toSend, true))
 
 	// the unconfirmed balance should be almost the same
 	wr, err = b.Wallet(context.Background())
@@ -2403,15 +2388,10 @@ func TestWalletFormUnconfirmed(t *testing.T) {
 	cluster.AddHosts(1)
 
 	// send all money to ourselves, making sure it's unconfirmed
-	feeReserve := types.Siacoins(1).Div64(100)
+	feeReserve := types.Siacoins(1)
 	wr, err := b.Wallet(context.Background())
 	tt.OK(err)
-	tt.OK(b.SendSiacoins(context.Background(), []types.SiacoinOutput{
-		{
-			Address: wr.Address,
-			Value:   wr.Confirmed.Sub(feeReserve), // leave some for the fee
-		},
-	}, false))
+	tt.OKAll(b.SendSiacoins(context.Background(), wr.Address, wr.Confirmed.Sub(feeReserve), false)) // leave some for the fee
 
 	// check wallet only has the reserve in the confirmed balance
 	wr, err = b.Wallet(context.Background())


### PR DESCRIPTION
This PR adds a new `/wallet/send` endpoint which is a lot easier to use than the existing 2-step solution.

Other endpoints like the ones for forming and renewing contracts will also be updated to be single endpoints on the bus rather than multiple. The existing endpoints will remain in the API until we are ready for a breaking v2.0.0.

The biggest advantage of this endpoint over the existing one is the fact that it's type agnostic. Switching from v1 to v2 transactions can happen without the consumer of the API being aware of the transition.