### PR TITLE
Prevent write to log file after closing it

### DIFF
--- a/.changeset/prevent_attempted_write_after_closing_the_log_file.md
+++ b/.changeset/prevent_attempted_write_after_closing_the_log_file.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Prevent attempted write after closing the log file


### PR DESCRIPTION
This has been bothering me for a while now. We write after closing the log file. Turns out you cant use the logger to log the shutdown process.

```
2025-01-22 10:45:56.880843 +0100 CET m=+48.356201418 write error: attempted write to closed file
```