### PR TITLE
Improve error logging

### DIFF
--- a/.changeset/fix_error_output_in_the_renterdlog.md
+++ b/.changeset/fix_error_output_in_the_renterdlog.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix error output in the renterd.log

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -448,7 +448,7 @@ func (ap *Autopilot) performMaintenance(forceScan bool, tickerFired chan struct{
 	// fetch autopilot config
 	apCfg, err := ap.bus.AutopilotConfig(ap.shutdownCtx)
 	if err != nil {
-		ap.logger.Errorf("aborting maintenance, failed to fetch autopilot", zap.Error(err))
+		ap.logger.Errorw("aborting maintenance, failed to fetch autopilot", zap.Error(err))
 		return
 	}
 
@@ -598,12 +598,12 @@ func (ap *Autopilot) performWalletMaintenance(ctx context.Context) error {
 	// pending maintenance transaction - nothing to do
 	pending, err := b.WalletPending(ctx)
 	if err != nil {
-		return nil
+		return err
 	}
 	for _, txn := range pending {
 		for _, mTxnID := range ap.maintenanceTxnIDs {
 			if mTxnID == types.TransactionID(txn.ID) {
-				l.Debugf("wallet maintenance skipped, pending transaction found with id %v", mTxnID)
+				l.Infof("wallet maintenance skipped, pending transaction found with id %v", mTxnID)
 				return nil
 			}
 		}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -554,7 +554,7 @@ func (b *Bus) broadcastContract(ctx context.Context, fcid types.FileContractID) 
 	}
 	defer func() {
 		if err := b.contractLocker.Release(fcid, lockID); err != nil {
-			b.logger.Error("failed to release contract lock", zap.Error(err))
+			b.logger.Errorw("failed to release contract lock", zap.Error(err))
 		}
 	}()
 

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -166,7 +166,7 @@ func (b *Bus) accountsFundHandler(jc jape.Context) {
 		spending,
 	})
 	if err != nil {
-		b.logger.Error("failed to record contract spending", zap.Error(err))
+		b.logger.Errorw("failed to record contract spending", zap.Error(err))
 	}
 	jc.Encode(api.AccountsFundResponse{
 		Deposit: deposit,
@@ -963,7 +963,7 @@ func (b *Bus) contractPruneHandlerPOST(jc jape.Context) {
 	}
 	defer func() {
 		if err := b.contractLocker.Release(fcid, lockID); err != nil {
-			b.logger.Error("failed to release contract lock", zap.Error(err))
+			b.logger.Errorw("failed to release contract lock", zap.Error(err))
 		}
 	}()
 
@@ -1172,7 +1172,7 @@ func (b *Bus) contractIDRenewHandlerPOST(jc jape.Context) {
 	}
 	defer func() {
 		if err := b.contractLocker.Release(c.ID, lockID); err != nil {
-			b.logger.Error("failed to release contract lock", zap.Error(err))
+			b.logger.Errorw("failed to release contract lock", zap.Error(err))
 		}
 	}()
 

--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -403,9 +403,9 @@ func (n *node) Run() error {
 		time.Sleep(time.Millisecond) // give the web server a chance to start
 		_, port, err := net.SplitHostPort(n.apiListener.Addr().String())
 		if err != nil {
-			n.logger.Debug("failed to parse API address", zap.Error(err))
+			n.logger.Debugw("failed to parse API address", zap.Error(err))
 		} else if err := utils.OpenBrowser(fmt.Sprintf("http://127.0.0.1:%s", port)); err != nil {
-			n.logger.Debug("failed to open browser", zap.Error(err))
+			n.logger.Debugw("failed to open browser", zap.Error(err))
 		}
 	}
 	return nil

--- a/internal/accounts/accounts.go
+++ b/internal/accounts/accounts.go
@@ -246,7 +246,7 @@ func (a *Manager) run() {
 			break
 		}
 
-		a.logger.Warn("failed to fetch accounts from bus - retrying in a few seconds", zap.Error(err))
+		a.logger.Warnw("failed to fetch accounts from bus - retrying in a few seconds", zap.Error(err))
 		select {
 		case <-a.shutdownCtx.Done():
 			return
@@ -289,7 +289,7 @@ func (a *Manager) run() {
 	}
 	err = a.s.UpdateAccounts(a.shutdownCtx, uncleanAccounts)
 	if err != nil {
-		a.logger.Error("failed to mark account shutdown as unclean", zap.Error(err))
+		a.logger.Errorw("failed to mark account shutdown as unclean", zap.Error(err))
 	}
 
 	ticker = time.NewTicker(a.refillInterval)
@@ -382,7 +382,7 @@ func (a *Manager) refillAccounts() {
 				a.mu.Unlock()
 
 				if err != nil && shouldLog {
-					a.logger.Error("failed to refill account for host", zap.Stringer("hostKey", contract.HostKey), zap.Error(err))
+					a.logger.Errorw("failed to refill account for host", zap.Stringer("hostKey", contract.HostKey), zap.Error(err))
 				} else if refilled {
 					a.logger.Infow("successfully refilled account for host", zap.Stringer("hostKey", contract.HostKey), zap.Error(err))
 				}

--- a/internal/bus/pinmanager.go
+++ b/internal/bus/pinmanager.go
@@ -158,7 +158,7 @@ func (pm *pinManager) run() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		err := pm.updatePrices(ctx, forced)
 		if err != nil {
-			pm.logger.Warn("failed to update prices", zap.Error(err))
+			pm.logger.Warnw("failed to update prices", zap.Error(err))
 			pm.a.RegisterAlert(ctx, newPricePinningFailedAlert(err))
 		} else {
 			pm.a.DismissAlerts(ctx, alertPricePinningID)

--- a/internal/bus/walletmetricsrecorder.go
+++ b/internal/bus/walletmetricsrecorder.go
@@ -56,7 +56,7 @@ func (wmr *WalletMetricsRecorder) run(interval time.Duration) {
 		for {
 			balance, err := wmr.wallet.Balance()
 			if err != nil {
-				wmr.logger.Error("failed to get wallet balance", zap.Error(err))
+				wmr.logger.Errorw("failed to get wallet balance", zap.Error(err))
 			} else {
 				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 				if err = wmr.store.RecordWalletMetric(ctx, api.WalletMetric{
@@ -66,7 +66,7 @@ func (wmr *WalletMetricsRecorder) run(interval time.Duration) {
 					Unconfirmed: balance.Unconfirmed,
 					Immature:    balance.Immature,
 				}); err != nil {
-					wmr.logger.Error("failed to record wallet metric", zap.Error(err))
+					wmr.logger.Errorw("failed to record wallet metric", zap.Error(err))
 				} else {
 					wmr.logger.Debugw("successfully recorded wallet metrics",
 						zap.Stringer("spendable", balance.Spendable),

--- a/internal/rhp/dialer.go
+++ b/internal/rhp/dialer.go
@@ -81,7 +81,7 @@ func (d *FallbackDialer) Dial(ctx context.Context, hk types.PublicKey, address s
 
 	// If resolution fails, check the cache
 	if cachedIP, ok := d.cache.Get(host); ok {
-		logger.Debug("Failed to resolve host, using cached IP", zap.Error(err))
+		logger.Debugw("Failed to resolve host, using cached IP", zap.Error(err))
 		conn, err := d.dialer.DialContext(ctx, "tcp", net.JoinHostPort(cachedIP, port))
 		if err == nil {
 			return conn, nil

--- a/internal/rhp/v3/rhp.go
+++ b/internal/rhp/v3/rhp.go
@@ -131,7 +131,7 @@ func (c *Client) AppendSector(ctx context.Context, sectorRoot types.Hash256, sec
 	}
 	payment, err := payByContract(rev, expectedCost, accID, rk)
 	if err != nil {
-		return types.ZeroCurrency, ErrFailedToCreatePayment
+		return types.ZeroCurrency, fmt.Errorf("%w; %w", err, ErrFailedToCreatePayment)
 	}
 
 	var cost types.Currency

--- a/internal/sql/sql.go
+++ b/internal/sql/sql.go
@@ -167,7 +167,7 @@ LOOP:
 			}
 		}
 		if !locked {
-			break LOOP
+			return err
 		}
 		// exponential backoff
 		sleep := time.Duration(math.Pow(factor, float64(attempt))) * time.Millisecond
@@ -202,7 +202,7 @@ func (s *DB) transaction(ctx context.Context, fn func(tx Tx) error) error {
 	start := time.Now()
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+		return err
 	}
 	defer func() {
 		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {


### PR DESCRIPTION
Having spent some time in our `renterd.log` recently I noticed a lot of entries that appear to log an object rather than the structured logs with context you would expect. I think we string replaced `err` to `zap.Error(err)` or something and forgot to check the instances where we have to switch the logging method and use the one that logs the variadic key pairs. 

Example:
```
2025-01-08T14:28:58Z	DEBUG	worker.worker.fallbackdialer	Failed to resolve host, using cached IP{error 26 0  dial tcp: lookup pikrue.spdns.org: operation was canceled}	{"hostKey": "ed25519:82aec15c5786b9037b74ca0b59e958724641c4c71093916c2749dc22a5392de3", "host": "pikrue.spdns.org"}
```

