### PR TITLE
Add GET /bus/renterkey endpoint

### DIFF
--- a/.changeset/expose_renter_key.md
+++ b/.changeset/expose_renter_key.md
@@ -1,0 +1,5 @@
+---
+default: feature
+---
+
+# Added GET /bus/renterkey endpoint.

--- a/api/bus.go
+++ b/api/bus.go
@@ -100,4 +100,9 @@ type (
 		Contracts *ContractsConfig `json:"contracts"`
 		Hosts     *HostsConfig     `json:"hosts"`
 	}
+
+	// RenterKeyResponse is the response type for the /renterkey endpoint.
+	RenterKeyResponse struct {
+		RenterKey types.PrivateKey `json:"renterKey"`
+	}
 )

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -504,6 +504,8 @@ func (b *Bus) Handler() http.Handler {
 		"GET  /wallet/pending":      b.walletPendingHandler,
 		"POST /wallet/redistribute": b.walletRedistributeHandler,
 		"POST /wallet/send":         b.walletSendSiacoinsHandler,
+
+		"GET /renterkey": b.renterKeyHandler,
 	})
 }
 

--- a/bus/client/keys.go
+++ b/bus/client/keys.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"context"
+
+	"go.sia.tech/renterd/v2/api"
+)
+
+// RenterKey calls the /renterkey endpoint on the bus.
+func (c *Client) RenterKey(ctx context.Context) (resp api.RenterKeyResponse, err error) {
+	err = c.c.GET(ctx, "/renterkey", &resp)
+	return
+}

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -2332,3 +2332,10 @@ func (b *Bus) contractsFormHandler(jc jape.Context) {
 	// return the contract
 	jc.Encode(metadata)
 }
+
+func (b *Bus) renterKeyHandler(jc jape.Context) {
+	rk := b.masterKey.DeriveSubKey("renterkey")
+	jc.Encode(api.RenterKeyResponse{
+		RenterKey: rk,
+	})
+}

--- a/internal/utils/keys.go
+++ b/internal/utils/keys.go
@@ -17,19 +17,19 @@ type (
 // to derive individual account keys from.
 func (key *MasterKey) DeriveAccountsKey(workerID string) AccountsKey {
 	keyPath := fmt.Sprintf("accounts/%s", workerID)
-	return AccountsKey(key.deriveSubKey(keyPath))
+	return AccountsKey(key.DeriveSubKey(keyPath))
 }
 
 // DeriveAccountsKey derives an upload key from a masterkey which is used
 // to encrypt/decrypt files for uploading.
 func (key *MasterKey) DeriveUploadKey() UploadKey {
-	return UploadKey(key.deriveSubKey("uploads"))
+	return UploadKey(key.DeriveSubKey("uploads"))
 }
 
 // DeriveContractKey derives a contract key from a masterkey which is used to
 // form, renew and revise contracts.
 func (key *MasterKey) DeriveContractKey(hostKey types.PublicKey) types.PrivateKey {
-	seed := blake2b.Sum256(append(key.deriveSubKey("renterkey"), hostKey[:]...))
+	seed := blake2b.Sum256(append(key.DeriveSubKey("renterkey"), hostKey[:]...))
 	pk := types.NewPrivateKeyFromSeed(seed[:])
 	for i := range seed {
 		seed[i] = 0
@@ -45,10 +45,10 @@ func (key *UploadKey) DeriveKey(salt *[32]byte) [32]byte {
 	return sum
 }
 
-// deriveSubKey can be used to derive a sub-masterkey from the worker's
+// DeriveSubKey can be used to derive a sub-masterkey from the worker's
 // masterkey to use for a specific purpose. Such as deriving more keys for
 // ephemeral accounts.
-func (key *MasterKey) deriveSubKey(purpose string) types.PrivateKey {
+func (key *MasterKey) DeriveSubKey(purpose string) types.PrivateKey {
 	seed := blake2b.Sum256(append(key[:], []byte(purpose)...))
 	pk := types.NewPrivateKeyFromSeed(seed[:])
 	for i := range seed {


### PR DESCRIPTION
This PR adds a `GET /bus/renterkey` endpoint, which can be used by 3rd-party services like Sia Satellite.

What it can do:
* generate contract keys used to sign contracts
* create account tokens used to migrate sectors

What it cannot do:
* access the wallet of `renterd`, but Sia Satellite wouldn't need that anyway

Fixes #1884 