### PR TITLE
Infer mime type when creating multipart upload

### DIFF
--- a/.changeset/add_dl_query_param_to_download_endpoint_to_be_able_to_change_the_content_disposition_to_attachement.md
+++ b/.changeset/add_dl_query_param_to_download_endpoint_to_be_able_to_change_the_content_disposition_to_attachement.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Add dl query param to download endpoint to be able to change the Content-Disposition to "attachment"

--- a/.changeset/fix_missing_inferred_mimetype_for_objects_uploaded_via_multipart_uploads.md
+++ b/.changeset/fix_missing_inferred_mimetype_for_objects_uploaded_via_multipart_uploads.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix missing inferred MimeType for objects uploaded via multipart uploads

--- a/api/object.go
+++ b/api/object.go
@@ -93,12 +93,13 @@ type (
 
 	// HeadObjectResponse is the response type for the HEAD /worker/object endpoint.
 	HeadObjectResponse struct {
-		ContentType  string
-		Etag         string
-		LastModified TimeRFC3339
-		Range        *ContentRange
-		Size         int64
-		Metadata     ObjectUserMetadata
+		ContentDisposition string
+		ContentType        string
+		Etag               string
+		LastModified       TimeRFC3339
+		Range              *ContentRange
+		Size               int64
+		Metadata           ObjectUserMetadata
 	}
 
 	// ObjectsResponse is the response type for the /bus/objects endpoint.
@@ -200,11 +201,13 @@ type (
 	}
 
 	HeadObjectOptions struct {
-		Range *DownloadRange
+		Download *bool
+		Range    *DownloadRange
 	}
 
 	DownloadObjectOptions struct {
-		Range *DownloadRange
+		Download *bool
+		Range    *DownloadRange
 	}
 
 	GetObjectOptions struct {
@@ -279,6 +282,9 @@ func (opts DownloadObjectOptions) ApplyHeaders(h http.Header) {
 }
 
 func (opts HeadObjectOptions) Apply(values url.Values) {
+	if opts.Download != nil {
+		values.Set("dl", fmt.Sprint(*opts.Download))
+	}
 }
 
 func (opts HeadObjectOptions) ApplyHeaders(h http.Header) {

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"mime"
 	"net/http"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -2156,6 +2158,13 @@ func (b *Bus) multipartHandlerCreatePOST(jc jape.Context) {
 		key = object.NoOpKey
 	} else {
 		key = object.GenerateEncryptionKey(object.EncryptionKeyTypeSalted)
+	}
+
+	if req.MimeType == "" {
+		req.MimeType = mime.TypeByExtension(filepath.Ext(req.Key))
+		if req.MimeType == "" {
+			req.MimeType = "application/octet-stream"
+		}
 	}
 
 	resp, err := b.store.CreateMultipartUpload(jc.Request.Context(), req.Bucket, req.Key, key, req.MimeType, req.Metadata)

--- a/internal/test/e2e/cluster_test.go
+++ b/internal/test/e2e/cluster_test.go
@@ -2172,6 +2172,8 @@ func TestMultipartUploads(t *testing.T) {
 		t.Fatal(err)
 	} else if !bytes.Equal(data, expectedData) {
 		t.Fatal("unexpected data:", cmp.Diff(data, expectedData))
+	} else if gor.ContentType != "application/octet-stream" {
+		t.Fatalf("unexpected content type: %v", gor.ContentType)
 	}
 
 	// Download a range of the object
@@ -2185,6 +2187,8 @@ func TestMultipartUploads(t *testing.T) {
 		t.Fatal(err)
 	} else if expectedData := data1[:1]; !bytes.Equal(data, expectedData) {
 		t.Fatal("unexpected data:", cmp.Diff(data, expectedData))
+	} else if gor.ContentType != "application/octet-stream" {
+		t.Fatalf("unexpected content type: %v", gor.ContentType)
 	}
 
 	// Check objects stats.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -300,6 +300,14 @@ func (w *Worker) objectHandlerHEAD(jc jape.Context) {
 		return
 	}
 
+	// check whether the caller wants to force a download
+	var dl bool
+	if jc.DecodeForm("dl", &dl) != nil {
+		return
+	} else if dl {
+		jc.ResponseWriter.Header().Set("Content-Disposition", "attachment")
+	}
+
 	// serve the content to ensure we're setting the exact same headers as we
 	// would for a GET request
 	serveContent(jc.ResponseWriter, jc.Request, path, bytes.NewReader(nil), *hor)
@@ -349,6 +357,14 @@ func (w *Worker) objectHandlerGET(jc jape.Context) {
 		return
 	}
 	defer gor.Content.Close()
+
+	// check whether the caller wants to force a download
+	var dl bool
+	if jc.DecodeForm("dl", &dl) != nil {
+		return
+	} else if dl {
+		jc.ResponseWriter.Header().Set("Content-Disposition", "attachment")
+	}
 
 	// serve the content
 	serveContent(jc.ResponseWriter, jc.Request, key, gor.Content, gor.HeadObjectResponse)


### PR DESCRIPTION
We currently don't infer a content type for multipart uploads. Only regular uploads.
To be consistent with regular uploads and common S3 client implementations, this PR changes multipart uploads to also infer the type from the extension and if that doesn't work set it to `application/octet-stream`. 