### PR TITLE
Prevent deadlock/panic when forcing a rescan

### DIFF
--- a/.changeset/fix_potential_deadlockpanic_when_forcing_a_scan.md
+++ b/.changeset/fix_potential_deadlockpanic_when_forcing_a_scan.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix potential deadlock/panic when forcing a scan

--- a/autopilot/scanner/scanner.go
+++ b/autopilot/scanner/scanner.go
@@ -186,7 +186,7 @@ func (s *scanner) scanHosts(ctx context.Context, hs HostScanner, cutoff time.Tim
 	worker := func(jobs <-chan scanJob) {
 		for h := range jobs {
 			scan, err := hs.ScanHost(ctx, h.hostKey, DefaultScanTimeout)
-			if errors.Is(err, context.Canceled) {
+			if errors.Is(err, ErrShuttingDown) || errors.Is(err, ErrScanInterrupted) || errors.Is(err, context.Canceled) {
 				return
 			} else if err != nil {
 				s.logger.Errorw("worker stopped", zap.Error(err), "hk", h.hostKey)

--- a/autopilot/scanner/scanner_test.go
+++ b/autopilot/scanner/scanner_test.go
@@ -87,7 +87,11 @@ type mockHostScanner struct {
 
 func (w *mockHostScanner) ScanHost(ctx context.Context, hostKey types.PublicKey, _ time.Duration) (api.HostScanResponse, error) {
 	if w.blockChan != nil {
-		<-w.blockChan
+		select {
+		case <-ctx.Done():
+			return api.HostScanResponse{}, ctx.Err()
+		case <-w.blockChan:
+		}
 	}
 	w.hs.recordScan(hostKey)
 

--- a/bus/scanning.go
+++ b/bus/scanning.go
@@ -83,8 +83,6 @@ func (b *Bus) scanHostV1(ctx context.Context, timeout time.Duration, hostKey typ
 	// scan: first try
 	settings, pt, duration, err := scan()
 	if err != nil {
-		logger = logger.With(zap.Error(err))
-
 		// scan: second try
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
I ran into a deadlock on my node forcing a rescan. Because it closes a channel you can even make it panic if you request a rescan twice in short succession. I figured a decent approach would be to keep around a cancel function for the ongoing scan... This allows us to get rid of `shutdownChan` and `interruptChan` and is overall more readable imo.
 a scan is started, which we derive from the context given down to us. If we have to re-scan we can call cancel and wait for ongoing scans to be interrupted and start again. 