### PR TITLE
Write and append sector with single Siamux transport

### DIFF
--- a/.changeset/perform_sector_write_and_append_with_single_siamux_transport.md
+++ b/.changeset/perform_sector_write_and_append_with_single_siamux_transport.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Perform sector write and append with single siamux transport.

--- a/internal/hosts/manager.go
+++ b/internal/hosts/manager.go
@@ -153,19 +153,13 @@ func (c *hostV2UploadClient) UploadSector(ctx context.Context, sectorRoot types.
 			return types.ZeroCurrency, err
 		}
 
-		res, err := c.rhp4.WriteSector(ctx, c.hi.PublicKey, c.hi.SiamuxAddr(), prices, c.acc.Token(), utils.NewReaderLen(sector[:]), rhpv4.SectorSize)
+		revision, usage, err := c.rhp4.AppendSectors(ctx, c.hi.PublicKey, c.hi.SiamuxAddr(), prices, c.acc.Token(), c.rk, rev, utils.NewReaderLen(sector[:]))
 		if err != nil {
-			return types.ZeroCurrency, fmt.Errorf("failed to write sector: %w", err)
-		}
-		cost := res.Usage.RenterCost()
-
-		res2, err := c.rhp4.AppendSectors(ctx, c.hi.PublicKey, c.hi.SiamuxAddr(), prices, c.rk, rev, []types.Hash256{res.Root})
-		if err != nil {
-			return cost, fmt.Errorf("failed to write sector: %w", err)
+			return usage.RenterCost(), fmt.Errorf("failed to upload sector: %w", err)
 		}
 
-		c.csr.RecordV2(rhp.ContractRevision{ID: rev.ID, Revision: res2.Revision}, api.ContractSpending{Uploads: res2.Usage.RenterCost()})
-		return cost, nil
+		c.csr.RecordV2(rhp.ContractRevision{ID: rev.ID, Revision: revision}, api.ContractSpending{Uploads: usage.RenterCost()})
+		return usage.RenterCost(), nil
 	})
 }
 

--- a/internal/hosts/manager.go
+++ b/internal/hosts/manager.go
@@ -153,7 +153,7 @@ func (c *hostV2UploadClient) UploadSector(ctx context.Context, sectorRoot types.
 			return types.ZeroCurrency, err
 		}
 
-		revision, usage, err := c.rhp4.AppendSectors(ctx, c.hi.PublicKey, c.hi.SiamuxAddr(), prices, c.acc.Token(), c.rk, rev, utils.NewReaderLen(sector[:]))
+		revision, usage, err := c.rhp4.AppendSector(ctx, c.hi.PublicKey, c.hi.SiamuxAddr(), prices, c.acc.Token(), c.rk, rev, utils.NewReaderLen(sector[:]))
 		if err != nil {
 			return usage.RenterCost(), fmt.Errorf("failed to upload sector: %w", err)
 		}

--- a/internal/rhp/v4/rhp.go
+++ b/internal/rhp/v4/rhp.go
@@ -3,6 +3,7 @@ package rhp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"time"
@@ -75,15 +76,6 @@ func (c *Client) ReadSector(ctx context.Context, hk types.PublicKey, hostIP stri
 	return res, err
 }
 
