### PR TITLE
Drop n == 0 checks in chain.go

### DIFF
--- a/internal/bus/chainsubscriber.go
+++ b/internal/bus/chainsubscriber.go
@@ -278,7 +278,7 @@ func (s *chainSubscriber) sync() error {
 
 	// fetch updates until we're caught up
 	var cnt uint64
-	for index != s.cm.Tip() && !s.isClosed() {
+	for index != s.cm.Tip() && index.Height <= s.cm.Tip().Height && !s.isClosed() {
 		// fetch updates
 		istart := time.Now()
 		crus, caus, err := s.cm.UpdatesSince(index, updatesBatchSize)

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -693,7 +693,7 @@ func (c *TestCluster) MineBlocks(n uint64) {
 
 func (c *TestCluster) sync() {
 	tip := c.cm.Tip()
-	c.tt.Retry(3000, time.Millisecond, func() error {
+	c.tt.Retry(10000, time.Millisecond, func() error {
 		cs, err := c.Bus.ConsensusState(context.Background())
 		if err != nil {
 			return err

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -2787,6 +2787,13 @@ func TestConsensusResync(t *testing.T) {
 	// upload some data
 	tt.OKAll(cluster.Worker.UploadObject(context.Background(), bytes.NewReader([]byte{1, 2, 3}), testBucket, "foo", api.UploadObjectOptions{}))
 
+	// broadcast the revision for each contract
+	contracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
+	tt.OK(err)
+	for _, c := range contracts {
+		tt.OKAll(cluster.Bus.BroadcastContract(context.Background(), c.ID))
+	}
+
 	// mine to renew the contracts
 	cluster.MineToRenewWindow()
 	tt.Retry(100, 100*time.Millisecond, func() error {

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -2787,13 +2787,6 @@ func TestConsensusResync(t *testing.T) {
 	// upload some data
 	tt.OKAll(cluster.Worker.UploadObject(context.Background(), bytes.NewReader([]byte{1, 2, 3}), testBucket, "foo", api.UploadObjectOptions{}))
 
-	// broadcast the revision for each contract
-	contracts, err := cluster.Bus.Contracts(context.Background(), api.ContractsOpts{})
-	tt.OK(err)
-	for _, c := range contracts {
-		tt.OKAll(cluster.Bus.BroadcastContract(context.Background(), c.ID))
-	}
-
 	// mine to renew the contracts
 	cluster.MineToRenewWindow()
 	tt.Retry(100, 100*time.Millisecond, func() error {

--- a/stores/sql/chain.go
+++ b/stores/sql/chain.go
@@ -78,8 +78,17 @@ func UpdateContractRevision(ctx context.Context, tx sql.Tx, fcid types.FileContr
 
 func UpdateContractProofHeight(ctx context.Context, tx sql.Tx, fcid types.FileContractID, proofHeight uint64, l *zap.SugaredLogger) error {
 	l.Debugw("update contract proof height", "fcid", fcid, "proof_height", proofHeight)
-	_, err := tx.Exec(ctx, `UPDATE contracts SET proof_height = ? WHERE fcid = ?`, proofHeight, FileContractID(fcid))
-	return err
+
+	res, err := tx.Exec(ctx, `UPDATE contracts SET proof_height = ? WHERE fcid = ?`, proofHeight, FileContractID(fcid))
+	if err != nil {
+		return err
+	} else if n, err := res.RowsAffected(); err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	} else if n == 0 {
+		return fmt.Errorf("expected to update 1 row, but updated %d", n)
+	}
+
+	return nil
 }
 
 func UpdateContractState(ctx context.Context, tx sql.Tx, fcid types.FileContractID, state api.ContractState, l *zap.SugaredLogger) error {
@@ -89,8 +98,17 @@ func UpdateContractState(ctx context.Context, tx sql.Tx, fcid types.FileContract
 	if err := cs.LoadString(string(state)); err != nil {
 		return err
 	}
-	_, err := tx.Exec(ctx, `UPDATE contracts SET state = ? WHERE fcid = ?`, cs, FileContractID(fcid))
-	return err
+
+	res, err := tx.Exec(ctx, `UPDATE contracts SET state = ? WHERE fcid = ?`, cs, FileContractID(fcid))
+	if err != nil {
+		return err
+	} else if n, err := res.RowsAffected(); err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	} else if n == 0 {
+		return fmt.Errorf("expected to update 1 row, but updated %d", n)
+	}
+
+	return nil
 }
 
 func UpdateFailedContracts(ctx context.Context, tx sql.Tx, blockHeight uint64, l *zap.SugaredLogger) error {

--- a/stores/sql/chain.go
+++ b/stores/sql/chain.go
@@ -35,18 +35,13 @@ func GetContractState(ctx context.Context, tx sql.Tx, fcid types.FileContractID)
 func UpdateChainIndex(ctx context.Context, tx sql.Tx, index types.ChainIndex, l *zap.SugaredLogger) error {
 	l.Debugw("update chain index", "height", index.Height, "block_id", index.ID)
 
-	if res, err := tx.Exec(ctx,
+	if _, err := tx.Exec(ctx,
 		fmt.Sprintf("UPDATE consensus_infos SET height = ?, block_id = ? WHERE id = %d", sql.ConsensusInfoID),
 		index.Height,
 		Hash256(index.ID),
 	); err != nil {
 		return fmt.Errorf("failed to update chain index: %w", err)
-	} else if n, err := res.RowsAffected(); err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	} else if n != 1 {
-		return fmt.Errorf("failed to update chain index: no rows affected")
 	}
-
 	return nil
 }
 

--- a/stores/sql/chain.go
+++ b/stores/sql/chain.go
@@ -78,17 +78,8 @@ func UpdateContractRevision(ctx context.Context, tx sql.Tx, fcid types.FileContr
 
 func UpdateContractProofHeight(ctx context.Context, tx sql.Tx, fcid types.FileContractID, proofHeight uint64, l *zap.SugaredLogger) error {
 	l.Debugw("update contract proof height", "fcid", fcid, "proof_height", proofHeight)
-
-	res, err := tx.Exec(ctx, `UPDATE contracts SET proof_height = ? WHERE fcid = ?`, proofHeight, FileContractID(fcid))
-	if err != nil {
-		return err
-	} else if n, err := res.RowsAffected(); err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	} else if n == 0 {
-		return fmt.Errorf("expected to update 1 row, but updated %d", n)
-	}
-
-	return nil
+	_, err := tx.Exec(ctx, `UPDATE contracts SET proof_height = ? WHERE fcid = ?`, proofHeight, FileContractID(fcid))
+	return err
 }
 
 func UpdateContractState(ctx context.Context, tx sql.Tx, fcid types.FileContractID, state api.ContractState, l *zap.SugaredLogger) error {
@@ -98,17 +89,8 @@ func UpdateContractState(ctx context.Context, tx sql.Tx, fcid types.FileContract
 	if err := cs.LoadString(string(state)); err != nil {
 		return err
 	}
-
-	res, err := tx.Exec(ctx, `UPDATE contracts SET state = ? WHERE fcid = ?`, cs, FileContractID(fcid))
-	if err != nil {
-		return err
-	} else if n, err := res.RowsAffected(); err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	} else if n == 0 {
-		return fmt.Errorf("expected to update 1 row, but updated %d", n)
-	}
-
-	return nil
+	_, err := tx.Exec(ctx, `UPDATE contracts SET state = ? WHERE fcid = ?`, cs, FileContractID(fcid))
+	return err
 }
 
 func UpdateFailedContracts(ctx context.Context, tx sql.Tx, blockHeight uint64, l *zap.SugaredLogger) error {

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -172,13 +172,9 @@ func ArchiveContract(ctx context.Context, tx sql.Tx, fcid types.FileContractID, 
 	}
 
 	// archive contract
-	res, err := tx.Exec(ctx, "UPDATE contracts SET host_id = NULL, archival_reason = ? WHERE fcid = ?", reason, FileContractID(fcid))
+	_, err := tx.Exec(ctx, "UPDATE contracts SET host_id = NULL, archival_reason = ? WHERE fcid = ?", reason, FileContractID(fcid))
 	if err != nil {
 		return fmt.Errorf("failed to archive contract: %w", err)
-	} else if n, err := res.RowsAffected(); err != nil {
-		return fmt.Errorf("failed to fetch rows affected: %w", err)
-	} else if n == 0 {
-		return fmt.Errorf("expected to update 1 row, updated %d", n)
 	}
 
 	// delete its sectors


### PR DESCRIPTION
Fixes an issue when resyncing a node on MySQL since MySQL will return `n == 0` when a row wasn't updated. Which is expected when resyncing.