### PR TITLE
Don't fail `WithWithdrawal` when account requires resync

### DIFF
--- a/.changeset/dont_fail_withwithdrawal_if_account_requires_resync_and_instead_optimistically_use_account.md
+++ b/.changeset/dont_fail_withwithdrawal_if_account_requires_resync_and_instead_optimistically_use_account.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Don't fail WithWithdrawal if account requires resync and instead optimistically use account

--- a/internal/accounts/accounts.go
+++ b/internal/accounts/accounts.go
@@ -502,13 +502,6 @@ func (a *Account) WithWithdrawal(amtFn func() (types.Currency, error)) error {
 	a.rwmu.RLock()
 	defer a.rwmu.RUnlock()
 
-	// return early if the account needs to sync
-	a.mu.Lock()
-	if a.acc.RequiresSync {
-		a.mu.Unlock()
-		return fmt.Errorf("%w; account requires resync", rhp3.ErrBalanceInsufficient)
-	}
-
 	// return early if our account is not funded
 	if a.acc.Balance.Cmp(big.NewInt(0)) <= 0 {
 		a.mu.Unlock()


### PR DESCRIPTION
With withdrawals no longer blocking when there aren't sufficient funds, we can now optimistically withdraw from an account. That way, uploads/downloads won't fail directly after rebooting `renterd` anymore since they are resyncing.