### PR TITLE
Allow empty migrations

### DIFF
--- a/internal/sql/migrations.go
+++ b/internal/sql/migrations.go
@@ -1,6 +1,7 @@
 package sql
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"fmt"
@@ -316,6 +317,8 @@ func execSQLFile(ctx context.Context, tx Tx, fs embed.FS, folder, filename strin
 	file, err := fs.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read %s: %w", path, err)
+	} else if len(bytes.TrimSpace(file)) == 0 {
+		return nil
 	}
 
 	// execute it


### PR DESCRIPTION
Occasionally we have to perform a migration only on the SQLite db and not the MySQL db or vice versa (see `00020_idx_db_directory`). Up until now MySQL would fail though with "empty query". Since it's nice to have a nice overview of migrations I think we should allow empty migrations and not execute them when we find they're empty.