### PR TITLE
Track contract elements 

### DIFF
--- a/.changeset/track_contract_elements.md
+++ b/.changeset/track_contract_elements.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Track accumulator state elements for file contracts in a new contract_elements table

--- a/internal/bus/chainsubscriber.go
+++ b/internal/bus/chainsubscriber.go
@@ -247,7 +247,7 @@ func (s *chainSubscriber) revertChainUpdate(tx sql.ChainUpdateTx, cru chain.Reve
 
 	// reverted contracts
 	if err := tx.RemoveFileContractElements(revertedContracts); err != nil {
-		return fmt.Errorf("failed to insert v2 file contract elements: %w", err)
+		return fmt.Errorf("failed to remove v2 file contract elements: %w", err)
 	}
 
 	// contract proofs

--- a/internal/sql/migrations.go
+++ b/internal/sql/migrations.go
@@ -373,6 +373,12 @@ var (
 					return performMigration(ctx, tx, migrationsFs, dbIdentifier, "00028_contract_usability", log)
 				},
 			},
+			{
+				ID: "00029_contract_elements",
+				Migrate: func(tx Tx) error {
+					return performMigration(ctx, tx, migrationsFs, dbIdentifier, "00029_contract_elements", log)
+				},
+			},
 		}
 	}
 	MetricsMigrations = func(ctx context.Context, migrationsFs embed.FS, log *zap.SugaredLogger) []Migration {

--- a/stores/chain_test.go
+++ b/stores/chain_test.go
@@ -450,7 +450,18 @@ func TestContractElements(t *testing.T) {
 		}
 		assertContractElement(tx, 1, []types.Hash256{{1}})
 
-		// TODO: update the element's proof
+		// update the element's proof
+		if err := tx.UpdateFileContractElementProofs(&passthroughProofUpdater{
+			fn: func(se *types.StateElement) {
+				*se = types.StateElement{
+					LeafIndex:   2,
+					MerkleProof: []types.Hash256{{2}},
+				}
+			},
+		}); err != nil {
+			return err
+		}
+		assertContractElement(tx, 2, []types.Hash256{{2}})
 
 		// remove the contract element
 		if err := tx.RemoveFileContractElements([]types.FileContractID{fcid}); err != nil {

--- a/stores/sql/chain.go
+++ b/stores/sql/chain.go
@@ -160,7 +160,7 @@ func FileContractElement(ctx context.Context, tx sql.Tx, fcid types.FileContract
 	var contract V2Contract
 	var leafIndex uint64
 	var proof MerkleProof
-	err := tx.QueryRow(ctx, "SELECT contract, leaf_index, merkle_proof FROM contract_elements ce INNER JOIN contracts c ON ce.db_contract_id = c.id WHERE c.fcid = ?", Hash256(fcid)).
+	err := tx.QueryRow(ctx, "SELECT contract, leaf_index, merkle_proof FROM contract_elements ce INNER JOIN contracts c ON ce.db_contract_id = c.id WHERE c.fcid = ?", FileContractID(fcid)).
 		Scan(&contract, &leafIndex, &proof)
 	if err != nil {
 		return types.V2FileContractElement{}, err
@@ -196,7 +196,7 @@ func InsertFileContractElements(ctx context.Context, tx sql.Tx, fces []types.V2F
 		} else if err != nil {
 			return err
 		}
-		_, err = insertStmt.Exec(ctx, time.Now().UTC(), contractID, V2Contract(fce.V2FileContract), fce.StateElement.LeafIndex, MerkleProof{fce.StateElement.MerkleProof})
+		_, err = insertStmt.Exec(ctx, time.Now(), contractID, V2Contract(fce.V2FileContract), fce.StateElement.LeafIndex, MerkleProof{fce.StateElement.MerkleProof})
 		if err != nil {
 			return fmt.Errorf("failed to insert file contract element: %w", err)
 		}
@@ -219,7 +219,7 @@ func RemoveFileContractElements(ctx context.Context, tx sql.Tx, fcids []types.Fi
 
 	for _, fcid := range fcids {
 		var contractID int64
-		if err := contractIDStmt.QueryRow(ctx, Hash256(fcid)).Scan(&contractID); errors.Is(err, dsql.ErrNoRows) {
+		if err := contractIDStmt.QueryRow(ctx, FileContractID(fcid)).Scan(&contractID); errors.Is(err, dsql.ErrNoRows) {
 			continue
 		} else if err != nil {
 			return err

--- a/stores/sql/chain.go
+++ b/stores/sql/chain.go
@@ -157,7 +157,7 @@ func updateSiacoinStateElements(ctx context.Context, tx sql.Tx, elements []Siaco
 }
 
 func InsertFileContractElements(ctx context.Context, tx sql.Tx, fces []types.V2FileContractElement) error {
-	contractIDStmt, err := tx.Prepare(ctx, "SELECT c.id FROM contracts c INNER JOIN contract_elements ce ON c.id = contract_elements.db_contract_id WHERE c.fcid = ?")
+	contractIDStmt, err := tx.Prepare(ctx, "SELECT c.id FROM contracts c INNER JOIN contract_elements ce ON c.id = ce.db_contract_id WHERE c.fcid = ?")
 	if err != nil {
 		return err
 	}

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -19,6 +19,7 @@ import (
 type (
 	ChainUpdateTx interface {
 		ContractState(fcid types.FileContractID) (api.ContractState, error)
+		FileContractElement(fcid types.FileContractID) (types.V2FileContractElement, error)
 		InsertFileContractElements([]types.V2FileContractElement) error
 		RemoveFileContractElements([]types.FileContractID) error
 		UpdateChainIndex(index types.ChainIndex) error

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -19,7 +19,10 @@ import (
 type (
 	ChainUpdateTx interface {
 		ContractState(fcid types.FileContractID) (api.ContractState, error)
+		InsertFileContractElements([]types.V2FileContractElement) error
+		RemoveFileContractElements([]types.FileContractID) error
 		UpdateChainIndex(index types.ChainIndex) error
+		UpdateFileContractElementProofs(updater wallet.ProofUpdater) error
 		UpdateContractProofHeight(fcid types.FileContractID, proofHeight uint64) error
 		UpdateContractRevision(fcid types.FileContractID, revisionHeight, revisionNumber, size uint64) error
 		UpdateContractState(fcid types.FileContractID, state api.ContractState) error

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -1856,6 +1856,8 @@ func ResetChainState(ctx context.Context, tx sql.Tx) error {
 		return err
 	} else if _, err := tx.Exec(ctx, "DELETE FROM wallet_outputs"); err != nil {
 		return err
+	} else if _, err := tx.Exec(ctx, "DELETE FROM contract_elements"); err != nil {
+		return err
 	}
 	return nil
 }
@@ -2420,8 +2422,17 @@ func scanSiacoinElement(s Scanner) (el types.SiacoinElement, err error) {
 	}, nil
 }
 
-func scanStateElement(s Scanner) (se StateElement, err error) {
-	err = s.Scan(&se.ID, &se.LeafIndex, &se.MerkleProof)
+func scanFileContractStateElement(s Scanner) (se FileContractStateElement, err error) {
+	var proof MerkleProof
+	err = s.Scan(&se.ID, &se.LeafIndex, &proof)
+	se.MerkleProof = proof.Hashes
+	return
+}
+
+func scanSiacoinStateElement(s Scanner) (se SiacoinStateElement, err error) {
+	var proof MerkleProof
+	err = s.Scan(&se.ID, &se.LeafIndex, &proof)
+	se.MerkleProof = proof.Hashes
 	return
 }
 

--- a/stores/sql/mysql/chain.go
+++ b/stores/sql/mysql/chain.go
@@ -200,6 +200,18 @@ func (c chainUpdateTx) UpdateContractState(fcid types.FileContractID, state api.
 	return ssql.UpdateContractState(c.ctx, c.tx, fcid, state, c.l)
 }
 
+func (c chainUpdateTx) InsertFileContractElements(fces []types.V2FileContractElement) error {
+	return ssql.InsertFileContractElements(c.ctx, c.tx, fces)
+}
+
+func (c chainUpdateTx) RemoveFileContractElements(fcids []types.FileContractID) error {
+	return ssql.RemoveFileContractElements(c.ctx, c.tx, fcids)
+}
+
+func (c chainUpdateTx) UpdateFileContractElementProofs(updater wallet.ProofUpdater) error {
+	return ssql.UpdateFileContractElementProofs(c.ctx, c.tx, updater)
+}
+
 func (c chainUpdateTx) UpdateFailedContracts(blockHeight uint64) error {
 	return ssql.UpdateFailedContracts(c.ctx, c.tx, blockHeight, c.l)
 }

--- a/stores/sql/mysql/chain.go
+++ b/stores/sql/mysql/chain.go
@@ -200,6 +200,10 @@ func (c chainUpdateTx) UpdateContractState(fcid types.FileContractID, state api.
 	return ssql.UpdateContractState(c.ctx, c.tx, fcid, state, c.l)
 }
 
+func (c chainUpdateTx) FileContractElement(fcid types.FileContractID) (types.V2FileContractElement, error) {
+	return ssql.FileContractElement(c.ctx, c.tx, fcid)
+}
+
 func (c chainUpdateTx) InsertFileContractElements(fces []types.V2FileContractElement) error {
 	return ssql.InsertFileContractElements(c.ctx, c.tx, fces)
 }

--- a/stores/sql/mysql/migrations/main/migration_00029_contract_elements.sql
+++ b/stores/sql/mysql/migrations/main/migration_00029_contract_elements.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `contract_elements` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(3) DEFAULT NULL,
+  `db_contract_id` bigint unsigned NOT NULL,
+  `contract` longblob NOT NULL,
+  `leaf_index` bigint,
+  `merkle_proof` longblob NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_contract_elements_db_contrat_id` (`db_contract_id`),
+  CONSTRAINT `fk_contract_elements_contracts` FOREIGN KEY (`db_contract_id`) REFERENCES `contracts` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/stores/sql/mysql/migrations/main/schema.sql
+++ b/stores/sql/mysql/migrations/main/schema.sql
@@ -479,3 +479,16 @@ CREATE TABLE `wallet_outputs` (
   UNIQUE KEY `output_id` (`output_id`),
   KEY `idx_wallet_outputs_maturity_height` (`maturity_height`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- contract elements
+CREATE TABLE `contract_elements` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(3) DEFAULT NULL,
+  `db_contract_id` bigint unsigned NOT NULL,
+  `contract` longblob NOT NULL,
+  `leaf_index` bigint,
+  `merkle_proof` longblob NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_contract_elements_db_contrat_id` (`db_contract_id`),
+  CONSTRAINT `fk_contract_elements_contracts` FOREIGN KEY (`db_contract_id`) REFERENCES `contracts` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/stores/sql/sqlite/chain.go
+++ b/stores/sql/sqlite/chain.go
@@ -203,6 +203,18 @@ func (c chainUpdateTx) UpdateContractState(fcid types.FileContractID, state api.
 	return ssql.UpdateContractState(c.ctx, c.tx, fcid, state, c.l)
 }
 
+func (c chainUpdateTx) InsertFileContractElements(fces []types.V2FileContractElement) error {
+	return ssql.InsertFileContractElements(c.ctx, c.tx, fces)
+}
+
+func (c chainUpdateTx) RemoveFileContractElements(fcids []types.FileContractID) error {
+	return ssql.RemoveFileContractElements(c.ctx, c.tx, fcids)
+}
+
+func (c chainUpdateTx) UpdateFileContractElementProofs(updater wallet.ProofUpdater) error {
+	return ssql.UpdateFileContractElementProofs(c.ctx, c.tx, updater)
+}
+
 func (c chainUpdateTx) UpdateFailedContracts(blockHeight uint64) error {
 	return ssql.UpdateFailedContracts(c.ctx, c.tx, blockHeight, c.l)
 }

--- a/stores/sql/sqlite/chain.go
+++ b/stores/sql/sqlite/chain.go
@@ -203,6 +203,10 @@ func (c chainUpdateTx) UpdateContractState(fcid types.FileContractID, state api.
 	return ssql.UpdateContractState(c.ctx, c.tx, fcid, state, c.l)
 }
 
+func (c chainUpdateTx) FileContractElement(fcid types.FileContractID) (types.V2FileContractElement, error) {
+	return ssql.FileContractElement(c.ctx, c.tx, fcid)
+}
+
 func (c chainUpdateTx) InsertFileContractElements(fces []types.V2FileContractElement) error {
 	return ssql.InsertFileContractElements(c.ctx, c.tx, fces)
 }

--- a/stores/sql/sqlite/migrations/main/migration_00029_contract_elements.sql
+++ b/stores/sql/sqlite/migrations/main/migration_00029_contract_elements.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `contract_elements` (
+    `id` integer PRIMARY KEY AUTOINCREMENT,
+    `created_at` datetime,
+    `db_contract_id` integer NOT NULL,
+    `contract` blob NOT NULL,
+    `leaf_index` integer,
+    `merkle_proof` longblob NOT NULL,
+    CONSTRAINT `fk_contract_elements_contracts` FOREIGN KEY (`db_contract_id`) REFERENCES `contracts`(`id`) ON DELETE CASCADE);
+CREATE UNIQUE INDEX `idx_contract_elements_db_contract_id` ON `contract_elements`(`db_contract_id`);

--- a/stores/sql/sqlite/migrations/main/schema.sql
+++ b/stores/sql/sqlite/migrations/main/schema.sql
@@ -176,8 +176,9 @@ CREATE INDEX `idx_wallet_outputs_maturity_height` ON `wallet_outputs`(`maturity_
 CREATE TABLE `contract_elements` (
     `id` integer PRIMARY KEY AUTOINCREMENT,
     `created_at` datetime,
-    `db_contract_id` integer NOT NULL REFERENCES `contracts`(`id`) ON DELETE CASCADE,
-    `contract` blob,
+    `db_contract_id` integer NOT NULL,
+    `contract` blob NOT NULL,
     `leaf_index` integer,
-    `merkle_proof` longblob NOT NULL);
+    `merkle_proof` longblob NOT NULL,
+    CONSTRAINT `fk_contract_elements_contracts` FOREIGN KEY (`db_contract_id`) REFERENCES `contracts`(`id`) ON DELETE CASCADE);
 CREATE UNIQUE INDEX `idx_contract_elements_db_contract_id` ON `contract_elements`(`db_contract_id`);

--- a/stores/sql/sqlite/migrations/main/schema.sql
+++ b/stores/sql/sqlite/migrations/main/schema.sql
@@ -179,6 +179,5 @@ CREATE TABLE `contract_elements` (
     `db_contract_id` integer NOT NULL REFERENCES `contracts`(`id`) ON DELETE CASCADE,
     `contract` blob,
     `leaf_index` integer,
-    `merkle_proof` longblob NOT NULL,
-);
-CREATE UNIQUE INDEX `idx_contract_elements_db_contract_id` ON `contracts`(`db_contract_id`);
+    `merkle_proof` longblob NOT NULL);
+CREATE UNIQUE INDEX `idx_contract_elements_db_contract_id` ON `contract_elements`(`db_contract_id`);

--- a/stores/sql/sqlite/migrations/main/schema.sql
+++ b/stores/sql/sqlite/migrations/main/schema.sql
@@ -171,3 +171,14 @@ CREATE INDEX `idx_wallet_events_block_id_height` ON `wallet_events`(`block_id`,`
 CREATE TABLE `wallet_outputs` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`output_id` blob NOT NULL,`leaf_index` integer,`merkle_proof` longblob NOT NULL,`value` text,`address` blob,`maturity_height` integer);
 CREATE UNIQUE INDEX `idx_wallet_outputs_output_id` ON `wallet_outputs`(`output_id`);
 CREATE INDEX `idx_wallet_outputs_maturity_height` ON `wallet_outputs`(`maturity_height`);
+
+-- contract elements
+CREATE TABLE `contract_elements` (
+    `id` integer PRIMARY KEY AUTOINCREMENT,
+    `created_at` datetime,
+    `db_contract_id` integer NOT NULL REFERENCES `contracts`(`id`) ON DELETE CASCADE,
+    `contract` blob,
+    `leaf_index` integer,
+    `merkle_proof` longblob NOT NULL,
+);
+CREATE UNIQUE INDEX `idx_contract_elements_db_contract_id` ON `contracts`(`db_contract_id`);


### PR DESCRIPTION
This PR adds a `contract_elements` table which contains elements for all contracts in our database and updates their accumulator proofs. This a requirement for broadcasting file contract related txns such as broadcasting revisions.