### PR TITLE
Fix deadlock in test suite

### DIFF
--- a/.changeset/fix_deadlock_in_test_suite.md
+++ b/.changeset/fix_deadlock_in_test_suite.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix deadlock in test suite

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -2502,7 +2502,7 @@ func TestHostScan(t *testing.T) {
 	assertHost(ls, true, true, 2)
 
 	// close the host to make scans fail
-	tt.OK(host.Close())
+	cluster.RemoveHost(host)
 
 	// scan the host a third time
 	ls = time.Now()
@@ -2878,7 +2878,7 @@ func TestContractFundsReturnWhenHostOffline(t *testing.T) {
 	}
 
 	// stop the host
-	tt.OK(hosts[0].Close())
+	cluster.RemoveHost(hosts[0])
 
 	// mine until the contract is expired
 	cluster.mineBlocks(types.VoidAddress, contract.WindowEnd-cs.BlockHeight)


### PR DESCRIPTION
There are two tests where we manually close/remove a host, `TestContractFundsReturnWhenHostOffline` and `TestHostScan`, turns out calling `Close` on a test host twice causes a potential deadlock in the syncer because we `Connect` after closing. This has to be fixed in the syncer of course but on our end we can avoid calling `Close` twice and properly remove the host from the cluster instead.

see https://github.com/SiaFoundation/coreutils/issues/100