### PR TITLE
Add hardening to writing partial slab data on download

### DIFF
--- a/.changeset/add_hardening_against_writing_incomplete_partial_slab_data.md
+++ b/.changeset/add_hardening_against_writing_incomplete_partial_slab_data.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Add hardening against writing incomplete partial slab data.

--- a/internal/download/downloadmanager.go
+++ b/internal/download/downloadmanager.go
@@ -270,6 +270,7 @@ func (mgr *Manager) DownloadObject(ctx context.Context, w io.Writer, o object.Ob
 	// collect the response, responses might come in out of order so we keep
 	// them in a map and return what we can when we can
 	responses := make(map[int]*slabDownloadResponse)
+	seen := make(map[int]struct{})
 	var respIndex int
 outer:
 	for {
@@ -296,16 +297,29 @@ outer:
 				return resp.err
 			}
 
+			_, ok := seen[resp.index]
+			if ok {
+				mgr.logger.Errorw("duplicate slab index",
+					zap.Int("index", resp.index),
+					zap.Error(resp.err),
+				)
+				return fmt.Errorf("duplicate slab index: %v", resp.index)
+			}
+			seen[resp.index] = struct{}{}
+
 			responses[resp.index] = resp
 			for {
 				if next, exists := responses[respIndex]; exists {
 					s := slabs[respIndex]
 					if s.PartialSlab {
 						// Partial slab.
-						_, err = bw.Write(s.Data)
+						n, err := bw.Write(s.Data)
 						if err != nil {
 							mgr.logger.Errorf("failed to send partial slab", respIndex, err)
 							return err
+						} else if n != int(s.Length) {
+							mgr.logger.Errorf("incomplete partial slab: %v/%v", n, s.Length)
+							return fmt.Errorf("incomplete partial slab: %v/%v", n, s.Length)
 						}
 					} else {
 						// Regular slab.

--- a/internal/download/downloadmanager.go
+++ b/internal/download/downloadmanager.go
@@ -270,7 +270,6 @@ func (mgr *Manager) DownloadObject(ctx context.Context, w io.Writer, o object.Ob
 	// collect the response, responses might come in out of order so we keep
 	// them in a map and return what we can when we can
 	responses := make(map[int]*slabDownloadResponse)
-	seen := make(map[int]struct{})
 	var respIndex int
 outer:
 	for {
@@ -296,16 +295,6 @@ outer:
 				)
 				return resp.err
 			}
-
-			_, ok := seen[resp.index]
-			if ok {
-				mgr.logger.Errorw("duplicate slab index",
-					zap.Int("index", resp.index),
-					zap.Error(resp.err),
-				)
-				return fmt.Errorf("duplicate slab index: %v", resp.index)
-			}
-			seen[resp.index] = struct{}{}
 
 			responses[resp.index] = resp
 			for {


### PR DESCRIPTION
This PR is related to https://github.com/SiaFoundation/renterd/issues/1889. I can't reproduce it by uploading files myself, but I can reproduce the exact issue by writing an empty slice in place of partial slab data. Note that this won't fail the download, but merely add a log entry to indicate it is in fact a slab without shards.