### PR TITLE
Reset chain state when element is not present in accumulator

### DIFF
--- a/.changeset/reset_chain_state_when_element_is_not_present_in_accumulator.md
+++ b/.changeset/reset_chain_state_when_element_is_not_present_in_accumulator.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Reset chain state when element is not present in accumulator.


### PR DESCRIPTION
One user on [discord](https://discord.com/channels/809849352516141067/827641215356764210/1386783798011760772) ran into the following panic after updating renterd to "latest". I'm assuming that's latest master. Not sure what we can do other than trigger a resync by resetting the chain state.


```
panic: cannot update an element that is not present in the accumulator

goroutine 169 [running]:
go.sia.tech/core/consensus.(*elementRevertUpdate).updateElementProof(0x478c09?, 0x80?)
        go.sia.tech/core@v0.13.2/consensus/merkle.go:481 +0xac
go.sia.tech/core/consensus.RevertUpdate.UpdateElementProof(...)
        go.sia.tech/core@v0.13.2/consensus/application.go:814
go.sia.tech/renterd/v2/stores/sql.UpdateFileContractElementProofs({0x1976fc8, 0xc000398410}, {0x19777d0, 0xc00128de18}, {0x196dfc0, 0xc002f74008})
        go.sia.tech/renterd/v2/stores/sql/chain.go:250 +0xd6
go.sia.tech/renterd/v2/stores/sql/sqlite.chainUpdateTx.UpdateFileContractElementProofs(...)
        go.sia.tech/renterd/v2/stores/sql/sqlite/chain.go:271
go.sia.tech/renterd/v2/internal/bus.(*chainSubscriber).revertChainUpdate(_, {_, _}, {{{0xc003147208, 0xf, 0x10}, {0x0, 0x0, 0x0}, {0xc00029c200, ...}, ...}, ...})
        go.sia.tech/renterd/v2/internal/bus/chainsubscriber.go:285 +0x792
go.sia.tech/renterd/v2/internal/bus.(*chainSubscriber).processUpdates.func1({0x197f0c0, 0xc00309b620})
        go.sia.tech/renterd/v2/internal/bus/chainsubscriber.go:362 +0x1b6
go.sia.tech/renterd/v2/stores/sql/sqlite.(*MainDatabaseTx).ProcessChainUpdate(0xc00128de18, {0x1976fc8, 0xc000398410}, 0xc0002aac80)
        go.sia.tech/renterd/v2/stores/sql/sqlite/main.go:627 +0x10f
go.sia.tech/renterd/v2/stores.(*SQLStore).ProcessChainUpdate.func1({0x1986290?, 0xc00128de18?})
        go.sia.tech/renterd/v2/stores/chain.go:31 +0x33
...
```