### PR TITLE
Fix TestContractApplyChainUpdates NDF

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,34 +49,34 @@ jobs:
           host port: 3800
           mysql version: '8'
           mysql root password: test
-      # - name: Test Stores
-      #   uses: n8maninger/action-golang-test@v1
-      #   with:
-      #     args: "-race;-short"
-      # - name: Test Stores - MySQL
-      #   if: matrix.os == 'ubuntu-latest'
-      #   uses: n8maninger/action-golang-test@v1
-      #   env:
-      #     RENTERD_DB_URI: 127.0.0.1:3800
-      #     RENTERD_DB_USER: root
-      #     RENTERD_DB_PASSWORD: test
-      #   with:
-      #     package: "./stores"
-      #     args: "-race;-short"
+      - name: Test Stores
+        uses: n8maninger/action-golang-test@v1
+        with:
+          args: "-race;-short"
+      - name: Test Stores - MySQL
+        if: matrix.os == 'ubuntu-latest'
+        uses: n8maninger/action-golang-test@v1
+        env:
+          RENTERD_DB_URI: 127.0.0.1:3800
+          RENTERD_DB_USER: root
+          RENTERD_DB_PASSWORD: test
+        with:
+          package: "./stores"
+          args: "-race;-short"
       - name: Test Integration
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/test/e2e/..."
-          args: "-failfast;-race;-tags=testing;-timeout=60m;-count=100;-run=TestContractApplyChainUpdates"
-      # - name: Test Integration - MySQL
-      #   if: matrix.os == 'ubuntu-latest'
-      #   uses: n8maninger/action-golang-test@v1
-      #   env:
-      #     RENTERD_DB_URI: 127.0.0.1:3800
-      #     RENTERD_DB_USER: root
-      #     RENTERD_DB_PASSWORD: test
-      #   with:
-      #     package: "./internal/test/e2e/..."
-      #     args: "-failfast;-race;-tags=testing;-timeout=60m"
+          args: "-failfast;-race;-tags=testing;-timeout=60m"
+      - name: Test Integration - MySQL
+        if: matrix.os == 'ubuntu-latest'
+        uses: n8maninger/action-golang-test@v1
+        env:
+          RENTERD_DB_URI: 127.0.0.1:3800
+          RENTERD_DB_USER: root
+          RENTERD_DB_PASSWORD: test
+        with:
+          package: "./internal/test/e2e/..."
+          args: "-failfast;-race;-tags=testing;-timeout=60m"
       - name: Build
         run: go build -o bin/ ./cmd/renterd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,34 +49,34 @@ jobs:
           host port: 3800
           mysql version: '8'
           mysql root password: test
