### PR TITLE
Soft-delete host sectors on archive

### DIFF
--- a/internal/sql/migrations.go
+++ b/internal/sql/migrations.go
@@ -543,6 +543,12 @@ var (
 					return performMigration(ctx, tx, migrationsFs, dbIdentifier, "00034_v2", log)
 				},
 			},
+			{
+				ID: "00035_soft_delete_host_sector",
+				Migrate: func(tx Tx) error {
+					return performMigration(ctx, tx, migrationsFs, dbIdentifier, "00035_soft_delete_host_sector", log)
+				},
+			},
 		}
 	}
 	MetricsMigrations = func(ctx context.Context, migrationsFs embed.FS, log *zap.SugaredLogger) []Migration {

--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -33,12 +33,17 @@ const (
 	// redundancy.
 	slabPruningBatchSize = 100
 
+	// hostSectorPruningBatchSize is the number of host sectors per batch when
+	// we prune host sectors.
+	hostSectorPruningBatchSize = 10000
+
 	refreshHealthMinHealthValidity = 12 * time.Hour
 	refreshHealthMaxHealthValidity = 72 * time.Hour
 )
 
 var (
-	pruneSlabsAlertID = frand.Entropy256()
+	pruneHostSectorsAlertID = frand.Entropy256()
+	pruneSlabsAlertID       = frand.Entropy256()
 )
 
 var objectDeleteBatchSizes = []int64{10, 50, 100, 200, 500, 1000, 5000, 10000, 50000, 100000}
@@ -127,6 +132,8 @@ func (s *SQLStore) ArchiveContract(ctx context.Context, id types.FileContractID,
 }
 
 func (s *SQLStore) ArchiveContracts(ctx context.Context, toArchive map[types.FileContractID]string) error {
+	defer s.triggerHostSectorPruning()
+
 	// archive contracts one-by-one to avoid overwhelming the database due to
 	// the cascade deletion of contract-sectors.
 	var errs []string
@@ -576,6 +583,54 @@ func (s *SQLStore) MarkPackedSlabsUploaded(ctx context.Context, slabs []api.Uplo
 	return nil
 }
 
+func (s *SQLStore) pruneHostSectorLoop() {
+	for {
+		select {
+		case <-s.hostSectorPruneSigChan:
+		case <-s.shutdownCtx.Done():
+			return
+		}
+
+		// prune host sectors
+		pruneSuccess := true
+		for {
+			var deleted int64
+			err := s.db.Transaction(s.shutdownCtx, func(dt sql.DatabaseTx) error {
+				var err error
+				deleted, err = dt.PruneHostSectors(s.shutdownCtx, hostSectorPruningBatchSize)
+				return err
+			})
+			if err != nil {
+				s.logger.Errorw("hest sector pruning failed", zap.Error(err))
+				s.alerts.RegisterAlert(s.shutdownCtx, alerts.Alert{
+					ID:        pruneHostSectorsAlertID,
+					Severity:  alerts.SeverityWarning,
+					Message:   "Failed to prune host sectors",
+					Timestamp: time.Now(),
+					Data: map[string]interface{}{
+						"error": err.Error(),
+						"hint":  "This might happen when your database is under a lot of load due to deleting objects rapidly. This alert will disappear the next time host sectors are pruned successfully.",
+					},
+				})
+				pruneSuccess = false
+			} else {
+				s.alerts.DismissAlerts(s.shutdownCtx, pruneHostSectorsAlertID)
+			}
+
+			if deleted < hostSectorPruningBatchSize {
+				break // done
+			}
+		}
+
+		// mark the last prune time where both slabs and dirs were pruned
+		if pruneSuccess {
+			s.mu.Lock()
+			s.lastPrunedHostSectorsAt = time.Now()
+			s.mu.Unlock()
+		}
+	}
+}
+
 func (s *SQLStore) pruneSlabsLoop() {
 	for {
 		select {
@@ -618,9 +673,16 @@ func (s *SQLStore) pruneSlabsLoop() {
 		// mark the last prune time where both slabs and dirs were pruned
 		if pruneSuccess {
 			s.mu.Lock()
-			s.lastPrunedAt = time.Now()
+			s.lastPrunedSlabsAt = time.Now()
 			s.mu.Unlock()
 		}
+	}
+}
+
+func (s *SQLStore) triggerHostSectorPruning() {
+	select {
+	case s.hostSectorPruneSigChan <- struct{}{}:
+	default:
 	}
 }
 

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -97,7 +97,7 @@ func (s *SQLStore) waitForPruneLoop(ts time.Time) error {
 	return test.Retry(100, 100*time.Millisecond, func() error {
 		s.mu.Lock()
 		defer s.mu.Unlock()
-		if !s.lastPrunedAt.After(ts) {
+		if !s.lastPrunedSlabsAt.After(ts) {
 			return errors.New("slabs have not been pruned yet")
 		}
 		return nil

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -28,6 +28,15 @@ import (
 
 const testBucket = "testbucket"
 
+func (s *testSQLStore) ArchiveContractBlocking(ctx context.Context, id types.FileContractID, reason string) error {
+	ts := time.Now()
+	time.Sleep(time.Millisecond)
+	if err := s.ArchiveContract(ctx, id, reason); err != nil {
+		return err
+	}
+	return s.waitForHostSectorPruneLoop(ts)
+}
+
 func (s *testSQLStore) InsertSlab(slab object.Slab) {
 	s.t.Helper()
 	obj := object.Object{
@@ -50,7 +59,7 @@ func (s *SQLStore) RemoveObjectBlocking(ctx context.Context, bucket, key string)
 	if err := s.RemoveObject(ctx, bucket, key); err != nil {
 		return err
 	}
-	return s.waitForPruneLoop(ts)
+	return s.waitForSlabPruneLoop(ts)
 }
 
 func (s *SQLStore) RemoveObjectsBlocking(ctx context.Context, bucket, prefix string) error {
@@ -59,7 +68,7 @@ func (s *SQLStore) RemoveObjectsBlocking(ctx context.Context, bucket, prefix str
 	if err := s.RemoveObjects(ctx, bucket, prefix); err != nil {
 		return err
 	}
-	return s.waitForPruneLoop(ts)
+	return s.waitForSlabPruneLoop(ts)
 }
 
 func (s *SQLStore) RenameObjectBlocking(ctx context.Context, bucket, keyOld, keyNew string, force bool) error {
@@ -68,7 +77,7 @@ func (s *SQLStore) RenameObjectBlocking(ctx context.Context, bucket, keyOld, key
 	if err := s.RenameObject(ctx, bucket, keyOld, keyNew, force); err != nil {
 		return err
 	}
-	return s.waitForPruneLoop(ts)
+	return s.waitForSlabPruneLoop(ts)
 }
 
 func (s *SQLStore) RenameObjectsBlocking(ctx context.Context, bucket, prefixOld, prefixNew string, force bool) error {
@@ -77,7 +86,7 @@ func (s *SQLStore) RenameObjectsBlocking(ctx context.Context, bucket, prefixOld,
 	if err := s.RenameObjects(ctx, bucket, prefixOld, prefixNew, force); err != nil {
 		return err
 	}
-	return s.waitForPruneLoop(ts)
+	return s.waitForSlabPruneLoop(ts)
 }
 
 func (s *SQLStore) UpdateObjectBlocking(ctx context.Context, bucket, path, eTag, mimeType string, metadata api.ObjectUserMetadata, o object.Object) error {
@@ -90,10 +99,21 @@ func (s *SQLStore) UpdateObjectBlocking(ctx context.Context, bucket, path, eTag,
 	if err := s.UpdateObject(ctx, bucket, path, eTag, mimeType, metadata, o); err != nil {
 		return err
 	}
-	return s.waitForPruneLoop(ts)
+	return s.waitForSlabPruneLoop(ts)
 }
 
-func (s *SQLStore) waitForPruneLoop(ts time.Time) error {
+func (s *SQLStore) waitForHostSectorPruneLoop(ts time.Time) error {
+	return test.Retry(100, 100*time.Millisecond, func() error {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if !s.lastPrunedHostSectorsAt.After(ts) {
+			return errors.New("host sectors have not been pruned yet")
+		}
+		return nil
+	})
+}
+
+func (s *SQLStore) waitForSlabPruneLoop(ts time.Time) error {
 	return test.Retry(100, 100*time.Millisecond, func() error {
 		s.mu.Lock()
 		defer s.mu.Unlock()
@@ -4832,7 +4852,7 @@ func TestHostSectors(t *testing.T) {
 	}
 
 	// archive the 2nd contract
-	if err := ss.ArchiveContract(context.Background(), fcids[1], "foo"); err != nil {
+	if err := ss.ArchiveContractBlocking(context.Background(), fcids[1], "foo"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -242,6 +242,10 @@ type (
 		// the contract.
 		PrunableContractRoots(ctx context.Context, fcid types.FileContractID, roots []types.Hash256) (indices []uint64, err error)
 
+		// PruneHostSectors deletes host-sector links for sectors that are no
+		// longer linked to an active contract.
+		PruneHostSectors(ctx context.Context, limit int64) (int64, error)
+
 		// PruneSlabs deletes slabs that are no longer referenced by any slice
 		// or slab buffer.
 		PruneSlabs(ctx context.Context, limit int64) (int64, error)

--- a/stores/sql/mysql/migrations/main/migration_00035_soft_delete_host_sector.sql
+++ b/stores/sql/mysql/migrations/main/migration_00035_soft_delete_host_sector.sql
@@ -1,0 +1,2 @@
+ALTER TABLE host_sectors ADD COLUMN `deleted_at` datetime(3) DEFAULT NULL;
+CREATE INDEX `idx_host_sectors_deleted_at` ON `host_sectors` (`deleted_at`);

--- a/stores/sql/mysql/migrations/main/schema.sql
+++ b/stores/sql/mysql/migrations/main/schema.sql
@@ -156,10 +156,12 @@ CREATE TABLE `contract_sectors` (
 -- dbHost <-> dbSector
 CREATE TABLE `host_sectors` (
   `updated_at` datetime(3) DEFAULT NULL,
+  `deleted_at` datetime(3) DEFAULT NULL,
   `db_sector_id` bigint unsigned NOT NULL,
   `db_host_id` bigint unsigned NOT NULL,
   PRIMARY KEY (`db_sector_id`, `db_host_id`),
   KEY `idx_host_sectors_updated_at` (`updated_at`),
+  KEY `idx_host_sectors_deleted_at` (`deleted_at`),
   KEY `idx_host_sectors_db_sector_id` (`db_sector_id`),
   KEY `idx_host_sectors_db_host_id` (`db_host_id`),
   CONSTRAINT `fk_host_sectors_db_sector` FOREIGN KEY (`db_sector_id`) REFERENCES `sectors` (`id`) ON DELETE CASCADE,

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -727,6 +727,21 @@ CREATE INDEX %s_idx ON %s (root);`, tmpTable, tmpTable, tmpTable, tmpTable))
 	return
 }
 
+func (tx *MainDatabaseTx) PruneHostSectors(ctx context.Context, limit int64) (int64, error) {
+	res, err := tx.Exec(ctx, `DELETE FROM host_sectors
+		WHERE rowid IN (
+			SELECT rowid
+			FROM host_sectors
+			WHERE deleted_at IS NOT NULL
+			ORDER BY rowid
+			LIMIT ?
+		)`, limit)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 func (tx *MainDatabaseTx) PruneSlabs(ctx context.Context, limit int64) (int64, error) {
 	res, err := tx.Exec(ctx, `
 	DELETE FROM slabs
@@ -1183,7 +1198,7 @@ func (tx *MainDatabaseTx) UpsertContractSectors(ctx context.Context, contractSec
 	defer insertContractSectorStmt.Close()
 
 	// insert host <-> sector links
-	insertHostSectorStmt, err := tx.Prepare(ctx, `INSERT INTO host_sectors (updated_at, db_sector_id, db_host_id) VALUES (?, ?, ?) ON CONFLICT DO UPDATE SET updated_at = EXCLUDED.updated_at`)
+	insertHostSectorStmt, err := tx.Prepare(ctx, `INSERT INTO host_sectors (updated_at, db_sector_id, db_host_id) VALUES (?, ?, ?) ON CONFLICT DO UPDATE SET updated_at = EXCLUDED.updated_at, deleted_at = NULL`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement to insert host sector link: %w", err)
 	}

--- a/stores/sql/sqlite/migrations/main/migration_00035_soft_delete_host_sector.sql
+++ b/stores/sql/sqlite/migrations/main/migration_00035_soft_delete_host_sector.sql
@@ -1,0 +1,2 @@
+ALTER TABLE host_sectors ADD COLUMN `deleted_at` datetime;
+CREATE INDEX `idx_host_sectors_deleted_at` ON `host_sectors` (`deleted_at`);

--- a/stores/sql/sqlite/migrations/main/schema.sql
+++ b/stores/sql/sqlite/migrations/main/schema.sql
@@ -89,8 +89,9 @@ CREATE INDEX `idx_contract_sectors_db_contract_id` ON `contract_sectors`(`db_con
 CREATE INDEX `idx_contract_sectors_db_sector_id` ON `contract_sectors`(`db_sector_id`);
 
 -- dbHost <-> dbSector
-CREATE TABLE `host_sectors` (`updated_at` datetime, `db_sector_id` integer,`db_host_id` integer,PRIMARY KEY (`db_sector_id`,`db_host_id`),CONSTRAINT `fk_host_sectors_db_sector` FOREIGN KEY (`db_sector_id`) REFERENCES `sectors`(`id`) ON DELETE CASCADE,CONSTRAINT `fk_contract_sectors_db_host` FOREIGN KEY (`db_host_id`) REFERENCES `hosts`(`id`) ON DELETE CASCADE);
+CREATE TABLE `host_sectors` (`updated_at` datetime, `deleted_at` datetime, `db_sector_id` integer,`db_host_id` integer,PRIMARY KEY (`db_sector_id`,`db_host_id`),CONSTRAINT `fk_host_sectors_db_sector` FOREIGN KEY (`db_sector_id`) REFERENCES `sectors`(`id`) ON DELETE CASCADE,CONSTRAINT `fk_contract_sectors_db_host` FOREIGN KEY (`db_host_id`) REFERENCES `hosts`(`id`) ON DELETE CASCADE);
 CREATE INDEX `idx_host_sectors_updated_at` ON `host_sectors`(`updated_at`);
+CREATE INDEX `idx_host_sectors_deleted_at` ON `host_sectors`(`deleted_at`);
 CREATE INDEX `idx_host_sectors_db_host_id` ON `host_sectors`(`db_host_id`);
 CREATE INDEX `idx_host_sectors_db_sector_id` ON `host_sectors`(`db_sector_id`);
 


### PR DESCRIPTION
This PR soft deletes host sectors and adds a prune loop that runs in the background to remove all sectors that are no longer attached to an active contract. Very much like how we deal with slab pruning. I've tried and benchmarked a couple of alternatives where I was batching deletes, rewriting the query to avoid `NOT EXISTS` but overall ended up resorting to soft deletion. I considered having a single prune loop, but opted to keep it separate.