### PR TITLE
Populate autopilots in pinned settings

### DIFF
--- a/bus/routes.go
+++ b/bus/routes.go
@@ -1315,7 +1315,6 @@ func (b *Bus) packedSlabsHandlerDonePOST(jc jape.Context) {
 func (b *Bus) settingsGougingHandlerGET(jc jape.Context) {
 	gs, err := b.ss.GougingSettings(jc.Request.Context())
 	if errors.Is(err, sql.ErrSettingNotFound) {
-		b.logger.Warn("gouging settings not found, returning defaults")
 		jc.Encode(api.DefaultGougingSettings)
 		return
 	} else if jc.Check("failed to get gouging settings", err) == nil {
@@ -1346,7 +1345,6 @@ func (b *Bus) settingsGougingHandlerPUT(jc jape.Context) {
 func (b *Bus) settingsPinnedHandlerGET(jc jape.Context) {
 	ps, err := b.ss.PinnedSettings(jc.Request.Context())
 	if errors.Is(err, sql.ErrSettingNotFound) {
-		b.logger.Warn("pinned settings not found, using defaults")
 		ps = api.DefaultPinnedSettings
 	} else if jc.Check("failed to get pinned settings", err) != nil {
 		return
@@ -1396,7 +1394,6 @@ func (b *Bus) settingsPinnedHandlerPUT(jc jape.Context) {
 func (b *Bus) settingsUploadHandlerGET(jc jape.Context) {
 	us, err := b.ss.UploadSettings(jc.Request.Context())
 	if errors.Is(err, sql.ErrSettingNotFound) {
-		b.logger.Warn("upload settings not found, returning defaults")
 		jc.Encode(api.DefaultUploadSettings(b.cm.TipState().Network.Name))
 		return
 	} else if jc.Check("failed to get upload settings", err) == nil {
@@ -1426,7 +1423,6 @@ func (b *Bus) settingsUploadHandlerPUT(jc jape.Context) {
 func (b *Bus) settingsS3HandlerGET(jc jape.Context) {
 	s3s, err := b.ss.S3Settings(jc.Request.Context())
 	if errors.Is(err, sql.ErrSettingNotFound) {
-		b.logger.Warn("S3 settings not found, returning defaults")
 		jc.Encode(api.DefaultS3Settings)
 		return
 	} else if jc.Check("failed to get S3 settings", err) == nil {

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -1346,25 +1346,26 @@ func (b *Bus) settingsGougingHandlerPUT(jc jape.Context) {
 func (b *Bus) settingsPinnedHandlerGET(jc jape.Context) {
 	ps, err := b.ss.PinnedSettings(jc.Request.Context())
 	if errors.Is(err, sql.ErrSettingNotFound) {
-		b.logger.Warn("pinned settings not found, returning defaults")
-		jc.Encode(api.DefaultPinnedSettings)
+		b.logger.Warn("pinned settings not found, using defaults")
+		ps = api.DefaultPinnedSettings
+	} else if jc.Check("failed to get pinned settings", err) != nil {
 		return
-	} else if jc.Check("failed to get pinned settings", err) == nil {
-		// populate the Autopilots map with the current autopilots
-		aps, err := b.as.Autopilots(jc.Request.Context())
-		if jc.Check("failed to fetch autopilots", err) != nil {
-			return
-		}
-		if ps.Autopilots == nil {
-			ps.Autopilots = make(map[string]api.AutopilotPins)
-		}
-		for _, ap := range aps {
-			if _, exists := ps.Autopilots[ap.ID]; !exists {
-				ps.Autopilots[ap.ID] = api.AutopilotPins{}
-			}
-		}
-		jc.Encode(ps)
 	}
+
+	// populate the Autopilots map with the current autopilots
+	aps, err := b.as.Autopilots(jc.Request.Context())
+	if jc.Check("failed to fetch autopilots", err) != nil {
+		return
+	}
+	if ps.Autopilots == nil {
+		ps.Autopilots = make(map[string]api.AutopilotPins)
+	}
+	for _, ap := range aps {
+		if _, exists := ps.Autopilots[ap.ID]; !exists {
+			ps.Autopilots[ap.ID] = api.AutopilotPins{}
+		}
+	}
+	jc.Encode(ps)
 }
 
 func (b *Bus) settingsPinnedHandlerPUT(jc jape.Context) {

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -502,7 +502,6 @@ func newTestCluster(t *testing.T, opts testClusterOptions) *TestCluster {
 
 	// Update the bus settings.
 	tt.OK(busClient.UpdateGougingSettings(ctx, test.GougingSettings))
-	tt.OK(busClient.UpdatePinnedSettings(ctx, test.PricePinSettings))
 	tt.OK(busClient.UpdateUploadSettings(ctx, us))
 	tt.OK(busClient.UpdateS3Settings(ctx, s3))
 

--- a/stores/sql/sqlite/migrations/main/migration_00019_settings.sql
+++ b/stores/sql/sqlite/migrations/main/migration_00019_settings.sql
@@ -42,7 +42,7 @@ FROM (
     WHERE
         json_extract(v, "$.currency") IS NOT NULL AND
         json_extract(v, "$.threshold") IS NOT NULL
-)
+);
 
 -- delete old settings
 DELETE FROM settings WHERE `key` IN ("uploadpacking", "redundancy", "contractset", "s3authentication", "pricepinning");


### PR DESCRIPTION
Hm look like this slipped through. When I saw the issue I was surprised because I was sure I added it, but it looks like I'm not populating the autopilots if the setting isn't found and we return the default settings.

Fixes https://github.com/SiaFoundation/renterd/issues/1532

