### PR TITLE
Update openapi.yml to `v3.1.0` fix deprecated fields

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: "3.1.0"
 info:
   title: Renterd API
   version: 2.0.0
@@ -290,7 +290,8 @@ paths:
             text/plain:
               schema:
                 type: string
-                example: "account doesn't exist"
+                examples:
+                  - "account doesn't exist"
 
   /worker/memory:
     get:
@@ -327,9 +328,8 @@ paths:
           in: path
           required: true
           schema:
-            type: string
-            example: "folder/file"
-            minLength: 1
+            $ref: "#/components/schemas/FolderOrFile"
+          example: "folder/file"
         - name: bucket
           description: The name of the bucket the multipart upload belongs to
           in: query
@@ -343,7 +343,9 @@ paths:
           schema:
             allOf:
               - $ref: "#/components/schemas/MultipartUploadID"
-              - example: 7aaac83c6d553865755286c326e852a68300bebf7feea1b435d61bd3610bf82b
+          examples: 
+            7aaac83c6d553865755286c326e852a68300bebf7feea1b435d61bd3610bf82b:
+                value: 7aaac83c6d553865755286c326e852a68300bebf7feea1b435d61bd3610bf82b
         - name: partnumber
           description: The part number of the part being uploaded
           example: 0
@@ -409,9 +411,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
-            example: "folder/file"
-            minLength: 1
+            $ref: "#/components/schemas/FolderOrFile"
         - name: bucket
           description: The name of the bucket the object belongs to
           in: query
@@ -489,8 +489,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "folder/file"
-            minLength: 1
+            $ref: "#/components/schemas/FolderOrFile"
         - name: bucket
           description: The name of the bucket the object belongs to
           in: query
@@ -552,8 +551,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "folder/file"
-            minLength: 1
+            $ref: "#/components/schemas/FolderOrFile"
         - name: bucket
           description: The name of the bucket the object belongs to
           example: "myBucket"
@@ -2287,10 +2285,7 @@ paths:
                 bucket:
                   $ref: "#/components/schemas/BucketName"
                 key:
-                  type: string
-                  description: The key of the object to upload
-                  example: "folder/file"
-                  minLength: 1
+                  $ref: "#/components/schemas/FolderOrFile"
                 mimeType:
                   type: string
                   description: The MIME type of the object
@@ -2331,10 +2326,7 @@ paths:
                 bucket:
                   $ref: "#/components/schemas/BucketName"
                 key:
-                  type: string
-                  description: The key of the object
-                  example: "folder/file"
-                  minLength: 1
+                  $ref: "#/components/schemas/FolderOrFile"
                 uploadID:
                   type: string
                   description: The ID of the multipart upload to abort
@@ -2361,10 +2353,7 @@ paths:
                 bucket:
                   $ref: "#/components/schemas/BucketName"
                 key:
-                  type: string
-                  description: The key of the object
-                  example: "folder/file"
-                  minLength: 1
+                  $ref: "#/components/schemas/FolderOrFile"
                 uploadID:
                     allOf:
                       - $ref: "#/components/schemas/UploadID"
@@ -2406,10 +2395,8 @@ paths:
                 eTag:
                   $ref: "#/components/schemas/ETag"
                 key:
-                  type: string
+                  $ref: "#/components/schemas/FolderOrFile"
                   description: The key of the object
-                  example: "folder/file"
-                  minLength: 1
                 uploadID:
                   $ref: "#/components/schemas/UploadID"
                 partNumber:
@@ -2567,10 +2554,8 @@ paths:
                 bucket:
                   $ref: "#/components/schemas/BucketName"
                 key:
-                  type: string
+                  $ref: "#/components/schemas/FolderOrFile"
                   description: The key of the object
-                  example: "folder/file"
-                  minLength: 1
                 uploadID:
                     allOf:
                       - $ref: "#/components/schemas/UploadID"
@@ -2826,8 +2811,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
-            example: "folder/file"
+            $ref: "#/components/schemas/FolderOrFile"
             pattern: ".*" # greedy match
           description: The key of the object to fetch
         - name: bucket
@@ -2862,8 +2846,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
-            example: "folder/file"
+            $ref: "#/components/schemas/FolderOrFile"
             pattern: ".*" # greedy match
           description: The key of the object
       requestBody:
@@ -2901,8 +2884,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
-            example: "folder/file"
+            $ref: "#/components/schemas/FolderOrFile"
             pattern: ".*" # greedy match
           description: The key of the object to delete
         - name: bucket
@@ -4356,6 +4338,13 @@ components:
         revisionNumber:
           $ref: "#/components/schemas/RevisionNumber"
 
+    FolderOrFile:
+      type: string
+      minLength: 1
+      description: The key of the object to upload
+      examples:
+         - "folder/file"
+
     Hash256:
       type: string
       pattern: ^[0-9a-fA-F]{64}$
@@ -5099,7 +5088,8 @@ components:
       type: string
       pattern: (?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$
       description: The name of the bucket.
-      example: "default"
+      examples: 
+        - "default"
 
     BuildState:
       type: object


### PR DESCRIPTION
Update to latest spec and remove deprecated field (`example` -> `examples`)
For more information, please refer to this https://spec.openapis.org/oas/v3.1.0.html#example-object

Closes #1789 