### PR TITLE
Add default values for PricePinSettings

### DIFF
--- a/api/setting.go
+++ b/api/setting.go
@@ -54,7 +54,10 @@ var (
 	// configured with on startup. These values can be adjusted using the
 	// settings API.
 	DefaultPricePinSettings = PricePinSettings{
-		Enabled: false,
+		Enabled:          false,
+		Currency:         "usd",
+		ForexEndpointURL: "https://api.siascan.com/exchange-rate/siacoin",
+		Threshold:        0.05,
 	}
 
 	// DefaultUploadPackingSettings define the default upload packing settings
@@ -202,9 +205,6 @@ func (p Pin) IsPinned() bool {
 
 // Validate returns an error if the price pin settings are not considered valid.
 func (pps PricePinSettings) Validate() error {
-	if !pps.Enabled {
-		return nil
-	}
 	if pps.ForexEndpointURL == "" {
 		return fmt.Errorf("price pin settings must have a forex endpoint URL")
 	}

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -52,9 +52,7 @@ var (
 		MinMaxEphemeralAccountBalance: types.Siacoins(1), // 1SC
 	}
 
-	PricePinSettings = api.PricePinSettings{
-		Enabled: false,
-	}
+	PricePinSettings = api.DefaultPricePinSettings
 
 	RedundancySettings = api.RedundancySettings{
 		MinShards:   2,

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -184,9 +184,18 @@ func TestNewTestCluster(t *testing.T) {
 		t.Fatalf("expected upload packing to be disabled by default, got %v", ups.Enabled)
 	}
 
-	// Autopilot shouldn't have its prices pinned
+	// PricePinningSettings should have default values
 	pps, err := b.PricePinningSettings(context.Background())
 	tt.OK(err)
+	if pps.ForexEndpointURL == "" {
+		t.Fatal("expected default value for ForexEndpointURL")
+	} else if pps.Currency == "" {
+		t.Fatal("expected default value for Currency")
+	} else if pps.Threshold == 0 {
+		t.Fatal("expected default value for Threshold")
+	}
+
+	// Autopilot shouldn't have its prices pinned
 	if len(pps.Autopilots) != 1 {
 		t.Fatalf("expected 1 autopilot, got %v", len(pps.Autopilots))
 	} else if pin, exists := pps.Autopilots[api.DefaultAutopilotID]; !exists {


### PR DESCRIPTION
This PR adds default values for the `PricePinSettings`. The UI only needs a default for the `ForexEndpointURL` but I figured we might as well add a sane default for all values, except for the actual pins, for documentation purposes.