### PR TITLE
Build binaries with `netgo`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,8 @@ on:
       - master
       - dev
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-**'
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-**"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -56,12 +56,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [ amd64, arm64 ]
+        arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: "stable"
       - name: Setup
         run: |
           go generate ./...
@@ -78,7 +78,7 @@ jobs:
         run: |
           mkdir -p release
           ZIP_OUTPUT=release/renterd_${GOOS}_${GOARCH}.zip
-          go build -trimpath -o bin/ -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
+          go build -trimpath -o bin/ -tags='netgo timetzdata' -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
           cp README.md LICENSE bin/
           zip -qj $ZIP_OUTPUT bin/*
       - uses: actions/upload-artifact@v4
@@ -89,12 +89,12 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        arch: [ amd64, arm64 ]
+        arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: "stable"
       - name: Setup Notarization
         env:
           APPLE_CERT_ID: ${{ secrets.APPLE_CERT_ID }}
@@ -143,7 +143,7 @@ jobs:
         run: |
           mkdir -p release
           ZIP_OUTPUT=release/renterd${{ env.ZIP_OUTPUT_SUFFIX }}_${GOOS}_${GOARCH}.zip
-          go build -trimpath -o bin/ -a -ldflags '-s -w' ./cmd/renterd
+          go build -trimpath -o bin/ -tags='netgo timetzdata' -a -ldflags '-s -w' ./cmd/renterd
           cp README.md LICENSE bin/
           /usr/bin/codesign --deep -f -v --timestamp -o runtime,library -s $APPLE_CERT_ID bin/renterd
           ditto -ck bin $ZIP_OUTPUT
@@ -156,12 +156,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        arch: [ amd64 ]
+        arch: [amd64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: "stable"
       - name: Setup
         shell: bash
         run: |
@@ -176,7 +176,7 @@ jobs:
         run: |
           mkdir -p release
           ZIP_OUTPUT=release/renterd${{ env.ZIP_OUTPUT_SUFFIX }}_${GOOS}_${GOARCH}.zip
-          go build -trimpath -o bin/ -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
+          go build -trimpath -o bin/ -tags='netgo timetzdata' -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
           azuresigntool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v bin/renterd.exe
           cp README.md LICENSE bin/
           7z a $ZIP_OUTPUT bin/*
@@ -187,7 +187,7 @@ jobs:
 
   combine-release-assets:
     runs-on: ubuntu-latest
-    needs: [ build-linux, build-mac, build-windows ]
+    needs: [build-linux, build-mac, build-windows]
     steps:
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4
@@ -196,7 +196,7 @@ jobs:
 
   dispatch-homebrew: # only runs on full releases
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
-    needs: [ build-mac ]
+    needs: [build-mac]
     runs-on: ubuntu-latest
     steps:
       - name: Extract Tag Name
@@ -218,7 +218,7 @@ jobs:
             }
   dispatch-linux: # run on full releases, release candidates, and master branch
     if: startsWith(github.ref, 'refs/tags/v') || endsWith(github.ref, 'master')
-    needs: [ build-linux ]
+    needs: [build-linux]
     runs-on: ubuntu-latest
     steps:
       - name: Build Dispatch Payload

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest , macos-latest, windows-latest ]
-        go-version: [ '1.22', '1.23' ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: ["1.22", "1.23"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,12 +52,12 @@ jobs:
         uses: mirromutth/mysql-action@v1.1
         with:
           host port: 3800
-          mysql version: '8'
+          mysql version: "8"
           mysql root password: test
       - name: Test Stores
         uses: n8maninger/action-golang-test@v1
         with:
-          args: "-race;-short"
+          args: "-race;-short;-tags=netgo"
       - name: Test Stores - MySQL
         if: matrix.os == 'ubuntu-latest'
         uses: n8maninger/action-golang-test@v1
@@ -67,12 +67,12 @@ jobs:
           RENTERD_DB_PASSWORD: test
         with:
           package: "./stores"
-          args: "-race;-short"
+          args: "-race;-short;-tags=netgo"
       - name: Test Integration
         uses: n8maninger/action-golang-test@v1
         with:
           package: "./internal/test/e2e/..."
-          args: "-failfast;-race;-timeout=60m"
+          args: "-failfast;-race;-timeout=60m;-tags=netgo"
       - name: Test Integration - MySQL
         if: matrix.os == 'ubuntu-latest'
         uses: n8maninger/action-golang-test@v1
@@ -82,6 +82,6 @@ jobs:
           RENTERD_DB_PASSWORD: test
         with:
           package: "./internal/test/e2e/..."
-          args: "-failfast;-race;-timeout=60m"
+          args: "-failfast;-race;-timeout=60m;-tags=netgo"
       - name: Build
-        run: go build -o bin/ ./cmd/renterd
+        run: go build -o bin/ -tags='netgo timetzdata' ./cmd/renterd

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN if [ "$BUILD_RUN_GO_GENERATE" = "true" ] ; then go generate ./... ; fi
 # Build renterd.
 RUN --mount=type=cache,target=/root/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=1 go build -ldflags='-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
+    CGO_ENABLED=1 go build -tags='netgo timetzdata' -ldflags='-s -w -linkmode external -extldflags "-static"' ./cmd/renterd
 
 # Build image that will be used to run renterd.
 FROM scratch
@@ -37,7 +37,7 @@ ENV PUID=0
 ENV PGID=0
 
 # Renterd env args
-ENV RENTERD_API_PASSWORD= 
+ENV RENTERD_API_PASSWORD=
 ENV RENTERD_SEED=
 ENV RENTERD_CONFIG_FILE=/data/renterd.yml
 ENV RENTERD_NETWORK='mainnet'


### PR DESCRIPTION
Changes `go build` calls to be consistent with `hostd` by adding `netgo` and `timetzdata` until we move to the common workflow.