### PR TITLE
Compare recommended fee against contract price

### DIFF
--- a/api/bus.go
+++ b/api/bus.go
@@ -41,7 +41,6 @@ type (
 		ConsensusState     ConsensusState
 		GougingSettings    GougingSettings
 		RedundancySettings RedundancySettings
-		TransactionFee     types.Currency
 	}
 )
 

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -185,10 +185,6 @@ func (ap *Autopilot) configHandlerPOST(jc jape.Context) {
 	if jc.Check("failed to get consensus state", err) != nil {
 		return
 	}
-	fee, err := ap.bus.RecommendedFee(ctx)
-	if jc.Check("failed to get recommended fee", err) != nil {
-		return
-	}
 
 	// fetch hosts
 	hosts, err := ap.bus.SearchHosts(ctx, api.SearchHostOptions{Limit: -1, FilterMode: api.HostFilterModeAllowed})
@@ -197,7 +193,7 @@ func (ap *Autopilot) configHandlerPOST(jc jape.Context) {
 	}
 
 	// evaluate the config
-	res, err := contractor.EvaluateConfig(reqCfg, cs, fee, rs, gs, hosts)
+	res, err := contractor.EvaluateConfig(reqCfg, cs, rs, gs, hosts)
 	if errors.Is(err, contractor.ErrMissingRequiredFields) {
 		jc.Error(err, http.StatusBadRequest)
 		return

--- a/autopilot/contractor/evaluate.go
+++ b/autopilot/contractor/evaluate.go
@@ -10,8 +10,8 @@ import (
 
 var ErrMissingRequiredFields = errors.New("missing required fields in configuration, both allowance and amount must be set")
 
-func countUsableHosts(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Currency, period uint64, rs api.RedundancySettings, gs api.GougingSettings, hosts []api.Host) (usables uint64) {
-	gc := gouging.NewChecker(gs, cs, fee, &period, &cfg.Contracts.RenewWindow)
+func countUsableHosts(cfg api.AutopilotConfig, cs api.ConsensusState, period uint64, rs api.RedundancySettings, gs api.GougingSettings, hosts []api.Host) (usables uint64) {
+	gc := gouging.NewChecker(gs, cs, &period, &cfg.Contracts.RenewWindow)
 	for _, host := range hosts {
 		hc := checkHost(gc, scoreHost(host, cfg, rs.Redundancy()), minValidScore)
 		if hc.Usability.IsUsable() {
@@ -24,14 +24,14 @@ func countUsableHosts(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.
 // EvaluateConfig evaluates the given configuration and if the gouging settings
 // are too strict for the number of contracts required by 'cfg', it will provide
 // a recommendation on how to loosen it.
-func EvaluateConfig(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Currency, rs api.RedundancySettings, gs api.GougingSettings, hosts []api.Host) (resp api.ConfigEvaluationResponse, _ error) {
+func EvaluateConfig(cfg api.AutopilotConfig, cs api.ConsensusState, rs api.RedundancySettings, gs api.GougingSettings, hosts []api.Host) (resp api.ConfigEvaluationResponse, _ error) {
 	// we need an allowance and a target amount of contracts to evaluate
 	if cfg.Contracts.Allowance.IsZero() || cfg.Contracts.Amount == 0 {
 		return api.ConfigEvaluationResponse{}, ErrMissingRequiredFields
 	}
 
 	period := cfg.Contracts.Period
-	gc := gouging.NewChecker(gs, cs, fee, &period, &cfg.Contracts.RenewWindow)
+	gc := gouging.NewChecker(gs, cs, &period, &cfg.Contracts.RenewWindow)
 
 	resp.Hosts = uint64(len(hosts))
 	for i, host := range hosts {
@@ -99,35 +99,35 @@ func EvaluateConfig(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Cu
 	// MaxRPCPrice
 	tmpGS := maxGS()
 	tmpGS.MaxRPCPrice = gs.MaxRPCPrice
-	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxRPCPrice, cfg, cs, fee, period, rs, hosts) {
+	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxRPCPrice, cfg, cs, period, rs, hosts) {
 		optimisedGS.MaxRPCPrice = tmpGS.MaxRPCPrice
 		success = true
 	}
 	// MaxContractPrice
 	tmpGS = maxGS()
 	tmpGS.MaxContractPrice = gs.MaxContractPrice
-	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxContractPrice, cfg, cs, fee, period, rs, hosts) {
+	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxContractPrice, cfg, cs, period, rs, hosts) {
 		optimisedGS.MaxContractPrice = tmpGS.MaxContractPrice
 		success = true
 	}
 	// MaxDownloadPrice
 	tmpGS = maxGS()
 	tmpGS.MaxDownloadPrice = gs.MaxDownloadPrice
-	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxDownloadPrice, cfg, cs, fee, period, rs, hosts) {
+	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxDownloadPrice, cfg, cs, period, rs, hosts) {
 		optimisedGS.MaxDownloadPrice = tmpGS.MaxDownloadPrice
 		success = true
 	}
 	// MaxUploadPrice
 	tmpGS = maxGS()
 	tmpGS.MaxUploadPrice = gs.MaxUploadPrice
-	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxUploadPrice, cfg, cs, fee, period, rs, hosts) {
+	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxUploadPrice, cfg, cs, period, rs, hosts) {
 		optimisedGS.MaxUploadPrice = tmpGS.MaxUploadPrice
 		success = true
 	}
 	// MaxStoragePrice
 	tmpGS = maxGS()
 	tmpGS.MaxStoragePrice = gs.MaxStoragePrice
-	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxStoragePrice, cfg, cs, fee, period, rs, hosts) {
+	if optimiseGougingSetting(&tmpGS, &tmpGS.MaxStoragePrice, cfg, cs, period, rs, hosts) {
 		optimisedGS.MaxStoragePrice = tmpGS.MaxStoragePrice
 		success = true
 	}
@@ -143,7 +143,7 @@ func EvaluateConfig(cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Cu
 
 // optimiseGougingSetting tries to optimise one field of the gouging settings to
 // try and hit the target number of contracts.
-func optimiseGougingSetting(gs *api.GougingSettings, field *types.Currency, cfg api.AutopilotConfig, cs api.ConsensusState, fee types.Currency, currentPeriod uint64, rs api.RedundancySettings, hosts []api.Host) bool {
+func optimiseGougingSetting(gs *api.GougingSettings, field *types.Currency, cfg api.AutopilotConfig, cs api.ConsensusState, currentPeriod uint64, rs api.RedundancySettings, hosts []api.Host) bool {
 	if cfg.Contracts.Amount == 0 {
 		return true // nothing to do
 	}
@@ -154,7 +154,7 @@ func optimiseGougingSetting(gs *api.GougingSettings, field *types.Currency, cfg 
 	nSteps := 0
 	prevVal := *field // to keep accurate value
 	for {
-		nUsable := countUsableHosts(cfg, cs, fee, currentPeriod, rs, *gs, hosts)
+		nUsable := countUsableHosts(cfg, cs, currentPeriod, rs, *gs, hosts)
 		targetHit := nUsable >= cfg.Contracts.Amount
 
 		if targetHit && nSteps == 0 {

--- a/autopilot/contractor/evaluate_test.go
+++ b/autopilot/contractor/evaluate_test.go
@@ -56,7 +56,6 @@ func TestOptimiseGougingSetting(t *testing.T) {
 		LastBlockTime: api.TimeNow(),
 		Synced:        true,
 	}
-	fee := types.ZeroCurrency
 	rs := api.RedundancySettings{MinShards: 10, TotalShards: 30}
 	gs := api.GougingSettings{
 		MaxRPCPrice:           types.Siacoins(1),
@@ -70,7 +69,7 @@ func TestOptimiseGougingSetting(t *testing.T) {
 	// confirm all hosts are usable
 	assertUsable := func(n int) {
 		t.Helper()
-		nUsable := countUsableHosts(cfg, cs, fee, 0, rs, gs, hosts)
+		nUsable := countUsableHosts(cfg, cs, 0, rs, gs, hosts)
 		if nUsable != uint64(n) {
 			t.Fatalf("expected %v usable hosts, got %v", len(hosts), nUsable)
 		}
@@ -82,7 +81,7 @@ func TestOptimiseGougingSetting(t *testing.T) {
 		hosts[i].Settings.StoragePrice = types.Siacoins(uint32(i + 1))
 	}
 	assertUsable(1)
-	if !optimiseGougingSetting(&gs, &gs.MaxStoragePrice, cfg, cs, fee, 0, rs, hosts) {
+	if !optimiseGougingSetting(&gs, &gs.MaxStoragePrice, cfg, cs, 0, rs, hosts) {
 		t.Fatal("optimising failed")
 	}
 	assertUsable(len(hosts))
@@ -94,7 +93,7 @@ func TestOptimiseGougingSetting(t *testing.T) {
 	// hosts
 	hosts[0].Settings.StoragePrice = types.Siacoins(100000)
 	assertUsable(9)
-	if optimiseGougingSetting(&gs, &gs.MaxStoragePrice, cfg, cs, fee, 0, rs, hosts) {
+	if optimiseGougingSetting(&gs, &gs.MaxStoragePrice, cfg, cs, 0, rs, hosts) {
 		t.Fatal("optimising succeeded")
 	}
 	if gs.MaxStoragePrice.ExactString() != "41631744000000000000000000000" { // ~41.63 KS
@@ -107,7 +106,7 @@ func TestOptimiseGougingSetting(t *testing.T) {
 	}
 	gs.MaxStoragePrice = types.MaxCurrency.Sub(types.Siacoins(1))
 	assertUsable(0)
-	if optimiseGougingSetting(&gs, &gs.MaxStoragePrice, cfg, cs, fee, 0, rs, hosts) {
+	if optimiseGougingSetting(&gs, &gs.MaxStoragePrice, cfg, cs, 0, rs, hosts) {
 		t.Fatal("optimising succeeded")
 	}
 	if gs.MaxStoragePrice.ExactString() != "340282366920937463463374607431768211455" { // ~340.3 TS

--- a/autopilot/contractor/state.go
+++ b/autopilot/contractor/state.go
@@ -75,7 +75,7 @@ func (ctx *mCtx) Err() error {
 
 func (ctx *mCtx) GougingChecker(cs api.ConsensusState) gouging.Checker {
 	period, renewWindow := ctx.Period(), ctx.RenewWindow()
-	return gouging.NewChecker(ctx.state.GS, cs, ctx.state.Fee, &period, &renewWindow)
+	return gouging.NewChecker(ctx.state.GS, cs, &period, &renewWindow)
 }
 
 func (ctx *mCtx) HostScore(h api.Host) (sb api.HostScoreBreakdown, err error) {

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -872,7 +872,7 @@ func (b *Bus) renewContract(ctx context.Context, cs consensus.State, gp api.Goug
 	}
 
 	// renew contract
-	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState, gp.TransactionFee, nil, nil)
+	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState, nil, nil)
 	renterKey := b.deriveRenterKey(c.HostKey)
 	prepareRenew := b.prepareRenew(cs, rev, hs.Address, b.w.Address(), renterFunds, minNewCollateral, maxFundAmount, endHeight, expectedNewStorage)
 	newRevision, txnSet, contractPrice, fundAmount, err := b.rhp3.Renew(ctx, gc, rev, renterKey, c.HostKey, c.SiamuxAddr, prepareRenew, b.w.SignTransaction)

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -885,7 +885,7 @@ func (b *Bus) contractPruneHandlerPOST(jc jape.Context) {
 	if jc.Check("couldn't fetch gouging parameters", err) != nil {
 		return
 	}
-	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState, gp.TransactionFee, nil, nil)
+	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState, nil, nil)
 
 	// apply timeout
 	pruneCtx := ctx
@@ -1874,7 +1874,6 @@ func (b *Bus) gougingParams(ctx context.Context) (api.GougingParams, error) {
 		ConsensusState:     cs,
 		GougingSettings:    gs,
 		RedundancySettings: rs,
-		TransactionFee:     b.cm.RecommendedFee(),
 	}, nil
 }
 
@@ -2425,7 +2424,7 @@ func (b *Bus) contractsFormHandler(jc jape.Context) {
 	if jc.Check("could not get gouging parameters", err) != nil {
 		return
 	}
-	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState, gp.TransactionFee, nil, nil)
+	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState, nil, nil)
 
 	// fetch host settings
 	settings, err := b.rhp2.Settings(ctx, rfr.HostKey, rfr.HostIP)

--- a/internal/gouging/gouging.go
+++ b/internal/gouging/gouging.go
@@ -215,7 +215,7 @@ func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, pt *rhpv
 	}
 
 	// check TxnFeeMaxRecommended - expect it to be lower or equal than the max contract price
-	if pt.TxnFeeMaxRecommended.Mul64(4096).Cmp(gs.MaxContractPrice) > 0 {
+	if !gs.MaxContractPrice.IsZero() && pt.TxnFeeMaxRecommended.Mul64(4096).Cmp(gs.MaxContractPrice) > 0 {
 		return fmt.Errorf("TxnFeeMaxRecommended %v exceeds %v", pt.TxnFeeMaxRecommended, gs.MaxContractPrice.Div64(4096))
 	}
 

--- a/internal/gouging/gouging.go
+++ b/internal/gouging/gouging.go
@@ -51,7 +51,6 @@ type (
 	checker struct {
 		consensusState api.ConsensusState
 		settings       api.GougingSettings
-		txFee          types.Currency
 
 		period      *uint64
 		renewWindow *uint64
@@ -60,11 +59,10 @@ type (
 
 var _ Checker = checker{}
 
-func NewChecker(gs api.GougingSettings, cs api.ConsensusState, txnFee types.Currency, period, renewWindow *uint64) Checker {
+func NewChecker(gs api.GougingSettings, cs api.ConsensusState, period, renewWindow *uint64) Checker {
 	return checker{
 		consensusState: cs,
 		settings:       gs,
-		txFee:          txnFee,
 
 		period:      period,
 		renewWindow: renewWindow,
@@ -93,7 +91,7 @@ func (gc checker) Check(hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable) api.Ho
 		),
 		DownloadErr: errsToStr(checkDownloadGougingRHPv3(gc.settings, pt)),
 		GougingErr: errsToStr(
-			checkPriceGougingPT(gc.settings, gc.consensusState, gc.txFee, pt),
+			checkPriceGougingPT(gc.settings, gc.consensusState, pt),
 			checkPriceGougingHS(gc.settings, hs),
 		),
 		PruneErr:  errsToStr(checkPruneGougingRHPv2(gc.settings, hs)),
@@ -158,7 +156,7 @@ func checkPriceGougingHS(gs api.GougingSettings, hs *rhpv2.HostSettings) error {
 // TODO: if we ever stop assuming that certain prices in the pricetable are
 // always set to 1H we should account for those fields in
 // `hostPeriodCostForScore` as well.
-func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, txnFee types.Currency, pt *rhpv3.HostPriceTable) error {
+func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, pt *rhpv3.HostPriceTable) error {
 	// check if we have a price table
 	if pt == nil {
 		return nil
@@ -216,9 +214,9 @@ func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, txnFee t
 		}
 	}
 
-	// check TxnFeeMaxRecommended - expect at most a multiple of our fee
-	if !txnFee.IsZero() && pt.TxnFeeMaxRecommended.Cmp(txnFee.Mul64(5)) > 0 {
-		return fmt.Errorf("TxnFeeMaxRecommended %v exceeds %v", pt.TxnFeeMaxRecommended, txnFee.Mul64(5))
+	// check TxnFeeMaxRecommended - expect it to be lower or equal than the max contract price
+	if pt.TxnFeeMaxRecommended.Mul64(4096).Cmp(gs.MaxContractPrice) > 0 {
+		return fmt.Errorf("TxnFeeMaxRecommended %v exceeds %v", pt.TxnFeeMaxRecommended, gs.MaxContractPrice.Div64(4096))
 	}
 
 	// check TxnFeeMinRecommended - expect it to be lower or equal than the max

--- a/internal/worker/cache.go
+++ b/internal/worker/cache.go
@@ -233,7 +233,6 @@ func (c *cache) handleConsensusUpdate(event api.EventConsensusUpdate) {
 	// update gouging params
 	gp := value.(api.GougingParams)
 	gp.ConsensusState = event.ConsensusState
-	gp.TransactionFee = event.TransactionFee
 	c.cache.Set(cacheKeyGougingParams, gp)
 }
 

--- a/internal/worker/cache_test.go
+++ b/internal/worker/cache_test.go
@@ -55,7 +55,6 @@ func newMockBus() *mockBus {
 		gougingParams: api.GougingParams{
 			RedundancySettings: test.RedundancySettings,
 			GougingSettings:    test.GougingSettings,
-			TransactionFee:     types.Siacoins(1),
 			ConsensusState: api.ConsensusState{
 				BlockHeight:   1,
 				LastBlockTime: api.TimeRFC3339{},
@@ -92,8 +91,6 @@ func TestWorkerCache(t *testing.T) {
 		t.Fatal("expected redundancy settings to match", gp.RedundancySettings, test.RedundancySettings)
 	} else if gp.GougingSettings != test.GougingSettings {
 		t.Fatal("expected gouging settings to match", gp.GougingSettings, test.GougingSettings)
-	} else if !gp.TransactionFee.Equals(types.Siacoins(1)) {
-		t.Fatal("expected transaction fee to match", gp.TransactionFee, types.Siacoins(1))
 	}
 
 	// assert warnings are printed when the cache is not ready yet
@@ -143,7 +140,7 @@ func TestWorkerCache(t *testing.T) {
 	}
 
 	// update gouging params & expire cache entry manually
-	b.gougingParams.TransactionFee = b.gougingParams.TransactionFee.Mul64(2)
+	b.gougingParams.ConsensusState.BlockHeight += 1
 
 	// expire cache entry manually
 	mc.mu.Lock()
@@ -154,8 +151,6 @@ func TestWorkerCache(t *testing.T) {
 	gp, err = c.GougingParams(context.Background())
 	if err != nil {
 		t.Fatal(err)
-	} else if !gp.TransactionFee.Equals(b.gougingParams.TransactionFee) {
-		t.Fatal("expected transaction fee to be updated, got", gp.TransactionFee)
 	} else if logs := observedLogs.FilterLevelExact(zap.WarnLevel); logs.Len() != 1 {
 		t.Fatal("expected 1 warning, got", logs.Len(), logs.All())
 	} else if lines := observedLogs.TakeAll(); !strings.Contains(lines[0].Message, errCacheOutdated.Error()) || !strings.Contains(lines[0].Message, cacheKeyGougingParams) {

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/internal/gouging"
 )
@@ -29,11 +28,11 @@ func WithGougingChecker(ctx context.Context, cs gouging.ConsensusState, gp api.G
 		if err != nil {
 			return nil, fmt.Errorf("failed to get consensus state: %w", err)
 		}
-		return newGougingChecker(gp.GougingSettings, cs, gp.TransactionFee, criticalMigration), nil
+		return newGougingChecker(gp.GougingSettings, cs, criticalMigration), nil
 	})
 }
 
-func newGougingChecker(settings api.GougingSettings, cs api.ConsensusState, txnFee types.Currency, criticalMigration bool) gouging.Checker {
+func newGougingChecker(settings api.GougingSettings, cs api.ConsensusState, criticalMigration bool) gouging.Checker {
 	// adjust the max download price if we are dealing with a critical
 	// migration that might be failing due to gouging checks
 	if criticalMigration && settings.MigrationSurchargeMultiplier > 0 {
@@ -41,5 +40,5 @@ func newGougingChecker(settings api.GougingSettings, cs api.ConsensusState, txnF
 			settings.MaxDownloadPrice = adjustedMaxDownloadPrice
 		}
 	}
-	return gouging.NewChecker(settings, cs, txnFee, nil, nil)
+	return gouging.NewChecker(settings, cs, nil, nil)
 }


### PR DESCRIPTION
Icarus experienced large contract churn on 9/20 around 10pm, ~60 contracts got removed from the set. The logs indicate hosts were considered gouging because their recommended transaction fee exceeded a certain amount.  We hit a renew window around that time as well as a considerable drop in hash rate (40%), the theory is that the transaction pool clogged up causing the hosts to set higher transaction fees, which in turn caused renters to flip out about it.

We use the recommended fee when we renew contracts with the host. It's expressed as a fee per byte so we multiply it by `4096`. This PR updates the gouging checks to compare the recommended fee against the max contract price, essentially protection against the same exploit but with a (configurable) setting that's a bit more lenient.