### PR TITLE
Reduce default logging

### DIFF
--- a/.changeset/reduce_info_level_logging_spam_related_to_host_scanning_and_pruning.md
+++ b/.changeset/reduce_info_level_logging_spam_related_to_host_scanning_and_pruning.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Reduce info level logging spam related to host scanning and pruning

--- a/autopilot/contractor/contractor.go
+++ b/autopilot/contractor/contractor.go
@@ -825,7 +825,7 @@ func performContractChecks(ctx *mCtx, alerter alerts.Alerter, s Database, churn 
 
 		// check usability
 		if !host.Checks.UsabilityBreakdown.IsUsable() {
-			logger.Info("unusable host")
+			logger.Debug("unusable host")
 			updateUsability(ctx, host, cm, api.ContractUsabilityBad, host.Checks.UsabilityBreakdown.String())
 			continue
 		}

--- a/autopilot/contractor/hostset.go
+++ b/autopilot/contractor/hostset.go
@@ -72,7 +72,7 @@ func (hs *hostSet) HasRedundantIP(ctx context.Context, host api.Host) bool {
 	// the scanning code will lead to the host being marked as offline.
 	resolvedAddresses, err := hs.resolveHostIP(ctx, host)
 	if err != nil {
-		logger.With(zap.Error(err)).Error("failed to resolve host ips - not redundant")
+		logger.With(zap.Error(err)).Warn("failed to resolve host ips - not redundant")
 		return false
 	}
 

--- a/autopilot/pruner/pruning.go
+++ b/autopilot/pruner/pruning.go
@@ -223,7 +223,9 @@ func (p *Pruner) performContractPruning(ctx context.Context) {
 	}
 
 	// log total pruned
-	log.Info(fmt.Sprintf("pruned %d (%s) from %v contracts", total, humanReadableSize(int(total)), len(prunable)))
+	if total > 0 {
+		log.Info(fmt.Sprintf("pruned %d (%s) from %v contracts", total, humanReadableSize(int(total)), len(prunable)))
+	}
 }
 
 func (p *Pruner) pruneContract(ctx context.Context, fcid types.FileContractID, hk types.PublicKey, hostVersion, hostRelease string, logger *zap.SugaredLogger) (uint64, error) {
@@ -274,7 +276,7 @@ func (p *Pruner) pruneContract(ctx context.Context, fcid types.FileContractID, h
 	// handle logs
 	if res.Error != "" {
 		log.Errorw("unexpected error interrupted pruning", zap.Error(errors.New(res.Error)))
-	} else {
+	} else if res.Pruned > 0 {
 		log.Info("successfully pruned contract")
 	}
 

--- a/bus/scanning.go
+++ b/bus/scanning.go
@@ -93,9 +93,9 @@ func (b *Bus) scanHostV1(ctx context.Context, timeout time.Duration, hostKey typ
 
 		logger = logger.With("elapsed", duration).With(zap.Error(err))
 		if err == nil {
-			logger.Info("successfully scanned host on second try")
+			logger.Debug("successfully scanned host on second try")
 		} else if !isErrHostUnreachable(err) {
-			logger.Infow("failed to scan host")
+			logger.Debugw("failed to scan host")
 		}
 	}
 

--- a/bus/scanning.go
+++ b/bus/scanning.go
@@ -95,7 +95,7 @@ func (b *Bus) scanHostV1(ctx context.Context, timeout time.Duration, hostKey typ
 		if err == nil {
 			logger.Debug("successfully scanned host on second try")
 		} else if !isErrHostUnreachable(err) {
-			logger.Debugw("failed to scan host")
+			logger.Debug("failed to scan host")
 		}
 	}
 

--- a/internal/accounts/accounts.go
+++ b/internal/accounts/accounts.go
@@ -382,7 +382,7 @@ func (a *Manager) refillAccounts() {
 				a.mu.Unlock()
 
 				if err != nil && shouldLog {
-					a.logger.Errorw("failed to refill account for host", zap.Stringer("hostKey", contract.HostKey), zap.Error(err))
+					a.logger.Warnw("failed to refill account for host", zap.Stringer("hostKey", contract.HostKey), zap.Error(err))
 				} else if refilled {
 					a.logger.Infow("successfully refilled account for host", zap.Stringer("hostKey", contract.HostKey), zap.Error(err))
 				}
@@ -623,7 +623,7 @@ func (a *Account) setBalance(balance *big.Int) {
 	a.acc.RequiresSync = false
 
 	// log account changes
-	a.logger.Infow("account balance was reset",
+	a.logger.Debugw("account balance was reset",
 		zap.Stringer("account", a.acc.ID),
 		zap.Stringer("host", a.acc.HostKey),
 		zap.Stringer("balanceBefore", prevBalance),


### PR DESCRIPTION
This is a quick PR related to https://github.com/SiaFoundation/renterd/issues/1810 to tackle some of the low-hanging fruits.

On my node the logs were multiple GBs large. After removing the debug logging about half a GB remained. That was mostly 3 issues. 
1. repeatedly logging that pruning 0 bytes from a contract succeeded
2. logging that we failed to scan a host
3. logging that the account balance was reset

Moving these 3 to Debug should significantly reduce the logging. 
There are a few more changes but non as significant