### PR TITLE
Fix race when fetching prices

### DIFF
--- a/.changeset/fixed_data_race_when_fetching_a_new_price_table.md
+++ b/.changeset/fixed_data_race_when_fetching_a_new_price_table.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed data race when fetching a new price table

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -70,10 +70,9 @@ func (p *cachedPrices) fetch(ctx context.Context, h PricesFetcher) (rhpv4.HostPr
 	// grab the current price table
 	p.mu.Lock()
 	prices := p.prices
-	renewTime := p.renewTime
 
 	// figure out whether we should update the price table, if not we can return
-	if !renewTime.IsZero() && time.Now().Before(renewTime) {
+	if !p.renewTime.IsZero() && time.Now().Before(p.renewTime) {
 		p.mu.Unlock()
 		return prices, nil
 	}


### PR DESCRIPTION
The race:

```
  === RUN   TestPricesCache
  ==================
  WARNING: DATA RACE
  Write at 0x00c000138c28 by goroutine 9:
    go.sia.tech/renterd/internal/prices.(*cachedPrices).fetch()
        /home/runner/work/renterd/renterd/internal/prices/prices.go:125 +0x8d0
    go.sia.tech/renterd/internal/prices.(*PricesCache).Fetch()
        /home/runner/work/renterd/renterd/internal/prices/prices.go:66 +0x304
    go.sia.tech/renterd/internal/prices.TestPricesCache.gowrap1()
        /home/runner/work/renterd/renterd/internal/prices/prices_test.go:69 +0xa4
  
  Previous read at 0x00c000138c28 by goroutine 8:
    go.sia.tech/renterd/internal/prices.(*cachedPrices).fetch()
        /home/runner/work/renterd/renterd/internal/prices/prices.go:90 +0x10e
    go.sia.tech/renterd/internal/prices.(*PricesCache).Fetch()
        /home/runner/work/renterd/renterd/internal/prices/prices.go:66 +0x304
    go.sia.tech/renterd/internal/prices.TestPricesCache()
        /home/runner/work/renterd/renterd/internal/prices/prices_test.go:84 +0x87c
    testing.tRunner()
        /opt/hostedtoolcache/go/1.23.4/x64/src/testing/testing.go:1690 +0x226
    testing.(*T).Run.gowrap1()
        /opt/hostedtoolcache/go/1.23.4/x64/src/testing/testing.go:1743 +0x44
  
  Goroutine 9 (running) created at:
    go.sia.tech/renterd/internal/prices.TestPricesCache()
        /home/runner/work/renterd/renterd/internal/prices/prices_test.go:69 +0x685
    testing.tRunner()
        /opt/hostedtoolcache/go/1.23.4/x64/src/testing/testing.go:1690 +0x226
    testing.(*T).Run.gowrap1()
        /opt/hostedtoolcache/go/1.23.4/x64/src/testing/testing.go:1743 +0x44
  
  Goroutine 8 (running) created at:
    testing.(*T).Run()
        /opt/hostedtoolcache/go/1.23.4/x64/src/testing/testing.go:1743 +0x825
    testing.runTests.func1()
        /opt/hostedtoolcache/go/1.23.4/x64/src/testing/testing.go:2168 +0x85
    testing.tRunner()
        /opt/hostedtoolcache/go/1.23.4/x64/src/testing/testing.go:1690 +0x226
    testing.runTests()
        /opt/hostedtoolcache/go/1.23.4/x64/src/testing/testing.go:2166 +0x8be
    testing.(*M).Run()
        /opt/hostedtoolcache/go/1.23.4/x64/src/testing/testing.go:2034 +0xf17
    main.main()
        _testmain.go:47 +0x164
  ==================
      testing.go:1399: race detected during execution of test
  --- FAIL: TestPricesCache (0.05s)
```