### PR TITLE
Fix failed upload using archived contracts

### DIFF
--- a/.changeset/fix_upload_failure.md
+++ b/.changeset/fix_upload_failure.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix uploads that fail if a contract used in the upload was archived in the meantime

--- a/stores/contracts_test.go
+++ b/stores/contracts_test.go
@@ -1,0 +1,89 @@
+package stores
+
+import (
+	"context"
+	"testing"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/api"
+	isql "go.sia.tech/renterd/internal/sql"
+	"go.sia.tech/renterd/stores/sql"
+)
+
+func TestFetchUsedContracts(t *testing.T) {
+	ss := newTestSQLStore(t, defaultTestSQLStoreConfig)
+	defer ss.Close()
+
+	// define helper
+	hasContract := func(ucs []sql.UsedContract, fcid types.FileContractID) bool {
+		t.Helper()
+		for _, uc := range ucs {
+			if types.FileContractID(uc.FCID) == fcid {
+				return true
+			}
+		}
+		return false
+	}
+
+	// add host
+	hk := types.PublicKey{1}
+	if err := ss.addTestHost(types.PublicKey{1}); err != nil {
+		t.Fatal(err)
+	}
+
+	// add 3 contracts
+	for i := 1; i <= 3; i++ {
+		if _, err := ss.addTestContract(types.FileContractID{byte(i)}, hk); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// renew the first contract
+	if err := ss.renewTestContract(types.PublicKey{1}, types.FileContractID{1}, types.FileContractID{4}, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	// fetch used contracts
+	var ucs []sql.UsedContract
+	if err := ss.DB().Transaction(context.Background(), func(tx isql.Tx) (err error) {
+		ucs, err = sql.FetchUsedContracts(context.Background(), tx, []types.FileContractID{
+			{1}, // renewed
+			{2}, // untouched
+			{3}, // untouched
+		})
+		return
+	}); err != nil {
+		t.Fatal(err)
+	} else if len(ucs) != 3 {
+		t.Fatal(err)
+	} else if !hasContract(ucs, types.FileContractID{1}) {
+		t.Fatal("unexpected result", ucs)
+	} else if !hasContract(ucs, types.FileContractID{2}) {
+		t.Fatal("unexpected result", ucs)
+	} else if !hasContract(ucs, types.FileContractID{3}) {
+		t.Fatal("unexpected result", ucs)
+	}
+
+	// archive the second contract
+	if err := ss.ArchiveContract(context.Background(), types.FileContractID{2}, api.ContractArchivalReasonRenewed); err != nil {
+		t.Fatal(err)
+	}
+
+	// fetch used contracts
+	if err := ss.DB().Transaction(context.Background(), func(tx isql.Tx) (err error) {
+		ucs, err = sql.FetchUsedContracts(context.Background(), tx, []types.FileContractID{
+			{1}, // renewed
+			{2}, // archived
+			{3}, // untouched
+		})
+		return
+	}); err != nil {
+		t.Fatal(err)
+	} else if len(ucs) != 2 {
+		t.Fatal(err)
+	} else if !hasContract(ucs, types.FileContractID{1}) {
+		t.Fatal("unexpected result", ucs)
+	} else if !hasContract(ucs, types.FileContractID{3}) {
+		t.Fatal("unexpected result", ucs)
+	}
+}

--- a/stores/contracts_test.go
+++ b/stores/contracts_test.go
@@ -14,17 +14,6 @@ func TestFetchUsedContracts(t *testing.T) {
 	ss := newTestSQLStore(t, defaultTestSQLStoreConfig)
 	defer ss.Close()
 
-	// define helper
-	hasContract := func(ucs []sql.UsedContract, fcid types.FileContractID) bool {
-		t.Helper()
-		for _, uc := range ucs {
-			if types.FileContractID(uc.FCID) == fcid {
-				return true
-			}
-		}
-		return false
-	}
-
 	// add host
 	hk := types.PublicKey{1}
 	if err := ss.addTestHost(types.PublicKey{1}); err != nil {
@@ -44,7 +33,7 @@ func TestFetchUsedContracts(t *testing.T) {
 	}
 
 	// fetch used contracts
-	var ucs []sql.UsedContract
+	var ucs map[types.FileContractID]sql.UsedContract
 	if err := ss.DB().Transaction(context.Background(), func(tx isql.Tx) (err error) {
 		ucs, err = sql.FetchUsedContracts(context.Background(), tx, []types.FileContractID{
 			{1}, // renewed
@@ -56,11 +45,11 @@ func TestFetchUsedContracts(t *testing.T) {
 		t.Fatal(err)
 	} else if len(ucs) != 3 {
 		t.Fatal(err)
-	} else if !hasContract(ucs, types.FileContractID{1}) {
+	} else if _, ok := ucs[types.FileContractID{1}]; !ok {
 		t.Fatal("unexpected result", ucs)
-	} else if !hasContract(ucs, types.FileContractID{2}) {
+	} else if _, ok := ucs[types.FileContractID{2}]; !ok {
 		t.Fatal("unexpected result", ucs)
-	} else if !hasContract(ucs, types.FileContractID{3}) {
+	} else if _, ok := ucs[types.FileContractID{3}]; !ok {
 		t.Fatal("unexpected result", ucs)
 	}
 
@@ -81,9 +70,9 @@ func TestFetchUsedContracts(t *testing.T) {
 		t.Fatal(err)
 	} else if len(ucs) != 2 {
 		t.Fatal(err)
-	} else if !hasContract(ucs, types.FileContractID{1}) {
+	} else if _, ok := ucs[types.FileContractID{1}]; !ok {
 		t.Fatal("unexpected result", ucs)
-	} else if !hasContract(ucs, types.FileContractID{3}) {
+	} else if _, ok := ucs[types.FileContractID{3}]; !ok {
 		t.Fatal("unexpected result", ucs)
 	}
 }

--- a/stores/sql/database.go
+++ b/stores/sql/database.go
@@ -421,10 +421,9 @@ type (
 	}
 
 	UsedContract struct {
-		ID          int64
-		FCID        FileContractID
-		RenewedFrom FileContractID
-		HostID      int64
+		ID     int64
+		FCID   FileContractID
+		HostID int64
 	}
 
 	ContractSector struct {

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -594,63 +594,48 @@ func DeleteWebhook(ctx context.Context, tx sql.Tx, wh webhooks.Webhook) error {
 	return nil
 }
 
-func FetchUsedContracts(ctx context.Context, tx sql.Tx, fcids []types.FileContractID) (map[types.FileContractID]UsedContract, error) {
+func FetchUsedContracts(ctx context.Context, tx sql.Tx, fcids []types.FileContractID) (used []UsedContract, _ error) {
 	if len(fcids) == 0 {
-		return make(map[types.FileContractID]UsedContract), nil
+		return nil, nil
 	}
 
-	// flatten map to get all used contract ids
-	usedFCIDs := make([]FileContractID, 0, len(fcids))
+	// build args
+	var args []interface{}
+	lookup := make(map[FileContractID]struct{}, len(fcids))
 	for _, fcid := range fcids {
-		usedFCIDs = append(usedFCIDs, FileContractID(fcid))
+		args = append(args, FileContractID(fcid))
+		lookup[FileContractID(fcid)] = struct{}{}
 	}
+	args = append(args, args...)
 
-	placeholders := make([]string, len(usedFCIDs))
-	for i := range usedFCIDs {
-		placeholders[i] = "?"
-	}
-	placeholdersStr := strings.Join(placeholders, ", ")
+	// build placeholder
+	placeholder := strings.Repeat("?, ", len(fcids)-1) + "?"
 
-	args := make([]interface{}, len(usedFCIDs)*2)
-	for i := range args {
-		args[i] = usedFCIDs[i%len(usedFCIDs)]
-	}
-
-	// fetch all contracts, take into account renewals
-	rows, err := tx.Query(ctx, fmt.Sprintf(`SELECT id, fcid, renewed_from, host_id
-				   FROM contracts
-				   WHERE contracts.fcid IN (%s) OR renewed_from IN (%s)
-				   `, placeholdersStr, placeholdersStr), args...)
+	// fetch used contracts
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+SELECT id, fcid, host_id, renewed_from
+FROM contracts
+WHERE (fcid IN (%s) OR renewed_from IN (%s)) AND contracts.archival_reason IS NULL`, placeholder, placeholder), args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch used contracts: %w", err)
 	}
 	defer rows.Close()
 
-	var contracts []UsedContract
+	// build used contracts
 	for rows.Next() {
 		var c UsedContract
-		if err := rows.Scan(&c.ID, &c.FCID, &c.RenewedFrom, &c.HostID); err != nil {
+		var rf FileContractID
+		if err := rows.Scan(&c.ID, &c.FCID, &c.HostID, &rf); err != nil {
 			return nil, fmt.Errorf("failed to scan used contract: %w", err)
 		}
-		contracts = append(contracts, c)
-	}
 
-	fcidMap := make(map[types.FileContractID]struct{}, len(fcids))
-	for _, fcid := range fcids {
-		fcidMap[fcid] = struct{}{}
-	}
-
-	// build map of used contracts
-	usedContracts := make(map[types.FileContractID]UsedContract, len(contracts))
-	for _, c := range contracts {
-		if _, used := fcidMap[types.FileContractID(c.FCID)]; used {
-			usedContracts[types.FileContractID(c.FCID)] = c
+		// swap the fcid for renewals
+		if _, ok := lookup[c.FCID]; !ok {
+			c.FCID = rf
 		}
-		if _, used := fcidMap[types.FileContractID(c.RenewedFrom)]; used {
-			usedContracts[types.FileContractID(c.RenewedFrom)] = c
-		}
+		used = append(used, c)
 	}
-	return usedContracts, nil
+	return
 }
 
 func HasMigration(ctx context.Context, tx sql.Tx, id string) (applied bool, err error) {
@@ -2151,10 +2136,16 @@ func UpdateSlab(ctx context.Context, tx Tx, key object.EncryptionKey, updated []
 		fcids = append(fcids, s.ContractID)
 	}
 
-	// fetch contracts
-	contracts, err := FetchUsedContracts(ctx, tx, fcids)
+	// fetch used contracts
+	ucs, err := FetchUsedContracts(ctx, tx, fcids)
 	if err != nil {
 		return err
+	}
+
+	// build used contracts map
+	contracts := make(map[types.FileContractID]UsedContract, 0)
+	for _, c := range ucs {
+		contracts[types.FileContractID(c.FCID)] = c
 	}
 
 	// build contract <-> sector links
@@ -2477,9 +2468,15 @@ func MarkPackedSlabUploaded(ctx context.Context, tx Tx, slab api.UploadedPackedS
 	}
 
 	// fetch used contracts
-	usedContracts, err := FetchUsedContracts(ctx, tx, slab.Contracts())
+	ucs, err := FetchUsedContracts(ctx, tx, slab.Contracts())
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch used contracts: %w", err)
+	}
+
+	// build used contracts map
+	contracts := make(map[types.FileContractID]UsedContract, 0)
+	for _, c := range ucs {
+		contracts[types.FileContractID(c.FCID)] = c
 	}
 
 	// stmt to add sector
@@ -2515,7 +2512,7 @@ func MarkPackedSlabUploaded(ctx context.Context, tx Tx, slab api.UploadedPackedS
 			return "", fmt.Errorf("failed to get sector id: %w", err)
 		}
 
-		uc, ok := usedContracts[sector.ContractID]
+		uc, ok := contracts[sector.ContractID]
 		if !ok {
 			continue
 		}

--- a/stores/sql/main.go
+++ b/stores/sql/main.go
@@ -596,7 +596,7 @@ func DeleteWebhook(ctx context.Context, tx sql.Tx, wh webhooks.Webhook) error {
 
 func FetchUsedContracts(ctx context.Context, tx sql.Tx, fcids []types.FileContractID) (map[types.FileContractID]UsedContract, error) {
 	if len(fcids) == 0 {
-		return nil, nil
+		return make(map[types.FileContractID]UsedContract), nil
 	}
 
 	// build args
@@ -621,8 +621,8 @@ WHERE (fcid IN (%s) OR renewed_from IN (%s)) AND contracts.archival_reason IS NU
 	}
 	defer rows.Close()
 
-	// build used contracts
-	used := make(map[types.FileContractID]UsedContract, len(fcids))
+	// build map of used contracts
+	usedContracts := make(map[types.FileContractID]UsedContract, len(fcids))
 	for rows.Next() {
 		var c UsedContract
 		var rf FileContractID
@@ -634,9 +634,9 @@ WHERE (fcid IN (%s) OR renewed_from IN (%s)) AND contracts.archival_reason IS NU
 		if _, ok := lookup[c.FCID]; !ok {
 			c.FCID = rf
 		}
-		used[types.FileContractID(c.FCID)] = c
+		usedContracts[types.FileContractID(c.FCID)] = c
 	}
-	return used, nil
+	return usedContracts, nil
 }
 
 func HasMigration(ctx context.Context, tx sql.Tx, id string) (applied bool, err error) {
@@ -2137,7 +2137,7 @@ func UpdateSlab(ctx context.Context, tx Tx, key object.EncryptionKey, updated []
 		fcids = append(fcids, s.ContractID)
 	}
 
-	// fetch used contracts
+	// fetch contracts
 	contracts, err := FetchUsedContracts(ctx, tx, fcids)
 	if err != nil {
 		return err

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -1201,9 +1201,16 @@ func (tx *MainDatabaseTx) insertSlabs(ctx context.Context, objID, partID *int64,
 		return nil // nothing to do
 	}
 
-	usedContracts, err := ssql.FetchUsedContracts(ctx, tx.Tx, slices.Contracts())
+	// fetch used contracts
+	ucs, err := ssql.FetchUsedContracts(ctx, tx.Tx, slices.Contracts())
 	if err != nil {
 		return fmt.Errorf("failed to fetch used contracts: %w", err)
+	}
+
+	// build used contracts map
+	contracts := make(map[types.FileContractID]ssql.UsedContract, 0)
+	for _, c := range ucs {
+		contracts[types.FileContractID(c.FCID)] = c
 	}
 
 	// insert slabs
@@ -1214,12 +1221,6 @@ func (tx *MainDatabaseTx) insertSlabs(ctx context.Context, objID, partID *int64,
 		return fmt.Errorf("failed to prepare statement to insert slab: %w", err)
 	}
 	defer insertSlabStmt.Close()
-
-	querySlabIDStmt, err := tx.Prepare(ctx, "SELECT id FROM slabs WHERE `key` = ?")
-	if err != nil {
-		return fmt.Errorf("failed to prepare statement to query slab id: %w", err)
-	}
-	defer querySlabIDStmt.Close()
 
 	slabIDs := make([]int64, len(slices))
 	for i := range slices {
@@ -1288,10 +1289,10 @@ func (tx *MainDatabaseTx) insertSlabs(ctx context.Context, objID, partID *int64,
 		for _, shard := range ss.Shards {
 			for _, fcids := range shard.Contracts {
 				for _, fcid := range fcids {
-					if _, ok := usedContracts[fcid]; ok {
+					if c, ok := contracts[fcid]; ok {
 						upsertContractSectors = append(upsertContractSectors, ssql.ContractSector{
-							HostID:     usedContracts[fcid].HostID,
-							ContractID: usedContracts[fcid].ID,
+							HostID:     c.HostID,
+							ContractID: c.ID,
 							SectorID:   sectorIDs[sectorIdx],
 						})
 					} else {

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -1202,15 +1202,9 @@ func (tx *MainDatabaseTx) insertSlabs(ctx context.Context, objID, partID *int64,
 	}
 
 	// fetch used contracts
-	ucs, err := ssql.FetchUsedContracts(ctx, tx.Tx, slices.Contracts())
+	contracts, err := ssql.FetchUsedContracts(ctx, tx.Tx, slices.Contracts())
 	if err != nil {
 		return fmt.Errorf("failed to fetch used contracts: %w", err)
-	}
-
-	// build used contracts map
-	contracts := make(map[types.FileContractID]ssql.UsedContract, 0)
-	for _, c := range ucs {
-		contracts[types.FileContractID(c.FCID)] = c
 	}
 
 	// insert slabs

--- a/stores/sql/mysql/main.go
+++ b/stores/sql/mysql/main.go
@@ -1202,7 +1202,7 @@ func (tx *MainDatabaseTx) insertSlabs(ctx context.Context, objID, partID *int64,
 	}
 
 	// fetch used contracts
-	contracts, err := ssql.FetchUsedContracts(ctx, tx.Tx, slices.Contracts())
+	usedContracts, err := ssql.FetchUsedContracts(ctx, tx.Tx, slices.Contracts())
 	if err != nil {
 		return fmt.Errorf("failed to fetch used contracts: %w", err)
 	}
@@ -1283,10 +1283,10 @@ func (tx *MainDatabaseTx) insertSlabs(ctx context.Context, objID, partID *int64,
 		for _, shard := range ss.Shards {
 			for _, fcids := range shard.Contracts {
 				for _, fcid := range fcids {
-					if c, ok := contracts[fcid]; ok {
+					if _, ok := usedContracts[fcid]; ok {
 						upsertContractSectors = append(upsertContractSectors, ssql.ContractSector{
-							HostID:     c.HostID,
-							ContractID: c.ID,
+							HostID:     usedContracts[fcid].HostID,
+							ContractID: usedContracts[fcid].ID,
 							SectorID:   sectorIDs[sectorIdx],
 						})
 					} else {

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -1208,8 +1208,7 @@ func (tx *MainDatabaseTx) insertSlabs(ctx context.Context, objID, partID *int64,
 		return nil // nothing to do
 	}
 
-	// fetch used contracts
-	contracts, err := ssql.FetchUsedContracts(ctx, tx.Tx, slices.Contracts())
+	usedContracts, err := ssql.FetchUsedContracts(ctx, tx.Tx, slices.Contracts())
 	if err != nil {
 		return fmt.Errorf("failed to fetch used contracts: %w", err)
 	}
@@ -1296,10 +1295,10 @@ func (tx *MainDatabaseTx) insertSlabs(ctx context.Context, objID, partID *int64,
 		for _, shard := range ss.Shards {
 			for _, fcids := range shard.Contracts {
 				for _, fcid := range fcids {
-					if c, ok := contracts[fcid]; ok {
+					if _, ok := usedContracts[fcid]; ok {
 						upsertContractSectors = append(upsertContractSectors, ssql.ContractSector{
-							HostID:     c.HostID,
-							ContractID: c.ID,
+							HostID:     usedContracts[fcid].HostID,
+							ContractID: usedContracts[fcid].ID,
 							SectorID:   sectorIDs[sectorIdx],
 						})
 					} else {

--- a/stores/sql/sqlite/main.go
+++ b/stores/sql/sqlite/main.go
@@ -1209,15 +1209,9 @@ func (tx *MainDatabaseTx) insertSlabs(ctx context.Context, objID, partID *int64,
 	}
 
 	// fetch used contracts
-	ucs, err := ssql.FetchUsedContracts(ctx, tx.Tx, slices.Contracts())
+	contracts, err := ssql.FetchUsedContracts(ctx, tx.Tx, slices.Contracts())
 	if err != nil {
 		return fmt.Errorf("failed to fetch used contracts: %w", err)
-	}
-
-	// build used contracts map
-	contracts := make(map[types.FileContractID]ssql.UsedContract, 0)
-	for _, c := range ucs {
-		contracts[types.FileContractID(c.FCID)] = c
 	}
 
 	// insert slabs


### PR DESCRIPTION
When we fetch used sectors we take into account that the contracts could have been renewed during the upload, we don't take into account however that a contract might've been archived in the mean time. This results in a scan failure and eventually ends up failing the upload.
