### PR TITLE
Remove context from bus initialisation

### DIFF
--- a/.changeset/remove_context_from_bus_initialisation.md
+++ b/.changeset/remove_context_from_bus_initialisation.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Remove context from bus initialisation

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -334,7 +334,7 @@ type Bus struct {
 }
 
 // New returns a new Bus
-func New(ctx context.Context, cfg config.Bus, masterKey [32]byte, am AlertManager, wm WebhooksManager, cm ChainManager, s Syncer, w Wallet, store Store, explorerURL string, l *zap.Logger) (_ *Bus, err error) {
+func New(cfg config.Bus, masterKey [32]byte, am AlertManager, wm WebhooksManager, cm ChainManager, s Syncer, w Wallet, store Store, explorerURL string, l *zap.Logger) (_ *Bus, err error) {
 	l = l.Named("bus")
 	dialer := rhp.NewFallbackDialer(store, net.Dialer{}, l)
 
@@ -360,6 +360,8 @@ func New(ctx context.Context, cfg config.Bus, masterKey [32]byte, am AlertManage
 	}
 
 	// initialize autopilot config
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 	err = store.InitAutopilotConfig(ctx)
 	if err != nil {
 		return nil, err

--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -152,12 +152,8 @@ func newNode(cfg config.Config, configPath string, network *consensus.Network, g
 	// initialise bus
 	busAddr, busPassword := cfg.Bus.RemoteAddr, cfg.Bus.RemotePassword
 	if cfg.Bus.RemoteAddr == "" {
-		// ensure we don't hang indefinitely
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
-
 		// create bus
-		b, shutdownFn, err := newBus(ctx, cfg, pk, network, genesis, logger)
+		b, shutdownFn, err := newBus(cfg, pk, network, genesis, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -281,7 +277,7 @@ func newAutopilot(masterKey [32]byte, cfg config.Autopilot, bus *bus.Client, l *
 	return autopilot.New(ctx, cancel, bus, c, m, p, s, w, cfg.Heartbeat, l), nil
 }
 
-func newBus(ctx context.Context, cfg config.Config, pk types.PrivateKey, network *consensus.Network, genesis types.Block, logger *zap.Logger) (*bus.Bus, func(ctx context.Context) error, error) {
+func newBus(cfg config.Config, pk types.PrivateKey, network *consensus.Network, genesis types.Block, logger *zap.Logger) (*bus.Bus, func(ctx context.Context) error, error) {
 	// create store
 	alertsMgr := alerts.NewManager()
 	storeCfg, err := buildStoreConfig(alertsMgr, cfg, pk, logger)
@@ -309,7 +305,7 @@ func newBus(ctx context.Context, cfg config.Config, pk types.PrivateKey, network
 	}
 
 	// migrate consensus database if necessary
-	migrateConsensusDatabase(ctx, sqlStore, consensusDir, logger)
+	migrateConsensusDatabase(sqlStore, consensusDir, logger)
 
 	// reset chain state if blockchain.db does not exist to make sure deleting
 	// it forces a resync
@@ -411,7 +407,7 @@ func newBus(ctx context.Context, cfg config.Config, pk types.PrivateKey, network
 	}
 
 	// create bus
-	b, err := bus.New(ctx, cfg.Bus, masterKey, alertsMgr, wh, cm, s, w, sqlStore, explorerURL, logger)
+	b, err := bus.New(cfg.Bus, masterKey, alertsMgr, wh, cm, s, w, sqlStore, explorerURL, logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create bus: %w", err)
 	}
@@ -574,7 +570,10 @@ func buildStoreConfig(am alerts.Alerter, cfg config.Config, pk types.PrivateKey,
 	}, nil
 }
 
-func migrateConsensusDatabase(ctx context.Context, store *stores.SQLStore, consensusDir string, logger *zap.Logger) error {
+func migrateConsensusDatabase(store *stores.SQLStore, consensusDir string, logger *zap.Logger) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
 	oldConsensus, err := os.Stat(filepath.Join(consensusDir, "consensus.db"))
 	if os.IsNotExist(err) {
 		return nil

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -359,7 +359,7 @@ func newTestCluster(t *testing.T, opts testClusterOptions) *TestCluster {
 
 	// Create bus.
 	busDir := filepath.Join(dir, "bus")
-	b, bShutdownFn, cm, bs, err := newTestBus(ctx, cm, genesis, busDir, busCfg, dbCfg, wk, logger)
+	b, bShutdownFn, cm, bs, err := newTestBus(cm, genesis, busDir, busCfg, dbCfg, wk, logger)
 	tt.OK(err)
 
 	tokens := api.NewTokenStore()
@@ -565,7 +565,7 @@ func newTestAutopilot(masterKey utils.MasterKey, cfg config.Autopilot, bus *bus.
 	return autopilot.New(ctx, cancel, bus, c, m, p, s, w, cfg.Heartbeat, l), nil
 }
 
-func newTestBus(ctx context.Context, cm *chain.Manager, genesisBlock types.Block, dir string, cfg config.Bus, cfgDb dbConfig, pk types.PrivateKey, logger *zap.Logger) (*bus.Bus, func(ctx context.Context) error, *chain.Manager, bus.Store, error) {
+func newTestBus(cm *chain.Manager, genesisBlock types.Block, dir string, cfg config.Bus, cfgDb dbConfig, pk types.PrivateKey, logger *zap.Logger) (*bus.Bus, func(ctx context.Context) error, *chain.Manager, bus.Store, error) {
 	// create store config
 	alertsMgr := alerts.NewManager()
 	storeCfg, err := buildStoreConfig(alertsMgr, dir, cfg.SlabBufferCompletionThreshold, cfgDb, pk, logger)
@@ -647,7 +647,7 @@ func newTestBus(ctx context.Context, cm *chain.Manager, genesisBlock types.Block
 	masterKey := blake2b.Sum256(append([]byte("worker"), pk...))
 
 	// create bus
-	b, err := bus.New(ctx, cfg, masterKey, alertsMgr, wh, cm, s, w, sqlStore, "", logger)
+	b, err := bus.New(cfg, masterKey, alertsMgr, wh, cm, s, w, sqlStore, "", logger)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
We pass a sane timeout to bus constructors to avoid hanging indefinitely, since we now potentially have a reasonably long chain db migration I removed it and added a sane timeout to the two locations that apparently need it. It's mostly because our `Store` requires a context on all of its methods, like initialising the autopilot config.