### PR TITLE
Fix bug when renaming multiple objects

### DIFF
--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -452,9 +452,9 @@ func TestObjectsWithDelimiterSlash(t *testing.T) {
 			entries[i].ModTime = api.TimeRFC3339{}
 
 			// assert mime type
-			isDir := strings.HasSuffix(entries[i].Key, "/") && entries[i].Key != "//double/" // double is a file
+			isDir := strings.HasSuffix(entries[i].Key, "/")
 			if (isDir && entries[i].MimeType != "") || (!isDir && entries[i].MimeType == "") {
-				t.Fatal("unexpected mime type", entries[i].MimeType)
+				t.Fatal("unexpected mime type", entries[i], entries[i].MimeType)
 			}
 			entries[i].MimeType = ""
 

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -452,7 +452,7 @@ func TestObjectsWithDelimiterSlash(t *testing.T) {
 			entries[i].ModTime = api.TimeRFC3339{}
 
 			// assert mime type
-			isDir := strings.HasSuffix(entries[i].Key, "/")
+			isDir := strings.HasSuffix(entries[i].Key, "/") && entries[i].Key != "//double/" // double is a file
 			if (isDir && entries[i].MimeType != "") || (!isDir && entries[i].MimeType == "") {
 				t.Fatal("unexpected mime type", entries[i], entries[i].MimeType)
 			}

--- a/object/path.go
+++ b/object/path.go
@@ -4,20 +4,22 @@ import "strings"
 
 // Directories returns the directories for the given path, excluding the root
 // directory.
-func Directories(path string) (dirs []string) {
-	lsc := 1
-	for {
-		path = strings.TrimPrefix(path, "/")
-		if !strings.HasPrefix(path, "/") {
-			break
-		}
-		lsc++
-		dirs = append(dirs, strings.Repeat("/", lsc))
+func Directories(path string, explicit bool) (dirs []string) {
+	if explicit {
+		path = strings.TrimSuffix(path, "/")
 	}
-
-	parts := strings.Split(path, "/")
-	for i := 1; i < len(parts); i++ {
-		dirs = append(dirs, strings.Repeat("/", lsc)+strings.Join(parts[:i], "/")+"/")
+	if path == "/" {
+		return nil
+	}
+	for i, r := range path {
+		if r != '/' {
+			continue
+		}
+		dir := path[:i+1]
+		if dir == "/" {
+			continue
+		}
+		dirs = append(dirs, dir)
 	}
 	return
 }

--- a/object/path.go
+++ b/object/path.go
@@ -2,8 +2,9 @@ package object
 
 import "strings"
 
-// Directories returns the directories for the given path, excluding the root
-// directory.
+// Directories returns the directories for the given path. When explicit is
+// true, the returned directories do not include the path itself should it be a
+// directory. The root path ('/') is always excluded.
 func Directories(path string, explicit bool) (dirs []string) {
 	if explicit {
 		path = strings.TrimSuffix(path, "/")

--- a/object/path.go
+++ b/object/path.go
@@ -1,0 +1,23 @@
+package object
+
+import "strings"
+
+// Directories returns the directories for the given path, excluding the root
+// directory.
+func Directories(path string) (dirs []string) {
+	lsc := 1
+	for {
+		path = strings.TrimPrefix(path, "/")
+		if !strings.HasPrefix(path, "/") {
+			break
+		}
+		lsc++
+		dirs = append(dirs, strings.Repeat("/", lsc))
+	}
+
+	parts := strings.Split(path, "/")
+	for i := 1; i < len(parts); i++ {
+		dirs = append(dirs, strings.Repeat("/", lsc)+strings.Join(parts[:i], "/")+"/")
+	}
+	return
+}

--- a/object/path_test.go
+++ b/object/path_test.go
@@ -25,5 +25,4 @@ func TestDirectories(t *testing.T) {
 			t.Fatalf("unexpected dirs for path %v (explicit %t), %v != %v", c.path, c.explicit, got, c.dirs)
 		}
 	}
-
 }

--- a/object/path_test.go
+++ b/object/path_test.go
@@ -1,0 +1,29 @@
+package object
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDirectories(t *testing.T) {
+	cases := []struct {
+		path     string
+		explicit bool
+		dirs     []string
+	}{
+		{"/", true, nil},
+		{"/", false, nil},
+		{"/foo", true, nil},
+		{"/foo", false, nil},
+		{"/foo/bar", true, []string{"/foo/"}},
+		{"/foo/bar", false, []string{"/foo/"}},
+		{"/foo/bar/", true, []string{"/foo/"}},
+		{"/foo/bar/", false, []string{"/foo/", "/foo/bar/"}},
+	}
+	for _, c := range cases {
+		if got := Directories(c.path, c.explicit); !reflect.DeepEqual(got, c.dirs) {
+			t.Fatalf("unexpected dirs for path %v (explicit %t), %v != %v", c.path, c.explicit, got, c.dirs)
+		}
+	}
+
+}

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -418,10 +418,10 @@ func (s *SQLStore) RenameObject(ctx context.Context, bucket, keyOld, keyNew stri
 func (s *SQLStore) RenameObjects(ctx context.Context, bucket, prefixOld, prefixNew string, force bool) error {
 	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		// create new dir
-		dirID, err := tx.InsertDirectories(ctx, object.Directories(prefixNew))
+		dirID, renamedIDs, err := tx.InsertDirectoriesForRename(ctx, prefixOld, prefixNew)
 		if err != nil {
 			return fmt.Errorf("RenameObjects: failed to create new directory: %w", err)
-		} else if err := tx.RenameObjects(ctx, bucket, prefixOld, prefixNew, dirID, force); err != nil {
+		} else if err := tx.RenameObjects(ctx, bucket, prefixOld, prefixNew, dirID, renamedIDs, force); err != nil {
 			return err
 		}
 		// prune old dirs

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -400,7 +400,7 @@ func (s *SQLStore) RecordContractSpending(ctx context.Context, records []api.Con
 func (s *SQLStore) RenameObject(ctx context.Context, bucket, keyOld, keyNew string, force bool) error {
 	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		// create new dir
-		dirID, err := tx.MakeDirsForPath(ctx, keyNew)
+		dirID, err := tx.InsertDirectories(ctx, object.Directories(keyNew))
 		if err != nil {
 			return err
 		}
@@ -418,7 +418,7 @@ func (s *SQLStore) RenameObject(ctx context.Context, bucket, keyOld, keyNew stri
 func (s *SQLStore) RenameObjects(ctx context.Context, bucket, prefixOld, prefixNew string, force bool) error {
 	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		// create new dir
-		dirID, err := tx.MakeDirsForPath(ctx, prefixNew)
+		dirID, err := tx.InsertDirectories(ctx, object.Directories(prefixNew))
 		if err != nil {
 			return fmt.Errorf("RenameObjects: failed to create new directory: %w", err)
 		} else if err := tx.RenameObjects(ctx, bucket, prefixOld, prefixNew, dirID, force); err != nil {
@@ -491,7 +491,7 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, key, contractSet, e
 		}
 
 		// create the dir
-		dirID, err := tx.MakeDirsForPath(ctx, key)
+		dirID, err := tx.InsertDirectories(ctx, object.Directories(key))
 		if err != nil {
 			return fmt.Errorf("failed to create directories for key '%s': %w", key, err)
 		}

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -400,7 +400,7 @@ func (s *SQLStore) RecordContractSpending(ctx context.Context, records []api.Con
 func (s *SQLStore) RenameObject(ctx context.Context, bucket, keyOld, keyNew string, force bool) error {
 	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		// create new dir
-		dirID, err := tx.InsertDirectories(ctx, object.Directories(keyNew))
+		dirID, err := tx.InsertDirectories(ctx, object.Directories(keyNew, true))
 		if err != nil {
 			return err
 		}
@@ -491,7 +491,7 @@ func (s *SQLStore) UpdateObject(ctx context.Context, bucket, key, contractSet, e
 		}
 
 		// create the dir
-		dirID, err := tx.InsertDirectories(ctx, object.Directories(key))
+		dirID, err := tx.InsertDirectories(ctx, object.Directories(key, true))
 		if err != nil {
 			return fmt.Errorf("failed to create directories for key '%s': %w", key, err)
 		}

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -4009,7 +4009,7 @@ func TestSlabCleanup(t *testing.T) {
 	var dirID int64
 	err = ss.db.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
 		var err error
-		dirID, err = tx.MakeDirsForPath(context.Background(), "1")
+		dirID, err = tx.InsertDirectories(context.Background(), object.Directories("1"))
 		return err
 	})
 	if err != nil {
@@ -4550,20 +4550,20 @@ func TestDirectories(t *testing.T) {
 	ss := newTestSQLStore(t, defaultTestSQLStoreConfig)
 	defer ss.Close()
 
-	objects := []string{
+	paths := []string{
 		"/foo",
-		"/bar/baz",
+		"/fileś/baz",
 		"///somefile",
 		"/dir/fakedir/",
 		"/",
-		"/bar/fileinsamedirasbefore",
+		"/fileś/fileinsamedirasbefore",
 	}
 
-	for _, o := range objects {
+	for _, o := range paths {
 		var dirID int64
 		err := ss.db.Transaction(context.Background(), func(tx sql.DatabaseTx) error {
 			var err error
-			dirID, err = tx.MakeDirsForPath(context.Background(), o)
+			dirID, err = tx.InsertDirectories(context.Background(), object.Directories(o))
 			return err
 		})
 		if err != nil {
@@ -4584,7 +4584,7 @@ func TestDirectories(t *testing.T) {
 			parentID: 0,
 		},
 		{
-			name:     "/bar/",
+			name:     "/fileś/",
 			id:       2,
 			parentID: 1,
 		},
@@ -4602,6 +4602,11 @@ func TestDirectories(t *testing.T) {
 			name:     "/dir/",
 			id:       5,
 			parentID: 1,
+		},
+		{
+			name:     "/dir/fakedir/",
+			id:       6,
+			parentID: 5,
 		},
 	}
 

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1289,7 +1289,7 @@ func TestObjectsExplicitDir(t *testing.T) {
 	}{
 		{"/", "", "", "", []api.ObjectMetadata{
 			{Key: "/dir/", Size: 1, Health: 0.5},
-			{Key: "/dir2/", Size: 2, Health: 1, ETag: "d34db33f", MimeType: testMimeType}, // has MimeType and ETag since it's a file
+			{ETag: "d34db33f", Key: "/dir2/", Size: 2, Health: 1, MimeType: testMimeType}, // has MimeType and ETag since it's a file
 		}},
 		{"/dir/", "", "", "", []api.ObjectMetadata{{ETag: "d34db33f", Key: "/dir/file", Size: 1, Health: 0.5, MimeType: testMimeType}}},
 	}

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -177,6 +177,16 @@ type (
 		// that was created.
 		InsertBufferedSlab(ctx context.Context, fileName string, contractSetID int64, ec object.EncryptionKey, minShards, totalShards uint8) (int64, error)
 
+		// InsertDirectories inserts the given directories and returns the ID of
+		// the child directory.
+		InsertDirectories(ctx context.Context, dirs []string) (int64, error)
+
+		// InsertDirectoriesForRename will insert directories for the new prefix
+		// and return the ID of the child directory as well as a mapping for the
+		// old directories to the new. This is necessary so the corresponding
+		// directory IDs on the objects can be updated accordingly.
+		InsertDirectoriesForRename(ctx context.Context, prefixOld, prefixNew string) (int64, []int64, error)
+
 		// InsertMultipartUpload creates a new multipart upload and returns a
 		// unique upload ID.
 		InsertMultipartUpload(ctx context.Context, bucket, key string, ec object.EncryptionKey, mimeType string, metadata api.ObjectUserMetadata) (string, error)
@@ -187,10 +197,6 @@ type (
 		// InvalidateSlabHealthByFCID invalidates the health of all slabs that
 		// are associated with any of the provided contracts.
 		InvalidateSlabHealthByFCID(ctx context.Context, fcids []types.FileContractID, limit int64) (int64, error)
-
-		// InsertDirectories inserts the given directories and returns the ID of
-		// the child directory.
-		InsertDirectories(ctx context.Context, dirs []string) (int64, error)
 
 		// MarkPackedSlabUploaded marks the packed slab as uploaded in the
 		// database, causing the provided shards to be associated with the slab.
@@ -286,7 +292,7 @@ type (
 		// `api.ErrOBjectNotFound` is returned. If 'force' is false and an
 		// object already exists with the new prefix, `api.ErrObjectExists` is
 		// returned.
-		RenameObjects(ctx context.Context, bucket, prefixOld, prefixNew string, dirID int64, force bool) error
+		RenameObjects(ctx context.Context, bucket, prefixOld, prefixNew string, dirID int64, renamedIDs []int64, force bool) error
 
 		// RenewedContract returns the metadata of the contract that was renewed
 		// from the specified contract or ErrContractNotFound otherwise.

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -188,8 +188,9 @@ type (
 		// are associated with any of the provided contracts.
 		InvalidateSlabHealthByFCID(ctx context.Context, fcids []types.FileContractID, limit int64) (int64, error)
 
-		// MakeDirsForPath creates all directories for a given object's path.
-		MakeDirsForPath(ctx context.Context, path string) (int64, error)
+		// InsertDirectories inserts the given directories and returns the ID of
+		// the child directory.
+		InsertDirectories(ctx context.Context, dirs []string) (int64, error)
 
 		// MarkPackedSlabUploaded marks the packed slab as uploaded in the
 		// database, causing the provided shards to be associated with the slab.

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -2097,6 +2097,19 @@ WHERE fcid = ?`,
 	return nil
 }
 
+func UpdateObjectDirectorIdExpr(dirIds []int64) string {
+	if len(dirIds) == 0 {
+		return "db_directory_id = ?"
+	}
+
+	expr := "db_directory_id = CASE "
+	for i := 0; i < len(dirIds); i += 2 {
+		expr += fmt.Sprintf("WHEN db_directory_id = ? THEN ? ")
+	}
+	expr += "ELSE db_directory_id = ? END"
+	return expr
+}
+
 func UpdatePeerInfo(ctx context.Context, tx sql.Tx, addr string, fn func(*syncer.PeerInfo)) error {
 	info, err := PeerInfo(ctx, tx, addr)
 	if err != nil {

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -2126,7 +2126,7 @@ func UpdateObjectDirectorIdExpr(dirIds []int64) string {
 
 	expr := "db_directory_id = CASE "
 	for i := 0; i < len(dirIds); i += 2 {
-		expr += fmt.Sprintf("WHEN db_directory_id = ? THEN ? ")
+		expr += "WHEN db_directory_id = ? THEN ? "
 	}
 	expr += "ELSE CASE WHEN size = 0 THEN db_directory_id ELSE ? END END"
 	return expr

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -2128,7 +2128,7 @@ func UpdateObjectDirectorIdExpr(dirIds []int64) string {
 	for i := 0; i < len(dirIds); i += 2 {
 		expr += fmt.Sprintf("WHEN db_directory_id = ? THEN ? ")
 	}
-	expr += "ELSE db_directory_id = ? END"
+	expr += "ELSE CASE WHEN size = 0 THEN db_directory_id ELSE ? END END"
 	return expr
 }
 

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -73,7 +73,7 @@ func (b *MainDatabase) LoadSlabBuffers(ctx context.Context) ([]ssql.LoadedSlabBu
 
 func (b *MainDatabase) MakeDirsForPath(ctx context.Context, tx sql.Tx, path string) (int64, error) {
 	mtx := b.wrapTxn(tx)
-	return mtx.InsertDirectories(ctx, object.Directories(path))
+	return mtx.InsertDirectories(ctx, object.Directories(path, true))
 }
 
 func (b *MainDatabase) Migrate(ctx context.Context) error {
@@ -235,7 +235,7 @@ func (tx *MainDatabaseTx) CompleteMultipartUpload(ctx context.Context, bucket, k
 	}
 
 	// create the directory.
-	dirID, err := tx.InsertDirectories(ctx, object.Directories(key))
+	dirID, err := tx.InsertDirectories(ctx, object.Directories(key, true))
 	if err != nil {
 		return "", fmt.Errorf("failed to create directory for key %s: %w", key, err)
 	}
@@ -513,7 +513,7 @@ func (tx *MainDatabaseTx) InsertDirectoriesForRename(ctx context.Context, prefix
 	// prepare a helper that inserts all directories for given path
 	insertDirectories := func(path string) (int64, error) {
 		dirID := int64(sql.DirectoriesRootID)
-		for _, dir := range object.Directories(path) {
+		for _, dir := range object.Directories(path, false) {
 			if res, err := insertDirStmt.Exec(ctx, dir, dirID); err != nil {
 				return 0, fmt.Errorf("failed to create directory %v: %w", dir, err)
 			} else if childID, err := res.LastInsertId(); err != nil {
@@ -818,13 +818,16 @@ func (tx *MainDatabaseTx) RenameObjects(ctx context.Context, bucket, prefixOld, 
 				SELECT CONCAT(?, SUBSTR(object_id, ?))
 				FROM objects
 				WHERE object_id LIKE ?
+				AND SUBSTR(object_id, 1, ?) = ?
 				AND db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?)
 			) as i
-		)`,
+		) OR (object_id = ? AND size = 0)`,
 			prefixNew,
 			utf8.RuneCountInString(prefixOld)+1,
 			prefixOld+"%",
-			bucket)
+			utf8.RuneCountInString(prefixOld), prefixOld,
+			bucket,
+			prefixNew)
 		if err != nil {
 			return err
 		}
@@ -836,6 +839,7 @@ func (tx *MainDatabaseTx) RenameObjects(ctx context.Context, bucket, prefixOld, 
 		SET object_id = CONCAT(?, SUBSTR(object_id, ?)),
 		%s
 		WHERE object_id LIKE ?
+		AND SUBSTR(object_id, 1, ?) = ?
 		AND db_bucket_id = (SELECT id FROM buckets WHERE buckets.name = ?)`, ssql.UpdateObjectDirectorIdExpr(renamedIDs))
 
 	// build arguments
@@ -846,6 +850,7 @@ func (tx *MainDatabaseTx) RenameObjects(ctx context.Context, bucket, prefixOld, 
 	args = append(args,
 		dirID,
 		prefixOld+"%",
+		utf8.RuneCountInString(prefixOld), prefixOld,
 		bucket,
 	)
 	resp, err := tx.Exec(ctx, query, args...)

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -80,6 +80,10 @@ func (b *MainDatabase) Migrate(ctx context.Context) error {
 	return sql.PerformMigrations(ctx, b, migrationsFs, "main", sql.MainMigrations(ctx, b, migrationsFs, b.log))
 }
 
+func (b *MainDatabase) ObjectsWithCorruptedDirectoryID(ctx context.Context, tx sql.Tx) ([]sql.Object, error) {
+	return ssql.ObjectsWithCorruptedDirectoryID(ctx, tx)
+}
+
 func (b *MainDatabase) Transaction(ctx context.Context, fn func(tx ssql.DatabaseTx) error) error {
 	return b.db.Transaction(ctx, func(tx sql.Tx) error {
 		return fn(b.wrapTxn(tx))

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -498,6 +498,10 @@ func (tx *MainDatabaseTx) InsertDirectories(ctx context.Context, dirs []string) 
 	return dirID, nil
 }
 
+func (tx *MainDatabaseTx) InsertDirectoriesForRename(ctx context.Context, prefixOld, prefixNew string) (int64, []int64, error) {
+	panic("TODO")
+}
+
 func (tx *MainDatabaseTx) MarkPackedSlabUploaded(ctx context.Context, slab api.UploadedPackedSlab) (string, error) {
 	return ssql.MarkPackedSlabUploaded(ctx, tx, slab)
 }
@@ -738,7 +742,7 @@ func (tx *MainDatabaseTx) RenameObject(ctx context.Context, bucket, keyOld, keyN
 	return nil
 }
 
-func (tx *MainDatabaseTx) RenameObjects(ctx context.Context, bucket, prefixOld, prefixNew string, dirID int64, force bool) error {
+func (tx *MainDatabaseTx) RenameObjects(ctx context.Context, bucket, prefixOld, prefixNew string, dirID int64, renamedIDs []int64, force bool) error {
 	if force {
 		_, err := tx.Exec(ctx, `
 		DELETE

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -531,24 +531,31 @@ func (tx *MainDatabaseTx) InsertDirectoriesForRename(ctx context.Context, prefix
 		return 0, nil, fmt.Errorf("failed to create root directory: %w", err)
 	}
 
-	// create a mapping of existing directories to renamed directories
-	var mapping []int64
+	// fetch directories with given prefix
 	rows, err := tx.Query(ctx, "SELECT id, name FROM directories WHERE name LIKE ?", prefixOld+"%")
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to fetch existing directories: %w", err)
 	}
 	defer rows.Close()
+
+	dirs := make(map[string]int64)
 	for rows.Next() {
-		var dirID int64
-		var dirName string
-		if err := rows.Scan(&dirID, &dirName); err != nil {
+		var id int64
+		var name string
+		if err := rows.Scan(&id, &name); err != nil {
 			return 0, nil, fmt.Errorf("failed to scan directory: %w", err)
 		}
-		renamedDirID, err := insertDirectories(strings.Replace(dirName, prefixOld, prefixNew, 1))
+		dirs[name] = id
+	}
+
+	// create a mapping of existing directories to renamed directories
+	var mapping []int64
+	for name, id := range dirs {
+		renamedDirID, err := insertDirectories(strings.Replace(name, prefixOld, prefixNew, 1))
 		if err != nil {
 			return 0, nil, err
 		}
-		mapping = append(mapping, dirID, renamedDirID)
+		mapping = append(mapping, id, renamedDirID)
 	}
 
 	// create directories for the new prefix

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -79,6 +79,10 @@ func (b *MainDatabase) Migrate(ctx context.Context) error {
 	return sql.PerformMigrations(ctx, b, migrationsFs, "main", sql.MainMigrations(ctx, b, migrationsFs, b.log))
 }
 
+func (b *MainDatabase) ObjectsWithCorruptedDirectoryID(ctx context.Context, tx sql.Tx) ([]sql.Object, error) {
+	return ssql.ObjectsWithCorruptedDirectoryID(ctx, tx)
+}
+
 func (b *MainDatabase) Transaction(ctx context.Context, fn func(tx ssql.DatabaseTx) error) error {
 	return b.db.Transaction(ctx, func(tx sql.Tx) error {
 		return fn(b.wrapTxn(tx))


### PR DESCRIPTION
This was quite the rabbit hole, I'll try and concisely describe:
- how we use directories
- what happens when you add an object
- what happens when you rename an object
- what happens when you rename multiple objects, and how it went wrong
- what I had to do to fix it

Aside from the above I noticed `MakeDirsForPath` doesn't work properly handle multi-byte UTF-8 characters because we use `utf8.RuneCountInString` and then access the bytes of the string at certain position, not the runes.

This PR also adds a migration which queries the objects that were corrupted by a rename and recreates their directory structure and points them to the proper parent. Has to be tested still on `arequipa` or another node that has corrupted directory structure.

Fixes https://github.com/SiaFoundation/renterd/issues/1599

- - - - 

1. Directories
In `renterd` every object is linked to a directory. Important to note here is that directories are not scoped to a bucket. Objects from different buckets can point to the same directory if the path from the root is identical. They are merely used to store structure and to speed up listing queries.

2. Adding an object
When you add an object we pre-create the directories using `MakeDirsForPath`. What's important about this method is that it returns the ID of the parent directory, which we'll use when we insert the object. Another important thing to mention is that if you supply it a path that ends with a `/` it will return the ID of the parent folder.

3. Renaming objects
When we rename an object we pre-create the directories again using `MakeDirsForPath`. We then update existing objects and update the key of an object to whatever renamed value. Important here is that the target object can already exist, in which case a rename fails unless you rename by force.

4. Renaming multiple objects
Renaming multiple objects is used in the UI to rename folder names. That makes sense because you want all contents of that folder to still be in the same place after renaming the folder. This feature reuses `MakeDirsForPath`, and this was the problem because we use whatever parent directory ID to set as the directory ID of the objects we are renaming.

Imagine having a file (and directory structure) like `/firefly/s1/ep1` and I want to rename `s1` to `s01`. I would make directories for this new path and `MakeDirsForPath` would return me the ID of the `firefly` directory. It would then go and update the episode 1 and point it to the firefly directory -> wreaking total havoc

5. To fix it I had to change two things:

- I added `InsertDirectoriesForRename` which return a mapping of old directory IDs to renamed directory IDs
- I added a helper method `object.Directories` which return directories for a path, it takes a special boolean that returns the path itself should the path be a directory (this is important when we rename multiple objects at a time)

This very quickly becomes quite complicated because the UI also creates dummy objects for directories. Typing it all out here is quite lengthy so for now I'll refer to `TestRenameObjectsRegression` where I showcase some tricky renames in a regression test.
