### PR TITLE
Add `bus` section to open api spec

### DIFF
--- a/bus/routes.go
+++ b/bus/routes.go
@@ -45,13 +45,16 @@ func (b *Bus) accountsFundHandler(jc jape.Context) {
 		return
 	}
 
-	// contract metadata
+	// fetch contract
 	cm, err := b.store.Contract(jc.Request.Context(), req.ContractID)
-	if jc.Check("failed to fetch contract metadata", err) != nil {
+	if errors.Is(err, api.ErrContractNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if jc.Check("failed to fetch contract metadata", err) != nil {
 		return
 	}
 
-	// host
+	// fetch host
 	host, err := b.store.Host(jc.Request.Context(), cm.HostKey)
 	if jc.Check("failed to fetch host for contract", err) != nil {
 		return

--- a/openapi.yml
+++ b/openapi.yml
@@ -180,7 +180,7 @@ paths:
 
   #############################
   #
-  # Autopilot routes
+  # Worker routes
   #
   #############################
   /worker/account/{hostkey}:
@@ -715,6 +715,110 @@ paths:
                           allOf:
                             - $ref: "#/components/schemas/PublicKey"
                             - description: The host's public key
+
+  #############################
+  #
+  # Bus routes
+  #
+  #############################
+  /bus/accounts:
+    get:
+      summary: Get all ephemeral accounts
+      description: Returns all known ephemeral accounts.
+      responses:
+        "200":
+          description: Successfully retrieved ephemeral accounts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Account"
+    post:
+      summary: Save accounts
+      description: Saves the provided accounts to the database.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                accounts:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/Account"
+      responses:
+        "200":
+          description: Successfully saved accounts
+          content:
+            text/plain:
+              schema:
+                type: string
+        "400":
+          description: Malformed request
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                missingOwnerField:
+                  summary: Missing owner field example
+                  value: "account is missing a valid 'owner' field"
+        "500":
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+  /bus/accounts/fund:
+    post:
+      summary: Fund account
+      description: Funds the specified account with the provided amount.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                accountID:
+                  allOf:
+                    - $ref: "#/components/schemas/PublicKey"
+                    - description: The ID of the account to fund.
+                amount:
+                  allOf:
+                    - $ref: "#/components/schemas/Currency"
+                    - description: The amount to fund the account with.
+                contractID:
+                  allOf:
+                    - $ref: "#/components/schemas/FileContractID"
+                    - description: The ID of the contract to fund the account with.
+      responses:
+        "200":
+          description: Successfully funded account
+          content:
+            text/plain:
+              schema:
+                type: string
+        "400":
+          description: Malformed request
+          content:
+            text/plain:
+              schema:
+                type: string
+        "404":
+          description: Contract not found
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+
+
 components:
   schemas:
     #############################


### PR DESCRIPTION
Added a `bus` API section containing the `/accounts` routes for now. 