### PR TITLE
Improve error output after a failed FK constraint check

### DIFF
--- a/.changeset/improve_migration_out_after_foreignkey_check_fails.md
+++ b/.changeset/improve_migration_out_after_foreignkey_check_fails.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Improve migration out after foreignkey check fails

--- a/stores/sql/sqlite/common.go
+++ b/stores/sql/sqlite/common.go
@@ -44,9 +44,26 @@ func applyMigration(ctx context.Context, db *sql.DB, fn func(tx sql.Tx) (bool, e
 		} else if !migrated {
 			return nil
 		}
+
 		// perform foreign key integrity check
-		if err := tx.QueryRow(ctx, "PRAGMA foreign_key_check").Scan(); !errors.Is(err, dsql.ErrNoRows) {
-			return fmt.Errorf("foreign key constraints are not satisfied")
+		rows, err := tx.Query(ctx, "PRAGMA foreign_key_check")
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		// check if there are any foreign key constraint violations
+		var tableName, foreignKey string
+		var rowID int
+		for rows.Next() {
+			if err := rows.Scan(&tableName, &rowID, &foreignKey); err != nil {
+				return fmt.Errorf("failed to scan foreign key check result: %w", err)
+			}
+			return fmt.Errorf("foreign key constraint violation in table '%s': row %d, foreign key %s", tableName, rowID, foreignKey)
+		}
+
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("error iterating foreign key check results: %w", err)
 		}
 		return nil
 	})


### PR DESCRIPTION
If `PRAGMA foreign_key_check` fails after running a migration, `renterd` currently outputs totally useless information. I updated the code to scan for all errors and indicate what FK failed on what table on what row.

Before:
```
failed to create node: failed to perform migrations: migration X failed: transaction failed (attempt 1): foreign key constraints are not satisfied, err sql: expected 4 destination arguments in Scan, not 0
```

After:
```
failed to create node: failed to perform migrations: migration X failed: transaction failed (attempt 1): foreign key constraint violation in table 'slabs': row 2423432, foreign key buffered_slabs
```