### PR TITLE
ci: fix openapi spec sync workflow path

### DIFF
--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   sync:
-    uses: foundation/workflows/.github/workflows/sync-openapi-version.yml@master
+    uses: SiaFoundation/workflows/.github/workflows/sync-openapi-version.yml@master
     with:
       spec_path: openapi.yml


### PR DESCRIPTION
- The org name was incorrect.