### PR TITLE
Fix inconsistent URL escaping for the 'bucket' parameter

### DIFF
--- a/internal/utils/web.go
+++ b/internal/utils/web.go
@@ -94,9 +94,9 @@ func DoRequest(req *http.Request, resp interface{}) (http.Header, int, error) {
 	if r.StatusCode < 200 || r.StatusCode >= 300 {
 		lr := io.LimitReader(r.Body, 1<<20) // 1MiB
 		errMsg, _ := io.ReadAll(lr)
-		return http.Header{}, 0, fmt.Errorf("HTTP error: %s (status: %d)", string(errMsg), r.StatusCode)
+		return r.Header, r.StatusCode, fmt.Errorf("HTTP error: %s (status: %d)", string(errMsg), r.StatusCode)
 	} else if resp != nil {
-		return http.Header{}, 0, json.NewDecoder(r.Body).Decode(resp)
+		return r.Header, r.StatusCode, json.NewDecoder(r.Body).Decode(resp)
 	}
 	return r.Header, r.StatusCode, nil
 }

--- a/worker/client/client.go
+++ b/worker/client/client.go
@@ -94,7 +94,7 @@ func (c *Client) HeadObject(ctx context.Context, bucket, key string, opts api.He
 	c.c.Custom("HEAD", fmt.Sprintf("/object/%s", key), nil, nil)
 
 	values := url.Values{}
-	values.Set("bucket", url.QueryEscape(bucket))
+	values.Set("bucket", bucket)
 	opts.Apply(values)
 	key = api.ObjectKeyEscape(key)
 	key += "?" + values.Encode()
@@ -262,7 +262,7 @@ func (c *Client) NotifyEvent(ctx context.Context, e webhooks.Event) (err error) 
 
 func (c *Client) object(ctx context.Context, bucket, key string, opts api.DownloadObjectOptions) (_ io.ReadCloser, _ http.Header, err error) {
 	values := url.Values{}
-	values.Set("bucket", url.QueryEscape(bucket))
+	values.Set("bucket", bucket)
 	key += "?" + values.Encode()
 
 	c.c.Custom("GET", fmt.Sprintf("/object/%s", key), nil, (*[]api.ObjectMetadata)(nil))


### PR DESCRIPTION
We are inconsistent when it comes to escaping the bucket name in the query string. This PR makes the behaviour consistent and allows for bucket names with spaces in them. I'm wondering whether we should allow special characters in bucket names. If not we should add an assertion in create bucket.

Related to https://github.com/SiaFoundation/renterd/issues/1498