### PR TITLE
Add support for recording V2 scans and use V2 settings for gouging 

### DIFF
--- a/api/autopilot.go
+++ b/api/autopilot.go
@@ -121,6 +121,7 @@ type (
 				Pruning  uint64 `json:"pruning"`
 				Upload   uint64 `json:"upload"`
 			} `json:"gouging"`
+			LowMaxDuration        uint64 `json:"lowMaxDuration"`
 			NotAcceptingContracts uint64 `json:"notAcceptingContracts"`
 			NotScanned            uint64 `json:"notScanned"`
 		} `json:"unusable"`

--- a/api/bus.go
+++ b/api/bus.go
@@ -5,8 +5,8 @@ import (
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
-	rhpv4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	rhp4 "go.sia.tech/renterd/internal/rhp/v4"
 )
 
 var (
@@ -97,6 +97,6 @@ type (
 		ScanError  string               `json:"scanError,omitempty"`
 		Settings   rhpv2.HostSettings   `json:"settings,omitempty"`
 		PriceTable rhpv3.HostPriceTable `json:"priceTable,omitempty"`
-		V2Settings rhpv4.HostSettings   `json:"v2Settings,omitempty"`
+		V2Settings rhp4.HostSettings    `json:"v2Settings,omitempty"`
 	}
 )

