### PR TITLE
Fix superfluous response.WriteHeader call

### DIFF
--- a/bus/routes.go
+++ b/bus/routes.go
@@ -1018,12 +1018,13 @@ func (b *Bus) contractIDRenewHandlerPOST(jc jape.Context) {
 	// validate the request
 	if rrr.EndHeight == 0 {
 		http.Error(jc.ResponseWriter, "EndHeight can not be zero", http.StatusBadRequest)
+		return
 	} else if rrr.ExpectedNewStorage == 0 {
 		http.Error(jc.ResponseWriter, "ExpectedNewStorage can not be zero", http.StatusBadRequest)
+		return
 	} else if rrr.MaxFundAmount.IsZero() {
 		http.Error(jc.ResponseWriter, "MaxFundAmount can not be zero", http.StatusBadRequest)
-	} else if rrr.MinNewCollateral.IsZero() {
-		http.Error(jc.ResponseWriter, "MinNewCollateral can not be zero", http.StatusBadRequest)
+		return
 	} else if rrr.RenterFunds.IsZero() {
 		http.Error(jc.ResponseWriter, "RenterFunds can not be zero", http.StatusBadRequest)
 		return


### PR DESCRIPTION
I occasionally saw "superfluous response.WriteHeader call" in testing and decided to trace it down today. Turns out it comes from the renew handler. We also assert `MinNewCollateral` can't be zero but I think it can.