### PR TITLE
Remove internal import

### DIFF
--- a/.changeset/remove_internal_imports_in_main_package.md
+++ b/.changeset/remove_internal_imports_in_main_package.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Remove internal imports in main package

--- a/internal/utils/web.go
+++ b/internal/utils/web.go
@@ -2,48 +2,11 @@ package utils
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	_ "net/http/pprof"
-	"os/exec"
-	"runtime"
-	"strings"
-
-	"go.uber.org/zap"
 )
-
-func ListenTCP(addr string, logger *zap.Logger) (net.Listener, error) {
-	l, err := net.Listen("tcp", addr)
-	if IsErr(err, errors.New("no such host")) && strings.Contains(addr, "localhost") {
-		// fall back to 127.0.0.1 if 'localhost' doesn't work
-		_, port, err := net.SplitHostPort(addr)
-		if err != nil {
-			return nil, err
-		}
-		fallbackAddr := fmt.Sprintf("127.0.0.1:%s", port)
-		logger.Sugar().Warnf("failed to listen on %s, falling back to %s", addr, fallbackAddr)
-		return net.Listen("tcp", fallbackAddr)
-	} else if err != nil {
-		return nil, err
-	}
-	return l, nil
-}
-
-func OpenBrowser(url string) error {
-	switch runtime.GOOS {
-	case "linux":
-		return exec.Command("xdg-open", url).Start()
-	case "windows":
-		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
-	case "darwin":
-		return exec.Command("open", url).Start()
-	default:
-		return fmt.Errorf("unsupported platform %q", runtime.GOOS)
-	}
-}
 
 func DoRequest(req *http.Request, resp interface{}) (http.Header, int, error) {
 	r, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
It doesn't prevent you from creating a `renterd` node but the rule states our `main` packages must be free of `internal` imports