### PR TITLE
Fix creation of directory table related index

### DIFF
--- a/.changeset/fix_issue_where_db_migration_migration_00020_idx_db_directorysql_would_fail_due_to_a_column_being_missing.md
+++ b/.changeset/fix_issue_where_db_migration_migration_00020_idx_db_directorysql_would_fail_due_to_a_column_being_missing.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix issue where db migration 'migration_00020_idx_db_directory.sql' would fail due to a column being missing

--- a/stores/sql/sqlite/migrations/main/migration_00020_idx_db_directory.sql
+++ b/stores/sql/sqlite/migrations/main/migration_00020_idx_db_directory.sql
@@ -1,1 +1,0 @@
-CREATE INDEX IF NOT EXISTS `idx_objects_db_directory_id` ON `objects`(`db_directory_id`);


### PR DESCRIPTION
Closes https://github.com/SiaFoundation/renterd/issues/1803

Some users have been reporting that creating this index fails due to the directory reference being missing on the `objects` table. Which happens when the migrations were run out of order. Easiest fix is to avoid that migration altogether since the table was dropped.