### PR TITLE
Fix hosts failing `shouldScanHost` check appearing in every batch

### DIFF
--- a/.changeset/fix_hosts_that_fail_the_pre_scan_checks_not_having_a_failed_scan_recorded_.md
+++ b/.changeset/fix_hosts_that_fail_the_pre_scan_checks_not_having_a_failed_scan_recorded_.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# fix hosts that fail the pre-scan checks not having a failed scan recorded 

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -704,11 +704,26 @@ func (b *Bus) hostsScanHandlerPOST(jc jape.Context) {
 	} else {
 		settings, pt, ping, err = b.scanHostV1(jc.Request.Context(), time.Duration(rsr.Timeout), hk, h.NetAddress)
 	}
+
+	// check if the scan failed due to a shutdown - shouldn't be necessary but
+	// just in case since recording a failed scan might have serious
+	// repercussions
+	select {
+	case <-jc.Request.Context().Done():
+		jc.Error(errors.New("scan failed due to bus shutting down"), http.StatusServiceUnavailable)
+	default:
+	}
+
+	// record host scan - make sure this is interrupted by the request ctx and
+	// not the context with the timeout used to time out the scan itself.
+	// Otherwise scans that time out won't be recorded.
+	b.recordHostScan(jc.Request.Context(), err, hk, settings, pt, v2Settings)
+
+	// send response
 	var errStr string
 	if err != nil {
 		errStr = err.Error()
 	}
