### PR TITLE
Allow worker id to be empty when worker isn't enabled

### DIFF
--- a/.changeset/allow_worker_id_to_be_empty_when_worker_is_disabled.md
+++ b/.changeset/allow_worker_id_to_be_empty_when_worker_is_disabled.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Allow worker id to be empty when worker is disabled

--- a/cmd/renterd/config.go
+++ b/cmd/renterd/config.go
@@ -134,9 +134,14 @@ func defaultConfig() config.Config {
 }
 
 func assertWorkerID(cfg *config.Config) error {
-	if cfg.Bus.RemoteAddr != "" && cfg.Worker.ID == "" {
+	if !cfg.Worker.Enabled {
+		// no worker
+		return nil
+	} else if cfg.Bus.RemoteAddr != "" && cfg.Worker.ID == "" {
+		// remote worker
 		return errors.New("a unique worker ID must be set in a cluster setup")
 	} else if cfg.Worker.ID == "" {
+		// local worker
 		cfg.Worker.ID = "worker"
 	}
 	return nil


### PR DESCRIPTION
Closes https://github.com/SiaFoundation/renterd/issues/1766