-// WriteSector writes a sector to the host.
-func (c *Client) WriteSector(ctx context.Context, hk types.PublicKey, hostIP string, prices rhp4.HostPrices, token rhp4.AccountToken, rl rhp.ReaderLen, length uint64) (res rhp.RPCWriteSectorResult, _ error) {
-	err := c.tpool.withTransport(ctx, hk, hostIP, func(t rhp.TransportClient) (err error) {
-		res, err = rhp.RPCWriteSector(ctx, t, prices, token, rl, length)
-		return
-	})
-	return res, err
-}
-
 // VerifySector verifies that the host is properly storing a sector
 func (c *Client) VerifySector(ctx context.Context, prices rhp4.HostPrices, token rhp4.AccountToken, root types.Hash256) (rhp.RPCVerifySectorResult, error) {
 	panic("not implemented")
@@ -99,8 +91,14 @@ func (c *Client) FreeSectors(ctx context.Context, hk types.PublicKey, hostIP str
 }
 
 // AppendSectors appends sectors a host is storing to a contract.
-func (c *Client) AppendSectors(ctx context.Context, hk types.PublicKey, hostIP string, prices rhp4.HostPrices, sk types.PrivateKey, contract rhp.ContractRevision, roots []types.Hash256) (res rhp.RPCAppendSectorsResult, _ error) {
+func (c *Client) AppendSectors(ctx context.Context, hk types.PublicKey, hostIP string, prices rhp4.HostPrices, token rhp4.AccountToken, sk types.PrivateKey, contract rhp.ContractRevision, rl rhp.ReaderLen) (revision types.V2FileContract, usage rhp4.Usage, _ error) {
 	err := c.tpool.withTransport(ctx, hk, hostIP, func(t rhp.TransportClient) (err error) {
+		writeRes, err := rhp.RPCWriteSector(ctx, t, prices, token, rl, rhp4.SectorSize)
+		if err != nil {
+			return fmt.Errorf("failed to write sector: %w", err)
+		}
+		usage = writeRes.Usage
+
 		// NOTE: construct an empty state object here to pass to
 		// RPCAppendSectors since it only uses it for hashing
 		cs := consensus.State{}
@@ -108,10 +106,15 @@ func (c *Client) AppendSectors(ctx context.Context, hk types.PublicKey, hostIP s
 		// NOTE: immediately append the sector for the time being, eventually
 		// this will be a 2-step process where uploads are unblocked as soon as
 		// the sector is on the host, but not yet added to the contract
-		res, err = rhp.RPCAppendSectors(ctx, t, sk, cs, prices, contract, roots)
+		appendRes, err := rhp.RPCAppendSectors(ctx, t, sk, cs, prices, contract, []types.Hash256{writeRes.Root})
+		if err != nil {
+			return fmt.Errorf("failed to append sector: %w", err)
+		}
+		usage = usage.Add(appendRes.Usage)
+		revision = appendRes.Revision
 		return
 	})
-	return res, err
+	return revision, usage, err
 }
 
 // FundAccounts funds accounts on the host.

--- a/internal/rhp/v4/rhp.go
+++ b/internal/rhp/v4/rhp.go
@@ -90,8 +90,8 @@ func (c *Client) FreeSectors(ctx context.Context, hk types.PublicKey, hostIP str
 	return res, err
 }
 
-// AppendSectors appends sectors a host is storing to a contract.
-func (c *Client) AppendSectors(ctx context.Context, hk types.PublicKey, hostIP string, prices rhp4.HostPrices, token rhp4.AccountToken, sk types.PrivateKey, contract rhp.ContractRevision, rl rhp.ReaderLen) (revision types.V2FileContract, usage rhp4.Usage, _ error) {
+// AppendSector appends sectors a host is storing to a contract.
+func (c *Client) AppendSector(ctx context.Context, hk types.PublicKey, hostIP string, prices rhp4.HostPrices, token rhp4.AccountToken, sk types.PrivateKey, contract rhp.ContractRevision, rl rhp.ReaderLen) (revision types.V2FileContract, usage rhp4.Usage, _ error) {
 	err := c.tpool.withTransport(ctx, hk, hostIP, func(t rhp.TransportClient) (err error) {
 		writeRes, err := rhp.RPCWriteSector(ctx, t, prices, token, rl, rhp4.SectorSize)
 		if err != nil {


### PR DESCRIPTION
Since we are always writing a sector and then appending it makes sense to avoid establishing a siamux connection twice in a row by combining the RPCs. 

If we end up refactoring `renterd` to separately write sectors and append we can split it up again but that probably won't happen soon.