### PR TITLE
Don't prune slabs on startup

### DIFF
--- a/.changeset/dont_perform_full_slab_prune_on_startup.md
+++ b/.changeset/dont_perform_full_slab_prune_on_startup.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# don't perform full slab prune on startup

--- a/stores/sql.go
+++ b/stores/sql.go
@@ -3,7 +3,6 @@ package stores
 import (
 	"context"
 	"fmt"
-	"math"
 	"os"
 	"sync"
 	"time"
@@ -110,25 +109,17 @@ func NewSQLStore(cfg Config) (*SQLStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := ss.initSlabPruning(); err != nil {
-		return nil, err
-	}
+	ss.initSlabPruning()
 	return ss, nil
 }
 
-func (s *SQLStore) initSlabPruning() error {
+func (s *SQLStore) initSlabPruning() {
 	// start pruning loop
 	s.wg.Add(1)
 	go func() {
 		s.pruneSlabsLoop()
 		s.wg.Done()
 	}()
-
-	// prune once to guarantee consistency on startup
-	return s.db.Transaction(s.shutdownCtx, func(tx sql.DatabaseTx) error {
-		_, err := tx.PruneSlabs(s.shutdownCtx, math.MaxInt64)
-		return err
-	})
 }
 
 // Close closes the underlying database connection of the store.


### PR DESCRIPTION
If the database is busy due to lots of slabs requiring pruning, this can prevent renterd from starting. Instead the background loop should handle this.

Ran this on gompa to get it to break out of a restart loop