### PR TITLE
Use standard directories

### DIFF
--- a/.changeset/use_standard_directories.md
+++ b/.changeset/use_standard_directories.md
@@ -1,0 +1,23 @@
+---
+default: major
+---
+
+# Use standard locations for application data
+
+ Uses standard locations for application data instead of the current directory. This brings `renterd` in line with other system services and makes it easier to manage application data.
+
+ #### Linux, FreeBSD, OpenBSD
+ - Configuration: `/etc/renterd/renterd.yml`
+ - Data directory: `/var/lib/renterd`
+
+ #### macOS
+ - Configuration: `~/Library/Application Support/renterd.yml`
+ - Data directory: `~/Library/Application Support/renterd`
+
+ #### Windows
+ - Configuration: `%APPDATA%\SiaFoundation\renterd.yml`
+ - Data directory: `%APPDATA%\SiaFoundation\renterd`
+
+ #### Docker
+ - Configuration: `/data/renterd.yml`
+ - Data directory: `/data`

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ ENV PGID=0
 # Renterd env args
 ENV RENTERD_API_PASSWORD=
 ENV RENTERD_SEED=
+ENV RENTERD_DATA_DIR=/data
 ENV RENTERD_CONFIG_FILE=/data/renterd.yml
 ENV RENTERD_NETWORK='mainnet'
 
@@ -50,4 +51,4 @@ VOLUME [ "/data" ]
 USER ${PUID}:${PGID}
 
 # Copy the script and set it as the entrypoint.
-ENTRYPOINT ["renterd", "-env", "-http", ":9980", "-s3.address", ":8080", "-dir", "./data"]
+ENTRYPOINT ["renterd", "-env", "-http", ":9980", "-s3.address", ":8080"]

--- a/cmd/renterd/commands.go
+++ b/cmd/renterd/commands.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/renterd/build"
-	"go.sia.tech/renterd/config"
 	"go.sia.tech/renterd/stores/sql/sqlite"
 	"gopkg.in/yaml.v3"
 )
@@ -19,54 +20,53 @@ func cmdBackup() {
 	checkFatalError("failed to backup sqlite database", err)
 }
 
