### PR TITLE
Add contract additions to worker cache

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -17,6 +17,7 @@ const (
 	ModuleHost        = "host"
 	ModuleSetting     = "setting"
 
+	EventAdd     = "add"
 	EventUpdate  = "update"
 	EventDelete  = "delete"
 	EventArchive = "archive"
@@ -32,6 +33,11 @@ type (
 		ConsensusState
 		TransactionFee types.Currency `json:"transactionFee"`
 		Timestamp      time.Time      `json:"timestamp"`
+	}
+
+	EventContractAdd struct {
+		Added     ContractMetadata `json:"added"`
+		Timestamp time.Time        `json:"timestamp"`
 	}
 
 	EventContractArchive struct {
@@ -75,6 +81,15 @@ var (
 			Event:   EventUpdate,
 			Headers: headers,
 			Module:  ModuleConsensus,
+			URL:     url,
+		}
+	}
+
+	WebhookContractAdd = func(url string, headers map[string]string) webhooks.Webhook {
+		return webhooks.Webhook{
+			Event:   EventAdd,
+			Headers: headers,
+			Module:  ModuleContract,
 			URL:     url,
 		}
 	}
@@ -142,6 +157,12 @@ func ParseEventWebhook(event webhooks.Event) (interface{}, error) {
 	switch event.Module {
 	case ModuleContract:
 		switch event.Event {
+		case EventAdd:
+			var e EventContractAdd
+			if err := json.Unmarshal(bytes, &e); err != nil {
+				return nil, err
+			}
+			return e, nil
 		case EventArchive:
 			var e EventContractArchive
 			if err := json.Unmarshal(bytes, &e); err != nil {

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -947,19 +947,17 @@ func (b *Bus) contractIDHandlerPOST(jc jape.Context) {
 	var req api.ContractAddRequest
 	if jc.DecodeParam("id", &id) != nil || jc.Decode(&req) != nil {
 		return
-	}
-	if req.Contract.ID() != id {
+	} else if req.Contract.ID() != id {
 		http.Error(jc.ResponseWriter, "contract ID mismatch", http.StatusBadRequest)
 		return
-	}
-	if req.TotalCost.IsZero() {
+	} else if req.TotalCost.IsZero() {
 		http.Error(jc.ResponseWriter, "TotalCost can not be zero", http.StatusBadRequest)
 		return
 	}
 
 	a, err := b.ms.AddContract(jc.Request.Context(), req.Contract, req.ContractPrice, req.TotalCost, req.StartHeight, req.State)
-	if jc.Check("couldn't store contract", err) == nil {
-		jc.Encode(a)
+	if jc.Check("couldn't store contract", err) != nil {
+		return
 	}
 
 	b.broadcastAction(webhooks.Event{
@@ -970,6 +968,8 @@ func (b *Bus) contractIDHandlerPOST(jc jape.Context) {
 			Timestamp: time.Now().UTC(),
 		},
 	})
+
+	jc.Encode(a)
 }
 
 func (b *Bus) contractIDRenewedHandlerPOST(jc jape.Context) {

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -961,6 +961,15 @@ func (b *Bus) contractIDHandlerPOST(jc jape.Context) {
 	if jc.Check("couldn't store contract", err) == nil {
 		jc.Encode(a)
 	}
+
+	b.broadcastAction(webhooks.Event{
+		Module: api.ModuleContract,
+		Event:  api.EventAdd,
+		Payload: api.EventContractAdd{
+			Added:     a,
+			Timestamp: time.Now().UTC(),
+		},
+	})
 }
 
 func (b *Bus) contractIDRenewedHandlerPOST(jc jape.Context) {

--- a/internal/worker/events.go
+++ b/internal/worker/events.go
@@ -112,6 +112,7 @@ func (e *eventSubscriber) Register(ctx context.Context, eventsURL string, opts .
 	// prepare webhooks
 	webhooks := []webhooks.Webhook{
 		api.WebhookConsensusUpdate(eventsURL, headers),
+		api.WebhookContractAdd(eventsURL, headers),
 		api.WebhookContractArchive(eventsURL, headers),
 		api.WebhookContractRenew(eventsURL, headers),
 		api.WebhookHostUpdate(eventsURL, headers),

--- a/internal/worker/events_test.go
+++ b/internal/worker/events_test.go
@@ -157,7 +157,7 @@ func TestEventSubscriber(t *testing.T) {
 
 	// assert webhook was registered
 	if webhooks := w.Webhooks(); len(webhooks) != 6 {
-		t.Fatal("expected 5 webhooks, got", len(webhooks))
+		t.Fatal("expected 6 webhooks, got", len(webhooks))
 	}
 
 	// send the same event again

--- a/internal/worker/events_test.go
+++ b/internal/worker/events_test.go
@@ -156,7 +156,7 @@ func TestEventSubscriber(t *testing.T) {
 	time.Sleep(testRegisterInterval)
 
 	// assert webhook was registered
-	if webhooks := w.Webhooks(); len(webhooks) != 5 {
+	if webhooks := w.Webhooks(); len(webhooks) != 6 {
 		t.Fatal("expected 5 webhooks, got", len(webhooks))
 	}
 


### PR DESCRIPTION
It seems like right now the cached contracts are not updated when a new contract is added. This fixes that.

I noticed because the worker failed to refill ephemeral accounts in my open PR since the cached contracts were always 0 because the cache was initialized before the contracts had been formed. 