### PR TITLE
Add openapi.yml file with autopilot routes

### DIFF
--- a/.changeset/add_openapiyml_file_with_autopilot_routes.md
+++ b/.changeset/add_openapiyml_file_with_autopilot_routes.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Add openapi.yml file with autopilot routes
+
+Added an openapi.yml spec with the specifications for the autopilot routes and a CI step to validate it. The goal is to eventually have a complete spec for the V2 API that we can use to generate API docs as well as making sure that there is always a valid spec for every given commit in the repo.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Validate OpenAPI spec
+        uses: swaggerexpert/swagger-editor-validate@v1
+        with:
+          definition-file: openapi.yaml
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,14 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup node
+        uses: actions/setup-node@v4
       - name: Checkout
         uses: actions/checkout@v4
       - name: Validate OpenAPI spec
-        uses: swaggerexpert/swagger-editor-validate@v1
-        with:
-          definition-file: openapi.yaml
+        run: |
+          npm install --global swagger-spec-validator
+          swagger-spec-validator openapi.yml
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/api/prometheus.go
+++ b/api/prometheus.go
@@ -478,11 +478,11 @@ func formatSettingsMetricName(gp GougingParams, name string) (metrics []promethe
 	})
 	metrics = append(metrics, prometheus.Metric{
 		Name:  fmt.Sprintf("renterd_%s_settings_minpricetablevalidity", name),
-		Value: float64(gp.GougingSettings.MinPriceTableValidity.Milliseconds()),
+		Value: float64(time.Duration(gp.GougingSettings.MinPriceTableValidity).Milliseconds()),
 	})
 	metrics = append(metrics, prometheus.Metric{
 		Name:  fmt.Sprintf("renterd_%s_settings_minaccountexpiry", name),
-		Value: float64(gp.GougingSettings.MinAccountExpiry.Milliseconds()),
+		Value: float64(time.Duration(gp.GougingSettings.MinAccountExpiry).Milliseconds()),
 	})
 	metrics = append(metrics, prometheus.Metric{
 		Name:  fmt.Sprintf("renterd_%s_settings_minmaxephemeralaccountbalance", name),

--- a/api/setting.go
+++ b/api/setting.go
@@ -104,11 +104,11 @@ type (
 
 		// MinPriceTableValidity is the minimum accepted value for `Validity` in the
 		// host's price settings.
-		MinPriceTableValidity time.Duration `json:"minPriceTableValidity"`
+		MinPriceTableValidity DurationMS `json:"minPriceTableValidity"`
 
 		// MinAccountExpiry is the minimum accepted value for `AccountExpiry` in the
 		// host's price settings.
-		MinAccountExpiry time.Duration `json:"minAccountExpiry"`
+		MinAccountExpiry DurationMS `json:"minAccountExpiry"`
 
 		// MinMaxEphemeralAccountBalance is the minimum accepted value for
 		// `MaxEphemeralAccountBalance` in the host's price settings.

--- a/api/setting.go
+++ b/api/setting.go
@@ -31,8 +31,8 @@ var (
 		MaxUploadPrice:                types.Siacoins(3000).Div64(1e12),                 // 3000 SC per 1 TB
 		MaxStoragePrice:               types.Siacoins(3000).Div64(1e12).Div64(144 * 30), // 3000 SC per TB per month
 		HostBlockHeightLeeway:         6,                                                // 6 blocks
-		MinPriceTableValidity:         5 * time.Minute,                                  // 5 minutes
-		MinAccountExpiry:              24 * time.Hour,                                   // 1 day
+		MinPriceTableValidity:         DurationMS(5 * time.Minute),                      // 5 minutes
+		MinAccountExpiry:              DurationMS(24 * time.Hour),                       // 1 day
 		MinMaxEphemeralAccountBalance: types.Siacoins(1),                                // 1 SC
 	}
 
@@ -207,13 +207,13 @@ func (gs GougingSettings) Validate() error {
 	if gs.HostBlockHeightLeeway < 3 {
 		return errors.New("HostBlockHeightLeeway must be at least 3 blocks")
 	}
-	if gs.MinAccountExpiry < time.Hour {
+	if time.Duration(gs.MinAccountExpiry) < time.Hour {
 		return errors.New("MinAccountExpiry must be at least 1 hour")
 	}
 	if gs.MinMaxEphemeralAccountBalance.Cmp(types.Siacoins(1)) < 0 {
 		return errors.New("MinMaxEphemeralAccountBalance must be at least 1 SC")
 	}
-	if gs.MinPriceTableValidity < 10*time.Second {
+	if time.Duration(gs.MinPriceTableValidity) < 10*time.Second {
 		return errors.New("MinPriceTableValidity must be at least 10 seconds")
 	}
 	return nil

--- a/internal/gouging/gouging.go
+++ b/internal/gouging/gouging.go
@@ -142,16 +142,16 @@ func (gc checker) CheckV2(hs rhp.HostSettings) (gb api.HostGougingBreakdown) {
 	if hs.MaxCollateral.IsZero() {
 		errs = append(errs, errors.New("max collateral is zero"))
 	}
-	if hs.Validity < gs.MinPriceTableValidity {
+	if hs.Validity < time.Duration(gs.MinPriceTableValidity) {
 		errs = append(errs, fmt.Errorf("price table validity is less than %v: %v", gs.MinPriceTableValidity, hs.Validity))
 	}
 	if err := checkBlockHeight(gc.consensusState, hs.Prices.TipHeight, uint64(gs.HostBlockHeightLeeway)); err != nil {
 		errs = append(errs, err)
 	}
-	if hs.Validity < gs.MinPriceTableValidity {
+	if hs.Validity < time.Duration(gs.MinPriceTableValidity) {
 		errs = append(errs, fmt.Errorf("price table validity is less than %v: %v", gs.MinPriceTableValidity, hs.Validity))
 	}
-	if hs.Validity < gs.MinPriceTableValidity {
+	if hs.Validity < time.Duration(gs.MinPriceTableValidity) {
 		errs = append(errs, fmt.Errorf("price table validity is less than %v: %v", gs.MinPriceTableValidity, hs.Validity))
 	}
 	if gougingErr := errsToStr(errs...); gougingErr != "" {
@@ -209,7 +209,7 @@ func checkPriceGougingHS(gs api.GougingSettings, hs *rhpv2.HostSettings) error {
 	}
 
 	// check EA expiry
-	if hs.EphemeralAccountExpiry < gs.MinAccountExpiry {
+	if hs.EphemeralAccountExpiry < time.Duration(gs.MinAccountExpiry) {
 		return fmt.Errorf("'EphemeralAccountExpiry' is less than the allowed minimum value, %v < %v", hs.EphemeralAccountExpiry, gs.MinAccountExpiry)
 	}
 
@@ -279,7 +279,7 @@ func checkPriceGougingPT(gs api.GougingSettings, cs api.ConsensusState, pt *rhpv
 	}
 
 	// check Validity
-	if pt.Validity < gs.MinPriceTableValidity {
+	if pt.Validity < time.Duration(gs.MinPriceTableValidity) {
 		return fmt.Errorf("'Validity' is less than the allowed minimum value, %v < %v", pt.Validity, gs.MinPriceTableValidity)
 	}
 

--- a/internal/gouging/gouging_test.go
+++ b/internal/gouging/gouging_test.go
@@ -35,7 +35,7 @@ func TestCheckV2(t *testing.T) {
 		MaxUploadPrice:        types.Siacoins(1),
 		MaxStoragePrice:       types.Siacoins(1),
 		HostBlockHeightLeeway: 1,
-		MinPriceTableValidity: time.Minute,
+		MinPriceTableValidity: api.DurationMS(time.Minute),
 	}, api.ConsensusState{
 		BlockHeight:   10,
 		Synced:        true,

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -38,9 +38,9 @@ var (
 
 		HostBlockHeightLeeway: 240, // amount of leeway given to host block height
 
-		MinPriceTableValidity:         10 * time.Second,  // minimum value for price table validity
-		MinAccountExpiry:              time.Hour,         // minimum value for account expiry
-		MinMaxEphemeralAccountBalance: types.Siacoins(1), // 1SC
+		MinPriceTableValidity:         api.DurationMS(10 * time.Second), // minimum value for price table validity
+		MinAccountExpiry:              api.DurationMS(time.Hour),        // minimum value for account expiry
+		MinMaxEphemeralAccountBalance: types.Siacoins(1),                // 1SC
 	}
 
 	PricePinSettings = api.DefaultPinnedSettings

--- a/openapi.yml
+++ b/openapi.yml
@@ -316,7 +316,7 @@ components:
           type: integer
           minimum: 1
           format: int32
-          description: The number of data shards a piece of an object gets erasure-coded intoo
+          description: The number of data shards a piece of an object gets erasure-coded into
         totalShards:
           type: integer
           minimum: 2

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,104 @@
+openapi: "3.0.0"
+info:
+  title: Autopilot API
+  version: 2.0.0
+  description: API for managing Autopilot configuration and related operations.
+
+paths:
+  #############################
+  #
+  # Autopilot routes
+  #
+  #############################
+  /autopilot/state:
+    get:
+      summary: Get the autopilot state
+      description: Returns the current state of the autopilot, including migration, pruning, and scanning status.
+      responses:
+        "200":
+          description: The current state of the autopilot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutopilotStateResponse"
+
+components:
+  schemas:
+    #############################
+    #
+    # Requests and responses
+    #
+    #############################
+
+    # GET /autopilot/state response
+    AutopilotStateResponse:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/BuildState"
+      properties:
+        enabled:
+          type: boolean
+          description: Whether the autopilot is enabled
+        migrating:
+          type: boolean
+          description: Indicates if the autopilot is currently migrating
+        migratingLastStart:
+          type: string
+          format: date-time
+          description: When migration last started
+        pruning:
+          type: boolean
+          description: Indicates if the autopilot is currently pruning
+        pruningLastStart:
+          type: string
+          format: date-time
+          description: When pruning last started
+        scanning:
+          type: boolean
+          description: Indicates if the autopilot is currently scanning
+        scanningLastStart:
+          type: string
+          format: date-time
+          description: When scanning last started
+        uptimeMs:
+          type: integer
+          format: int64
+          description: The autopilot uptime in milliseconds
+        startTime:
+          type: string
+          format: date-time
+          description: When the autopilot was started
+      required:
+        - enabled
+        - migrating
+        - migratingLastStart
+        - pruning
+        - pruningLastStart
+        - scanning
+        - scanningLastStart
+        - uptimeMs
+        - startTime
+        - buildState
+
+    #############################
+    #
+    # Helper types
+    #
+    #############################
+
+    BuildState:
+      type: object
+      properties:
+        buildTime:
+          type: string
+          format: date-time
+          description: The build time of the build
+        commit:
+          type: string
+          description: The commit hash of the build
+        version:
+          type: string
+          description: The version of the build
+        os:
+          type: string
+          description: The operating system of the build

--- a/openapi.yml
+++ b/openapi.yml
@@ -317,10 +317,8 @@ components:
           minimum: 1
           format: int32
           description: The number of data shards a piece of an object gets erasure-coded intoo
-          default: 0
         totalShards:
           type: integer
           minimum: 2
           format: int32
           description: The number of total data shards a piece of an object gets erasure-coded into
-          default: 0

--- a/openapi.yml
+++ b/openapi.yml
@@ -10,6 +10,95 @@ paths:
   # Autopilot routes
   #
   #############################
+  /autopilot/config/evaluate:
+    post:
+      summary: Evaluate autopilot configuration
+      description: Evaluates the provided autopilot configuration and returns some information about the hosts that would be considered usable using that configuration. If possible, it also returns a recommendation for a better configuration that would allow for forming contracts with more hosts.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                autopilotConfig:
+                  $ref: "#/components/schemas/AutopilotConfig"
+                gougingSettings:
+                  $ref: "#/components/schemas/GougingSettings"
+                redundancySettings:
+                  $ref: "#/components/schemas/RedundancySettings"
+      responses:
+        "400":
+          description: Malformed request
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+        "200":
+          description: The evaluated autopilot configuration
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hosts:
+                    type: integer
+                    format: uin64
+                    description: Number of hosts available
+                  usable:
+                    type: integer
+                    format: uint64
+                    description: Number of hosts that the autopilot could form contracts with using the provided config
+                  unusable:
+                    type: object
+                    properties:
+                      blocked:
+                        type: integer
+                        format: uint64
+                        description: Number of hosts unavailable due to being blocklisted
+                      gouging:
+                        type: object
+                        properties:
+                          contract:
+                            type: integer
+                            format: uint64
+                            description: Number of hosts that fail the contract gouging checks
+                          download:
+                            type: integer
+                            format: uint64
+                            description: Number of hosts that fail the download gouging checks
+                          gouging:
+                            type: integer
+                            format: uint64
+                            description: Number of hosts that fail the general gouging checks
+                          pruning:
+                            type: integer
+                            format: uint64
+                            description: Number of hosts that fail the pruning gouging checks
+                          upload:
+                            type: integer
+                            format: uint64
+                            description: Number of hosts that fail the upload gouging checks
+                      lowMaxDuration:
+                        type: integer
+                        format: uint64
+                        description: Number of hosts that have a max contract duration that is too low
+                      notAcceptingContracts:
+                        type: integer
+                        format: uint64
+                        description: Number of hosts that are not accepting contracts
+                      notScanned:
+                        type: integer
+                        format: uint64
+                        description: Number of hosts that haven't been successfully scanned yet
+                  recommendation:
+                    $ref: "#/components/schemas/ConfigRecommendation"
+
   /autopilot/state:
     get:
       summary: Get the autopilot state
@@ -20,71 +109,93 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AutopilotStateResponse"
+                type: object
+                allOf:
+                  - $ref: "#/components/schemas/BuildState"
+                properties:
+                  enabled:
+                    type: boolean
+                    description: Whether the autopilot is enabled
+                  migrating:
+                    type: boolean
+                    description: Indicates if the autopilot is currently migrating
+                  migratingLastStart:
+                    type: string
+                    format: date-time
+                    description: When migration last started
+                  pruning:
+                    type: boolean
+                    description: Indicates if the autopilot is currently pruning
+                  pruningLastStart:
+                    type: string
+                    format: date-time
+                    description: When pruning last started
+                  scanning:
+                    type: boolean
+                    description: Indicates if the autopilot is currently scanning
+                  scanningLastStart:
+                    type: string
+                    format: date-time
+                    description: When scanning last started
+                  uptimeMs:
+                    type: integer
+                    format: int64
+                    description: The autopilot uptime in milliseconds
+                  startTime:
+                    type: string
+                    format: date-time
+                    description: When the autopilot was started
+
+  /autopilot/trigger:
+    post:
+      summary: Wake up autopilot
+      description: Triggers the autopilot to start an iteration of contract maintenance and host scanning.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                forceScan:
+                  type: boolean
+                  description: If true, the autopilot force a new batch of host scans even if it recently scanned the hosts.
+                  default: false
+      responses:
+        "400":
+          description: Malformed request
+          content:
+            text/plain:
+              schema:
+                type: string
+        "200":
+          description: Successfully attempted to trigger the autopilot
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  triggered:
+                    type: boolean
+                    description: Indicates whether the request triggered a new iteration of the maintenance loop. If maintenance was already ongoing, this will be false.
 
 components:
   schemas:
     #############################
     #
-    # Requests and responses
+    # Helper types
     #
     #############################
 
-    # GET /autopilot/state response
-    AutopilotStateResponse:
+    AutopilotConfig:
       type: object
-      allOf:
-        - $ref: "#/components/schemas/BuildState"
       properties:
         enabled:
           type: boolean
           description: Whether the autopilot is enabled
-        migrating:
-          type: boolean
-          description: Indicates if the autopilot is currently migrating
-        migratingLastStart:
-          type: string
-          format: date-time
-          description: When migration last started
-        pruning:
-          type: boolean
-          description: Indicates if the autopilot is currently pruning
-        pruningLastStart:
-          type: string
-          format: date-time
-          description: When pruning last started
-        scanning:
-          type: boolean
-          description: Indicates if the autopilot is currently scanning
-        scanningLastStart:
-          type: string
-          format: date-time
-          description: When scanning last started
-        uptimeMs:
-          type: integer
-          format: int64
-          description: The autopilot uptime in milliseconds
-        startTime:
-          type: string
-          format: date-time
-          description: When the autopilot was started
-      required:
-        - enabled
-        - migrating
-        - migratingLastStart
-        - pruning
-        - pruningLastStart
-        - scanning
-        - scanningLastStart
-        - uptimeMs
-        - startTime
-        - buildState
-
-    #############################
-    #
-    # Helper types
-    #
-    #############################
+        contracts:
+          $ref: "#/components/schemas/ContractsConfig"
+        hosts:
+          $ref: "#/components/schemas/HostsConfig"
 
     BuildState:
       type: object
@@ -102,3 +213,114 @@ components:
         os:
           type: string
           description: The operating system of the build
+
+    ConfigRecommendation:
+      type: object
+      properties:
+        gougingSettings:
+          $ref: "#/components/schemas/GougingSettings"
+
+    ContractsConfig:
+      type: object
+      properties:
+        amount:
+          type: integer
+          format: uint64
+          description: The minimum number of contracts to form
+          default: 0
+        period:
+          type: integer
+          format: uint64
+          description: The length of a contract's period in blocks (1 block being 10 minutes on average)
+          default: 0
+        renewWindow:
+          type: integer
+          format: uint64
+          description: The number of blocks before the end of a contract that a contract should be renewed
+          default: 0
+        download:
+          type: integer
+          format: uint64
+          description: Expected download bandwidth used per period in bytes
+          default: 0
+        upload:
+          type: integer
+          format: uint64
+          description: Expected upload bandwidth used per period in bytes
+          default: 0
+        storage:
+          type: integer
+          format: uint64
+          description: Expected amount of data stored in bytes
+          default: 0
+        prune:
+          type: boolean
+          description: Whether to automatically prune deleted data from contracts
+          default: false
+
+    GougingSettings:
+      type: object
+      properties:
+        maxRPCPrice:
+          type: string
+          description: The maximum base price a host can charge per RPC
+        maxContractPrice:
+          type: string
+          description: The maximum price a host can charge for a contract formation
+        maxDownloadPrice:
+          type: string
+          description: The maximum price a host can charge for downloading in hastings / byte
+        maxUploadPrice:
+          type: string
+          description: The maximum price a host can charge for uploading in hastings / byte
+        maxStoragePrice:
+          type: string
+          description: The maximum price a host can charge for storage in hastings / byte / block
+        hostBlockHeightLeeway:
+          type: integer
+          format: uint32
+          description: The number of blocks a host's chain's height can diverge from our own before we stop using it
+        minPriceTableValidity:
+          type: integer
+          format: uint64
+          description: The time a host's price table should be valid after acquiring it in milliseconds
+        minAccountExpiry:
+          type: integer
+          format: uint64
+          description: The minimum amount of time an account on a host can be idle for before expiring
+        minMaxEphemeralAccountBalance:
+          type: string
+          description: The minimum max balance a host should allow us to fund an account with
+
+    HostsConfig:
+      type: object
+      properties:
+        maxConsecutiveScanFailures:
+          type: integer
+          format: uint64
+          description: The maximum number of consecutive scan failures before a host is removed from the database
+          default: 0
+        maxDowntimeHours:
+          type: integer
+          format: uint64
+          description: The maximum number of hours a host can be offline before it is removed from the database
+          default: 0
+        minProtocolVersion:
+          type: string
+          description: The minimum supported protocol version of a host to be considered good
+
+    RedundancySettings:
+      type: object
+      properties:
+        minShards:
+          type: integer
+          minimum: 1
+          format: int32
+          description: The number of data shards a piece of an object gets erasure-coded intoo
+          default: 0
+        totalShards:
+          type: integer
+          minimum: 2
+          format: int32
+          description: The number of total data shards a piece of an object gets erasure-coded into
+          default: 0


### PR DESCRIPTION
Added an openapi.yml spec with the specifications for the autopilot routes and a CI step to validate it. The goal is to eventually have a complete spec for the V2 API that we can use to generate API docs as well as making sure that there is always a valid spec for every given commit in the repo.