### PR TITLE
Check for pre-existing migration

### DIFF
--- a/.changeset/check_for_existing_migration_00027_remove_directories_and_skip_both_00020_idx_db_directory_and_00020_remove_directories_if_already_applied.md
+++ b/.changeset/check_for_existing_migration_00027_remove_directories_and_skip_both_00020_idx_db_directory_and_00020_remove_directories_if_already_applied.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Check for existing migration '00027_remove_directories' and skip both '00020_idx_db_directory' and '00020_remove_directories' if already applied.

--- a/internal/sql/migrations.go
+++ b/internal/sql/migrations.go
@@ -23,6 +23,7 @@ type (
 	// required during migrations
 	Migrator interface {
 		ApplyMigration(ctx context.Context, fn func(tx Tx) (bool, error)) error
+		HasMigration(ctx context.Context, tx Tx, id string) (bool, error)
 		CreateMigrationTable(ctx context.Context) error
 		DB() *DB
 	}
@@ -311,12 +312,22 @@ var (
 			{
 				ID: "00020_idx_db_directory",
 				Migrate: func(tx Tx) error {
+					if applied, err := m.HasMigration(ctx, tx, "00027_remove_directories"); err != nil {
+						return fmt.Errorf("failed to check if migration '00027_remove_directories' was already applied: %w", err)
+					} else if applied {
+						return nil
+					}
 					return performMigration(ctx, tx, migrationsFs, dbIdentifier, "00020_idx_db_directory", log)
 				},
 			},
 			{
 				ID: "00020_remove_directories",
 				Migrate: func(tx Tx) error {
+					if applied, err := m.HasMigration(ctx, tx, "00027_remove_directories"); err != nil {
+						return fmt.Errorf("failed to check if migration '00027_remove_directories' was already applied: %w", err)
+					} else if applied {
+						return nil
+					}
 					return performMigration(ctx, tx, migrationsFs, dbIdentifier, "00020_remove_directories", log)
 				},
 			},

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -655,6 +655,11 @@ func FetchUsedContracts(ctx context.Context, tx sql.Tx, fcids []types.FileContra
 	return usedContracts, nil
 }
 
+func HasMigration(ctx context.Context, tx sql.Tx, id string) (applied bool, err error) {
+	err = tx.QueryRow(ctx, "SELECT EXISTS (SELECT 1 FROM migrations WHERE id = ?)", id).Scan(&applied)
+	return
+}
+
 func HostAllowlist(ctx context.Context, tx sql.Tx) ([]types.PublicKey, error) {
 	rows, err := tx.Query(ctx, "SELECT entry FROM host_allowlist_entries")
 	if err != nil {

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -55,6 +55,10 @@ func (b *MainDatabase) ApplyMigration(ctx context.Context, fn func(tx sql.Tx) (b
 	return applyMigration(ctx, b.db, fn)
 }
 
+func (b *MainDatabase) HasMigration(ctx context.Context, tx sql.Tx, id string) (bool, error) {
+	return ssql.HasMigration(ctx, tx, id)
+}
+
 func (b *MainDatabase) Close() error {
 	return b.db.Close()
 }

--- a/stores/sql/mysql/metrics.go
+++ b/stores/sql/mysql/metrics.go
@@ -55,6 +55,10 @@ func (b *MetricsDatabase) CreateMigrationTable(ctx context.Context) error {
 	return createMigrationTable(ctx, b.db)
 }
 
+func (b *MetricsDatabase) HasMigration(ctx context.Context, tx sql.Tx, id string) (bool, error) {
+	return ssql.HasMigration(ctx, tx, id)
+}
+
 func (b *MetricsDatabase) Migrate(ctx context.Context) error {
 	return sql.PerformMigrations(ctx, b, migrationsFs, "metrics", sql.MetricsMigrations(ctx, migrationsFs, b.log))
 }

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -54,6 +54,10 @@ func (b *MainDatabase) ApplyMigration(ctx context.Context, fn func(tx sql.Tx) (b
 	return applyMigration(ctx, b.db, fn)
 }
 
+func (b *MainDatabase) HasMigration(ctx context.Context, tx sql.Tx, id string) (bool, error) {
+	return ssql.HasMigration(ctx, tx, id)
+}
+
 func (b *MainDatabase) Close() error {
 	return closeDB(b.db, b.log)
 }

--- a/stores/sql/sqlite/metrics.go
+++ b/stores/sql/sqlite/metrics.go
@@ -54,6 +54,10 @@ func (b *MetricsDatabase) CreateMigrationTable(ctx context.Context) error {
 	return createMigrationTable(ctx, b.db)
 }
 
+func (b *MetricsDatabase) HasMigration(ctx context.Context, tx sql.Tx, id string) (bool, error) {
+	return ssql.HasMigration(ctx, tx, id)
+}
+
 func (b *MetricsDatabase) Migrate(ctx context.Context) error {
 	return sql.PerformMigrations(ctx, b, migrationsFs, "metrics", sql.MetricsMigrations(ctx, migrationsFs, b.log))
 }


### PR DESCRIPTION
Renaming `00027_remove_directories` to `00020_remove_directories` when merging in `master` back into `dev` has a nasty side-effect on nodes that already ran `00027_remove_directories` because the migration will try and run again and look for FKs that have already been removed. 

In hindsight, we should've immediately merged it as a hotfix, into `master` first and then `dev`. Updating the identifier to try and keep it a sequential list of IDs was the second mistake. Migrations should probably just have a descriptive name.