### PR TITLE
Fix migration_00021_archived_contracts for SQLite

### DIFF
--- a/stores/sql/sqlite/migrations/main/migration_00021_archived_contracts.sql
+++ b/stores/sql/sqlite/migrations/main/migration_00021_archived_contracts.sql
@@ -27,6 +27,19 @@ CREATE TABLE contracts_temp (
     `fund_account_spending` text,
     `upload_spending` text
 );
+
+DROP INDEX IF EXISTS `idx_contracts_archival_reason`;
+DROP INDEX IF EXISTS `idx_contracts_fcid`;
+DROP INDEX IF EXISTS `idx_contracts_host_key`;
+DROP INDEX IF EXISTS `idx_contracts_proof_height`;
+DROP INDEX IF EXISTS `idx_contracts_renewed_from`;
+DROP INDEX IF EXISTS `idx_contracts_renewed_to`;
+DROP INDEX IF EXISTS `idx_contracts_revision_height`;
+DROP INDEX IF EXISTS `idx_contracts_start_height`;
+DROP INDEX IF EXISTS `idx_contracts_state`;
+DROP INDEX IF EXISTS `idx_contracts_window_end`;
+DROP INDEX IF EXISTS `idx_contracts_window_start`;
+
 CREATE INDEX `idx_contracts_archival_reason` ON `contracts_temp`(`archival_reason`);
 CREATE INDEX `idx_contracts_fcid` ON `contracts_temp`(`fcid`);
 CREATE INDEX `idx_contracts_host_key` ON `contracts_temp`(`host_key`);

--- a/stores/sql/sqlite/migrations/metrics/migration_00004_contract_spending.sql
+++ b/stores/sql/sqlite/migrations/metrics/migration_00004_contract_spending.sql
@@ -18,6 +18,19 @@ CREATE TABLE `contracts_temp` (
     `sector_roots_spending_lo` BIGINT NOT NULL,
     `sector_roots_spending_hi` BIGINT NOT NULL
 );
+
+DROP INDEX IF EXISTS `idx_sector_roots_spending`;
+DROP INDEX IF EXISTS `idx_fund_account_spending`;
+DROP INDEX IF EXISTS `idx_contracts_fc_id`;
+DROP INDEX IF EXISTS `idx_remaining_collateral`;
+DROP INDEX IF EXISTS `idx_contracts_host`;
+DROP INDEX IF EXISTS `idx_contracts_timestamp`;
+DROP INDEX IF EXISTS `idx_delete_spending`;
+DROP INDEX IF EXISTS `idx_upload_spending`;
+DROP INDEX IF EXISTS `idx_contracts_revision_number`;
+DROP INDEX IF EXISTS `idx_remaining_funds`;
+DROP INDEX IF EXISTS `idx_contracts_fcid_timestamp`;
+
 CREATE INDEX `idx_sector_roots_spending` ON `contracts_temp`(`sector_roots_spending_lo`,`sector_roots_spending_hi`);
 CREATE INDEX `idx_fund_account_spending` ON `contracts_temp`(`fund_account_spending_lo`,`fund_account_spending_hi`);
 CREATE INDEX `idx_contracts_fc_id` ON `contracts_temp`(`fcid`);


### PR DESCRIPTION
In SQLite index names have to be unique across all tables, not like in MySQL where it has to be unique within each table. For SQLite the migration errors out with `Error: index idx_contracts_proof_height already exists`, this PR fixes that by recreating all indices. I don't think we can get around that in SQLite, either that or we have to do it from the application side but I don't see an issue recreating them, it was super fast on arequipa.