### PR TITLE
Fragment the wallet into outputs with a larger value

### DIFF
--- a/.changeset/fragment_the_wallet_into_larger_outputs.md
+++ b/.changeset/fragment_the_wallet_into_larger_outputs.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fragment the wallet into larger outputs.

--- a/autopilot/autopilot.go
+++ b/autopilot/autopilot.go
@@ -612,7 +612,7 @@ func (ap *Autopilot) performWalletMaintenance(ctx context.Context) error {
 	}
 
 	// redistribute outputs
-	ids, err := b.WalletRedistribute(ctx, wantedNumOutputs, balance.Div64(11))
+	ids, err := b.WalletRedistribute(ctx, wantedNumOutputs, amount)
 	if err != nil {
 		return fmt.Errorf("failed to redistribute wallet into %d outputs of amount %v, balance %v, err %v", wantedNumOutputs, amount, balance, err)
 	}

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -2384,10 +2384,7 @@ func TestMultipartUploadWrappedByPartialSlabs(t *testing.T) {
 }
 
 func TestWalletRedistribute(t *testing.T) {
-	cluster := newTestCluster(t, testClusterOptions{
-		hosts:         test.RedundancySettings.TotalShards,
-		uploadPacking: true,
-	})
+	cluster := newTestCluster(t, testClusterOptions{skipRunningAutopilot: true})
 	defer cluster.Shutdown()
 
 	// mine to get more money


### PR DESCRIPTION
I want to propose a change in how we redistribute wallet outputs. I understand this feels a little arbitrary but my node runs so much smoother after making this change and I personally don't understand why we wouldn't give ourselves a little leeway when it comes to spendable and usable outputs in our wallet. The current logic really doesn't make sense to me, so definitely we have to tweak it a bit I think. 

Some extra context:

On my node I ran into several occasions where my wallet was trying to spend nonexisting siacoin outputs. I can't reproduce it and the logging I had was not sufficient to debug it any further. I only had an output ID but it never appeared in the logs other than the error message, it wasn't present in the database either so I'm a bit puzzled. 

It happend on contract formations and renewals which all allow to use unconfirmed transaction, I'm going to see if we have a test, or maybe I can tweak a test to assert that works properly but also that we can properly chain it a couple of times. I have seen that work though, so really not sure what happened. I had one 50KS output and for multiple hours my node was unable to fragment the wallet, nor refresh any of my contracts because I was stuck. I don't think I've seen this on any other node but this one (mine) though..