### PR TITLE
Bucket name validation

### DIFF
--- a/.changeset/enforce_s3_bucket_name_validation_rules_on_bucket_creation_request.md
+++ b/.changeset/enforce_s3_bucket_name_validation_rules_on_bucket_creation_request.md
@@ -1,0 +1,5 @@
+---
+default: major
+---
+
+# Enforce S3 bucket name validation rules on bucket creation request

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"errors"
+	"regexp"
+	"strings"
 )
 
 var (
@@ -44,3 +46,17 @@ type (
 		Policy BucketPolicy `json:"policy"`
 	}
 )
+
+var validBucketExp = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$`)
+
+func (req BucketCreateRequest) Validate() error {
+	// make sure the bucket name complies with the restrictions for S3 transfer
+	// acceleration which are the regular S3 conventions with the additional
+	// restriction that the bucket name can't contain a period.
+	if strings.HasPrefix(req.Name, "xn--") ||
+		strings.HasSuffix(req.Name, "-s3alias") ||
+		!validBucketExp.MatchString(req.Name) {
+		return errors.New("the bucket name doesn't comply with the S3 bucket naming convention (https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)")
+	}
+	return nil
+}

--- a/api/bucket_test.go
+++ b/api/bucket_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBucketNameValidation(t *testing.T) {
+	tests := []struct {
+		name  string
+		valid bool
+		desc  string
+	}{
+		{
+			name:  "valid-bucket-name",
+			valid: true,
+			desc:  "valid bucket name",
+		},
+		{
+			name:  strings.Repeat("x", 2),
+			valid: false,
+			desc:  "too short",
+		},
+		{
+			name:  strings.Repeat("x", 64),
+			valid: false,
+			desc:  "too long",
+		},
+		{
+			name:  "foo.bar",
+			valid: false,
+			desc:  "contains period",
+		},
+		{
+			name:  "UPPERCASE",
+			valid: false,
+			desc:  "contains uppercase letter",
+		},
+		{
+			name:  "xn--forbidden-prefix",
+			valid: false,
+			desc:  "forbidden prefix",
+		},
+		{
+			name:  "forbidden-suffix-s3alias",
+			valid: false,
+			desc:  "forbidden suffix",
+		},
+		{
+			name:  "$pecial-©haracters",
+			valid: false,
+			desc:  "special characters",
+		},
+		{
+			name:  "with spaces",
+			valid: false,
+			desc:  "spaces",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			valid := BucketCreateRequest{Name: test.name}.Validate() == nil
+			if valid != test.valid {
+				t.Fatalf("'valid' should be %v but was %v", test.valid, valid)
+			}
+		})
+	}
+}

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -221,13 +221,13 @@ func (b *Bus) bucketsHandlerGET(jc jape.Context) {
 }
 
 func (b *Bus) bucketsHandlerPOST(jc jape.Context) {
-	var bucket api.BucketCreateRequest
-	if jc.Decode(&bucket) != nil {
+	var req api.BucketCreateRequest
+	if jc.Decode(&req) != nil {
 		return
-	} else if bucket.Name == "" {
-		jc.Error(errors.New("no name provided"), http.StatusBadRequest)
+	} else if err := req.Validate(); err != nil {
+		jc.Error(err, http.StatusBadRequest)
 		return
-	} else if jc.Check("failed to create bucket", b.store.CreateBucket(jc.Request.Context(), bucket.Name, bucket.Policy)) != nil {
+	} else if jc.Check("failed to create bucket", b.store.CreateBucket(jc.Request.Context(), req.Name, req.Policy)) != nil {
 		return
 	}
 }

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -384,7 +384,7 @@ func TestObjectsBucket(t *testing.T) {
 	tt := cluster.tt
 
 	// create a test bucket
-	bucket := "hello world"
+	bucket := "hello-world"
 	tt.OK(b.CreateBucket(context.Background(), bucket, api.CreateBucketOptions{}))
 
 	// upload an object to this bucket


### PR DESCRIPTION
Closes https://github.com/SiaFoundation/renterd/issues/1583

Right now we don't have any naming rules on buckets except for the name not being an empty string. Since that is not particularly useful and opens up room for odd edge cases, this PR adds the same bucket name validation rules that S3 has. That way any bucket name valid on S3 is also valid in `renterd` which makes it very easy to migrate buckets back and forth if so desired. 