### PR TITLE
Fix renewal with insufficient allowance

### DIFF
--- a/.changeset/fix_renter_expecting_host_putting_up_too_much_collateral_for_v2_contracts.md
+++ b/.changeset/fix_renter_expecting_host_putting_up_too_much_collateral_for_v2_contracts.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix renter expecting host putting up too much collateral for v2 contracts.

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -862,6 +862,9 @@ func (b *Bus) renewContractV2(ctx context.Context, cs consensus.State, h api.Hos
 	if newCollateral.Cmp(settings.MaxCollateral) > 0 {
 		newCollateral = settings.MaxCollateral
 	}
+	if max := rhpv4.MaxHostCollateral(settings.Prices, renterFunds); newCollateral.Cmp(max) > 0 {
+		newCollateral = max
+	}
 	if newCollateral.Cmp(minNewCollateral) < 0 {
 		return api.ContractMetadata{}, fmt.Errorf("new collateral %v is less than minimum %v (max: %v)", newCollateral, minNewCollateral, settings.MaxCollateral)
 	}

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -862,8 +862,8 @@ func (b *Bus) renewContractV2(ctx context.Context, cs consensus.State, h api.Hos
 	if newCollateral.Cmp(settings.MaxCollateral) > 0 {
 		newCollateral = settings.MaxCollateral
 	}
-	if max := rhpv4.MaxHostCollateral(settings.Prices, renterFunds); newCollateral.Cmp(max) > 0 {
-		newCollateral = max
+	if hostMax := rhpv4.MaxHostCollateral(settings.Prices, renterFunds); newCollateral.Cmp(hostMax) > 0 {
+		newCollateral = hostMax
 	}
 	if newCollateral.Cmp(minNewCollateral) < 0 {
 		return api.ContractMetadata{}, fmt.Errorf("new collateral %v is less than minimum %v (max: %v)", newCollateral, minNewCollateral, settings.MaxCollateral)


### PR DESCRIPTION
Depends on https://github.com/SiaFoundation/core/pull/299

Noticed that none of my Zen contracts renewed. This change fixed it.


Need to update go.mod once the dependencies are merged.