### PR TITLE
Distribute utxos based on balance

### DIFF
--- a/.changeset/increase_value_of_redistributed_utxos.md
+++ b/.changeset/increase_value_of_redistributed_utxos.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Increase value of redistributed UTXOs.

--- a/autopilot/walletmaintainer/wallet.go
+++ b/autopilot/walletmaintainer/wallet.go
@@ -98,11 +98,13 @@ func (w *walletMaintainer) PerformWalletMaintenance(ctx context.Context, cfg api
 	}
 
 	// calculate number of outputs
-	amount := contractor.InitialContractFunding
-	numOutputs := min(balance.Div(amount).Big().Uint64(), w.desiredNumOutputs)
+	amount := balance.Div64(w.desiredNumOutputs)
+	numOutputs := w.desiredNumOutputs
 
-	// skip maintenance if wallet balance is too low
-	if numOutputs < w.minNumOutputs {
+	if amount.Cmp(contractor.InitialContractFunding) < 0 {
+		w.logger.Warnf("wallet maintenance skipped, the balance of %v is too low to redistribute into outputs of %v, at a minimum we want to redistribute into %d outputs, so the balance should be at least %v", balance, amount, w.desiredNumOutputs, contractor.InitialContractFunding.Mul64(w.desiredNumOutputs))
+		return nil
+	} else if numOutputs < w.minNumOutputs {
 		w.logger.Warnf("wallet maintenance skipped, the balance of %v is too low to redistribute into outputs of %v, at a minimum we want to redistribute into %d outputs, so the balance should be at least %v", balance, amount, w.minNumOutputs, amount.Mul64(w.minNumOutputs))
 		return nil
 	}


### PR DESCRIPTION
Changes the wallet redistribution to evenly redistribute based on the wallet balance instead of hardcoded to 10SC. This should help large renters ramp up contract formations.