### PR TITLE
Make sure that SlowThreshold can't be 0

### DIFF
--- a/.changeset/make_sure_that_slowthreshold_cant_be_set_to_0.md
+++ b/.changeset/make_sure_that_slowthreshold_cant_be_set_to_0.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Make sure that SlowThreshold can't be set to 0.

--- a/cmd/renterd/node.go
+++ b/cmd/renterd/node.go
@@ -533,6 +533,10 @@ func buildStoreConfig(am alerts.Alerter, cfg config.Config, pk types.PrivateKey,
 		}
 	}
 
+	if cfg.Log.Database.SlowThreshold == 0 {
+		return stores.Config{}, errors.New("Log.Database.SlowThreshold must be greater than 0")
+	}
+
 	return stores.Config{
 		Alerts:                        alerts.WithOrigin(am, "bus"),
 		DB:                            dbMain,


### PR DESCRIPTION
`SlowThreshold` being 0 can lead to a confusing error message that mentions `LongQueryDuration` and `LongTxDuration` which aren't actually part of `renterd.yml` themselves.

Fixes https://github.com/SiaFoundation/renterd/issues/1966