### PR TITLE
Fix upload error on contracts being refreshed in the background

### DIFF
--- a/.changeset/fix_upload_bug_that_caused_failures_when_uploading_to_contracts_that_are_being_refreshed_in_the_background.md
+++ b/.changeset/fix_upload_bug_that_caused_failures_when_uploading_to_contracts_that_are_being_refreshed_in_the_background.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix upload bug that caused failures when uploading to contracts that are being refreshed in the background.

--- a/internal/test/mocks/contractstore.go
+++ b/internal/test/mocks/contractstore.go
@@ -2,7 +2,6 @@ package mocks
 
 import (
 	"context"
-	"errors"
 	"sync"
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
@@ -79,17 +78,17 @@ func (cs *ContractStore) DeleteContracdt(fcid types.FileContractID) {
 	delete(cs.contracts, fcid)
 }
 
-func (cs *ContractStore) RenewContract(hk types.PublicKey) (*Contract, error) {
+func (cs *ContractStore) RenewContract(hk types.PublicKey) *Contract {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 
 	curr, ok := cs.hosts2fcid[hk]
 	if !ok {
-		return nil, errors.New("host not found")
+		panic("host not found") // developer error
 	}
 	c := cs.contracts[curr]
 	if c == nil {
-		return nil, errors.New("host does not have a contract to renew")
+		panic("contract not found") // developer error
 	}
 	delete(cs.contracts, curr)
 
@@ -99,7 +98,7 @@ func (cs *ContractStore) RenewContract(hk types.PublicKey) (*Contract, error) {
 	renewal.metadata.WindowEnd = renewal.metadata.WindowStart + (c.metadata.WindowEnd - c.metadata.WindowStart)
 	cs.contracts[renewal.metadata.ID] = renewal
 	cs.hosts2fcid[hk] = renewal.metadata.ID
-	return renewal, nil
+	return renewal
 }
 
 func (cs *ContractStore) newFileContractID() types.FileContractID {

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -138,11 +138,7 @@ func (w *testWorker) RenewContract(hk types.PublicKey) *mocks.Contract {
 		w.tt.Fatal("host not found")
 	}
 
-	renewal, err := w.cs.RenewContract(hk)
-	if err != nil {
-		w.tt.Fatal(err)
-	}
-	return renewal
+	return w.cs.RenewContract(hk)
 }
 
 func (w *testWorker) UsableHosts() []api.HostInfo {


### PR DESCRIPTION
I encountered these upload failures on my node and found out we don't properly refresh the uploader's contract ID if it got refreshed/renewed in the background. Possible solution was a host store but I think this is superior, avoids a lot of dependency injection and most annoyingly I found that it's quite cumbersome to get at `api.HostInfo` for a single host...

```
2025-01-10T13:51:23Z    DEBUG   worker.worker.uploadmanager     sector upload failure was ignored       {"uploadError": "failed to upload sector to contract e6237a2a66ffe5d4e6d1e017983d2cffe039f07bbb9f73b82ac5b5ceedb9ef68; contract has reached the maximum number of revisions", "uploadDuration": "0s", "totalDuration": "28.417729ms", "overdrive": false, "hk": "ed25519:05e1b50b4d0104bc1ec30f3ec570f3abcea34e38b903cd24896b718032ef2c6a"}
```