-func cmdBuildConfig(cfg *config.Config) {
-	if _, err := os.Stat("renterd.yml"); err == nil {
-		if !promptYesNo("renterd.yml already exists. Would you like to overwrite it?") {
+func cmdBuildConfig(fp string) {
+	fmt.Println("renterd Configuration Wizard")
+	fmt.Println("This wizard will help you configure renterd for the first time.")
+	fmt.Println("You can always change these settings with the config command or by editing the config file.")
+
+	if fp == "" {
+		fp = configPath()
+	}
+
+	fmt.Println("")
+	fmt.Printf("Config Location %q\n", fp)
+
+	if _, err := os.Stat(fp); err == nil {
+		if !promptYesNo(fmt.Sprintf("%q already exists. Would you like to overwrite it?", fp)) {
 			return
 		}
-	}
-
-	fmt.Println("")
-	if cfg.Seed != "" {
-		fmt.Println(wrapANSI("\033[33m", "A wallet seed phrase is already set.", "\033[0m"))
-		fmt.Println("If you change your wallet seed phrase, your renter will not be able to access Siacoin associated with this wallet.")
-		fmt.Println("Ensure that you have backed up your wallet seed phrase before continuing.")
-		if promptYesNo("Would you like to change your wallet seed phrase?") {
-			setSeedPhrase(cfg)
-		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		checkFatalError("failed to check if config file exists", err)
 	} else {
-		setSeedPhrase(cfg)
+		// ensure the config directory exists
+		checkFatalError("failed to create config directory", os.MkdirAll(filepath.Dir(fp), 0700))
 	}
 
 	fmt.Println("")
-	if cfg.HTTP.Password != "" {
-		fmt.Println(wrapANSI("\033[33m", "An admin password is already set.", "\033[0m"))
-		fmt.Println("If you change your admin password, you will need to update any scripts or applications that use the admin API.")
-		if promptYesNo("Would you like to change your admin password?") {
-			setAPIPassword(cfg)
-		}
-	} else {
-		setAPIPassword(cfg)
-	}
+	setDataDirectory()
 
 	fmt.Println("")
-	setS3Config(cfg)
+	setSeedPhrase()
 
 	fmt.Println("")
-	setAdvancedConfig(cfg)
+	setAPIPassword()
 
-	// write the config file
-	configPath := "renterd.yml"
-	if str := os.Getenv("RENTERD_CONFIG_FILE"); str != "" {
-		configPath = str
-	}
+	fmt.Println("")
+	setS3Config()
 
-	f, err := os.Create(configPath)
+	fmt.Println("")
+	setAdvancedConfig()
+
+	f, err := os.Create(fp)
 	checkFatalError("Failed to create config file", err)
 	defer f.Close()
 
 	enc := yaml.NewEncoder(f)
+	defer enc.Close()
+
 	checkFatalError("Failed to encode config file", enc.Encode(cfg))
+	checkFatalError("Failed to sync config file", f.Sync())
 }
 
 func cmdSeed() {

--- a/cmd/renterd/config.go
+++ b/cmd/renterd/config.go
@@ -458,7 +458,7 @@ func setListenAddress(context string, value *string, allowEmpty bool) {
 
 func setDataDirectory() {
 	if cfg.Directory == "" {
-		cfg.Directory = "."
+		cfg.Directory = defaultDataDirectory(cfg.Directory)
 	}
 
 	dir, err := filepath.Abs(cfg.Directory)
@@ -468,9 +468,10 @@ func setDataDirectory() {
 	fmt.Println("This directory should be on a fast, reliable storage device, preferably an SSD.")
 	fmt.Println("")
 
-	_, existsErr := os.Stat(filepath.Join(dir, "consensus"))
-	dataExists := existsErr == nil
-	if dataExists {
+	entries, err := os.ReadDir(dir)
+	checkFatalError("failed to read directory contents", err)
+
+	if len(entries) > 0 {
 		fmt.Println(wrapANSI("\033[33m", "There is existing data in the data directory.", "\033[0m"))
 		fmt.Println(wrapANSI("\033[33m", "If you change your data directory, you will need to manually move consensus, gateway, transactionpool, partial_slabs and (potentially) the db folder to the new directory.", "\033[0m"))
 	}

--- a/cmd/renterd/config.go
+++ b/cmd/renterd/config.go
@@ -182,9 +182,6 @@ func sanitizeConfig() error {
 		cfg.Log.Database.Level = cfg.Log.Level
 	}
 
-	// default data directory
-	cfg.Directory = defaultDataDirectory(cfg.Directory)
-
 	// validate worker settings
 	if err := assertWorkerID(); err != nil {
 		return err
@@ -458,7 +455,7 @@ func setListenAddress(context string, value *string, allowEmpty bool) {
 
 func setDataDirectory() {
 	if cfg.Directory == "" {
-		cfg.Directory = defaultDataDirectory(cfg.Directory)
+		cfg.Directory = "."
 	}
 
 	dir, err := filepath.Abs(cfg.Directory)
@@ -468,10 +465,8 @@ func setDataDirectory() {
 	fmt.Println("This directory should be on a fast, reliable storage device, preferably an SSD.")
 	fmt.Println("")
 
-	entries, err := os.ReadDir(dir)
-	checkFatalError("failed to read directory contents", err)
-
-	if len(entries) > 0 {
+	_, existsErr := os.Stat(filepath.Join(dir, "consensus"))
+	if existsErr == nil {
 		fmt.Println(wrapANSI("\033[33m", "There is existing data in the data directory.", "\033[0m"))
 		fmt.Println(wrapANSI("\033[33m", "If you change your data directory, you will need to manually move consensus, gateway, transactionpool, partial_slabs and (potentially) the db folder to the new directory.", "\033[0m"))
 	}

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -55,6 +55,9 @@ func main() {
 	// load config file
 	configPath := tryLoadConfig()
 
+	// default data directory
+	cfg.Directory = defaultDataDirectory(cfg.Directory)
+
 	// override config file with CLI flags and/or environment variables
 	parseCLIFlags()
 	parseEnvironmentVariables()

--- a/cmd/renterd/main.go
+++ b/cmd/renterd/main.go
@@ -7,6 +7,18 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+
+	"go.sia.tech/core/consensus"
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/chain"
+)
+
+const (
+	apiPasswordEnvVar = "RENTERD_API_PASSWORD"
+	configFileEnvVar  = "RENTERD_CONFIG_FILE"
+	dataDirEnvVar     = "RENTERD_DATA_DIR"
+	logFileEnvVar     = "RENTERD_LOG_FILE"
+	seedEnvVar        = "RENTERD_SEED"
 )
 
 const (
@@ -40,9 +52,26 @@ on how to configure and use renterd.
 func main() {
 	log.SetFlags(0)
 
-	// load the config
-	cfg, network, genesis, err := loadConfig()
-	checkFatalError("failed to load config", err)
+	// load config file
+	configPath := tryLoadConfig()
+
+	// override config file with CLI flags and/or environment variables
+	parseCLIFlags()
+	parseEnvironmentVariables()
+
+	// check network
+	var network *consensus.Network
+	var genesis types.Block
+	switch cfg.Network {
+	case "anagami":
+		network, genesis = chain.TestnetAnagami()
+	case "mainnet":
+		network, genesis = chain.Mainnet()
+	case "zen":
+		network, genesis = chain.TestnetZen()
+	default:
+		checkFatalError("invalid network settings", fmt.Errorf("unknown network '%s'", cfg.Network))
+	}
 
 	// NOTE: update the usage header when adding new commands
 	if flag.Arg(0) == "version" {
@@ -52,7 +81,7 @@ func main() {
 		cmdSeed()
 		return
 	} else if flag.Arg(0) == "config" {
-		cmdBuildConfig(&cfg)
+		cmdBuildConfig(configPath)
 		return
 	} else if flag.Arg(0) == "sqlite" && flag.Arg(1) == "backup" &&
 		flag.Arg(2) != "" && flag.Arg(3) != "" {
@@ -64,10 +93,10 @@ func main() {
 	}
 
 	// sanitize the config
-	checkFatalError("failed to sanitize config", sanitizeConfig(&cfg))
+	checkFatalError(fmt.Sprintf("failed to sanitize config %q", configPath), sanitizeConfig())
 
 	// create node
-	node, err := newNode(cfg, network, genesis)
+	node, err := newNode(cfg, configPath, network, genesis)
 	checkFatalError("failed to create node", err)
 
 	// start node

--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -602,7 +602,7 @@ func defaultDataDirectory(fp string) string {
 	}
 
 	// check for databases in the current directory
-	if _, err := os.Stat("db.sqlite"); err == nil {
+	if _, err := os.Stat("db/db.sqlite"); err == nil {
 		return "."
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,12 @@
 package config
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 type (
@@ -155,4 +159,24 @@ func MySQLConfigFromEnv() MySQL {
 		Database:        os.Getenv("RENTERD_DB_NAME"),
 		MetricsDatabase: os.Getenv("RENTERD_DB_METRICS_NAME"),
 	}
+}
+
+// LoadFile loads the configuration from the provided file path.
+// If the file does not exist, an error is returned.
+// If the file exists but cannot be decoded, the function will attempt
+// to upgrade the config file.
+func LoadFile(fp string, cfg *Config) error {
+	buf, err := os.ReadFile(fp)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	r := bytes.NewReader(buf)
+	dec := yaml.NewDecoder(r)
+	dec.KnownFields(true)
+
+	if err := dec.Decode(cfg); err != nil {
+		return fmt.Errorf("failed to decode config file: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
Uses standard locations for application data instead of the current directory. This brings `renterd` in line with other system services and makes it easier to manage application data.

 #### Linux, FreeBSD, OpenBSD
 - Configuration: `/etc/walletd/walletd.yml`
 - Data directory: `/var/lib/walletd`

 #### macOS
 - Configuration: `~/Library/Application Support/walletd.yml`
 - Data directory: `~/Library/Application Support/walletd`

 #### Windows
 - Configuration: `%APPDATA%\SiaFoundation\walletd.yml`
 - Data directory: `%APPDATA%\SiaFoundation\walletd`

 #### Docker
 - Configuration: `/data/walletd.yml`
 - Data directory: `/data`