-
 	jc.Encode(api.HostScanResponse{
 		Ping:       api.DurationMS(ping),
 		PriceTable: pt,

--- a/bus/scanning.go
+++ b/bus/scanning.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
@@ -12,6 +13,30 @@ import (
 	"go.sia.tech/renterd/internal/utils"
 	"go.uber.org/zap"
 )
+
+func (b *Bus) recordHostScan(ctx context.Context, err error, hostKey types.PublicKey, settings rhpv2.HostSettings, pt rhpv3.HostPriceTable, v2Settings rhp4.HostSettings) {
+	// record host scan - make sure this is interrupted by the request ctx and
+	// not the context with the timeout used to time out the scan itself.
+	// Otherwise scans that time out won't be recorded.
+	scanErr := b.store.RecordHostScans(ctx, []api.HostScan{
+		{
+			HostKey:    hostKey,
+			PriceTable: pt,
+
+			// NOTE: A scan is considered successful if both fetching the price
+			// table and the settings succeeded. Right now scanning can't fail
+			// due to a reason that is our fault unless we are offline. If that
+			// changes, we should adjust this code to account for that.
+			Success:    err == nil,
+			Settings:   settings,
+			V2Settings: v2Settings,
+			Timestamp:  time.Now(),
+		},
+	})
+	if scanErr != nil {
+		b.logger.Errorw("failed to record host scan", zap.Error(scanErr))
+	}
+}
 
 func (b *Bus) scanHostV1(ctx context.Context, timeout time.Duration, hostKey types.PublicKey, hostIP string) (rhpv2.HostSettings, rhpv3.HostPriceTable, time.Duration, error) {
 	logger := b.logger.
@@ -52,6 +77,10 @@ func (b *Bus) scanHostV1(ctx context.Context, timeout time.Duration, hostKey typ
 	// resolve host ip, don't scan if the host is on a private network or if it
 	// resolves to more than two addresses of the same type
 	if err := b.shouldScanAddr(hostIP); err != nil {
+		// record host scan even if we don't actually scan the host since
+		// something is still wrong with the host
+		err = fmt.Errorf("host failed pre-scan checks: %w", err)
+		b.recordHostScan(ctx, err, hostKey, rhpv2.HostSettings{}, rhpv3.HostPriceTable{}, rhp4.HostSettings{})
 		return rhpv2.HostSettings{}, rhpv3.HostPriceTable{}, 0, err
 	}
 
@@ -88,23 +117,8 @@ func (b *Bus) scanHostV1(ctx context.Context, timeout time.Duration, hostKey typ
 	// record host scan - make sure this is interrupted by the request ctx and
 	// not the context with the timeout used to time out the scan itself.
 	// Otherwise scans that time out won't be recorded.
-	scanErr := b.store.RecordHostScans(ctx, []api.HostScan{
-		{
-			HostKey:    hostKey,
-			PriceTable: pt,
+	b.recordHostScan(ctx, err, hostKey, settings, pt, rhp4.HostSettings{})
 
-			// NOTE: A scan is considered successful if both fetching the price
-			// table and the settings succeeded. Right now scanning can't fail
-			// due to a reason that is our fault unless we are offline. If that
-			// changes, we should adjust this code to account for that.
-			Success:   err == nil,
-			Settings:  settings,
-			Timestamp: time.Now(),
-		},
-	})
-	if scanErr != nil {
-		logger.Errorw("failed to record host scan", zap.Error(scanErr))
-	}
 	logger.With(zap.Error(err)).Debugw("scanned host", "success", err == nil)
 	return settings, pt, duration, err
 }
@@ -137,6 +151,10 @@ func (b *Bus) scanHostV2(ctx context.Context, timeout time.Duration, hostKey typ
 	// resolve host ip, don't scan if the host is on a private network or if it
 	// resolves to more than two addresses of the same type
 	if err := b.shouldScanAddr(hostIP); err != nil {
+		// record host scan even if we don't actually scan the host since
+		// something is still wrong with the host
+		err = fmt.Errorf("host failed pre-scan checks: %w", err)
+		b.recordHostScan(ctx, err, hostKey, rhpv2.HostSettings{}, rhpv3.HostPriceTable{}, rhp4.HostSettings{})
 		return rhp4.HostSettings{}, 0, err
 	}
 
@@ -173,22 +191,8 @@ func (b *Bus) scanHostV2(ctx context.Context, timeout time.Duration, hostKey typ
 	// record host scan - make sure this is interrupted by the request ctx and
 	// not the context with the timeout used to time out the scan itself.
 	// Otherwise scans that time out won't be recorded.
-	scanErr := b.store.RecordHostScans(ctx, []api.HostScan{
-		{
-			HostKey: hostKey,
+	b.recordHostScan(ctx, err, hostKey, rhpv2.HostSettings{}, rhpv3.HostPriceTable{}, settings)
 
-			// NOTE: A scan is considered successful if fetching the settings succeeded.
-			// Right now scanning can't fail due to a reason that is our fault unless we
-			// are offline. If that changes, we should adjust this code to account for
-			// that.
-			Success:    err == nil,
-			V2Settings: settings,
-			Timestamp:  time.Now(),
-		},
-	})
-	if scanErr != nil {
-		logger.Errorw("failed to record host scan", zap.Error(scanErr))
-	}
 	logger.With(zap.Error(err)).Debugw("scanned host", "success", err == nil)
 	return settings, duration, err
 }

--- a/bus/scanning.go
+++ b/bus/scanning.go
@@ -164,13 +164,10 @@ func (b *Bus) scanHostV2(ctx context.Context, timeout time.Duration, hostKey typ
 // shouldScanAddr checks whether the provided addr should be scanned according
 // to the bus's configuration. A scanned address needs to:
 // - be resolvable
-// - pass the IP checks we enforce on hosts
 // - not be a private IP if the bus is configured to disallow private IPs
 func (b *Bus) shouldScanAddr(addr string) error {
 	resolved, err := utils.ResolveHostIPs(context.Background(), []string{addr})
 	if err != nil {
-		return err
-	} else if err := utils.PerformHostIPChecks(resolved); err != nil {
 		return err
 	}
 	for _, ipAddr := range resolved {


### PR DESCRIPTION
I noticed that hosts which fail the checks before the actual scan appeared quite a lot in the logs of gompa. Turns out that we never consider these hosts scanned which caused them to end up in every batch of the scans. This PR fixes that. 