### PR TITLE
Fix broadcastExpiredFileContractResolutions not including unconfirmed transactions when broadcasting revisions

### DIFF
--- a/.changeset/docs_add_descriptions_to_all_routes_and_schemas.md
+++ b/.changeset/docs_add_descriptions_to_all_routes_and_schemas.md
@@ -2,4 +2,4 @@
 default: patch
 ---
 
-# docs: add descriptions to all routes and schemas
+# Add missing descriptions to all routes and schemas

--- a/.changeset/fix_broadcastexpiredfilecontractresolutions_not_including_unconfirmed_transactions_when_broadcasting_revisions.md
+++ b/.changeset/fix_broadcastexpiredfilecontractresolutions_not_including_unconfirmed_transactions_when_broadcasting_revisions.md
@@ -2,8 +2,4 @@
 default: patch
 ---
 
-# Fix broadcastExpiredFileContractResolutions not including unconfirmed transactions when broadcasting revisions
-
-#1860 by @chris124567
-
-Fix https://github.com/SiaFoundation/renterd/issues/1856
+# Include unconfirmed parents of transactions when broadcasting revisions for expired contracts

--- a/.changeset/fix_broadcastexpiredfilecontractresolutions_not_including_unconfirmed_transactions_when_broadcasting_revisions.md
+++ b/.changeset/fix_broadcastexpiredfilecontractresolutions_not_including_unconfirmed_transactions_when_broadcasting_revisions.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Fix broadcastExpiredFileContractResolutions not including unconfirmed transactions when broadcasting revisions
+
+#1860 by @chris124567
+
+Fix https://github.com/SiaFoundation/renterd/issues/1856

--- a/internal/bus/chainsubscriber.go
+++ b/internal/bus/chainsubscriber.go
@@ -425,7 +425,7 @@ func (s *chainSubscriber) broadcastExpiredFileContractResolutions(tx sql.ChainUp
 			s.wallet.SignV2Inputs(&txn, toSign)
 
 			basis, set, err := s.cm.V2TransactionSet(basis, txn)
-			if err != il {
+			if err != nil {
 				s.logger.Errorf("failed to get transaction set: %w", err)
 				return
 			}


### PR DESCRIPTION
Fix https://github.com/SiaFoundation/renterd/issues/1856