-      - name: Test Stores
-        uses: n8maninger/action-golang-test@v1
-        with:
-          args: "-race;-short"
-      - name: Test Stores - MySQL
-        if: matrix.os == 'ubuntu-latest'
-        uses: n8maninger/action-golang-test@v1
-        env:
-          RENTERD_DB_URI: 127.0.0.1:3800
-          RENTERD_DB_USER: root
-          RENTERD_DB_PASSWORD: test
-        with:
-          package: "./stores"
-          args: "-race;-short"
+      # - name: Test Stores
+      #   uses: n8maninger/action-golang-test@v1
+      #   with:
+      #     args: "-race;-short"
+      # - name: Test Stores - MySQL
+      #   if: matrix.os == 'ubuntu-latest'
+      #   uses: n8maninger/action-golang-test@v1
+      #   env:
+      #     RENTERD_DB_URI: 127.0.0.1:3800
+      #     RENTERD_DB_USER: root
+      #     RENTERD_DB_PASSWORD: test
+      #   with:
+      #     package: "./stores"
+      #     args: "-race;-short"
       - name: Test Integration
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/test/e2e/..."
-          args: "-failfast;-race;-tags=testing;-timeout=60m"
-      - name: Test Integration - MySQL
-        if: matrix.os == 'ubuntu-latest'
-        uses: n8maninger/action-golang-test@v1
-        env:
-          RENTERD_DB_URI: 127.0.0.1:3800
-          RENTERD_DB_USER: root
-          RENTERD_DB_PASSWORD: test
-        with:
-          package: "./internal/test/e2e/..."
-          args: "-failfast;-race;-tags=testing;-timeout=60m"
+          args: "-failfast;-race;-tags=testing;-timeout=60m;-count=100;-run=TestContractApplyChainUpdates"
+      # - name: Test Integration - MySQL
+      #   if: matrix.os == 'ubuntu-latest'
+      #   uses: n8maninger/action-golang-test@v1
+      #   env:
+      #     RENTERD_DB_URI: 127.0.0.1:3800
+      #     RENTERD_DB_USER: root
+      #     RENTERD_DB_PASSWORD: test
+      #   with:
+      #     package: "./internal/test/e2e/..."
+      #     args: "-failfast;-race;-tags=testing;-timeout=60m"
       - name: Build
         run: go build -o bin/ ./cmd/renterd

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -834,8 +834,8 @@ func (c *TestCluster) AddHost(h *Host) {
 	c.tt.OK(addStorageFolderToHost(ctx, []*Host{h}))
 	c.tt.OK(announceHosts([]*Host{h}))
 
-	// Mine a few blocks. The host should show up eventually.
-	c.tt.Retry(10, time.Second, func() error {
+	// Mine until the host shows up.
+	c.tt.Retry(100, 100*time.Millisecond, func() error {
 		c.tt.Helper()
 
 		_, err := c.Bus.Host(context.Background(), h.PublicKey())

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -812,8 +812,10 @@ func (c *TestCluster) AddHost(h *Host) {
 	c.hosts = append(c.hosts, h)
 
 	// Fund host from bus.
-	fundAmt := types.Siacoins(25e3)
-	c.tt.OKAll(c.Bus.SendSiacoins(context.Background(), h.WalletAddress(), fundAmt, true))
+	fundAmt := types.Siacoins(5e3)
+	for i := 0; i < 5; i++ {
+		c.tt.OKAll(c.Bus.SendSiacoins(context.Background(), h.WalletAddress(), fundAmt, true))
+	}
 
 	// Mine transaction.
 	c.MineBlocks(1)

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -1091,6 +1091,22 @@ func TestContractApplyChainUpdates(t *testing.T) {
 	cs, _ := b.ConsensusState(context.Background())
 	wallet, _ := b.Wallet(context.Background())
 	rev, _, err := w.RHPForm(context.Background(), cs.BlockHeight+test.AutopilotConfig.Contracts.Period+test.AutopilotConfig.Contracts.RenewWindow, h.PublicKey, h.NetAddress, wallet.Address, types.Siacoins(1), types.Siacoins(1))
+	if err != nil {
+		sce, err := hosts[0].wallet.SpendableOutputs()
+		if err != nil {
+			panic(err)
+		}
+		t.Log("spendable outputs:")
+		for _, so := range sce {
+			t.Log(so)
+		}
+		bal, err := hosts[0].wallet.Balance()
+		if err != nil {
+			panic(err)
+		}
+		t.Log("balance:", bal)
+		t.Fatal(err)
+	}
 	tt.OK(err)
 	contract, err := b.AddContract(context.Background(), rev, rev.Revision.MissedHostPayout().Sub(types.Siacoins(1)), types.Siacoins(1), cs.BlockHeight, api.ContractStatePending)
 	tt.OK(err)

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -1090,7 +1090,8 @@ func TestContractApplyChainUpdates(t *testing.T) {
 	// manually form a contract with the host
 	cs, _ := b.ConsensusState(context.Background())
 	wallet, _ := b.Wallet(context.Background())
-	rev, _, _ := w.RHPForm(context.Background(), cs.BlockHeight+test.AutopilotConfig.Contracts.Period+test.AutopilotConfig.Contracts.RenewWindow, h.PublicKey, h.NetAddress, wallet.Address, types.Siacoins(1), types.Siacoins(1))
+	rev, _, err := w.RHPForm(context.Background(), cs.BlockHeight+test.AutopilotConfig.Contracts.Period+test.AutopilotConfig.Contracts.RenewWindow, h.PublicKey, h.NetAddress, wallet.Address, types.Siacoins(1), types.Siacoins(1))
+	tt.OK(err)
 	contract, err := b.AddContract(context.Background(), rev, rev.Revision.MissedHostPayout().Sub(types.Siacoins(1)), types.Siacoins(1), cs.BlockHeight, api.ContractStatePending)
 	tt.OK(err)
 

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -1091,22 +1091,6 @@ func TestContractApplyChainUpdates(t *testing.T) {
 	cs, _ := b.ConsensusState(context.Background())
 	wallet, _ := b.Wallet(context.Background())
 	rev, _, err := w.RHPForm(context.Background(), cs.BlockHeight+test.AutopilotConfig.Contracts.Period+test.AutopilotConfig.Contracts.RenewWindow, h.PublicKey, h.NetAddress, wallet.Address, types.Siacoins(1), types.Siacoins(1))
-	if err != nil {
-		sce, err := hosts[0].wallet.SpendableOutputs()
-		if err != nil {
-			panic(err)
-		}
-		t.Log("spendable outputs:")
-		for _, so := range sce {
-			t.Log(so)
-		}
-		bal, err := hosts[0].wallet.Balance()
-		if err != nil {
-			panic(err)
-		}
-		t.Log("balance:", bal)
-		t.Fatal(err)
-	}
 	tt.OK(err)
 	contract, err := b.AddContract(context.Background(), rev, rev.Revision.MissedHostPayout().Sub(types.Siacoins(1)), types.Siacoins(1), cs.BlockHeight, api.ContractStatePending)
 	tt.OK(err)

--- a/internal/test/e2e/host.go
+++ b/internal/test/e2e/host.go
@@ -174,7 +174,7 @@ func (h *Host) RHPv3Addr() string {
 
 // AddVolume adds a new volume to the host
 func (h *Host) AddVolume(ctx context.Context, path string, size uint64) error {
-	result := make(chan error)
+	result := make(chan error, 1)
 	_, err := h.storage.AddVolume(ctx, path, size, result)
 	if err != nil {
 		return err


### PR DESCRIPTION
This ensures the host has more than one spendable output to work with, avoiding the NDF where it fails to fund a contract formation txn. This PR also fixes the deadlock we've been seeing by passing a buffered error channel to the host's volume manager.