### PR TITLE
Move broadcast endpoint

### DIFF
--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -41,6 +41,7 @@ type Bus interface {
 	// contracts
 	AncestorContracts(ctx context.Context, id types.FileContractID, minStartHeight uint64) ([]api.ArchivedContract, error)
 	ArchiveContracts(ctx context.Context, toArchive map[types.FileContractID]string) error
+	BroadcastContract(ctx context.Context, fcid types.FileContractID) error
 	Contract(ctx context.Context, id types.FileContractID) (api.ContractMetadata, error)
 	Contracts(ctx context.Context, opts api.ContractsOpts) (contracts []api.ContractMetadata, err error)
 	FileContractTax(ctx context.Context, payout types.Currency) (types.Currency, error)

--- a/autopilot/contractor/contractor.go
+++ b/autopilot/contractor/contractor.go
@@ -83,6 +83,7 @@ const (
 type Bus interface {
 	AncestorContracts(ctx context.Context, id types.FileContractID, minStartHeight uint64) ([]api.ArchivedContract, error)
 	ArchiveContracts(ctx context.Context, toArchive map[types.FileContractID]string) error
+	BroadcastContract(ctx context.Context, fcid types.FileContractID) (err error)
 	ConsensusState(ctx context.Context) (api.ConsensusState, error)
 	Contract(ctx context.Context, id types.FileContractID) (api.ContractMetadata, error)
 	Contracts(ctx context.Context, opts api.ContractsOpts) (contracts []api.ContractMetadata, err error)
@@ -98,7 +99,6 @@ type Bus interface {
 
 type Worker interface {
 	Contracts(ctx context.Context, hostTimeout time.Duration) (api.ContractsResponse, error)
-	RHPBroadcast(ctx context.Context, fcid types.FileContractID) (err error)
 	RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (api.HostPriceTable, error)
 	RHPScan(ctx context.Context, hostKey types.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)
 }
@@ -433,7 +433,7 @@ func (c *Contractor) broadcastRevisions(ctx context.Context, w Worker, contracts
 
 		// broadcast revision
 		ctx, cancel := context.WithTimeout(ctx, timeoutBroadcastRevision)
-		err := w.RHPBroadcast(ctx, contract.ID)
+		err := c.bus.BroadcastContract(ctx, contract.ID)
 		cancel()
 		if utils.IsErr(err, errors.New("transaction has a file contract with an outdated revision number")) {
 			continue // don't log - revision was already broadcasted

--- a/autopilot/workerpool.go
+++ b/autopilot/workerpool.go
@@ -18,7 +18,6 @@ type Worker interface {
 	ID(ctx context.Context) (string, error)
 	MigrateSlab(ctx context.Context, s object.Slab, set string) (api.MigrateSlabResponse, error)
 
-	RHPBroadcast(ctx context.Context, fcid types.FileContractID) (err error)
 	RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (api.HostPriceTable, error)
 	RHPScan(ctx context.Context, hostKey types.PublicKey, hostIP string, timeout time.Duration) (api.RHPScanResponse, error)
 }

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -44,9 +44,10 @@ const (
 	defaultPinUpdateInterval          = 5 * time.Minute
 	defaultPinRateWindow              = 6 * time.Hour
 
-	lockingPriorityPruning = 20
-	lockingPriorityFunding = 40
-	lockingPriorityRenew   = 80
+	lockingPriorityPruning   = 20
+	lockingPriorityFunding   = 40
+	lockingPriorityRenew     = 80
+	lockingPriorityBroadcast = 100
 
 	stdTxnSize = 1200 // bytes
 )
@@ -424,6 +425,7 @@ func (b *Bus) Handler() http.Handler {
 		"DELETE /contract/:id":           b.contractIDHandlerDELETE,
 		"POST   /contract/:id/acquire":   b.contractAcquireHandlerPOST,
 		"GET    /contract/:id/ancestors": b.contractIDAncestorsHandler,
+		"POST   /contract/:id/broadcast": b.contractIDBroadcastHandler,
 		"POST   /contract/:id/keepalive": b.contractKeepaliveHandlerPOST,
 		"POST   /contract/:id/prune":     b.contractPruneHandlerPOST,
 		"POST   /contract/:id/renew":     b.contractIDRenewHandlerPOST,
@@ -563,6 +565,64 @@ func (b *Bus) addRenewedContract(ctx context.Context, renewedFrom types.FileCont
 		},
 	})
 	return r, nil
+}
+
+func (b *Bus) broadcastContract(ctx context.Context, fcid types.FileContractID) error {
+	// acquire contract lock indefinitely and defer the release
+	lockID, err := b.contractLocker.Acquire(ctx, lockingPriorityRenew, fcid, time.Duration(math.MaxInt64))
+	if err != nil {
+		return fmt.Errorf("couldn't acquire contract lock; %w", err)
+	}
+	defer func() {
+		if err := b.contractLocker.Release(fcid, lockID); err != nil {
+			b.logger.Error("failed to release contract lock", zap.Error(err))
+		}
+	}()
+
+	// fetch contract
+	c, err := b.ms.Contract(ctx, fcid)
+	if err != nil {
+		return fmt.Errorf("couldn't fetch contract; %w", err)
+	}
+
+	// fetch revision
+	rk := b.deriveRenterKey(c.HostKey)
+	rev, err := b.rhp2.SignedRevision(ctx, c.HostIP, c.HostKey, rk, fcid, time.Minute)
+	if err != nil {
+		return fmt.Errorf("couldn't fetch revision; %w", err)
+	}
+
+	// send V2 transaction if we're passed the V2 hardfork allow height
+	if b.isPassedV2AllowHeight() {
+		panic("not implemented")
+	} else {
+		// create the transaction
+		txn := types.Transaction{
+			FileContractRevisions: []types.FileContractRevision{rev.Revision},
+			Signatures:            rev.Signatures[:],
+		}
+
+		// fund the transaction (only the fee)
+		toSign, err := b.w.FundTransaction(&txn, types.ZeroCurrency, true)
+		if err != nil {
+			return fmt.Errorf("couldn't fund transaction; %w", err)
+		}
+		// sign the transaction
+		b.w.SignTransaction(&txn, toSign, types.CoveredFields{WholeTransaction: true})
+
+		// verify the transaction and add it to the transaction pool
+		txnset := append(b.cm.UnconfirmedParents(txn), txn)
+		_, err = b.cm.AddPoolTransactions(txnset)
+		if err != nil {
+			b.w.ReleaseInputs([]types.Transaction{txn}, nil)
+			return fmt.Errorf("couldn't add transaction set to the pool; %w", err)
+		}
+
+		// broadcast the transaction
+		b.s.BroadcastTransactionSet(txnset)
+	}
+
+	return nil
 }
 
 func (b *Bus) formContract(ctx context.Context, hostSettings rhpv2.HostSettings, renterAddress types.Address, renterFunds, hostCollateral types.Currency, hostKey types.PublicKey, hostIP string, endHeight uint64) (rhpv2.ContractRevision, error) {

--- a/bus/client/contracts.go
+++ b/bus/client/contracts.go
@@ -62,6 +62,12 @@ func (c *Client) ArchiveContracts(ctx context.Context, toArchive map[types.FileC
 	return
 }
 
+// BroadcastContract broadcasts the latest revision for a contract.
+func (c *Client) BroadcastContract(ctx context.Context, contractID types.FileContractID) (err error) {
+	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/contract/%s/broadcast", contractID), nil, nil)
+	return
+}
+
 // Contract returns the contract with the given ID.
 func (c *Client) Contract(ctx context.Context, id types.FileContractID) (contract api.ContractMetadata, err error) {
 	err = c.c.WithContext(ctx).GET(fmt.Sprintf("/contract/%s", id), &contract)

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -1778,6 +1778,15 @@ func (b *Bus) contractIDAncestorsHandler(jc jape.Context) {
 	jc.Encode(ancestors)
 }
 
+func (b *Bus) contractIDBroadcastHandler(jc jape.Context) {
+	var fcid types.FileContractID
+	if jc.DecodeParam("id", &fcid) != nil {
+		return
+	}
+
+	jc.Check("failed to broadcast contract revision", b.broadcastContract(jc.Request.Context(), fcid))
+}
+
 func (b *Bus) paramsHandlerUploadGET(jc jape.Context) {
 	gp, err := b.gougingParams(jc.Request.Context())
 	if jc.Check("could not get gouging parameters", err) != nil {

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -1089,7 +1089,6 @@ func TestContractApplyChainUpdates(t *testing.T) {
 	defer cluster.Shutdown()
 
 	// convenience variables
-	w := cluster.Worker
 	b := cluster.Bus
 	tt := cluster.tt
 
@@ -1111,7 +1110,7 @@ func TestContractApplyChainUpdates(t *testing.T) {
 	}
 
 	// broadcast the revision for each contract
-	tt.OK(w.RHPBroadcast(context.Background(), contract.ID))
+	tt.OK(b.BroadcastContract(context.Background(), contract.ID))
 	cluster.MineBlocks(1)
 
 	// check the revision height was updated.

--- a/worker/client/rhp.go
+++ b/worker/client/rhp.go
@@ -2,18 +2,11 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 )
-
-// RHPBroadcast broadcasts the latest revision for a contract.
-func (c *Client) RHPBroadcast(ctx context.Context, contractID types.FileContractID) (err error) {
-	err = c.c.WithContext(ctx).POST(fmt.Sprintf("/rhp/contract/%s/broadcast", contractID), nil, nil)
-	return
-}
 
 // RHPPriceTable fetches a price table for a host.
 func (c *Client) RHPPriceTable(ctx context.Context, hostKey types.PublicKey, siamuxAddr string, timeout time.Duration) (pt api.HostPriceTable, err error) {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -41,11 +41,8 @@ import (
 const (
 	defaultRevisionFetchTimeout = 30 * time.Second
 
-	lockingPriorityActiveContractRevision = 100
-	lockingPriorityRenew                  = 80
-	lockingPriorityFunding                = 40
 	lockingPrioritySyncing                = 30
-	lockingPriorityPruning                = 20
+	lockingPriorityActiveContractRevision = 100
 
 	lockingPriorityBlockedUpload    = 15
 	lockingPriorityUpload           = 10
@@ -357,63 +354,6 @@ func (w *Worker) rhpPriceTableHandler(jc jape.Context) {
 		return
 	}
 	jc.Encode(hpt)
-}
-
-func (w *Worker) rhpBroadcastHandler(jc jape.Context) {
-	ctx := jc.Request.Context()
-
-	// decode the fcid
-	var fcid types.FileContractID
-	if jc.DecodeParam("id", &fcid) != nil {
-		return
-	}
-
-	// Acquire lock before fetching revision.
-	unlocker, err := w.acquireContractLock(ctx, fcid, lockingPriorityActiveContractRevision)
-	if jc.Check("could not acquire revision lock", err) != nil {
-		return
-	}
-	defer unlocker.Release(ctx)
-
-	// Fetch contract from bus.
-	c, err := w.bus.Contract(ctx, fcid)
-	if jc.Check("could not get contract", err) != nil {
-		return
-	}
-	rk := w.deriveRenterKey(c.HostKey)
-
-	rev, err := w.rhp2Client.SignedRevision(ctx, c.HostIP, c.HostKey, rk, fcid, time.Minute)
-	if jc.Check("could not fetch revision", err) != nil {
-		return
-	}
-
-	// Create txn with revision.
-	txn := types.Transaction{
-		FileContractRevisions: []types.FileContractRevision{rev.Revision},
-		Signatures:            rev.Signatures[:],
-	}
-	// Fund the txn. We pass 0 here since we only need the wallet to fund
-	// the fee.
-	toSign, parents, err := w.bus.WalletFund(ctx, &txn, types.ZeroCurrency, true)
-	if jc.Check("failed to fund transaction", err) != nil {
-		return
-	}
-	// Sign the txn.
-	err = w.bus.WalletSign(ctx, &txn, toSign, types.CoveredFields{
-		WholeTransaction: true,
-	})
-	if jc.Check("failed to sign transaction", err) != nil {
-		_ = w.bus.WalletDiscard(ctx, txn)
-		return
-	}
-	// Broadcast the txn.
-	txnSet := parents
-	txnSet = append(txnSet, txn)
-	err = w.bus.BroadcastTransaction(ctx, txnSet)
-	if jc.Check("failed to broadcast transaction", err) != nil {
-		_ = w.bus.WalletDiscard(ctx, txn)
-		return
-	}
 }
 
 func (w *Worker) slabMigrateHandler(jc jape.Context) {
@@ -1048,10 +988,9 @@ func (w *Worker) Handler() http.Handler {
 
 		"GET /memory": w.memoryGET,
 
-		"GET    /rhp/contracts":              w.rhpContractsHandlerGET,
-		"POST   /rhp/contract/:id/broadcast": w.rhpBroadcastHandler,
-		"POST   /rhp/scan":                   w.rhpScanHandler,
-		"POST   /rhp/pricetable":             w.rhpPriceTableHandler,
+		"GET    /rhp/contracts":  w.rhpContractsHandlerGET,
+		"POST   /rhp/scan":       w.rhpScanHandler,
+		"POST   /rhp/pricetable": w.rhpPriceTableHandler,
 
 		"GET    /stats/downloads": w.downloadsStatsHandlerGET,
 		"GET    /stats/uploads":   w.uploadsStatsHandlerGET,


### PR DESCRIPTION
This PR moves broadcasting the revision over to the `bus`. I think that's the last endpoint that revises a contract and thereby ticks of `Move routes that revise contracts to the bus` in https://github.com/SiaFoundation/renterd/issues/1136