### PR TITLE
ci: publish openapi to scalar, sync version

### DIFF
--- a/.github/workflows/openapi-publish.yml
+++ b/.github/workflows/openapi-publish.yml
@@ -1,0 +1,20 @@
+name: Publish OpenAPI to Scalar Registry
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - "openapi.yml"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    uses: SiaFoundation/workflows/.github/workflows/publish-openapi.yml@master
+    with:
+      slug: renterd
+      spec_path: openapi.yml
+    secrets:
+      SCALAR_API_KEY: ${{ secrets.SCALAR_API_KEY }}

--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -1,0 +1,16 @@
+name: Sync OpenAPI Versions
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  release:
+    types: [published, edited]
+  workflow_dispatch:
+
+jobs:
+  sync:
+    uses: foundation/workflows/.github/workflows/sync-openapi-version.yml@master
+    with:
+      spec_path: openapi.yml


### PR DESCRIPTION
- Workflow for publishing the openapi spec when the file changes on master or via manual trigger.
  - Note: this step will throw an error until tomorrow. I reported an issue with this API to the scalar team and they said it would be fixed in the next release (1-2 days).
- Workflow for syncing the openapi spec version field to the repo latest release version. When the versions are out of sync this workflow will open a PR.
  - Depends on https://github.com/SiaFoundation/workflows/pull/17 being merged.