--- a/api/host.go
+++ b/api/host.go
@@ -107,7 +107,8 @@ type (
 		PublicKey         types.PublicKey      `json:"publicKey"`
 		NetAddress        string               `json:"netAddress"`
 		PriceTable        HostPriceTable       `json:"priceTable"`
-		Settings          rhpv2.HostSettings   `json:"settings"`
+		Settings          rhpv2.HostSettings   `json:"settings,omitempty"`
+		V2Settings        rhpv4.HostSettings   `json:"v2Settings,omitempty"`
 		Interactions      HostInteractions     `json:"interactions"`
 		Scanned           bool                 `json:"scanned"`
 		Blocked           bool                 `json:"blocked"`

--- a/api/host.go
+++ b/api/host.go
@@ -9,8 +9,8 @@ import (
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
-	rhpv4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	rhp4 "go.sia.tech/renterd/internal/rhp/v4"
 )
 
 const (
@@ -108,7 +108,7 @@ type (
 		NetAddress        string               `json:"netAddress"`
 		PriceTable        HostPriceTable       `json:"priceTable"`
 		Settings          rhpv2.HostSettings   `json:"settings,omitempty"`
-		V2Settings        rhpv4.HostSettings   `json:"v2Settings,omitempty"`
+		V2Settings        rhp4.HostSettings    `json:"v2Settings,omitempty"`
 		Interactions      HostInteractions     `json:"interactions"`
 		Scanned           bool                 `json:"scanned"`
 		Blocked           bool                 `json:"blocked"`
@@ -140,7 +140,7 @@ type (
 		HostKey    types.PublicKey      `json:"hostKey"`
 		PriceTable rhpv3.HostPriceTable `json:"priceTable,omitempty"`
 		Settings   rhpv2.HostSettings   `json:"settings,omitempty"`
-		V2Settings rhpv4.HostSettings   `json:"v2Settings,omitempty"`
+		V2Settings rhp4.HostSettings    `json:"v2Settings,omitempty"`
 		Success    bool                 `json:"success"`
 		Timestamp  time.Time            `json:"timestamp"`
 	}

--- a/api/host.go
+++ b/api/host.go
@@ -164,7 +164,6 @@ type (
 	}
 
 	HostGougingBreakdown struct {
-		ContractErr string `json:"contractErr"`
 		DownloadErr string `json:"downloadErr"`
 		GougingErr  string `json:"gougingErr"`
 		PruneErr    string `json:"pruneErr"`
@@ -184,6 +183,7 @@ type (
 	HostUsabilityBreakdown struct {
 		Blocked               bool `json:"blocked"`
 		Offline               bool `json:"offline"`
+		LowMaxDuration        bool `json:"lowMaxDuration"`
 		LowScore              bool `json:"lowScore"`
 		RedundantIP           bool `json:"redundantIP"`
 		Gouging               bool `json:"gouging"`
@@ -221,6 +221,11 @@ func (h Host) IsOnline() bool {
 	return h.Interactions.LastScanSuccess || h.Interactions.SecondToLastScanSuccess
 }
 
+func (h Host) IsV2() bool {
+	// consider a host to be v2 if it has announced a v2 address
+	return len(h.V2SiamuxAddresses) > 0
+}
+
 func (h Host) V2SiamuxAddr() string {
 	// NOTE: eventually this can be smarter about picking an address
 	if len(h.V2SiamuxAddresses) > 0 {
@@ -235,7 +240,6 @@ func (sb HostScoreBreakdown) String() string {
 
 func (hgb HostGougingBreakdown) Gouging() bool {
 	for _, err := range []string{
-		hgb.ContractErr,
 		hgb.DownloadErr,
 		hgb.GougingErr,
 		hgb.PruneErr,
@@ -251,7 +255,6 @@ func (hgb HostGougingBreakdown) Gouging() bool {
 func (hgb HostGougingBreakdown) String() string {
 	var reasons []string
 	for _, errStr := range []string{
-		hgb.ContractErr,
 		hgb.DownloadErr,
 		hgb.GougingErr,
 		hgb.PruneErr,

--- a/api/host.go
+++ b/api/host.go
@@ -227,7 +227,10 @@ func (h Host) IsV2() bool {
 }
 
 func (h Host) V2SiamuxAddr() string {
-	// NOTE: eventually this can be smarter about picking an address
+	// NOTE: eventually we can improve this by implementing a dialer wrapper that
+	// can be created from a slice of addresses and tries them in order. It
+	// should also be aware of whether we support v4 or v6 and pick addresses
+	// accordingly.
 	if len(h.V2SiamuxAddresses) > 0 {
 		return h.V2SiamuxAddresses[0]
 	}

--- a/autopilot/contractor/contractor.go
+++ b/autopilot/contractor/contractor.go
@@ -1137,7 +1137,7 @@ func performHostChecks(ctx *mCtx, bus Bus, logger *zap.SugaredLogger) error {
 	}
 	for _, h := range scoredHosts {
 		h.host.PriceTable.HostBlockHeight = cs.BlockHeight // ignore HostBlockHeight
-		hc := checkHost(ctx.GougingChecker(cs), h, minScore)
+		hc := checkHost(ctx.GougingChecker(cs), h, minScore, ctx.Period())
 		if err := bus.UpdateHostCheck(ctx, ctx.ApID(), h.host.PublicKey, *hc); err != nil {
 			return fmt.Errorf("failed to update host check for host %v: %w", h.host.PublicKey, err)
 		}

--- a/autopilot/contractor/evaluate.go
+++ b/autopilot/contractor/evaluate.go
@@ -11,7 +11,7 @@ import (
 var ErrMissingRequiredFields = errors.New("missing required fields in configuration, both allowance and amount must be set")
 
 func countUsableHosts(cfg api.AutopilotConfig, cs api.ConsensusState, period uint64, rs api.RedundancySettings, gs api.GougingSettings, hosts []api.Host) (usables uint64) {
-	gc := gouging.NewChecker(gs, cs, &period, &cfg.Contracts.RenewWindow)
+	gc := gouging.NewChecker(gs, cs)
 	for _, host := range hosts {
 		hc := checkHost(gc, scoreHost(host, cfg, gs, rs.Redundancy()), minValidScore, period)
 		if hc.UsabilityBreakdown.IsUsable() {
@@ -31,7 +31,7 @@ func EvaluateConfig(cfg api.AutopilotConfig, cs api.ConsensusState, rs api.Redun
 	}
 
 	period := cfg.Contracts.Period
-	gc := gouging.NewChecker(gs, cs, &period, &cfg.Contracts.RenewWindow)
+	gc := gouging.NewChecker(gs, cs)
 
 	resp.Hosts = uint64(len(hosts))
 	for i, host := range hosts {

--- a/autopilot/contractor/hostfilter.go
+++ b/autopilot/contractor/hostfilter.go
@@ -244,13 +244,6 @@ func checkHost(gc gouging.Checker, sh scoredHost, minScore float64, period uint6
 			ub.Offline = true
 		}
 
-		// helper for duration checks
-		checkContractGouging := func(maxDuration uint64) {
-			if period > maxDuration {
-				ub.LowMaxDuration = true
-			}
-		}
-
 		if h.IsV2() {
 			// accepting contracts check
 			if !h.V2Settings.AcceptingContracts {
@@ -258,7 +251,7 @@ func checkHost(gc gouging.Checker, sh scoredHost, minScore float64, period uint6
 			}
 
 			// max duration check
-			checkContractGouging(h.V2Settings.MaxContractDuration)
+			ub.LowMaxDuration = period > h.V2Settings.MaxContractDuration
 
 			// gouging breakdown
 			gb = gc.CheckV2(h.V2Settings)
@@ -269,8 +262,7 @@ func checkHost(gc gouging.Checker, sh scoredHost, minScore float64, period uint6
 			}
 
 			// max duration check
-			checkContractGouging(h.Settings.MaxDuration)
-			checkContractGouging(h.PriceTable.MaxDuration)
+			ub.LowMaxDuration = period > h.Settings.MaxDuration || period > h.PriceTable.MaxDuration
 
 			// gouging breakdown
 			gb = gc.CheckV1(&h.Settings, &h.PriceTable.HostPriceTable)

--- a/autopilot/contractor/hostfilter.go
+++ b/autopilot/contractor/hostfilter.go
@@ -221,7 +221,7 @@ func isUpForRenewal(cfg api.AutopilotConfig, r api.Revision, blockHeight uint64)
 }
 
 // checkHost performs a series of checks on the host.
-func checkHost(gc gouging.Checker, sh scoredHost, minScore float64) *api.HostCheck {
+func checkHost(gc gouging.Checker, sh scoredHost, minScore float64, period uint64) *api.HostCheck {
 	h := sh.host
 
 	// prepare host breakdown fields
@@ -255,6 +255,19 @@ func checkHost(gc gouging.Checker, sh scoredHost, minScore float64) *api.HostChe
 			ub.Gouging = true
 		} else if minScore > 0 && !(sh.score > minScore) {
 			ub.LowScore = true
+		}
+
+		// check contract gouging separately
+		checkContractGouging := func(maxDuration uint64) {
+			if period > maxDuration {
+				ub.LowMaxDuration = true
+			}
+		}
+		if h.IsV2() {
+			checkContractGouging(h.V2Settings.MaxContractDuration)
+		} else {
+			checkContractGouging(h.Settings.MaxDuration)
+			checkContractGouging(h.PriceTable.MaxDuration)
 		}
 	}
 

--- a/autopilot/contractor/hostfilter.go
+++ b/autopilot/contractor/hostfilter.go
@@ -249,15 +249,7 @@ func checkHost(gc gouging.Checker, sh scoredHost, minScore float64, period uint6
 			ub.NotAcceptingContracts = true
 		}
 
-		// perform gouging and score checks
-		gb = gc.Check(&h.Settings, &h.PriceTable.HostPriceTable)
-		if gb.Gouging() {
-			ub.Gouging = true
-		} else if minScore > 0 && !(sh.score > minScore) {
-			ub.LowScore = true
-		}
-
-		// check contract gouging separately
+		// max duration check
 		checkContractGouging := func(maxDuration uint64) {
 			if period > maxDuration {
 				ub.LowMaxDuration = true
@@ -268,6 +260,18 @@ func checkHost(gc gouging.Checker, sh scoredHost, minScore float64, period uint6
 		} else {
 			checkContractGouging(h.Settings.MaxDuration)
 			checkContractGouging(h.PriceTable.MaxDuration)
+		}
+
+		// perform gouging and score checks
+		if h.IsV2() {
+			gb = gc.CheckV2(h.V2Settings)
+		} else {
+			gb = gc.CheckV1(&h.Settings, &h.PriceTable.HostPriceTable)
+		}
+		if gb.Gouging() {
+			ub.Gouging = true
+		} else if minScore > 0 && !(sh.score > minScore) {
+			ub.LowScore = true
 		}
 	}
 

--- a/autopilot/contractor/hostscore.go
+++ b/autopilot/contractor/hostscore.go
@@ -1,6 +1,7 @@
 package contractor
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 	"time"
@@ -46,10 +47,12 @@ func clampScore(score float64) float64 {
 
 func hostScore(cfg api.AutopilotConfig, gs api.GougingSettings, h api.Host, expectedRedundancy float64) (sb api.HostScoreBreakdown) {
 	cCfg := cfg.Contracts
+
 	// idealDataPerHost is the amount of data that we would have to put on each
 	// host assuming that our storage requirements were spread evenly across
 	// every single host.
 	idealDataPerHost := float64(cCfg.Storage) * expectedRedundancy / float64(cCfg.Amount)
+
 	// allocationPerHost is the amount of data that we would like to be able to
 	// put on each host, because data is not always spread evenly across the
 	// hosts during upload. Slower hosts may get very little data, more
@@ -59,14 +62,48 @@ func hostScore(cfg api.AutopilotConfig, gs api.GougingSettings, h api.Host, expe
 	// NOTE: assume that data is not spread evenly and the host with the most
 	// data will store twice the expectation
 	allocationPerHost := idealDataPerHost * 2
+
+	// extract inputs from the host depending on whether the host supports v1 or v2
+	var appendSectorCost types.Currency
+	var collateral, maxCollateral types.Currency
+	var dppb, uppb, sppb types.Currency
+	var remainingStorage uint64
+	var version string
+	if h.IsV2() {
+		appendSectorCost = h.V2Settings.Prices.RPCAppendSectorsCost(1, cfg.Contracts.Period).Storage
+		maxCollateral = h.V2Settings.MaxCollateral
+		collateral = h.V2Settings.Prices.Collateral
+		dppb = h.V2Settings.Prices.EgressPrice
+		uppb = h.V2Settings.Prices.IngressPrice
+		sppb = h.V2Settings.Prices.StoragePrice
+		remainingStorage = h.V2Settings.RemainingStorage
+		version = fmt.Sprintf("%d.%d.%d", h.V2Settings.ProtocolVersion[0], h.V2Settings.ProtocolVersion[1], h.V2Settings.ProtocolVersion[2])
+	} else {
+		var overflow bool
+		appendSectorCost = h.PriceTable.AppendSectorCost(cfg.Contracts.Period).Storage
+		maxCollateral = h.PriceTable.MaxCollateral
+		collateral = h.PriceTable.CollateralCost
+		dppb, overflow = gouging.DownloadPricePerByte(h.PriceTable.HostPriceTable)
+		if overflow {
+			dppb = types.MaxCurrency
+		}
+		uppb, overflow = gouging.UploadPricePerByte(h.PriceTable.HostPriceTable)
+		if overflow {
+			uppb = types.MaxCurrency
+		}
+		sppb = h.PriceTable.WriteStoreCost
+		remainingStorage = h.Settings.RemainingStorage
+		version = h.Settings.Version
+	}
+
 	return api.HostScoreBreakdown{
 		Age:              ageScore(h), // not clamped since values are hardcoded
-		Collateral:       clampScore(collateralScore(cCfg, h.PriceTable.HostPriceTable, uint64(allocationPerHost))),
+		Collateral:       clampScore(collateralScore(cCfg, appendSectorCost, maxCollateral, collateral, uint64(allocationPerHost))),
 		Interactions:     clampScore(interactionScore(h)),
-		Prices:           clampScore(priceAdjustmentScore(h.PriceTable.HostPriceTable, gs)),
-		StorageRemaining: clampScore(storageRemainingScore(h.Settings, h.StoredData, allocationPerHost)),
+		Prices:           clampScore(priceAdjustmentScore(dppb, uppb, sppb, gs)),
+		StorageRemaining: clampScore(storageRemainingScore(remainingStorage, h.StoredData, allocationPerHost)),
 		Uptime:           clampScore(uptimeScore(h)),
-		Version:          clampScore(versionScore(h.Settings, cfg.Hosts.MinProtocolVersion)),
+		Version:          clampScore(versionScore(version, cfg.Hosts.MinProtocolVersion)),
 	}
 }
 
@@ -81,18 +118,7 @@ func hostScore(cfg api.AutopilotConfig, gs api.GougingSettings, h api.Host, expe
 //   - If the host is more expensive than expected, an exponential malus is applied.
 //     A 2x ratio will already cause the score to drop to 0.16 and a 3x ratio causes
 //     it to drop to 0.05.
-func priceAdjustmentScore(pt rhpv3.HostPriceTable, gs api.GougingSettings) float64 {
-	// combine the upload and download prices to get a threshold
-	dppb, overflow := gouging.DownloadPricePerByte(pt)
-	if overflow {
-		return math.SmallestNonzeroFloat64
-	}
-	uppb, overflow := gouging.UploadPricePerByte(pt)
-	if overflow {
-		return math.SmallestNonzeroFloat64
-	}
-	sppb := pt.WriteStoreCost
-
+func priceAdjustmentScore(dppb, uppb, sppb types.Currency, gs api.GougingSettings) float64 {
 	priceScore := func(actual, max types.Currency) float64 {
 		threshold := max.Div64(2)
 		if threshold.IsZero() {
@@ -126,11 +152,11 @@ func priceAdjustmentScore(pt rhpv3.HostPriceTable, gs api.GougingSettings) float
 	return (downloadScore + uploadScore + storageScore) / 3.0
 }
 
-func storageRemainingScore(h rhpv2.HostSettings, storedData uint64, allocationPerHost float64) float64 {
+func storageRemainingScore(remainingStorage, storedData uint64, allocationPerHost float64) float64 {
 	// hostExpectedStorage is the amount of storage that we expect to be able to
 	// store on this host overall, which should include the stored data that is
 	// already on the host.
-	hostExpectedStorage := (float64(h.RemainingStorage) * 0.25) + float64(storedData)
+	hostExpectedStorage := (float64(remainingStorage) * 0.25) + float64(storedData)
 	// The score for the host is the square of the amount of storage we
 	// expected divided by the amount of storage we want. If we expect to be
 	// able to store more data on the host than we need to allocate, the host
@@ -177,9 +203,9 @@ func ageScore(h api.Host) float64 {
 	return weight
 }
 
-func collateralScore(cfg api.ContractsConfig, pt rhpv3.HostPriceTable, allocationPerHost uint64) float64 {
+func collateralScore(cfg api.ContractsConfig, appendSectorCost, maxCollateral, collateralCost types.Currency, allocationPerHost uint64) float64 {
 	// Ignore hosts which have set their max collateral to 0.
-	if pt.MaxCollateral.IsZero() || pt.CollateralCost.IsZero() {
+	if maxCollateral.IsZero() || collateralCost.IsZero() {
 		return 0
 	}
 
@@ -189,12 +215,12 @@ func collateralScore(cfg api.ContractsConfig, pt rhpv3.HostPriceTable, allocatio
 
 	// compute the cost of storing
 	numSectors := bytesToSectors(allocationPerHost)
-	storageCost := pt.AppendSectorCost(cfg.Period).Storage.Mul64(numSectors)
+	storageCost := appendSectorCost.Mul64(numSectors)
 
 	// calculate the expected collateral for the host allocation.
-	expectedCollateral := pt.CollateralCost.Mul64(allocationPerHost).Mul64(cfg.Period)
-	if expectedCollateral.Cmp(pt.MaxCollateral) > 0 {
-		expectedCollateral = pt.MaxCollateral
+	expectedCollateral := collateralCost.Mul64(allocationPerHost).Mul64(cfg.Period)
+	if expectedCollateral.Cmp(maxCollateral) > 0 {
+		expectedCollateral = maxCollateral
 	}
 
 	// avoid division by zero
@@ -290,7 +316,7 @@ func uptimeScore(h api.Host) float64 {
 	return math.Pow(ratio, 200*math.Min(1-ratio, 0.30))
 }
 
-func versionScore(settings rhpv2.HostSettings, minVersion string) float64 {
+func versionScore(version, minVersion string) float64 {
 	if minVersion == "" {
 		minVersion = minProtocolVersion
 	}
@@ -309,7 +335,7 @@ func versionScore(settings rhpv2.HostSettings, minVersion string) float64 {
 	}
 	weight := 1.0
 	for _, v := range versions {
-		if utils.VersionCmp(settings.Version, v.version) < 0 {
+		if utils.VersionCmp(version, v.version) < 0 {
 			weight *= v.penalty
 		}
 	}

--- a/autopilot/contractor/hostscore_test.go
+++ b/autopilot/contractor/hostscore_test.go
@@ -9,6 +9,7 @@ import (
 	rhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/internal/gouging"
 	"go.sia.tech/renterd/internal/test"
 )
 
@@ -148,7 +149,10 @@ func TestPriceAdjustmentScore(t *testing.T) {
 			DownloadBandwidthCost: types.NewCurrency64(50),
 			UploadBandwidthCost:   types.NewCurrency64(50),
 		}
-		return priceAdjustmentScore(pt, api.GougingSettings{
+		dppb, _ := gouging.DownloadPricePerByte(pt)
+		uppb, _ := gouging.UploadPricePerByte(pt)
+		sppb := pt.WriteStoreCost
+		return priceAdjustmentScore(dppb, uppb, sppb, api.GougingSettings{
 			MaxDownloadPrice: types.NewCurrency64(mdp),
 			MaxUploadPrice:   types.NewCurrency64(mup),
 			MaxStoragePrice:  types.NewCurrency64(msp),
@@ -238,7 +242,8 @@ func TestCollateralScore(t *testing.T) {
 			MaxCollateral:  types.NewCurrency64(maxCollateral),
 			WriteStoreCost: types.NewCurrency64(storageCost),
 		}
-		return collateralScore(cfg, pt, rhpv2.SectorSize)
+		appendSectorCost := pt.AppendSectorCost(period).Storage
+		return collateralScore(cfg, appendSectorCost, pt.MaxCollateral, pt.CollateralCost, rhpv2.SectorSize)
 	}
 
 	round := func(f float64) float64 {

--- a/autopilot/contractor/hostscore_test.go
+++ b/autopilot/contractor/hostscore_test.go
@@ -234,16 +234,13 @@ func TestCollateralScore(t *testing.T) {
 	storageCost := uint64(100)
 	score := func(collateral, maxCollateral uint64) float64 {
 		t.Helper()
-		cfg := api.ContractsConfig{
-			Period: period,
-		}
 		pt := rhpv3.HostPriceTable{
 			CollateralCost: types.NewCurrency64(collateral),
 			MaxCollateral:  types.NewCurrency64(maxCollateral),
 			WriteStoreCost: types.NewCurrency64(storageCost),
 		}
 		appendSectorCost := pt.AppendSectorCost(period).Storage
-		return collateralScore(cfg, appendSectorCost, pt.MaxCollateral, pt.CollateralCost, rhpv2.SectorSize)
+		return collateralScore(appendSectorCost, pt.MaxCollateral, pt.CollateralCost, rhpv2.SectorSize, period)
 	}
 
 	round := func(f float64) float64 {

--- a/autopilot/contractor/state.go
+++ b/autopilot/contractor/state.go
@@ -70,8 +70,7 @@ func (ctx *mCtx) Err() error {
 }
 
 func (ctx *mCtx) GougingChecker(cs api.ConsensusState) gouging.Checker {
-	period, renewWindow := ctx.Period(), ctx.RenewWindow()
-	return gouging.NewChecker(ctx.state.GS, cs, &period, &renewWindow)
+	return gouging.NewChecker(ctx.state.GS, cs)
 }
 
 func (ctx *mCtx) HostScore(h api.Host) (sb api.HostScoreBreakdown, err error) {

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -203,7 +203,6 @@ type (
 		HostBlocklist(ctx context.Context) ([]string, error)
 		Hosts(ctx context.Context, opts api.HostOptions) ([]api.Host, error)
 		RecordHostScans(ctx context.Context, scans []api.HostScan) error
-		RecordPriceTables(ctx context.Context, priceTableUpdate []api.HostPriceTableUpdate) error
 		RemoveOfflineHosts(ctx context.Context, maxConsecutiveScanFailures uint64, maxDowntime time.Duration) (uint64, error)
 		ResetLostSectors(ctx context.Context, hk types.PublicKey) error
 		UpdateHostAllowlistEntries(ctx context.Context, add, remove []types.PublicKey, clear bool) error

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -767,7 +767,7 @@ func (b *Bus) renewContract(ctx context.Context, cs consensus.State, gp api.Goug
 	}
 
 	// renew contract
-	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState, nil, nil)
+	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState)
 	prepareRenew := b.prepareRenew(cs, rev, hs.Address, b.w.Address(), renterFunds, minNewCollateral, endHeight, expectedNewStorage)
 	newRevision, txnSet, contractPrice, fundAmount, err := b.rhp3Client.Renew(ctx, gc, rev, renterKey, c.HostKey, c.SiamuxAddr, prepareRenew, b.w.SignTransaction)
 	if err != nil {

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -493,7 +493,7 @@ func (b *Bus) hostsHandlerGET(jc jape.Context) {
 	if jc.Check("could not get gouging parameters", err) != nil {
 		return
 	}
-	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState, nil, nil)
+	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState)
 
 	var infos []api.HostInfo
 	for _, h := range hosts {
@@ -905,7 +905,7 @@ func (b *Bus) contractPruneHandlerPOST(jc jape.Context) {
 	if jc.Check("couldn't fetch gouging parameters", err) != nil {
 		return
 	}
-	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState, nil, nil)
+	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState)
 
 	// apply timeout
 	pruneCtx := ctx
@@ -2359,7 +2359,7 @@ func (b *Bus) contractsFormHandler(jc jape.Context) {
 	if jc.Check("could not get gouging parameters", err) != nil {
 		return
 	}
-	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState, nil, nil)
+	gc := gouging.NewChecker(gp.GougingSettings, gp.ConsensusState)
 
 	// fetch host settings
 	settings, err := b.rhp2Client.Settings(ctx, rfr.HostKey, rfr.HostIP)

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -15,10 +15,10 @@ import (
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
-	rhpv4 "go.sia.tech/core/rhp/v4"
 
 	"go.sia.tech/renterd/internal/prometheus"
 	rhp3 "go.sia.tech/renterd/internal/rhp/v3"
+	rhp4 "go.sia.tech/renterd/internal/rhp/v4"
 	"go.sia.tech/renterd/stores/sql"
 
 	"go.sia.tech/renterd/internal/gouging"
@@ -629,7 +629,7 @@ func (b *Bus) hostsScanHandlerPOST(jc jape.Context) {
 	var pt rhpv3.HostPriceTable
 	var settings rhpv2.HostSettings
 	var ping time.Duration
-	var v2Settings rhpv4.HostSettings
+	var v2Settings rhp4.HostSettings
 	if h.V2SiamuxAddr() != "" {
 		v2Settings, ping, err = b.scanHostV2(jc.Request.Context(), time.Duration(rsr.Timeout), hk, h.V2SiamuxAddr())
 	} else {

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -497,7 +497,8 @@ func (b *Bus) hostsHandlerGET(jc jape.Context) {
 
 	var infos []api.HostInfo
 	for _, h := range hosts {
-		if !gc.Check(&h.HS, &h.PT).Gouging() {
+		if (len(h.V2SiamuxAddresses) > 0 && !gc.CheckV2(h.V2HS).Gouging()) ||
+			(len(h.V2SiamuxAddresses) == 0 && !gc.CheckV1(&h.HS, &h.PT).Gouging()) {
 			infos = append(infos, h.HostInfo)
 		}
 	}

--- a/bus/scanning.go
+++ b/bus/scanning.go
@@ -6,9 +6,9 @@ import (
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
-	rhpv4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/api"
+	rhp4 "go.sia.tech/renterd/internal/rhp/v4"
 	"go.sia.tech/renterd/internal/utils"
 	"go.uber.org/zap"
 )
@@ -109,7 +109,7 @@ func (b *Bus) scanHostV1(ctx context.Context, timeout time.Duration, hostKey typ
 	return settings, pt, duration, err
 }
 
-func (b *Bus) scanHostV2(ctx context.Context, timeout time.Duration, hostKey types.PublicKey, hostIP string) (rhpv4.HostSettings, time.Duration, error) {
+func (b *Bus) scanHostV2(ctx context.Context, timeout time.Duration, hostKey types.PublicKey, hostIP string) (rhp4.HostSettings, time.Duration, error) {
 	logger := b.logger.
 		With("host", hostKey).
 		With("hostIP", hostIP).
@@ -117,7 +117,7 @@ func (b *Bus) scanHostV2(ctx context.Context, timeout time.Duration, hostKey typ
 		With("version", "v2")
 
 	// prepare a helper for scanning
-	scan := func() (rhpv4.HostSettings, time.Duration, error) {
+	scan := func() (rhp4.HostSettings, time.Duration, error) {
 		// apply the timeout
 		scanCtx := ctx
 		if timeout > 0 {
@@ -137,7 +137,7 @@ func (b *Bus) scanHostV2(ctx context.Context, timeout time.Duration, hostKey typ
 	// resolve host ip, don't scan if the host is on a private network or if it
 	// resolves to more than two addresses of the same type
 	if err := b.shouldScanAddr(hostIP); err != nil {
-		return rhpv4.HostSettings{}, 0, err
+		return rhp4.HostSettings{}, 0, err
 	}
 
 	// scan: first try
@@ -148,7 +148,7 @@ func (b *Bus) scanHostV2(ctx context.Context, timeout time.Duration, hostKey typ
 		// scan: second try
 		select {
 		case <-ctx.Done():
-			return rhpv4.HostSettings{}, 0, context.Cause(ctx)
+			return rhp4.HostSettings{}, 0, context.Cause(ctx)
 		case <-time.After(time.Second):
 		}
 		settings, duration, err = scan()
@@ -166,7 +166,7 @@ func (b *Bus) scanHostV2(ctx context.Context, timeout time.Duration, hostKey typ
 	// repercussions
 	select {
 	case <-ctx.Done():
-		return rhpv4.HostSettings{}, 0, context.Cause(ctx)
+		return rhp4.HostSettings{}, 0, context.Cause(ctx)
 	default:
 	}
 

--- a/internal/gouging/gouging.go
+++ b/internal/gouging/gouging.go
@@ -478,7 +478,6 @@ func sectorUploadCostRHPv3(pt rhpv3.HostPriceTable) (types.Currency, bool) {
 	if overflow {
 		return types.ZeroCurrency, true
 	}
-	writeCost, overflow = writeCost.AddWithOverflow(pt.InitBaseCost)
 	if overflow {
 		return types.ZeroCurrency, true
 	}

--- a/internal/gouging/gouging.go
+++ b/internal/gouging/gouging.go
@@ -106,7 +106,6 @@ func (gc checker) CheckV1(hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable) api.
 	}
 }
 
-// TODO: write tests
 func (gc checker) CheckV2(hs rhp.HostSettings) (gb api.HostGougingBreakdown) {
 	prices := hs.Prices
 	gs := gc.settings

--- a/internal/gouging/gouging.go
+++ b/internal/gouging/gouging.go
@@ -136,10 +136,6 @@ func (gc checker) CheckV2(hs rhp.HostSettings) (gb api.HostGougingBreakdown) {
 	}
 
 	// general gouging
-	// TODO: remove this in next update of core deps
-	const sectorDuration = 144 * 3
-	const sectorBatchSize = 25600
-
 	var errs []error
 	if prices.ContractPrice.Cmp(gs.MaxContractPrice) > 0 {
 		errs = append(errs, fmt.Errorf("contract price exceeds max contract price: %v > %v", prices.ContractPrice, gs.MaxContractPrice))

--- a/internal/gouging/gouging.go
+++ b/internal/gouging/gouging.go
@@ -41,7 +41,7 @@ type (
 	}
 
 	Checker interface {
-		Check(*rhpv2.HostSettings, *rhpv3.HostPriceTable) api.HostGougingBreakdown
+		CheckV1(*rhpv2.HostSettings, *rhpv3.HostPriceTable) api.HostGougingBreakdown
 		CheckV2(rhpv4.HostSettings) api.HostGougingBreakdown
 		CheckSettings(rhpv2.HostSettings) api.HostGougingBreakdown
 		CheckUnusedDefaults(rhpv3.HostPriceTable) error
@@ -89,7 +89,7 @@ func (gc checker) BlocksUntilBlockHeightGouging(hostHeight uint64) int64 {
 	return int64(hostHeight) - int64(minHeight)
 }
 
-func (gc checker) Check(hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable) api.HostGougingBreakdown {
+func (gc checker) CheckV1(hs *rhpv2.HostSettings, pt *rhpv3.HostPriceTable) api.HostGougingBreakdown {
 	if hs == nil && pt == nil {
 		panic("gouging checker needs to be provided with at least host settings or a price table") // developer error
 	}
@@ -159,7 +159,7 @@ func (gc checker) CheckV2(hs rhpv4.HostSettings) (gb api.HostGougingBreakdown) {
 }
 
 func (gc checker) CheckSettings(hs rhpv2.HostSettings) api.HostGougingBreakdown {
-	return gc.Check(&hs, nil)
+	return gc.CheckV1(&hs, nil)
 }
 
 func (gc checker) CheckUnusedDefaults(pt rhpv3.HostPriceTable) error {

--- a/internal/gouging/gouging_test.go
+++ b/internal/gouging/gouging_test.go
@@ -1,0 +1,91 @@
+package gouging
+
+import (
+	"testing"
+	"time"
+
+	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/internal/rhp/v4"
+
+	rhpv4 "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+)
+
+func TestCheckV2(t *testing.T) {
+	goodSettings := func() rhp.HostSettings {
+		return rhp.HostSettings{
+			HostSettings: rhpv4.HostSettings{
+				MaxCollateral: types.Siacoins(1),
+				Prices: rhpv4.HostPrices{
+					ContractPrice:   types.Siacoins(1),
+					Collateral:      types.Siacoins(1),
+					StoragePrice:    types.Siacoins(1),
+					IngressPrice:    types.Siacoins(1),
+					EgressPrice:     types.Siacoins(1),
+					FreeSectorPrice: types.Siacoins(1).Div64((1 << 40) / rhpv4.SectorSize), // 1 SC / TiB
+					TipHeight:       10,
+				},
+			},
+			Validity: time.Minute,
+		}
+	}
+	gc := NewChecker(api.GougingSettings{
+		MaxContractPrice:      types.Siacoins(1),
+		MaxDownloadPrice:      types.Siacoins(1),
+		MaxUploadPrice:        types.Siacoins(1),
+		MaxStoragePrice:       types.Siacoins(1),
+		HostBlockHeightLeeway: 1,
+		MinPriceTableValidity: time.Minute,
+	}, api.ConsensusState{
+		BlockHeight:   10,
+		Synced:        true,
+		LastBlockTime: api.TimeRFC3339(time.Now()),
+	})
+
+	// good settings
+	if gb := gc.CheckV2(goodSettings()); gb.Gouging() {
+		t.Fatal("shouldn't be gouging", gb)
+	}
+
+	// gouging on 'MaxContractPrice'
+	settings := goodSettings()
+	settings.Prices.ContractPrice = settings.Prices.ContractPrice.Add(types.NewCurrency64(1))
+	if gb := gc.CheckV2(settings); !gb.Gouging() || gb.GougingErr == "" {
+		t.Fatal("should be gouging", gb)
+	}
+
+	// gouging on 'MaxDownloadPrice'
+	settings = goodSettings()
+	settings.Prices.EgressPrice = settings.Prices.EgressPrice.Add(types.NewCurrency64(1))
+	if gb := gc.CheckV2(settings); !gb.Gouging() || gb.DownloadErr == "" {
+		t.Fatal("should be gouging", gb)
+	}
+
+	// gouging on 'MaxUploadPrice'
+	settings = goodSettings()
+	settings.Prices.IngressPrice = settings.Prices.IngressPrice.Add(types.NewCurrency64(1))
+	if gb := gc.CheckV2(settings); !gb.Gouging() || gb.UploadErr == "" {
+		t.Fatal("should be gouging", gb)
+	}
+
+	// gouging on 'MaxStoragePrice'
+	settings = goodSettings()
+	settings.Prices.StoragePrice = settings.Prices.StoragePrice.Add(types.NewCurrency64(1))
+	if gb := gc.CheckV2(settings); !gb.Gouging() || gb.UploadErr == "" {
+		t.Fatal("should be gouging", gb)
+	}
+
+	// gouging on 'MinBlockHeightLeeway'
+	settings = goodSettings()
+	settings.Prices.TipHeight += uint64(gc.(checker).settings.HostBlockHeightLeeway) + 1
+	if gb := gc.CheckV2(settings); !gb.Gouging() || gb.GougingErr == "" {
+		t.Fatal("should be gouging", gb)
+	}
+
+	// gouging on 'MinPriceTableValidity'
+	settings = goodSettings()
+	settings.Validity -= time.Millisecond
+	if gb := gc.CheckV2(settings); !gb.Gouging() || gb.GougingErr == "" {
+		t.Fatal("should be gouging", gb)
+	}
+}

--- a/internal/rhp/v3/rpc.go
+++ b/internal/rhp/v3/rpc.go
@@ -368,7 +368,7 @@ func rpcRenew(ctx context.Context, t *transportV3, gc gouging.Checker, rev types
 	}
 
 	// Perform gouging checks.
-	if breakdown := gc.Check(nil, &pt); breakdown.Gouging() {
+	if breakdown := gc.CheckV1(nil, &pt); breakdown.Gouging() {
 		return rhpv2.ContractRevision{}, nil, types.Currency{}, types.Currency{}, fmt.Errorf("host gouging during renew: %v", breakdown)
 	}
 

--- a/internal/rhp/v4/rhp.go
+++ b/internal/rhp/v4/rhp.go
@@ -46,9 +46,13 @@ func (c *Client) Settings(ctx context.Context, hk types.PublicKey, addr string) 
 		if err != nil {
 			return err
 		}
+		var validity time.Duration
+		if v := time.Until(settings.Prices.ValidUntil); v > 0 {
+			validity = v
+		}
 		hs = HostSettings{
 			HostSettings: settings,
-			Validity:     time.Until(settings.Prices.ValidUntil),
+			Validity:     validity,
 		}
 		return err
 	})

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -34,11 +34,11 @@ var (
 	ContractSet = "testset"
 
 	GougingSettings = api.GougingSettings{
-		MaxRPCPrice:      types.Siacoins(1).Div64(1000),        // 1mS per RPC
-		MaxContractPrice: types.Siacoins(10),                   // 10 SC per contract
-		MaxDownloadPrice: types.Siacoins(1).Mul64(1000),        // 1000 SC per 1 TiB
-		MaxUploadPrice:   types.Siacoins(1).Mul64(1000),        // 1000 SC per 1 TiB
-		MaxStoragePrice:  types.Siacoins(1000).Div64(144 * 30), // 1000 SC per month
+		MaxRPCPrice:      types.Siacoins(1).Div64(1000),                    // 1mS per RPC
+		MaxContractPrice: types.Siacoins(10),                               // 10 SC per contract
+		MaxDownloadPrice: types.Siacoins(1).Mul64(1000).Div64(1e12),        // 1000 SC per 1 TB
+		MaxUploadPrice:   types.Siacoins(1).Mul64(1000).Div64(1e12),        // 1000 SC per 1 TB
+		MaxStoragePrice:  types.Siacoins(1000).Div64(1e12).Div64(144 * 30), // 1000 SC per TB per month
 
 		HostBlockHeightLeeway: 240, // amount of leeway given to host block height
 

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -650,15 +650,10 @@ func addStorageFolderToHost(ctx context.Context, hosts []*Host) error {
 
 // announceHosts configures hosts with default settings and announces them to
 // the group
-func announceHosts(hosts []*Host, network *consensus.Network) error {
+func announceHosts(hosts []*Host) error {
 	for _, host := range hosts {
-		tip := host.index.Tip()
 		settings := defaultHostSettings
-		if tip.Height < network.HardforkV2.AllowHeight {
-			settings.NetAddress = host.RHPv2Addr()
-		} else {
-			settings.NetAddress = host.rhp4Listener.Addr().String()
-		}
+		settings.NetAddress = host.RHPv2Addr()
 		if err := host.settings.UpdateSettings(settings); err != nil {
 			return err
 		}
@@ -863,7 +858,7 @@ func (c *TestCluster) AddHost(h *Host) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	c.tt.OK(addStorageFolderToHost(ctx, []*Host{h}))
-	c.tt.OK(announceHosts([]*Host{h}, c.network))
+	c.tt.OK(announceHosts([]*Host{h}))
 
 	// Mine a block and wait until the host shows up.
 	c.MineBlocks(1)

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -650,10 +650,15 @@ func addStorageFolderToHost(ctx context.Context, hosts []*Host) error {
 
 // announceHosts configures hosts with default settings and announces them to
 // the group
-func announceHosts(hosts []*Host) error {
+func announceHosts(hosts []*Host, network *consensus.Network) error {
 	for _, host := range hosts {
+		tip := host.index.Tip()
 		settings := defaultHostSettings
-		settings.NetAddress = host.RHPv2Addr()
+		if tip.Height < network.HardforkV2.AllowHeight {
+			settings.NetAddress = host.RHPv2Addr()
+		} else {
+			settings.NetAddress = host.rhp4Listener.Addr().String()
+		}
 		if err := host.settings.UpdateSettings(settings); err != nil {
 			return err
 		}
@@ -858,7 +863,7 @@ func (c *TestCluster) AddHost(h *Host) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	c.tt.OK(addStorageFolderToHost(ctx, []*Host{h}))
-	c.tt.OK(announceHosts([]*Host{h}))
+	c.tt.OK(announceHosts([]*Host{h}, c.network))
 
 	// Mine a block and wait until the host shows up.
 	c.MineBlocks(1)

--- a/stores/hostdb.go
+++ b/stores/hostdb.go
@@ -111,12 +111,6 @@ func (s *SQLStore) RecordHostScans(ctx context.Context, scans []api.HostScan) er
 	})
 }
 
-func (s *SQLStore) RecordPriceTables(ctx context.Context, priceTableUpdate []api.HostPriceTableUpdate) error {
-	return s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
-		return tx.RecordPriceTables(ctx, priceTableUpdate)
-	})
-}
-
 func (s *SQLStore) UsableHosts(ctx context.Context) (hosts []sql.HostInfo, err error) {
 	err = s.db.Transaction(ctx, func(tx sql.DatabaseTx) error {
 		hosts, err = tx.UsableHosts(ctx)

--- a/stores/hostdb_test.go
+++ b/stores/hostdb_test.go
@@ -524,7 +524,7 @@ func TestUsableHosts(t *testing.T) {
 	// create gouging checker
 	gs := test.GougingSettings
 	cs := api.ConsensusState{Synced: true}
-	gc := gouging.NewChecker(gs, cs, nil, nil)
+	gc := gouging.NewChecker(gs, cs)
 
 	// assert h1 is not gouging
 	h1 := hosts[0]

--- a/stores/hostdb_test.go
+++ b/stores/hostdb_test.go
@@ -528,7 +528,7 @@ func TestUsableHosts(t *testing.T) {
 
 	// assert h1 is not gouging
 	h1 := hosts[0]
-	if gc.Check(&h1.HS, &h1.PT).Gouging() {
+	if gc.CheckV1(&h1.HS, &h1.PT).Gouging() {
 		t.Fatal("unexpected")
 	}
 
@@ -551,7 +551,7 @@ func TestUsableHosts(t *testing.T) {
 
 	// assert h1 is now gouging
 	h1 = hosts[0]
-	if !gc.Check(&h1.HS, &h1.PT).Gouging() {
+	if !gc.CheckV1(&h1.HS, &h1.PT).Gouging() {
 		t.Fatal("unexpected")
 	}
 

--- a/stores/hostdb_test.go
+++ b/stores/hostdb_test.go
@@ -1332,7 +1332,6 @@ func newTestScan(hk types.PublicKey, scanTime time.Time, settings rhpv2.HostSett
 func newTestHostCheck() api.HostCheck {
 	return api.HostCheck{
 		GougingBreakdown: api.HostGougingBreakdown{
-			ContractErr: "foo",
 			DownloadErr: "bar",
 			GougingErr:  "baz",
 			PruneErr:    "qux",
@@ -1350,6 +1349,7 @@ func newTestHostCheck() api.HostCheck {
 		UsabilityBreakdown: api.HostUsabilityBreakdown{
 			Blocked:               false,
 			Offline:               false,
+			LowMaxDuration:        false,
 			LowScore:              false,
 			RedundantIP:           false,
 			Gouging:               false,

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -257,10 +257,6 @@ type (
 		// therefore only useful for gouging checks.
 		RecordHostScans(ctx context.Context, scans []api.HostScan) error
 
-		// RecordPriceTables records price tables for hosts in the database
-		// increasing the successful/failed interactions accordingly.
-		RecordPriceTables(ctx context.Context, priceTableUpdate []api.HostPriceTableUpdate) error
-
 		// RemoveContractSet removes the contract set with the given name from
 		// the database.
 		RemoveContractSet(ctx context.Context, contractSet string) error

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -897,7 +897,7 @@ func Hosts(ctx context.Context, tx sql.Tx, opts api.HostOptions) ([]api.Host, er
 	}
 	rows, err = tx.Query(ctx, fmt.Sprintf(`
 		SELECT h.public_key, ap.identifier, hc.usability_blocked, hc.usability_offline, hc.usability_low_score, hc.usability_redundant_ip,
-			hc.usability_gouging, usability_not_accepting_contracts, hc.usability_not_announced, hc.usability_not_completing_scan,
+			hc.usability_gouging, hc.usability_low_max_duration, usability_not_accepting_contracts, hc.usability_not_announced, hc.usability_not_completing_scan,
 			hc.score_age, hc.score_collateral, hc.score_interactions, hc.score_storage_remaining, hc.score_uptime,
 			hc.score_version, hc.score_prices, hc.gouging_contract_err, hc.gouging_download_err, hc.gouging_gouging_err,
 			hc.gouging_prune_err, hc.gouging_upload_err
@@ -922,9 +922,9 @@ func Hosts(ctx context.Context, tx sql.Tx, opts api.HostOptions) ([]api.Host, er
 		var pk PublicKey
 		var hc api.HostCheck
 		err := rows.Scan(&pk, &ap, &hc.UsabilityBreakdown.Blocked, &hc.UsabilityBreakdown.Offline, &hc.UsabilityBreakdown.LowScore, &hc.UsabilityBreakdown.RedundantIP,
-			&hc.UsabilityBreakdown.Gouging, &hc.UsabilityBreakdown.NotAcceptingContracts, &hc.UsabilityBreakdown.NotAnnounced, &hc.UsabilityBreakdown.NotCompletingScan,
+			&hc.UsabilityBreakdown.Gouging, &hc.UsabilityBreakdown.LowMaxDuration, &hc.UsabilityBreakdown.NotAcceptingContracts, &hc.UsabilityBreakdown.NotAnnounced, &hc.UsabilityBreakdown.NotCompletingScan,
 			&hc.ScoreBreakdown.Age, &hc.ScoreBreakdown.Collateral, &hc.ScoreBreakdown.Interactions, &hc.ScoreBreakdown.StorageRemaining, &hc.ScoreBreakdown.Uptime,
-			&hc.ScoreBreakdown.Version, &hc.ScoreBreakdown.Prices, &hc.GougingBreakdown.ContractErr, &hc.GougingBreakdown.DownloadErr, &hc.GougingBreakdown.GougingErr,
+			&hc.ScoreBreakdown.Version, &hc.ScoreBreakdown.Prices, &hc.GougingBreakdown.DownloadErr, &hc.GougingBreakdown.GougingErr,
 			&hc.GougingBreakdown.PruneErr, &hc.GougingBreakdown.UploadErr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan host: %w", err)

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -18,13 +18,13 @@ import (
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
-	rhpv4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
 	rhp4 "go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/syncer"
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/internal/rhp/v4"
 	"go.sia.tech/renterd/internal/sql"
 	"go.sia.tech/renterd/object"
 	"go.sia.tech/renterd/webhooks"
@@ -43,7 +43,7 @@ type (
 		api.HostInfo
 		HS   rhpv2.HostSettings
 		PT   rhpv3.HostPriceTable
-		V2HS rhpv4.HostSettings
+		V2HS rhp.HostSettings
 	}
 
 	multipartUpload struct {
@@ -2263,7 +2263,7 @@ EXISTS (
 			},
 			rhpv2.HostSettings(hs),
 			rhpv3.HostPriceTable(pt),
-			rhpv4.HostSettings(v2Hs),
+			rhp.HostSettings(v2Hs),
 		})
 		hostIDs = append(hostIDs, hostID)
 	}

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -1706,43 +1706,6 @@ func RecordHostScans(ctx context.Context, tx sql.Tx, scans []api.HostScan) error
 	return nil
 }
 
-func RecordPriceTables(ctx context.Context, tx sql.Tx, priceTableUpdates []api.HostPriceTableUpdate) error {
-	if len(priceTableUpdates) == 0 {
-		return nil
-	}
-
-	stmt, err := tx.Prepare(ctx, `
-		UPDATE hosts SET
-		recent_downtime = CASE WHEN ? THEN recent_downtime = 0 ELSE recent_downtime END,
-		recent_scan_failures = CASE WHEN ? THEN recent_scan_failures = 0 ELSE recent_scan_failures END,
-		price_table = CASE WHEN ? THEN ? ELSE price_table END,
-		price_table_expiry =  CASE WHEN ? THEN ? ELSE price_table_expiry END,
-		successful_interactions =  CASE WHEN ? THEN successful_interactions + 1 ELSE successful_interactions END,
-		failed_interactions = CASE WHEN ? THEN failed_interactions + 1 ELSE failed_interactions END
-		WHERE public_key = ?
-	`)
-	if err != nil {
-		return fmt.Errorf("failed to prepare statement to update host with price table: %w", err)
-	}
-	defer stmt.Close()
-
-	for _, ptu := range priceTableUpdates {
-		_, err := stmt.Exec(ctx,
-			ptu.Success,                                            // recent_downtime
-			ptu.Success,                                            // recent_scan_failures
-			ptu.Success, PriceTable(ptu.PriceTable.HostPriceTable), // price_table
-			ptu.Success, ptu.PriceTable.Expiry, // price_table_expiry
-			ptu.Success,  // successful_interactions
-			!ptu.Success, // failed_interactions
-			PublicKey(ptu.HostKey),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to update host with price table: %w", err)
-		}
-	}
-	return nil
-}
-
 func RemoveContractSet(ctx context.Context, tx sql.Tx, contractSet string) error {
 	_, err := tx.Exec(ctx, "DELETE FROM contract_sets WHERE name = ?", contractSet)
 	if err != nil {

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -901,7 +901,7 @@ func Hosts(ctx context.Context, tx sql.Tx, opts api.HostOptions) ([]api.Host, er
 		SELECT h.public_key, ap.identifier, hc.usability_blocked, hc.usability_offline, hc.usability_low_score, hc.usability_redundant_ip,
 			hc.usability_gouging, hc.usability_low_max_duration, usability_not_accepting_contracts, hc.usability_not_announced, hc.usability_not_completing_scan,
 			hc.score_age, hc.score_collateral, hc.score_interactions, hc.score_storage_remaining, hc.score_uptime,
-			hc.score_version, hc.score_prices, hc.gouging_contract_err, hc.gouging_download_err, hc.gouging_gouging_err,
+			hc.score_version, hc.score_prices, hc.gouging_download_err, hc.gouging_gouging_err,
 			hc.gouging_prune_err, hc.gouging_upload_err
 		FROM (
 			SELECT h.id, h.public_key

--- a/stores/sql/mysql/chain.go
+++ b/stores/sql/mysql/chain.go
@@ -210,8 +210,8 @@ func (c chainUpdateTx) UpdateHost(hk types.PublicKey, v1Addr string, v2Ha chain.
 	// create the host
 	var hostID int64
 	if res, err := c.tx.Exec(c.ctx, `
-	INSERT INTO hosts (created_at, public_key, settings, price_table, total_scans, last_scan, last_scan_success, second_to_last_scan_success, scanned, uptime, downtime, recent_downtime, recent_scan_failures, successful_interactions, failed_interactions, lost_sectors, last_announcement, net_address)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	INSERT INTO hosts (created_at, public_key, settings, v2_settings, price_table, total_scans, last_scan, last_scan_success, second_to_last_scan_success, scanned, uptime, downtime, recent_downtime, recent_scan_failures, successful_interactions, failed_interactions, lost_sectors, last_announcement, net_address)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	ON DUPLICATE KEY UPDATE
 		last_announcement = VALUES(last_announcement),
 		net_address = VALUES(net_address),
@@ -220,6 +220,7 @@ func (c chainUpdateTx) UpdateHost(hk types.PublicKey, v1Addr string, v2Ha chain.
 		time.Now().UTC(),
 		ssql.PublicKey(hk),
 		ssql.HostSettings{},
+		ssql.V2HostSettings{},
 		ssql.PriceTable{},
 		0,
 		0,

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -1108,7 +1108,7 @@ func (tx *MainDatabaseTx) UpdateHostBlocklistEntries(ctx context.Context, add, r
 func (tx *MainDatabaseTx) UpdateHostCheck(ctx context.Context, autopilot string, hk types.PublicKey, hc api.HostCheck) error {
 	_, err := tx.Exec(ctx, `
 		INSERT INTO host_checks (created_at, db_autopilot_id, db_host_id, usability_blocked, usability_offline, usability_low_score,
-			usability_redundant_ip, usability_gouging, usability_not_accepting_contracts, usability_not_announced, usability_not_completing_scan,
+			usability_redundant_ip, usability_gouging, usability_low_max_duration, usability_not_accepting_contracts, usability_not_announced, usability_not_completing_scan,
 			score_age, score_collateral, score_interactions, score_storage_remaining, score_uptime, score_version, score_prices,
 			gouging_contract_err, gouging_download_err, gouging_gouging_err, gouging_prune_err, gouging_upload_err)
 	    VALUES (?,
@@ -1118,16 +1118,16 @@ func (tx *MainDatabaseTx) UpdateHostCheck(ctx context.Context, autopilot string,
 		ON DUPLICATE KEY UPDATE
 			created_at = VALUES(created_at), db_autopilot_id = VALUES(db_autopilot_id), db_host_id = VALUES(db_host_id),
 			usability_blocked = VALUES(usability_blocked), usability_offline = VALUES(usability_offline), usability_low_score = VALUES(usability_low_score),
-			usability_redundant_ip = VALUES(usability_redundant_ip), usability_gouging = VALUES(usability_gouging), usability_not_accepting_contracts = VALUES(usability_not_accepting_contracts),
+			usability_redundant_ip = VALUES(usability_redundant_ip), usability_gouging = VALUES(usability_gouging), usability_low_max_duration = VALUES(usability_low_max_duration), usability_not_accepting_contracts = VALUES(usability_not_accepting_contracts),
 			usability_not_announced = VALUES(usability_not_announced), usability_not_completing_scan = VALUES(usability_not_completing_scan),
 			score_age = VALUES(score_age), score_collateral = VALUES(score_collateral), score_interactions = VALUES(score_interactions),
 			score_storage_remaining = VALUES(score_storage_remaining), score_uptime = VALUES(score_uptime), score_version = VALUES(score_version),
 			score_prices = VALUES(score_prices), gouging_contract_err = VALUES(gouging_contract_err), gouging_download_err = VALUES(gouging_download_err),
 			gouging_gouging_err = VALUES(gouging_gouging_err), gouging_prune_err = VALUES(gouging_prune_err), gouging_upload_err = VALUES(gouging_upload_err)
 	`, time.Now(), autopilot, ssql.PublicKey(hk), hc.UsabilityBreakdown.Blocked, hc.UsabilityBreakdown.Offline, hc.UsabilityBreakdown.LowScore,
-		hc.UsabilityBreakdown.RedundantIP, hc.UsabilityBreakdown.Gouging, hc.UsabilityBreakdown.NotAcceptingContracts, hc.UsabilityBreakdown.NotAnnounced, hc.UsabilityBreakdown.NotCompletingScan,
+		hc.UsabilityBreakdown.RedundantIP, hc.UsabilityBreakdown.Gouging, hc.UsabilityBreakdown.LowMaxDuration, hc.UsabilityBreakdown.NotAcceptingContracts, hc.UsabilityBreakdown.NotAnnounced, hc.UsabilityBreakdown.NotCompletingScan,
 		hc.ScoreBreakdown.Age, hc.ScoreBreakdown.Collateral, hc.ScoreBreakdown.Interactions, hc.ScoreBreakdown.StorageRemaining, hc.ScoreBreakdown.Uptime, hc.ScoreBreakdown.Version, hc.ScoreBreakdown.Prices,
-		hc.GougingBreakdown.ContractErr, hc.GougingBreakdown.DownloadErr, hc.GougingBreakdown.GougingErr, hc.GougingBreakdown.PruneErr, hc.GougingBreakdown.UploadErr,
+		hc.GougingBreakdown.DownloadErr, hc.GougingBreakdown.GougingErr, hc.GougingBreakdown.PruneErr, hc.GougingBreakdown.UploadErr,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to insert host check: %w", err)

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -753,10 +753,6 @@ func (tx *MainDatabaseTx) RecordHostScans(ctx context.Context, scans []api.HostS
 	return ssql.RecordHostScans(ctx, tx, scans)
 }
 
-func (tx *MainDatabaseTx) RecordPriceTables(ctx context.Context, priceTableUpdates []api.HostPriceTableUpdate) error {
-	return ssql.RecordPriceTables(ctx, tx, priceTableUpdates)
-}
-
 func (tx *MainDatabaseTx) RemoveContractSet(ctx context.Context, contractSet string) error {
 	return ssql.RemoveContractSet(ctx, tx, contractSet)
 }

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -1110,7 +1110,7 @@ func (tx *MainDatabaseTx) UpdateHostCheck(ctx context.Context, autopilot string,
 		INSERT INTO host_checks (created_at, db_autopilot_id, db_host_id, usability_blocked, usability_offline, usability_low_score,
 			usability_redundant_ip, usability_gouging, usability_low_max_duration, usability_not_accepting_contracts, usability_not_announced, usability_not_completing_scan,
 			score_age, score_collateral, score_interactions, score_storage_remaining, score_uptime, score_version, score_prices,
-			gouging_contract_err, gouging_download_err, gouging_gouging_err, gouging_prune_err, gouging_upload_err)
+			gouging_download_err, gouging_gouging_err, gouging_prune_err, gouging_upload_err)
 	    VALUES (?,
 			(SELECT id FROM autopilots WHERE identifier = ?),
 			(SELECT id FROM hosts WHERE public_key = ?),

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -1122,7 +1122,7 @@ func (tx *MainDatabaseTx) UpdateHostCheck(ctx context.Context, autopilot string,
 			usability_not_announced = VALUES(usability_not_announced), usability_not_completing_scan = VALUES(usability_not_completing_scan),
 			score_age = VALUES(score_age), score_collateral = VALUES(score_collateral), score_interactions = VALUES(score_interactions),
 			score_storage_remaining = VALUES(score_storage_remaining), score_uptime = VALUES(score_uptime), score_version = VALUES(score_version),
-			score_prices = VALUES(score_prices), gouging_contract_err = VALUES(gouging_contract_err), gouging_download_err = VALUES(gouging_download_err),
+			score_prices = VALUES(score_prices), gouging_download_err = VALUES(gouging_download_err),
 			gouging_gouging_err = VALUES(gouging_gouging_err), gouging_prune_err = VALUES(gouging_prune_err), gouging_upload_err = VALUES(gouging_upload_err)
 	`, time.Now(), autopilot, ssql.PublicKey(hk), hc.UsabilityBreakdown.Blocked, hc.UsabilityBreakdown.Offline, hc.UsabilityBreakdown.LowScore,
 		hc.UsabilityBreakdown.RedundantIP, hc.UsabilityBreakdown.Gouging, hc.UsabilityBreakdown.LowMaxDuration, hc.UsabilityBreakdown.NotAcceptingContracts, hc.UsabilityBreakdown.NotAnnounced, hc.UsabilityBreakdown.NotCompletingScan,

--- a/stores/sql/mysql/migrations/main/schema.sql
+++ b/stores/sql/mysql/migrations/main/schema.sql
@@ -43,6 +43,7 @@ CREATE TABLE `hosts` (
   `created_at` datetime(3) DEFAULT NULL,
   `public_key` varbinary(32) NOT NULL,
   `settings` JSON,
+  `v2_settings` JSON NOT NULL DEFAULT '{}',
   `price_table` longtext,
   `price_table_expiry` datetime(3) DEFAULT NULL,
   `total_scans` bigint unsigned DEFAULT NULL,

--- a/stores/sql/mysql/migrations/main/schema.sql
+++ b/stores/sql/mysql/migrations/main/schema.sql
@@ -405,6 +405,7 @@ CREATE TABLE `host_checks` (
   INDEX `idx_host_checks_usability_low_score` (`usability_low_score`),
   INDEX `idx_host_checks_usability_redundant_ip` (`usability_redundant_ip`),
   INDEX `idx_host_checks_usability_gouging` (`usability_gouging`),
+  INDEX `idx_host_checks_usability_low_max_duration` (`usability_low_max_duration`),
   INDEX `idx_host_checks_usability_not_accepting_contracts` (`usability_not_accepting_contracts`),
   INDEX `idx_host_checks_usability_not_announced` (`usability_not_announced`),
   INDEX `idx_host_checks_usability_not_completing_scan` (`usability_not_completing_scan`),

--- a/stores/sql/mysql/migrations/main/schema.sql
+++ b/stores/sql/mysql/migrations/main/schema.sql
@@ -380,6 +380,7 @@ CREATE TABLE `host_checks` (
   `usability_low_score` boolean NOT NULL DEFAULT false,
   `usability_redundant_ip` boolean NOT NULL DEFAULT false,
   `usability_gouging` boolean NOT NULL DEFAULT false,
+  `usability_low_max_duration` boolean NOT NULL DEFAULT false,
   `usability_not_accepting_contracts` boolean NOT NULL DEFAULT false,
   `usability_not_announced` boolean NOT NULL DEFAULT false,
   `usability_not_completing_scan` boolean NOT NULL DEFAULT false,
@@ -392,7 +393,6 @@ CREATE TABLE `host_checks` (
   `score_version` double NOT NULL,
   `score_prices` double NOT NULL,
 
-  `gouging_contract_err` text,
   `gouging_download_err` text,
   `gouging_gouging_err` text,
   `gouging_prune_err` text,

--- a/stores/sql/mysql/migrations/main/schema.sql
+++ b/stores/sql/mysql/migrations/main/schema.sql
@@ -43,7 +43,7 @@ CREATE TABLE `hosts` (
   `created_at` datetime(3) DEFAULT NULL,
   `public_key` varbinary(32) NOT NULL,
   `settings` JSON,
-  `v2_settings` JSON NOT NULL DEFAULT '{}',
+  `v2_settings` JSON,
   `price_table` longtext,
   `price_table_expiry` datetime(3) DEFAULT NULL,
   `total_scans` bigint unsigned DEFAULT NULL,

--- a/stores/sql/sqlite/chain.go
+++ b/stores/sql/sqlite/chain.go
@@ -213,8 +213,8 @@ func (c chainUpdateTx) UpdateHost(hk types.PublicKey, v1Addr string, v2Ha chain.
 	// create the host
 	var hostID int64
 	if err := c.tx.QueryRow(c.ctx, `
-	INSERT INTO hosts (created_at, public_key, settings, price_table, total_scans, last_scan, last_scan_success, second_to_last_scan_success, scanned, uptime, downtime, recent_downtime, recent_scan_failures, successful_interactions, failed_interactions, lost_sectors, last_announcement, net_address)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	INSERT INTO hosts (created_at, public_key, settings, v2_settings, price_table, total_scans, last_scan, last_scan_success, second_to_last_scan_success, scanned, uptime, downtime, recent_downtime, recent_scan_failures, successful_interactions, failed_interactions, lost_sectors, last_announcement, net_address)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	ON CONFLICT(public_key) DO UPDATE SET
 		last_announcement = EXCLUDED.last_announcement,
 		net_address = EXCLUDED.net_address
@@ -222,6 +222,7 @@ func (c chainUpdateTx) UpdateHost(hk types.PublicKey, v1Addr string, v2Ha chain.
 		time.Now().UTC(),
 		ssql.PublicKey(hk),
 		ssql.HostSettings{},
+		ssql.V2HostSettings{},
 		ssql.PriceTable{},
 		0,
 		0,

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -763,10 +763,6 @@ func (tx *MainDatabaseTx) RecordHostScans(ctx context.Context, scans []api.HostS
 	return ssql.RecordHostScans(ctx, tx, scans)
 }
 
-func (tx *MainDatabaseTx) RecordPriceTables(ctx context.Context, priceTableUpdates []api.HostPriceTableUpdate) error {
-	return ssql.RecordPriceTables(ctx, tx, priceTableUpdates)
-}
-
 func (tx *MainDatabaseTx) RemoveContractSet(ctx context.Context, contractSet string) error {
 	return ssql.RemoveContractSet(ctx, tx, contractSet)
 }

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -1125,16 +1125,16 @@ func (tx *MainDatabaseTx) UpdateHostCheck(ctx context.Context, autopilot string,
 	    ON CONFLICT (db_autopilot_id, db_host_id) DO UPDATE SET
 	        created_at = EXCLUDED.created_at, db_autopilot_id = EXCLUDED.db_autopilot_id, db_host_id = EXCLUDED.db_host_id,
 	        usability_blocked = EXCLUDED.usability_blocked, usability_offline = EXCLUDED.usability_offline, usability_low_score = EXCLUDED.usability_low_score,
-	        usability_redundant_ip = EXCLUDED.usability_redundant_ip, usability_gouging = EXCLUDED.usability_gouging, usability_not_accepting_contracts = EXCLUDED.usability_not_accepting_contracts,
+	        usability_redundant_ip = EXCLUDED.usability_redundant_ip, usability_gouging = EXCLUDED.usability_gouging, usability_low_max_duration = EXCLUDED.usability_low_max_duration, usability_not_accepting_contracts = EXCLUDED.usability_not_accepting_contracts,
 	        usability_not_announced = EXCLUDED.usability_not_announced, usability_not_completing_scan = EXCLUDED.usability_not_completing_scan,
 	        score_age = EXCLUDED.score_age, score_collateral = EXCLUDED.score_collateral, score_interactions = EXCLUDED.score_interactions,
 	        score_storage_remaining = EXCLUDED.score_storage_remaining, score_uptime = EXCLUDED.score_uptime, score_version = EXCLUDED.score_version,
-	        score_prices = EXCLUDED.score_prices, gouging_contract_err = EXCLUDED.gouging_contract_err, gouging_download_err = EXCLUDED.gouging_download_err,
+	        score_prices = EXCLUDED.score_prices, gouging_download_err = EXCLUDED.gouging_download_err,
 	        gouging_gouging_err = EXCLUDED.gouging_gouging_err, gouging_prune_err = EXCLUDED.gouging_prune_err, gouging_upload_err = EXCLUDED.gouging_upload_err
 	    `, time.Now(), autopilot, ssql.PublicKey(hk), hc.UsabilityBreakdown.Blocked, hc.UsabilityBreakdown.Offline, hc.UsabilityBreakdown.LowScore,
-		hc.UsabilityBreakdown.RedundantIP, hc.UsabilityBreakdown.Gouging, hc.UsabilityBreakdown.NotAcceptingContracts, hc.UsabilityBreakdown.NotAnnounced, hc.UsabilityBreakdown.NotCompletingScan,
+		hc.UsabilityBreakdown.RedundantIP, hc.UsabilityBreakdown.Gouging, hc.UsabilityBreakdown.LowMaxDuration, hc.UsabilityBreakdown.NotAcceptingContracts, hc.UsabilityBreakdown.NotAnnounced, hc.UsabilityBreakdown.NotCompletingScan,
 		hc.ScoreBreakdown.Age, hc.ScoreBreakdown.Collateral, hc.ScoreBreakdown.Interactions, hc.ScoreBreakdown.StorageRemaining, hc.ScoreBreakdown.Uptime, hc.ScoreBreakdown.Version, hc.ScoreBreakdown.Prices,
-		hc.GougingBreakdown.ContractErr, hc.GougingBreakdown.DownloadErr, hc.GougingBreakdown.GougingErr, hc.GougingBreakdown.PruneErr, hc.GougingBreakdown.UploadErr,
+		hc.GougingBreakdown.DownloadErr, hc.GougingBreakdown.GougingErr, hc.GougingBreakdown.PruneErr, hc.GougingBreakdown.UploadErr,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to insert host check: %w", err)

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -1115,7 +1115,7 @@ func (tx *MainDatabaseTx) UpdateHostBlocklistEntries(ctx context.Context, add, r
 func (tx *MainDatabaseTx) UpdateHostCheck(ctx context.Context, autopilot string, hk types.PublicKey, hc api.HostCheck) error {
 	_, err := tx.Exec(ctx, `
 	    INSERT INTO host_checks (created_at, db_autopilot_id, db_host_id, usability_blocked, usability_offline, usability_low_score,
-	        usability_redundant_ip, usability_gouging, usability_not_accepting_contracts, usability_not_announced, usability_not_completing_scan,
+	        usability_redundant_ip, usability_gouging, usability_low_max_duration, usability_not_accepting_contracts, usability_not_announced, usability_not_completing_scan,
 	        score_age, score_collateral, score_interactions, score_storage_remaining, score_uptime, score_version, score_prices,
 	        gouging_contract_err, gouging_download_err, gouging_gouging_err, gouging_prune_err, gouging_upload_err)
 	    VALUES (?,

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -1117,7 +1117,7 @@ func (tx *MainDatabaseTx) UpdateHostCheck(ctx context.Context, autopilot string,
 	    INSERT INTO host_checks (created_at, db_autopilot_id, db_host_id, usability_blocked, usability_offline, usability_low_score,
 	        usability_redundant_ip, usability_gouging, usability_low_max_duration, usability_not_accepting_contracts, usability_not_announced, usability_not_completing_scan,
 	        score_age, score_collateral, score_interactions, score_storage_remaining, score_uptime, score_version, score_prices,
-	        gouging_contract_err, gouging_download_err, gouging_gouging_err, gouging_prune_err, gouging_upload_err)
+	        gouging_download_err, gouging_gouging_err, gouging_prune_err, gouging_upload_err)
 	    VALUES (?,
 			(SELECT id FROM autopilots WHERE identifier = ?),
 			(SELECT id FROM hosts WHERE public_key = ?),

--- a/stores/sql/sqlite/migrations/main/schema.sql
+++ b/stores/sql/sqlite/migrations/main/schema.sql
@@ -193,6 +193,7 @@ CREATE INDEX `idx_host_checks_usability_offline` ON `host_checks` (`usability_of
 CREATE INDEX `idx_host_checks_usability_low_score` ON `host_checks` (`usability_low_score`);
 CREATE INDEX `idx_host_checks_usability_redundant_ip` ON `host_checks` (`usability_redundant_ip`);
 CREATE INDEX `idx_host_checks_usability_gouging` ON `host_checks` (`usability_gouging`);
+CREATE INDEX `idx_host_checks_usability_low_max_duration` ON `host_checks` (`usability_low_max_duration`);
 CREATE INDEX `idx_host_checks_usability_not_accepting_contracts` ON `host_checks` (`usability_not_accepting_contracts`);
 CREATE INDEX `idx_host_checks_usability_not_announced` ON `host_checks` (`usability_not_announced`);
 CREATE INDEX `idx_host_checks_usability_not_completing_scan` ON `host_checks` (`usability_not_completing_scan`);

--- a/stores/sql/sqlite/migrations/main/schema.sql
+++ b/stores/sql/sqlite/migrations/main/schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE `hosts` (
 `created_at` datetime,
 `public_key` blob NOT NULL UNIQUE,
 `settings` text,
-`v2_settings` text NOT NULL DEFAULT '{}',
+`v2_settings` text,
 `price_table` text,
 `price_table_expiry` datetime,
 `total_scans` integer,

--- a/stores/sql/sqlite/migrations/main/schema.sql
+++ b/stores/sql/sqlite/migrations/main/schema.sql
@@ -1,5 +1,26 @@
 -- dbHost
-CREATE TABLE `hosts` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`public_key` blob NOT NULL UNIQUE,`settings` text,`price_table` text,`price_table_expiry` datetime,`total_scans` integer,`last_scan` integer,`last_scan_success` numeric,`second_to_last_scan_success` numeric,`scanned` numeric,`uptime` integer,`downtime` integer,`recent_downtime` integer,`recent_scan_failures` integer,`successful_interactions` real,`failed_interactions` real,`lost_sectors` integer,`last_announcement` datetime,`net_address` text);
+CREATE TABLE `hosts` (
+`id` integer PRIMARY KEY AUTOINCREMENT,
+`created_at` datetime,
+`public_key` blob NOT NULL UNIQUE,
+`settings` text,
+`v2_settings` text NOT NULL DEFAULT '{}',
+`price_table` text,
+`price_table_expiry` datetime,
+`total_scans` integer,
+`last_scan` integer,
+`last_scan_success` numeric,
+`second_to_last_scan_success` numeric,
+`scanned` numeric,
+`uptime` integer,
+`downtime` integer,
+`recent_downtime` integer,
+`recent_scan_failures` integer,
+`successful_interactions` real,
+`failed_interactions` real,
+`lost_sectors` integer,
+`last_announcement` datetime,
+`net_address` text);
 CREATE INDEX `idx_hosts_recent_scan_failures` ON `hosts`(`recent_scan_failures`);
 CREATE INDEX `idx_hosts_recent_downtime` ON `hosts`(`recent_downtime`);
 CREATE INDEX `idx_hosts_scanned` ON `hosts`(`scanned`);

--- a/stores/sql/sqlite/migrations/main/schema.sql
+++ b/stores/sql/sqlite/migrations/main/schema.sql
@@ -161,7 +161,32 @@ CREATE TABLE `object_user_metadata` (`id` integer PRIMARY KEY AUTOINCREMENT,`cre
 CREATE UNIQUE INDEX `idx_object_user_metadata_key` ON `object_user_metadata`(`db_object_id`,`db_multipart_upload_id`,`key`);
 
 -- dbHostCheck
-CREATE TABLE `host_checks` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `created_at` datetime, `db_autopilot_id` INTEGER NOT NULL, `db_host_id` INTEGER NOT NULL, `usability_blocked` INTEGER NOT NULL DEFAULT 0, `usability_offline` INTEGER NOT NULL DEFAULT 0, `usability_low_score` INTEGER NOT NULL DEFAULT 0, `usability_redundant_ip` INTEGER NOT NULL DEFAULT 0, `usability_gouging` INTEGER NOT NULL DEFAULT 0, `usability_not_accepting_contracts` INTEGER NOT NULL DEFAULT 0, `usability_not_announced` INTEGER NOT NULL DEFAULT 0, `usability_not_completing_scan` INTEGER NOT NULL DEFAULT 0, `score_age` REAL NOT NULL, `score_collateral` REAL NOT NULL, `score_interactions` REAL NOT NULL, `score_storage_remaining` REAL NOT NULL, `score_uptime` REAL NOT NULL, `score_version` REAL NOT NULL, `score_prices` REAL NOT NULL, `gouging_contract_err` TEXT, `gouging_download_err` TEXT, `gouging_gouging_err` TEXT, `gouging_prune_err` TEXT, `gouging_upload_err` TEXT, FOREIGN KEY (`db_autopilot_id`) REFERENCES `autopilots` (`id`) ON DELETE CASCADE, FOREIGN KEY (`db_host_id`) REFERENCES `hosts` (`id`) ON DELETE CASCADE);
+CREATE TABLE `host_checks` (
+`id` INTEGER PRIMARY KEY AUTOINCREMENT,
+`created_at` datetime,
+`db_autopilot_id` INTEGER NOT NULL,
+`db_host_id` INTEGER NOT NULL,
+`usability_blocked` INTEGER NOT NULL DEFAULT 0,
+`usability_offline` INTEGER NOT NULL DEFAULT 0,
+`usability_low_score` INTEGER NOT NULL DEFAULT 0,
+`usability_redundant_ip` INTEGER NOT NULL DEFAULT 0,
+`usability_gouging` INTEGER NOT NULL DEFAULT 0,
+`usability_low_max_duration` INTEGER NOT NULL DEFAULT 0,
+`usability_not_accepting_contracts` INTEGER NOT NULL DEFAULT 0,
+`usability_not_announced` INTEGER NOT NULL DEFAULT 0,
+`usability_not_completing_scan` INTEGER NOT NULL DEFAULT 0,
+`score_age` REAL NOT NULL,
+`score_collateral` REAL NOT NULL,
+`score_interactions` REAL NOT NULL,
+`score_storage_remaining` REAL NOT NULL,
+`score_uptime` REAL NOT NULL,
+`score_version` REAL NOT NULL,
+`score_prices` REAL NOT NULL,
+`gouging_download_err` TEXT,
+`gouging_gouging_err` TEXT,
+`gouging_prune_err` TEXT,
+`gouging_upload_err` TEXT,
+FOREIGN KEY (`db_autopilot_id`) REFERENCES `autopilots` (`id`) ON DELETE CASCADE, FOREIGN KEY (`db_host_id`) REFERENCES `hosts` (`id`) ON DELETE CASCADE);
 CREATE UNIQUE INDEX `idx_host_checks_id` ON `host_checks` (`db_autopilot_id`, `db_host_id`);
 CREATE INDEX `idx_host_checks_usability_blocked` ON `host_checks` (`usability_blocked`);
 CREATE INDEX `idx_host_checks_usability_offline` ON `host_checks` (`usability_offline`);

--- a/stores/sql/types.go
+++ b/stores/sql/types.go
@@ -559,7 +559,7 @@ func (hs *V2HostSettings) Scan(value interface{}) error {
 	case []byte:
 		bytes = value
 	default:
-		return errors.New(fmt.Sprint("failed to unmarshal Settings value:", value))
+		return errors.New(fmt.Sprint("failed to unmarshal V2Settings value:", value))
 	}
 	return json.Unmarshal(bytes, hs)
 }

--- a/stores/sql/types.go
+++ b/stores/sql/types.go
@@ -559,7 +559,7 @@ func (hs *V2HostSettings) Scan(value interface{}) error {
 	case []byte:
 		bytes = value
 	default:
-		return errors.New(fmt.Sprint("failed to unmarshal V2Settings value:", value))
+		return errors.New(fmt.Sprint("failed to unmarshal V2HostSettings value:", value))
 	}
 	return json.Unmarshal(bytes, hs)
 }

--- a/stores/sql/types.go
+++ b/stores/sql/types.go
@@ -14,12 +14,12 @@ import (
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
-	rhpv4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
 	rhp4 "go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/renterd/api"
+	"go.sia.tech/renterd/internal/rhp/v4"
 	"go.sia.tech/renterd/object"
 )
 
@@ -50,7 +50,7 @@ type (
 	DurationMS      time.Duration
 	Unsigned64      uint64
 	ChainProtocol   chain.Protocol
-	V2HostSettings  rhpv4.HostSettings
+	V2HostSettings  rhp.HostSettings
 
 	StateElement struct {
 		ID          Hash256

--- a/stores/sql/types.go
+++ b/stores/sql/types.go
@@ -14,6 +14,7 @@ import (
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	rhpv3 "go.sia.tech/core/rhp/v3"
+	rhpv4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
 	rhp4 "go.sia.tech/coreutils/rhp/v4"
@@ -49,6 +50,7 @@ type (
 	DurationMS      time.Duration
 	Unsigned64      uint64
 	ChainProtocol   chain.Protocol
+	V2HostSettings  rhpv4.HostSettings
 
 	StateElement struct {
 		ID          Hash256
@@ -79,6 +81,8 @@ var (
 	_ scannerValuer = (*UnixTimeMS)(nil)
 	_ scannerValuer = (*DurationMS)(nil)
 	_ scannerValuer = (*Unsigned64)(nil)
+	_ scannerValuer = (*ChainProtocol)(nil)
+	_ scannerValuer = (*V2HostSettings)(nil)
 )
 
 // Scan scan value into AutopilotConfig, implements sql.Scanner interface.
@@ -544,4 +548,26 @@ func (p ChainProtocol) Value() (driver.Value, error) {
 	default:
 		return nil, fmt.Errorf("invalid ChainProtocol value: %v", p)
 	}
+}
+
+// Scan scan value into V2HostSettings, implements sql.Scanner interface.
+func (hs *V2HostSettings) Scan(value interface{}) error {
+	var bytes []byte
+	switch value := value.(type) {
+	case string:
+		bytes = []byte(value)
+	case []byte:
+		bytes = value
+	default:
+		return errors.New(fmt.Sprint("failed to unmarshal Settings value:", value))
+	}
+	return json.Unmarshal(bytes, hs)
+}
+
+// Value returns a V2HostSettings value, implements driver.Valuer interface.
+func (hs V2HostSettings) Value() (driver.Value, error) {
+	if hs == (V2HostSettings{}) {
+		return []byte("{}"), nil
+	}
+	return json.Marshal(hs)
 }

--- a/worker/gouging.go
+++ b/worker/gouging.go
@@ -40,5 +40,5 @@ func newGougingChecker(settings api.GougingSettings, cs api.ConsensusState, crit
 			settings.MaxDownloadPrice = adjustedMaxDownloadPrice
 		}
 	}
-	return gouging.NewChecker(settings, cs, nil, nil)
+	return gouging.NewChecker(settings, cs)
 }

--- a/worker/host.go
+++ b/worker/host.go
@@ -71,6 +71,33 @@ func (w *Worker) Downloader(hk types.PublicKey, siamuxAddr string) host.Download
 	}
 }
 
+func (h *hostClient) DownloadSector(ctx context.Context, w io.Writer, root types.Hash256, offset, length uint32, overpay bool) (err error) {
+	var amount types.Currency
+	return h.acc.WithWithdrawal(func() (types.Currency, error) {
+		pt, uptc, err := h.priceTables.fetch(ctx, h.hk, nil)
+		if err != nil {
+			return types.ZeroCurrency, err
+		}
+		hpt := pt.HostPriceTable
+		amount = uptc
+
+		// check for download gouging specifically
+		gc, err := GougingCheckerFromContext(ctx, overpay)
+		if err != nil {
+			return amount, err
+		}
+		if breakdown := gc.CheckV1(nil, &hpt); breakdown.DownloadErr != "" {
+			return amount, fmt.Errorf("%w: %v", gouging.ErrPriceTableGouging, breakdown.DownloadErr)
+		}
+
+		cost, err := h.client.ReadSector(ctx, offset, length, root, w, h.hk, h.siamuxAddr, h.acc.ID(), h.acc.Key(), hpt)
+		if err != nil {
+			return amount, err
+		}
+		return amount.Add(cost), nil
+	})
+}
+
 func (h *hostClient) PublicKey() types.PublicKey { return h.hk }
 
 func (h *hostClient) UploadSector(ctx context.Context, sectorRoot types.Hash256, sector *[rhpv2.SectorSize]byte, rev types.FileContractRevision) error {
@@ -209,7 +236,7 @@ func (h *hostClient) priceTable(ctx context.Context, rev *types.FileContractRevi
 	if err != nil {
 		return rhpv3.HostPriceTable{}, cost, err
 	}
-	if breakdown := gc.Check(nil, &pt.HostPriceTable); breakdown.Gouging() {
+	if breakdown := gc.CheckV1(nil, &pt.HostPriceTable); breakdown.Gouging() {
 		return rhpv3.HostPriceTable{}, cost, fmt.Errorf("%w: %v", gouging.ErrPriceTableGouging, breakdown)
 	}
 	return pt.HostPriceTable, cost, nil


### PR DESCRIPTION
This PR gets `renterd` to a point where it scans announced v2 hosts, checks their usability/gouging and finally tries to form contracts which fails since we don't have support for that yet.

Depends on https://github.com/SiaFoundation/renterd/pull/1669

Closes https://github.com/SiaFoundation/renterd/issues/1674
Closes https://github.com/SiaFoundation/renterd/issues/1675
Closes https://github.com/SiaFoundation/renterd/issues/1679