### PR TITLE
Fix memory manager config

### DIFF
--- a/.changeset/dont_return_an_error_when_a_v1_contract_doesnt_contain_any_sectors_to_prune.md
+++ b/.changeset/dont_return_an_error_when_a_v1_contract_doesnt_contain_any_sectors_to_prune.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Don't return an error when a v1 contract doesn't contain any sectors to prune

--- a/.changeset/fix_memory_manager_for_downloads_using_the_uploads_config.md
+++ b/.changeset/fix_memory_manager_for_downloads_using_the_uploads_config.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix memory manager for downloads using the uploads config

--- a/bus/pruning.go
+++ b/bus/pruning.go
@@ -35,8 +35,12 @@ func (b *Bus) pruneContractV1(ctx context.Context, rk types.PrivateKey, cm api.C
 		indices = filtered
 		return indices, nil
 	})
+
+	var pruneErr string
 	if err != nil && !errors.Is(err, rhp2.ErrNoSectorsToPrune) && !errors.Is(err, context.Canceled) {
 		return api.ContractPruneResponse{}, err
+	} else if err != nil && !errors.Is(err, rhp2.ErrNoSectorsToPrune) {
+		pruneErr = err.Error()
 	}
 
 	// record spending
@@ -54,11 +58,6 @@ func (b *Bus) pruneContractV1(ctx context.Context, rk types.PrivateKey, cm api.C
 				ValidRenterPayout: rev.ValidRenterPayout(),
 			},
 		})
-	}
-
-	var pruneErr string
-	if err != nil && !errors.Is(err, rhp2.ErrNoSectorsToPrune) {
-		pruneErr = err.Error()
 	}
 
 	return api.ContractPruneResponse{

--- a/bus/pruning.go
+++ b/bus/pruning.go
@@ -57,7 +57,7 @@ func (b *Bus) pruneContractV1(ctx context.Context, rk types.PrivateKey, cm api.C
 	}
 
 	var pruneErr string
-	if err != nil {
+	if err != nil && !errors.Is(err, rhp2.ErrNoSectorsToPrune) {
 		pruneErr = err.Error()
 	}
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -633,8 +633,8 @@ func New(cfg config.Worker, masterKey [32]byte, b Bus, l *zap.Logger) (*Worker, 
 	hm := hosts.NewManager(w.masterKey, w.accounts, w.contractSpendingRecorder, dialer, l)
 	w.hostManager = hm
 
-	dlmm := memory.NewManager(cfg.UploadMaxMemory, l.Named("uploadmanager"))
-	w.downloadManager = download.NewManager(w.shutdownCtx, &uploadKey, hm, dlmm, w.bus, cfg.UploadMaxOverdrive, cfg.UploadOverdriveTimeout, l)
+	dlmm := memory.NewManager(cfg.DownloadMaxMemory, l.Named("downloadmanager"))
+	w.downloadManager = download.NewManager(w.shutdownCtx, &uploadKey, hm, dlmm, w.bus, cfg.DownloadMaxOverdrive, cfg.DownloadOverdriveTimeout, l)
 
 	ulmm := memory.NewManager(cfg.UploadMaxMemory, l.Named("uploadmanager"))
 	w.uploadManager = upload.NewManager(w.shutdownCtx, &uploadKey, hm, ulmm, w.bus, w.bus, w.bus, cfg.UploadMaxOverdrive, cfg.UploadOverdriveTimeout, l)


### PR DESCRIPTION
Fixes the download manager using cfg.UploadMaxMemory
Prevents the pruning endpoint from returning an error when no sectors for pruning were found to prevent unnecessary errors in logs