### PR TITLE
Reset chain state

### DIFF
--- a/.changeset/reset_chain_state_if_consensusdb_was_deleted.md
+++ b/.changeset/reset_chain_state_if_consensusdb_was_deleted.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Reset chain state if consensus.db was deleted.

--- a/internal/bus/chainsubscriber.go
+++ b/internal/bus/chainsubscriber.go
@@ -288,7 +288,7 @@ func (s *chainSubscriber) sync() error {
 
 	// fetch updates until we're caught up
 	var cnt, resetAttempts uint64
-	for index != s.cm.Tip() && index.Height <= s.cm.Tip().Height && !s.isClosed() {
+	for index != s.cm.Tip() && !s.isClosed() {
 		// fetch updates
 		istart := time.Now()
 		crus, caus, err := s.cm.UpdatesSince(index, updatesBatchSize)

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -1134,8 +1134,11 @@ func newTestSyncer(cm syncer.ChainManager, store syncer.PeerStore, genesisID typ
 
 	// create the syncer
 	s := syncer.New(l, cm, store, header, syncer.WithLogger(logger.Named("syncer")),
-		syncer.WithSendBlocksTimeout(2*time.Second),
-		syncer.WithRPCTimeout(2*time.Second),
+		syncer.WithMaxSendBlocks(100),
+		syncer.WithPeerDiscoveryInterval(time.Second),
+		syncer.WithRPCTimeout(time.Second),
+		syncer.WithSendBlocksTimeout(time.Second),
+		syncer.WithSyncInterval(time.Second),
 	)
 	go s.Run()
 	return &TestSyncer{s: s}, nil

--- a/internal/test/e2e/host.go
+++ b/internal/test/e2e/host.go
@@ -81,8 +81,11 @@ func NewHost(privKey types.PrivateKey, cm *chain.Manager, dir string, network *c
 		UniqueID:   gateway.GenerateUniqueID(),
 		NetAddress: l.Addr().String(),
 	},
-		syncer.WithSendBlocksTimeout(2*time.Second),
-		syncer.WithRPCTimeout(2*time.Second),
+		syncer.WithMaxSendBlocks(100),
+		syncer.WithPeerDiscoveryInterval(time.Second),
+		syncer.WithRPCTimeout(time.Second),
+		syncer.WithSendBlocksTimeout(time.Second),
+		syncer.WithSyncInterval(time.Second),
 	)
 	go s.Run()
 


### PR DESCRIPTION
Some users are reporting that `renterd` seems stuck on the v2 allow height and that it is not properly resetting the chain state, even after deleting the `consensus.db`. That's definitely a regression and it was introduced [here](https://github.com/SiaFoundation/renterd/pull/1655). I believe we added that condition to speed up the test (TestConsensusResync), or maybe because it felt logical at the time.