### PR TITLE
Handle renaming of directories

### DIFF
--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -2184,6 +2184,10 @@ func TestRecordContractSpending(t *testing.T) {
 		t.Fatalf("unexpected size or revision number, %v %v", cm2.Size, cm2.RevisionNumber)
 	}
 }
+
+// TestRenameDirectory is a regression test that ensures renaming directories
+// doesn't orphan its children and properly updates the directory entry in the
+// database.
 func TestRenameDirectory(t *testing.T) {
 	ss := newTestSQLStore(t, defaultTestSQLStoreConfig)
 	defer ss.Close()

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -275,7 +275,7 @@ type (
 		// under the new directory specified by dirID. If the object with keyOld
 		// does not exist, api.ErrObjectNotFound is returned. If the object with
 		// keyNew already exists, api.ErrObjectExists is returned unless the
-		// rename is done by force in which case the existing object will be
+		// rename is done by force, in which case the existing object will be
 		// deleted.
 		RenameObject(ctx context.Context, bucket, keyOld, keyNew string, dirID int64, force bool) error
 

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -272,10 +272,10 @@ type (
 		RemoveOfflineHosts(ctx context.Context, minRecentFailures uint64, maxDownTime time.Duration) (int64, error)
 
 		// RenameObject renames an object in the database from keyOld to keyNew
-		// and the new directory dirID. returns api.ErrObjectExists if the an
-		// object already exists at the target location or api.ErrObjectNotFound
-		// if the object at keyOld doesn't exist. If force is true, the instead
-		// of returning api.ErrObjectExists, the existing object will be
+		// under the new directory specified by dirID. If the object with keyOld
+		// does not exist, api.ErrObjectNotFound is returned. If the object with
+		// keyNew already exists, api.ErrObjectExists is returned unless the
+		// rename is done by force in which case the existing object will be
 		// deleted.
 		RenameObject(ctx context.Context, bucket, keyOld, keyNew string, dirID int64, force bool) error
 


### PR DESCRIPTION
This PR ensures that we properly handle renaming of directories. I'm keeping it as a `DRAFT` for a little while longer to extend the testing but also to ensure this is the right approach. I have yet to check whether delimiter vs no delimiter (for S3) is at play here. I was also quite surprised to find directories are not scoped to buckets. 

Fixes #1599