### PR TITLE
Fix panic in TestBlocklist

### DIFF
--- a/stores/sql/mysql/chain.go
+++ b/stores/sql/mysql/chain.go
@@ -259,12 +259,18 @@ func (c chainUpdateTx) UpdateHost(hk types.PublicKey, ha chain.HostAnnouncement,
 		return fmt.Errorf("failed to fetch allow list: %w", err)
 	}
 	defer rows.Close()
+
+	allowlistEntries := make(map[types.PublicKey]int64)
 	for rows.Next() {
 		var id int64
 		var pk ssql.PublicKey
 		if err := rows.Scan(&id, &pk); err != nil {
 			return fmt.Errorf("failed to scan row: %w", err)
 		}
+		allowlistEntries[types.PublicKey(pk)] = id
+	}
+
+	for pk, id := range allowlistEntries {
 		if hk == types.PublicKey(pk) {
 			if _, err := c.tx.Exec(c.ctx,
 				"INSERT IGNORE INTO host_allowlist_entry_hosts (db_allowlist_entry_id, db_host_id) VALUES (?,?)",

--- a/stores/sql/sqlite/chain.go
+++ b/stores/sql/sqlite/chain.go
@@ -271,12 +271,18 @@ func (c chainUpdateTx) UpdateHost(hk types.PublicKey, ha chain.HostAnnouncement,
 		return fmt.Errorf("failed to fetch allow list: %w", err)
 	}
 	defer rows.Close()
+
+	allowlistEntries := make(map[types.PublicKey]int64)
 	for rows.Next() {
 		var id int64
 		var pk ssql.PublicKey
 		if err := rows.Scan(&id, &pk); err != nil {
 			return fmt.Errorf("failed to scan row: %w", err)
 		}
+		allowlistEntries[types.PublicKey(pk)] = id
+	}
+
+	for pk, id := range allowlistEntries {
 		if hk == types.PublicKey(pk) {
 			if _, err := c.tx.Exec(c.ctx,
 				"INSERT OR IGNORE INTO host_allowlist_entry_hosts (db_allowlist_entry_id, db_host_id) VALUES (?,?)",


### PR DESCRIPTION
A panic due to updating entries in the database while not having fully consumed the `rows` cursor yet.