### PR TITLE
Move memory manager from worker to dedicated package

### DIFF
--- a/api/worker.go
+++ b/api/worker.go
@@ -12,6 +12,7 @@ import (
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/internal/memory"
 )
 
 var (
@@ -59,13 +60,8 @@ type (
 	}
 
 	MemoryResponse struct {
-		Download MemoryStatus `json:"download"`
-		Upload   MemoryStatus `json:"upload"`
-	}
-
-	MemoryStatus struct {
-		Available uint64 `json:"available"`
-		Total     uint64 `json:"total"`
+		Download memory.Status `json:"download"`
+		Upload   memory.Status `json:"upload"`
 	}
 
 	// RHPFormResponse is the response type for the /rhp/form endpoint.

--- a/worker/download.go
+++ b/worker/download.go
@@ -14,6 +14,7 @@ import (
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/internal/memory"
 	rhp3 "go.sia.tech/renterd/internal/rhp/v3"
 	"go.sia.tech/renterd/internal/utils"
 	"go.sia.tech/renterd/object"
@@ -33,7 +34,7 @@ var (
 type (
 	downloadManager struct {
 		hm        HostManager
-		mm        MemoryManager
+		mm        memory.MemoryManager
 		os        ObjectStore
 		uploadKey *utils.UploadKey
 		logger    *zap.SugaredLogger
@@ -81,7 +82,7 @@ type (
 	}
 
 	slabDownloadResponse struct {
-		mem              Memory
+		mem              memory.Memory
 		surchargeApplied bool
 		shards           [][]byte
 		index            int
@@ -151,7 +152,7 @@ func newDownloadManager(ctx context.Context, uploadKey *utils.UploadKey, hm Host
 	logger = logger.Named("downloadmanager")
 	return &downloadManager{
 		hm:        hm,
-		mm:        newMemoryManager(maxMemory, logger),
+		mm:        memory.NewManager(maxMemory, logger),
 		os:        os,
 		uploadKey: uploadKey,
 		logger:    logger.Sugar(),

--- a/worker/mocks_test.go
+++ b/worker/mocks_test.go
@@ -15,6 +15,7 @@ import (
 	"go.sia.tech/renterd/alerts"
 	"go.sia.tech/renterd/api"
 	"go.sia.tech/renterd/internal/gouging"
+	"go.sia.tech/renterd/internal/memory"
 	"go.sia.tech/renterd/object"
 	"go.sia.tech/renterd/webhooks"
 )
@@ -293,11 +294,6 @@ func (hs *hostStoreMock) addHost() *hostMock {
 	return hs.hosts[hk]
 }
 
-var (
-	_ MemoryManager = (*memoryManagerMock)(nil)
-	_ Memory        = (*memoryMock)(nil)
-)
-
 type (
 	memoryMock        struct{}
 	memoryManagerMock struct{ memBlockChan chan struct{} }
@@ -312,13 +308,13 @@ func newMemoryManagerMock() *memoryManagerMock {
 func (m *memoryMock) Release()           {}
 func (m *memoryMock) ReleaseSome(uint64) {}
 
-func (mm *memoryManagerMock) Limit(amt uint64) (MemoryManager, error) {
+func (mm *memoryManagerMock) Limit(amt uint64) (memory.MemoryManager, error) {
 	return mm, nil
 }
 
-func (mm *memoryManagerMock) Status() api.MemoryStatus { return api.MemoryStatus{} }
+func (mm *memoryManagerMock) Status() memory.Status { return memory.Status{} }
 
-func (mm *memoryManagerMock) AcquireMemory(ctx context.Context, amt uint64) Memory {
+func (mm *memoryManagerMock) AcquireMemory(ctx context.Context, amt uint64) memory.Memory {
 	<-mm.memBlockChan
 	return &memoryMock{}
 }


### PR DESCRIPTION
This is one of the multiple steps required to merge the autopilot + migrations into the bus.
With both the worker and autopilot requiring the ability to upload, we need to isolate the upload manager.
To do that we need to isolate shared dependencies between upload and download manager.

Trying to achieve this in the smallest possible bites, I'm starting with the memory manager.