### PR TITLE
Fix TestEphemeralAccountSync NDF

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,34 +49,34 @@ jobs:
           host port: 3800
           mysql version: '8'
           mysql root password: test
-      - name: Test Stores
-        uses: n8maninger/action-golang-test@v1
-        with:
-          args: "-race;-short"
-      - name: Test Stores - MySQL
-        if: matrix.os == 'ubuntu-latest'
-        uses: n8maninger/action-golang-test@v1
-        env:
-          RENTERD_DB_URI: 127.0.0.1:3800
-          RENTERD_DB_USER: root
-          RENTERD_DB_PASSWORD: test
-        with:
-          package: "./stores"
-          args: "-race;-short"
+      # - name: Test Stores
+      #   uses: n8maninger/action-golang-test@v1
+      #   with:
+      #     args: "-race;-short"
+      # - name: Test Stores - MySQL
+      #   if: matrix.os == 'ubuntu-latest'
+      #   uses: n8maninger/action-golang-test@v1
+      #   env:
+      #     RENTERD_DB_URI: 127.0.0.1:3800
+      #     RENTERD_DB_USER: root
+      #     RENTERD_DB_PASSWORD: test
+      #   with:
+      #     package: "./stores"
+      #     args: "-race;-short"
       - name: Test Integration
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/test/e2e/..."
-          args: "-failfast;-race;-timeout=60m"
-      - name: Test Integration - MySQL
-        if: matrix.os == 'ubuntu-latest'
-        uses: n8maninger/action-golang-test@v1
-        env:
-          RENTERD_DB_URI: 127.0.0.1:3800
-          RENTERD_DB_USER: root
-          RENTERD_DB_PASSWORD: test
-        with:
-          package: "./internal/test/e2e/..."
-          args: "-failfast;-race;-timeout=60m"
+          args: "-failfast;-race;-timeout=60m;-count=100;-run=TestEphemeralAccountSync"
+      # - name: Test Integration - MySQL
+      #   if: matrix.os == 'ubuntu-latest'
+      #   uses: n8maninger/action-golang-test@v1
+      #   env:
+      #     RENTERD_DB_URI: 127.0.0.1:3800
+      #     RENTERD_DB_USER: root
+      #     RENTERD_DB_PASSWORD: test
+      #   with:
+      #     package: "./internal/test/e2e/..."
+      #     args: "-failfast;-race;-timeout=60m"
       - name: Build
         run: go build -o bin/ ./cmd/renterd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,34 +49,34 @@ jobs:
           host port: 3800
           mysql version: '8'
           mysql root password: test
-      # - name: Test Stores
-      #   uses: n8maninger/action-golang-test@v1
-      #   with:
-      #     args: "-race;-short"
-      # - name: Test Stores - MySQL
-      #   if: matrix.os == 'ubuntu-latest'
-      #   uses: n8maninger/action-golang-test@v1
-      #   env:
-      #     RENTERD_DB_URI: 127.0.0.1:3800
-      #     RENTERD_DB_USER: root
-      #     RENTERD_DB_PASSWORD: test
-      #   with:
-      #     package: "./stores"
-      #     args: "-race;-short"
+      - name: Test Stores
+        uses: n8maninger/action-golang-test@v1
+        with:
+          args: "-race;-short"
+      - name: Test Stores - MySQL
+        if: matrix.os == 'ubuntu-latest'
+        uses: n8maninger/action-golang-test@v1
+        env:
+          RENTERD_DB_URI: 127.0.0.1:3800
+          RENTERD_DB_USER: root
+          RENTERD_DB_PASSWORD: test
+        with:
+          package: "./stores"
+          args: "-race;-short"
       - name: Test Integration
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/test/e2e/..."
-          args: "-failfast;-race;-timeout=60m;-count=100;-run=TestEphemeralAccountSync"
-      # - name: Test Integration - MySQL
-      #   if: matrix.os == 'ubuntu-latest'
-      #   uses: n8maninger/action-golang-test@v1
-      #   env:
-      #     RENTERD_DB_URI: 127.0.0.1:3800
-      #     RENTERD_DB_USER: root
-      #     RENTERD_DB_PASSWORD: test
-      #   with:
-      #     package: "./internal/test/e2e/..."
-      #     args: "-failfast;-race;-timeout=60m"
+          args: "-failfast;-race;-timeout=60m"
+      - name: Test Integration - MySQL
+        if: matrix.os == 'ubuntu-latest'
+        uses: n8maninger/action-golang-test@v1
+        env:
+          RENTERD_DB_URI: 127.0.0.1:3800
+          RENTERD_DB_USER: root
+          RENTERD_DB_PASSWORD: test
+        with:
+          package: "./internal/test/e2e/..."
+          args: "-failfast;-race;-timeout=60m"
       - name: Build
         run: go build -o bin/ ./cmd/renterd

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -936,6 +936,20 @@ func (c *TestCluster) AddHostsBlocking(n int) []*Host {
 	return hosts
 }
 
+// MineTransactions tries to mine the transactions in the transaction pool until
+// it is empty.
+func (c *TestCluster) MineTransactions(ctx context.Context) error {
+	return test.Retry(100, 100*time.Millisecond, func() error {
+		txns, err := c.Bus.TransactionPool(ctx)
+		if err != nil {
+			return err
+		} else if len(txns) > 0 {
+			c.MineBlocks(1)
+		}
+		return nil
+	})
+}
+
 // Shutdown shuts down a TestCluster.
 func (c *TestCluster) Shutdown() {
 	c.tt.Helper()

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -1351,6 +1351,11 @@ func TestEphemeralAccountSync(t *testing.T) {
 	}
 	acc := accounts[0]
 
+	// stop autopilot and mine transactions, this prevents an NDF where we
+	// double spend outputs after restarting the bus
+	cluster.ShutdownAutopilot(context.Background())
+	tt.OK(cluster.MineTransactions(context.Background()))
+
 	// stop the cluster
 	host := cluster.hosts[0]
 	cluster.hosts = nil // exclude hosts from shutdown


### PR DESCRIPTION
```
cluster_test.go:1343: failed to accept block: reorg failed: couldn't apply block 293::4086dccb: block 293::4086dccb is invalid: transaction 1 is invalid: siacoin input 0 double-spends parent output (previously spent in txid:e70a27c3149f481a3d89a70dfc92eeab939d4d05e4b6a3490fc57f546af70dc7)
```