### PR TITLE
Fix index out of range

### DIFF
--- a/internal/bus/chainsubscriber.go
+++ b/internal/bus/chainsubscriber.go
@@ -372,7 +372,11 @@ func (s *chainSubscriber) processUpdates(ctx context.Context, crus []chain.Rever
 		}
 
 		// update chain index
-		index = caus[len(caus)-1].State.Index
+		if len(caus) > 0 {
+			index = caus[len(caus)-1].State.Index
+		} else {
+			index = crus[len(crus)-1].State.Index
+		}
 		if err := tx.UpdateChainIndex(index); err != nil {
 			return fmt.Errorf("failed to update chain index: %w", err)
 		}


### PR DESCRIPTION
```
panic: runtime error: index out of range [-1]

goroutine 151 [running]:
go.sia.tech/renterd/v2/internal/bus.(*chainSubscriber).processUpdates.func1({0x101ed6100, 0x14001c31650})
	/Users/peterjan/code/siafoundation/renterd/internal/bus/chainsubscriber.go:375 +0x39c
go.sia.tech/renterd/v2/stores/sql/sqlite.(*MainDatabaseTx).ProcessChainUpdate(0x140009813b0, {0x101ecff68, 0x1400021c2d0}, 0x140000522d0)
	/Users/peterjan/code/siafoundation/renterd/stores/sql/sqlite/main.go:627 +0x110
go.sia.tech/renterd/v2/stores.(*SQLStore).ProcessChainUpdate.func1({0x101edb918?, 0x140009813b0?})
	/Users/peterjan/code/siafoundation/renterd/stores/chain.go:31 +0x3c
go.sia.tech/renterd/v2/stores/sql/sqlite.(*MainDatabase).Transaction.func1({0x101ed0d70?, 0x14000981398?})
	/Users/peterjan/code/siafoundation/renterd/stores/sql/sqlite/main.go:109 +0x54
go.sia.tech/renterd/v2/internal/sql.(*DB).transaction(0x14000244380, {0x101ecff68, 0x1400021c2d0}, 0x140023f3a90)
	/Users/peterjan/code/siafoundation/renterd/internal/sql/sql.go:224 +0x144
go.sia.tech/renterd/v2/internal/sql.(*DB).Transaction(0x14000244380, {0x101ecff68, 0x1400021c2d0}, 0x140023f3a90)
	/Users/peterjan/code/siafoundation/renterd/internal/sql/sql.go:152 +0x2a4
go.sia.tech/renterd/v2/stores/sql/sqlite.(*MainDatabase).Transaction(0x48?, {0x101ecff68?, 0x1400021c2d0?}, 0x100c45cbc?)
	/Users/peterjan/code/siafoundation/renterd/stores/sql/sqlite/main.go:108 +0x40
go.sia.tech/renterd/v2/stores.(*SQLStore).ProcessChainUpdate(0x1400038a000, {0x101ecff68, 0x1400021c2d0}, 0x140000522d0)
	/Users/peterjan/code/siafoundation/renterd/stores/chain.go:30 +0x98
go.sia.tech/renterd/v2/internal/bus.(*chainSubscriber).processUpdates(0x140003aca00, {0x101ecff68, 0x1400021c2d0}, {0x140027d6000, 0x64, 0x81}, {0x0, 0x0, 0x0})
	/Users/peterjan/code/siafoundation/renterd/internal/bus/chainsubscriber.go:354 +0xf8
go.sia.tech/renterd/v2/internal/bus.(*chainSubscriber).sync(0x140003aca00)
	/Users/peterjan/code/siafoundation/renterd/internal/bus/chainsubscriber.go:336 +0x5ec
go.sia.tech/renterd/v2/internal/bus.(*chainSubscriber).run.func1()
	/Users/peterjan/code/siafoundation/renterd/internal/bus/chainsubscriber.go:303 +0xac
created by go.sia.tech/renterd/v2/internal/bus.(*chainSubscriber).run in goroutine 1
	/Users/peterjan/code/siafoundation/renterd/internal/bus/chainsubscriber.go:293 +0x6c
```