### PR TITLE
Improve slab pruning query

### DIFF
--- a/.changeset/speed_up_slab_pruning_query.md
+++ b/.changeset/speed_up_slab_pruning_query.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Speed up slab pruning query

--- a/api/prometheus.go
+++ b/api/prometheus.go
@@ -838,7 +838,6 @@ func (t TxPoolFeeResp) ToFloat64() (float64, error) {
 func (t TxPoolFeeResp) PrometheusMetric() (metrics []prometheus.Metric) {
 	floatValue, err := t.ToFloat64()
 	if err != nil {
-		fmt.Println("Error:", err)
 		return
 	}
 	return []prometheus.Metric{

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -1635,12 +1635,13 @@ func PruneSlabs(ctx context.Context, tx sql.Tx, limit int64) (int64, error) {
 	res, err := tx.Exec(ctx, `
 	DELETE FROM slabs
 	WHERE id IN (
-		SELECT s.id
-		FROM slabs s
-		LEFT JOIN slices sl ON sl.db_slab_id = s.id
-		WHERE s.db_buffered_slab_id IS NULL AND sl.db_slab_id IS NULL
-		LIMIT ?
-		)
+		SELECT id FROM (
+			SELECT s.id
+			FROM slabs s
+			LEFT JOIN slices sl ON sl.db_slab_id = s.id
+			WHERE s.db_buffered_slab_id IS NULL AND sl.db_slab_id IS NULL
+			LIMIT ?
+		) AS limited
 	)`, limit)
 	if err != nil {
 		return 0, err

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -1631,6 +1631,23 @@ func Peers(ctx context.Context, tx sql.Tx) ([]syncer.PeerInfo, error) {
 	return peers, nil
 }
 
+func PruneSlabs(ctx context.Context, tx sql.Tx, limit int64) (int64, error) {
+	res, err := tx.Exec(ctx, `
+	DELETE FROM slabs
+	WHERE id IN (
+		SELECT s.id
+		FROM slabs s
+		LEFT JOIN slices sl ON sl.db_slab_id = s.id
+		WHERE s.db_buffered_slab_id IS NULL AND sl.db_slab_id IS NULL
+		LIMIT ?
+		)
+	)`, limit)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 func RecordHostScans(ctx context.Context, tx sql.Tx, scans []api.HostScan) error {
 	if len(scans) == 0 {
 		return nil

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -718,24 +718,7 @@ CREATE INDEX %s_idx ON %s (root(32));`, tmpTable, tmpTable, tmpTable, tmpTable))
 }
 
 func (tx *MainDatabaseTx) PruneSlabs(ctx context.Context, limit int64) (int64, error) {
-	res, err := tx.Exec(ctx, `
-	DELETE FROM slabs
-	WHERE id IN (
-    SELECT id
-    FROM (
-        SELECT slabs.id
-        FROM slabs
-        WHERE NOT EXISTS (
-            SELECT 1 FROM slices WHERE slices.db_slab_id = slabs.id
-        )
-        AND slabs.db_buffered_slab_id IS NULL
-        LIMIT ?
-    ) AS limited
-	)`, limit)
-	if err != nil {
-		return 0, err
-	}
-	return res.RowsAffected()
+	return ssql.PruneSlabs(ctx, tx, limit)
 }
 
 func (tx *MainDatabaseTx) PutContract(ctx context.Context, c api.ContractMetadata) error {

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -728,24 +728,7 @@ CREATE INDEX %s_idx ON %s (root);`, tmpTable, tmpTable, tmpTable, tmpTable))
 }
 
 func (tx *MainDatabaseTx) PruneSlabs(ctx context.Context, limit int64) (int64, error) {
-	res, err := tx.Exec(ctx, `
-	DELETE FROM slabs
-	WHERE id IN (
-    SELECT id
-    FROM (
-        SELECT slabs.id
-        FROM slabs
-        WHERE NOT EXISTS (
-            SELECT 1 FROM slices WHERE slices.db_slab_id = slabs.id
-        )
-        AND slabs.db_buffered_slab_id IS NULL
-        LIMIT ?
-    ) AS limited
-	)`, limit)
-	if err != nil {
-		return 0, err
-	}
-	return res.RowsAffected()
+	return ssql.PruneSlabs(ctx, tx, limit)
 }
 
 func (tx *MainDatabaseTx) PutContract(ctx context.Context, c api.ContractMetadata) error {


### PR DESCRIPTION
This PR speeds up the selection of slabs to prune by about 3x on gompa

```
Limit: 100 row(s)  (cost=209e+9 rows=100) (actual time=3622..3622 rows=100 loops=1)
    -> Nested loop antijoin  (cost=209e+9 rows=2.09e+12) (actual time=3622..3622 rows=100 loops=1)
        -> Filter: (slabs.db_buffered_slab_id is null)  (cost=124725 rows=1.23e+6) (actual time=0.7..131 rows=358768 loops=1)
            -> Covering index lookup on slabs using idx_slabs_db_buffered_slab_id (db_buffered_slab_id = NULL)  (cost=124725 rows=1.23e+6) (actual time=0.699..110 rows=358768 loops=1)
        -> Single-row index lookup on <subquery2> using <auto_distinct_key> (db_slab_id = slabs.id)  (cost=580736..580736 rows=1) (actual time=0.00965..0.00965 rows=1 loops=358768)
            -> Materialize with deduplication  (cost=580736..580736 rows=1.71e+6) (actual time=2889..2889 rows=1.56e+6 loops=1)
                -> Filter: (slices.db_slab_id is not null)  (cost=186813 rows=1.71e+6) (actual time=0.879..653 rows=1.58e+6 loops=1)
                    -> Covering index scan on slices using idx_slices_db_slab_id  (cost=186813 rows=1.71e+6) (actual time=0.878..564 rows=1.58e+6 loops=1)
```

vs.

```
| -> Limit: 100 row(s)  (cost=1.2e+6 rows=100) (actual time=1006..1006 rows=100 loops=1)
    -> Filter: (sl.db_slab_id is null)  (cost=1.2e+6 rows=1.36e+6) (actual time=1006..1006 rows=100 loops=1)
        -> Nested loop left join  (cost=1.2e+6 rows=1.36e+6) (actual time=0.898..992 rows=362902 loops=1)
            -> Filter: (s.db_buffered_slab_id is null)  (cost=124728 rows=1.23e+6) (actual time=0.682..99.1 rows=358768 loops=1)
                -> Covering index lookup on s using idx_slabs_db_buffered_slab_id (db_buffered_slab_id = NULL)  (cost=124728 rows=1.23e+6) (actual time=0.682..78.4 rows=358768 loops=1)
            -> Covering index lookup on sl using idx_slices_db_slab_id (db_slab_id = s.id)  (cost=0.77 rows=1.11) (actual time=0.0019..0.00234 rows=1.01 loops=358768)
``


NOTE: I added a benchmark. For SQLite the performance remained the same but for MySQL the improvement was surprisingly an order of magnitude. 