### PR TITLE
Remove unused SQL triggers

### DIFF
--- a/internal/sql/migrations.go
+++ b/internal/sql/migrations.go
@@ -243,6 +243,12 @@ var (
 					return performMigration(ctx, tx, migrationsFs, dbIdentifier, "00021_archived_contracts", log)
 				},
 			},
+			{
+				ID: "00022_remove_triggers",
+				Migrate: func(tx Tx) error {
+					return performMigration(ctx, tx, migrationsFs, dbIdentifier, "00022_remove_triggers", log)
+				},
+			},
 		}
 	}
 	MetricsMigrations = func(ctx context.Context, migrationsFs embed.FS, log *zap.SugaredLogger) []Migration {

--- a/stores/sql/mysql/migrations/main/migration_00022_remove_triggers.sql
+++ b/stores/sql/mysql/migrations/main/migration_00022_remove_triggers.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER IF EXISTS before_delete_on_objects_delete_slices;
+DROP TRIGGER IF EXISTS before_delete_on_multipart_uploads_delete_multipart_parts;
+DROP TRIGGER IF EXISTS before_delete_on_multipart_parts_delete_slices;
+DROP TRIGGER IF EXISTS after_delete_on_slices_delete_slabs;

--- a/stores/sql/mysql/migrations/main/schema.sql
+++ b/stores/sql/mysql/migrations/main/schema.sql
@@ -432,40 +432,6 @@ CREATE TABLE `host_checks` (
   CONSTRAINT `fk_host_checks_host` FOREIGN KEY (`db_host_id`) REFERENCES `hosts` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
--- dbObject trigger to delete from slices
-CREATE TRIGGER before_delete_on_objects_delete_slices
-BEFORE DELETE
-ON objects FOR EACH ROW
-DELETE FROM slices
-WHERE slices.db_object_id = OLD.id;
-
--- dbMultipartUpload trigger to delete from dbMultipartPart
-CREATE TRIGGER before_delete_on_multipart_uploads_delete_multipart_parts
-BEFORE DELETE
-ON multipart_uploads FOR EACH ROW
-DELETE FROM multipart_parts
-WHERE multipart_parts.db_multipart_upload_id = OLD.id;
-
--- dbMultipartPart trigger to delete from slices
-CREATE TRIGGER before_delete_on_multipart_parts_delete_slices
-BEFORE DELETE
-ON multipart_parts FOR EACH ROW
-DELETE FROM slices
-WHERE slices.db_multipart_part_id = OLD.id;
-
--- dbSlices trigger to prune slabs
-CREATE TRIGGER after_delete_on_slices_delete_slabs
-AFTER DELETE
-ON slices FOR EACH ROW
-DELETE FROM slabs
-WHERE slabs.id = OLD.db_slab_id
-AND slabs.db_buffered_slab_id IS NULL
-AND NOT EXISTS (
-    SELECT 1
-    FROM slices
-    WHERE slices.db_slab_id = OLD.db_slab_id
-);
-
 -- dbSyncerPeer
 CREATE TABLE `syncer_peers` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,

--- a/stores/sql/sqlite/migrations/main/migration_00022_remove_triggers.sql
+++ b/stores/sql/sqlite/migrations/main/migration_00022_remove_triggers.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER IF EXISTS before_delete_on_objects_delete_slices;
+DROP TRIGGER IF EXISTS before_delete_on_multipart_uploads_delete_multipart_parts;
+DROP TRIGGER IF EXISTS before_delete_on_multipart_parts_delete_slices;
+DROP TRIGGER IF EXISTS after_delete_on_slices_delete_slabs;

--- a/stores/sql/sqlite/migrations/main/schema.sql
+++ b/stores/sql/sqlite/migrations/main/schema.sql
@@ -155,44 +155,6 @@ CREATE INDEX `idx_host_checks_score_uptime` ON `host_checks` (`score_uptime`);
 CREATE INDEX `idx_host_checks_score_version` ON `host_checks` (`score_version`);
 CREATE INDEX `idx_host_checks_score_prices` ON `host_checks` (`score_prices`);
 
--- dbObject trigger to delete from slices
-CREATE TRIGGER before_delete_on_objects_delete_slices
-BEFORE DELETE ON objects
-BEGIN
-    DELETE FROM slices
-    WHERE slices.db_object_id = OLD.id;
-END;
-
--- dbMultipartUpload trigger to delete from dbMultipartPart
-CREATE TRIGGER before_delete_on_multipart_uploads_delete_multipart_parts
-BEFORE DELETE ON multipart_uploads
-BEGIN
-    DELETE FROM multipart_parts
-    WHERE multipart_parts.db_multipart_upload_id = OLD.id;
-END;
-
--- dbMultipartPart trigger to delete from slices
-CREATE TRIGGER before_delete_on_multipart_parts_delete_slices
-BEFORE DELETE ON multipart_parts
-BEGIN
-    DELETE FROM slices
-    WHERE slices.db_multipart_part_id = OLD.id;
-END;
-
--- dbSlices trigger to prune slabs
-CREATE TRIGGER after_delete_on_slices_delete_slabs
-AFTER DELETE ON slices
-BEGIN
-    DELETE FROM slabs
-    WHERE slabs.id = OLD.db_slab_id
-    AND slabs.db_buffered_slab_id IS NULL
-    AND NOT EXISTS (
-        SELECT 1
-        FROM slices
-        WHERE slices.db_slab_id = OLD.db_slab_id
-    );
-END;
-
 -- dbSyncerPeer
 CREATE TABLE `syncer_peers` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`address` text NOT NULL,`first_seen` BIGINT NOT NULL,`last_connect` BIGINT,`synced_blocks` BIGINT,`sync_duration` BIGINT);
 CREATE UNIQUE INDEX `idx_syncer_peers_address` ON `syncer_peers`(`address`);


### PR DESCRIPTION
Seems like we forgot to remove the triggers from the schema when we removed them. So I did that here and added another migration to remove them.