### PR TITLE
Limit lowest possible sub-score for a host

### DIFF
--- a/autopilot/contractor/hostscore.go
+++ b/autopilot/contractor/hostscore.go
@@ -21,7 +21,28 @@ const (
 	// minValidScore is the smallest score that a host can have before
 	// being ignored.
 	minValidScore = math.SmallestNonzeroFloat64
+
+	// minSubScore is the smallest score that a host can have for a given
+	// sub-score such as its pricing. By choosing 0.1, a host that has a very bad
+	// price score but is otherwise perfect can at most be 90% less likely to be
+	// picked than a host that has a perfect score.
+	minSubScore = 0.1
 )
+
+// clampScore makes sure that a score can not be smaller than 'minSubScore'.
+// Unless the score is 0, which indicates a more severe issue with the host. By
+// doing so, we limit the impact of a single sub-score on the overall score of a
+// host.
+func clampScore(score float64) float64 {
+	if score <= 0.0 {
+		return 0.0
+	} else if score < minSubScore {
+		return minSubScore
+	} else if score > 1.0 {
+		return 1.0
+	}
+	return score
+}
 
 func hostScore(cfg api.AutopilotConfig, gs api.GougingSettings, h api.Host, expectedRedundancy float64) (sb api.HostScoreBreakdown) {
 	cCfg := cfg.Contracts
@@ -39,13 +60,13 @@ func hostScore(cfg api.AutopilotConfig, gs api.GougingSettings, h api.Host, expe
 	// data will store twice the expectation
 	allocationPerHost := idealDataPerHost * 2
 	return api.HostScoreBreakdown{
-		Age:              ageScore(h),
-		Collateral:       collateralScore(cCfg, h.PriceTable.HostPriceTable, uint64(allocationPerHost)),
-		Interactions:     interactionScore(h),
-		Prices:           priceAdjustmentScore(h.PriceTable.HostPriceTable, gs),
-		StorageRemaining: storageRemainingScore(h.Settings, h.StoredData, allocationPerHost),
-		Uptime:           uptimeScore(h),
-		Version:          versionScore(h.Settings, cfg.Hosts.MinProtocolVersion),
+		Age:              clampScore(ageScore(h)),
+		Collateral:       clampScore(collateralScore(cCfg, h.PriceTable.HostPriceTable, uint64(allocationPerHost))),
+		Interactions:     clampScore(interactionScore(h)),
+		Prices:           clampScore(priceAdjustmentScore(h.PriceTable.HostPriceTable, gs)),
+		StorageRemaining: clampScore(storageRemainingScore(h.Settings, h.StoredData, allocationPerHost)),
+		Uptime:           clampScore(uptimeScore(h)),
+		Version:          clampScore(versionScore(h.Settings, cfg.Hosts.MinProtocolVersion)),
 	}
 }
 
@@ -240,7 +261,7 @@ func uptimeScore(h api.Host) float64 {
 		} else if lastScanSuccess || secondToLastScanSuccess {
 			return 0.5
 		} else {
-			return 0.05
+			return minSubScore
 		}
 	}
 

--- a/autopilot/contractor/hostscore.go
+++ b/autopilot/contractor/hostscore.go
@@ -60,7 +60,7 @@ func hostScore(cfg api.AutopilotConfig, gs api.GougingSettings, h api.Host, expe
 	// data will store twice the expectation
 	allocationPerHost := idealDataPerHost * 2
 	return api.HostScoreBreakdown{
-		Age:              clampScore(ageScore(h)),
+		Age:              ageScore(h), // not clamped since values are hardcoded
 		Collateral:       clampScore(collateralScore(cCfg, h.PriceTable.HostPriceTable, uint64(allocationPerHost))),
 		Interactions:     clampScore(interactionScore(h)),
 		Prices:           clampScore(priceAdjustmentScore(h.PriceTable.HostPriceTable, gs)),

--- a/autopilot/contractor/hostscore_test.go
+++ b/autopilot/contractor/hostscore_test.go
@@ -84,7 +84,7 @@ func TestHostScore(t *testing.T) {
 	}
 
 	//	// assert age affects the score
-	h1.KnownSince = time.Now().Add(-1 * day)
+	h1.KnownSince = time.Now().Add(-100 * day)
 	if hostScore(cfg, gs, h1, redundancy).Score() <= hostScore(cfg, gs, h2, redundancy).Score() {
 		t.Fatal("unexpected")
 	}

--- a/autopilot/contractor/hostscore_test.go
+++ b/autopilot/contractor/hostscore_test.go
@@ -30,6 +30,39 @@ var cfg = api.AutopilotConfig{
 	},
 }
 
+func TestClampScore(t *testing.T) {
+	tests := []struct {
+		in  float64
+		out float64
+	}{
+		{
+			in:  -1,
+			out: 0,
+		},
+		{
+			in:  0,
+			out: 0,
+		},
+		{
+			in:  1,
+			out: 1,
+		},
+		{
+			in:  1.1,
+			out: 1,
+		},
+		{
+			in:  0.05,
+			out: minSubScore,
+		},
+	}
+	for _, test := range tests {
+		if out := clampScore(test.in); out != test.out {
+			t.Errorf("expected %v, got %v", test.out, out)
+		}
+	}
+}
+
 func TestHostScore(t *testing.T) {
 	day := 24 * time.Hour
 

--- a/autopilot/scanner/scanner.go
+++ b/autopilot/scanner/scanner.go
@@ -282,7 +282,7 @@ func (s *scanner) removeOfflineHosts(ctx context.Context) (removed uint64) {
 
 	var err error
 	removed, err = s.hs.RemoveOfflineHosts(ctx, s.hostsCfg.MaxConsecutiveScanFailures, maxDowntime)
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		s.logger.Errorw("removing offline hosts failed", zap.Error(err), "maxDowntime", maxDowntime, "maxConsecutiveScanFailures", s.hostsCfg.MaxConsecutiveScanFailures)
 		return
 	}


### PR DESCRIPTION
Closes https://github.com/SiaFoundation/renterd/issues/1595

The value `0.1` was picked mostly because it seemed reasonable that when comparing a perfect host to another one that fails in a single category would be 10x more likely to get picked as a host.
Similarly when compared to a host that fails in every category a perfect host would be 10,000,000x more likely to be picked.

So there is still an exponential component to it but the approach in this PR lessens the impact of potential temporary issues or bugs. 